### PR TITLE
fix(release): hydrate ADR promotion boundaries

### DIFF
--- a/scripts/adr-release-gate.mjs
+++ b/scripts/adr-release-gate.mjs
@@ -204,12 +204,40 @@ function stringList(value) {
 }
 
 /** @param {string} ref @param {string} head @param {string} root */
-function changedFilesBetween(ref, head, root) {
-  const result = childProcess.spawnSync(
-    'git',
-    ['diff', '--name-only', `${ref}...${head}`],
-    { cwd: root, encoding: 'utf8' },
-  );
+export function changedFilesBetween(ref, head, root) {
+  const runDiff = () =>
+    childProcess.spawnSync('git', ['diff', '--name-only', `${ref}...${head}`], {
+      cwd: root,
+      env: isolatedGitEnvironment(),
+      encoding: 'utf8',
+    });
+
+  let result = runDiff();
+  if (
+    result.status !== 0 &&
+    /^[0-9a-f]{40}$/u.test(ref) &&
+    /^[0-9a-f]{40}$/u.test(head)
+  ) {
+    // Buildchain checks out the immutable pull-request merge source with a
+    // shallow boundary. The PR event still names the exact base and head
+    // commits needed by the ADR settlement gate, so hydrate only those two
+    // boundaries (plus the promotion parents) before retrying the diff.
+    const fetch = childProcess.spawnSync(
+      'git',
+      ['fetch', '--no-tags', '--depth=2', 'origin', ref, head],
+      {
+        cwd: root,
+        env: isolatedGitEnvironment(),
+        encoding: 'utf8',
+      },
+    );
+    if (fetch.status !== 0) {
+      throw new Error(
+        `git diff ${ref}...${head} failed: ${String(result.stderr || '').trim()}; exact boundary fetch failed: ${String(fetch.stderr || '').trim()}`,
+      );
+    }
+    result = runDiff();
+  }
   if (result.status !== 0) {
     throw new Error(
       `git diff ${ref}...${head} failed: ${String(result.stderr || '').trim()}`,

--- a/scripts/adr-release-gate.test.mjs
+++ b/scripts/adr-release-gate.test.mjs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test } from 'node:test';
 
 import {
+  changedFilesBetween,
   evaluateReleaseGate,
   loadAdrs,
   parsePrManifest,
@@ -82,6 +84,23 @@ function run(root, mode, manifest, extra = {}) {
   });
 }
 
+function git(root, args, input = undefined) {
+  const result = childProcess.spawnSync('git', args, {
+    cwd: root,
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+    ),
+    encoding: 'utf8',
+    input,
+  });
+  assert.equal(
+    result.status,
+    0,
+    `git ${args.join(' ')} failed: ${String(result.stderr || '').trim()}`,
+  );
+  return String(result.stdout || '').trim();
+}
+
 test('fails closed when ADR identity authority reports a structural finding', () => {
   const root = fixture([{ id: 'ADR-9999', status: 'partial' }]);
   const result = run(
@@ -133,6 +152,69 @@ test('parses exactly one JSON manifest from the PR body', () => {
   );
   assert.equal(parsed.kind, 'adr-neutral');
   assert.throws(() => parsePrManifest('no manifest', contract.manifestMarker));
+});
+
+test('hydrates exact promotion boundaries in a shallow build checkout', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-adr-release-shallow-'),
+  );
+  roots.push(root);
+  const remote = path.join(root, 'remote.git');
+  const source = path.join(root, 'source');
+  const checkout = path.join(root, 'checkout');
+
+  git(root, ['init', '--bare', remote]);
+  fs.mkdirSync(source);
+  git(source, ['init', '--initial-branch=main']);
+  git(source, ['config', 'user.name', 'ADR Test']);
+  git(source, ['config', 'user.email', 'adr-test@example.invalid']);
+  fs.mkdirSync(path.join(source, 'adr'));
+  fs.writeFileSync(path.join(source, 'adr/decision.md'), 'alpha\n');
+  git(source, ['add', 'adr/decision.md']);
+  git(source, ['commit', '-m', 'alpha']);
+  const alpha = git(source, ['rev-parse', 'HEAD']);
+
+  fs.writeFileSync(path.join(source, 'adr/decision.md'), 'development\n');
+  git(source, ['commit', '-am', 'development']);
+  const development = git(source, ['rev-parse', 'HEAD']);
+  const tree = git(source, ['rev-parse', 'HEAD^{tree}']);
+  const promotion = git(
+    source,
+    ['commit-tree', tree, '-p', alpha, '-p', development],
+    'promote\n',
+  );
+  const merge = git(
+    source,
+    ['commit-tree', tree, '-p', alpha, '-p', promotion],
+    'pull request merge\n',
+  );
+  git(source, ['update-ref', 'refs/heads/merge', merge]);
+  git(source, ['remote', 'add', 'origin', remote]);
+  git(source, ['push', 'origin', 'refs/heads/merge']);
+  git(root, [
+    'clone',
+    '--depth=1',
+    '--branch=merge',
+    `file://${remote}`,
+    checkout,
+  ]);
+
+  const missingPromotion = childProcess.spawnSync(
+    'git',
+    ['cat-file', '-e', `${promotion}^{commit}`],
+    {
+      cwd: checkout,
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+      ),
+      encoding: 'utf8',
+    },
+  );
+  assert.notEqual(missingPromotion.status, 0);
+  assert.deepEqual(changedFilesBetween(alpha, promotion, checkout), [
+    'adr/decision.md',
+  ]);
+  assert.equal(git(checkout, ['rev-parse', '--is-shallow-repository']), 'true');
 });
 
 test('feature dev PR requires a stage-ready or implemented delivery', () => {


### PR DESCRIPTION
## Summary

Hydrate the exact alpha base and promotion head commits when ADR settlement runs inside Buildchain’s immutable depth-1 PR merge checkout, then retry the fail-closed changed-file computation.

The fetch accepts only two full 40-character commit OIDs from the trusted pull-request event and keeps the checkout shallow at depth 2.

## Verification

- shallow promotion fixture proves both boundaries are initially absent and exact hydration restores the ADR diff
- focused ADR release tests: 15/15 passed
- Biome check passed
- full staged commit hook passed, including documentation and invariant gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Preserve ADR settlement evidence in immutable shallow Buildchain checkouts"}
-->
