### PR TITLE
fix(release): close alpha qualification gaps

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -250,7 +250,9 @@ jobs:
       - name: Materialize exact KFD Runtime 100
         shell: bash
         env:
-          KFD_SHA: 1f3819f48d30f4fb2d5ebf5931193b0ad97da9fe
+          # KFD v1.0.0-alpha.42 carries the canonical Runtime 100 vector root
+          # consumed by this source tree.
+          KFD_SHA: 03deef6bbc6e2ac8aecfedc76f17f6c74a72b878
         run: |
           kfd_root="${RUNNER_TEMP}/kfd-runtime-100"
           git init "$kfd_root"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1071,7 +1071,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c351b7964598c94a365545941fffc08468cdeea87b8540f04bf70e2afe2c1b59",
+          "definitionDigest": "sha256:ffe5f826e5d47910a56ff234cf4640dff0b043e74caa11cdb3ce39cf6ef43c88",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -1167,7 +1167,7 @@
               "index": 14,
               "label": "name:Materialize exact KFD Runtime 100",
               "authority": "qualification",
-              "definitionDigest": "sha256:8fd002a7648e401304b5985d25086609fd715da74feed1bfd209e7cf14d58099"
+              "definitionDigest": "sha256:e138b795a81dc221702018286bcfcf9473822651332c6b989160b3be8e30369c"
             },
             {
               "index": 15,

--- a/framework/gui/scripts/run-electron-builder.mjs
+++ b/framework/gui/scripts/run-electron-builder.mjs
@@ -13,6 +13,7 @@
 // electronDist override.
 
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -36,12 +37,56 @@ export function normalizeBuilderArgs(args, resolvedElectronDist) {
   ];
 }
 
+export function shouldForceMacPullRequestSigning({
+  platform,
+  eventName,
+  repository,
+  baseRef,
+  event,
+}) {
+  return (
+    platform === 'darwin' &&
+    eventName === 'pull_request' &&
+    repository === 'kungfu-systems/kungfu' &&
+    /^(?:alpha|release)\//.test(baseRef || '') &&
+    event?.pull_request?.base?.repo?.full_name === repository &&
+    event?.pull_request?.base?.ref === baseRef &&
+    event?.pull_request?.head?.repo?.full_name === repository
+  );
+}
+
+function electronBuilderEnvironment() {
+  let event = null;
+  try {
+    if (process.env.GITHUB_EVENT_PATH) {
+      event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+    }
+  } catch {
+    return process.env;
+  }
+  if (
+    !shouldForceMacPullRequestSigning({
+      platform: process.platform,
+      eventName: process.env.GITHUB_EVENT_NAME,
+      repository: process.env.GITHUB_REPOSITORY,
+      baseRef: process.env.GITHUB_BASE_REF,
+      event,
+    })
+  ) {
+    return process.env;
+  }
+  return { ...process.env, CSC_FOR_PULL_REQUEST: 'true' };
+}
+
 function main() {
   const args = [
     ebBin,
     ...normalizeBuilderArgs(process.argv.slice(2), electronDist),
   ];
-  const result = spawnSync(process.execPath, args, { stdio: 'inherit' });
+  const result = spawnSync(process.execPath, args, {
+    stdio: 'inherit',
+    env: electronBuilderEnvironment(),
+  });
   process.exit(result.status ?? 1);
 }
 

--- a/framework/gui/scripts/run-electron-builder.test.mjs
+++ b/framework/gui/scripts/run-electron-builder.test.mjs
@@ -2,7 +2,10 @@
 
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { normalizeBuilderArgs } from './run-electron-builder.mjs';
+import {
+  normalizeBuilderArgs,
+  shouldForceMacPullRequestSigning,
+} from './run-electron-builder.mjs';
 
 test('electron-builder defaults to non-publishing mode in CI', () => {
   assert.deepEqual(normalizeBuilderArgs(['--dir'], '/tmp/electron'), [
@@ -16,5 +19,52 @@ test('electron-builder preserves an explicit publish mode', () => {
   assert.deepEqual(
     normalizeBuilderArgs(['--publish=always'], '/tmp/electron'),
     ['--publish=always', '--config.electronDist=/tmp/electron'],
+  );
+});
+
+test('macOS signing is forced only for same-repository channel pull requests', () => {
+  const request = {
+    platform: 'darwin',
+    eventName: 'pull_request',
+    repository: 'kungfu-systems/kungfu',
+    baseRef: 'alpha/v4/v4.0',
+    event: {
+      pull_request: {
+        base: {
+          ref: 'alpha/v4/v4.0',
+          repo: { full_name: 'kungfu-systems/kungfu' },
+        },
+        head: { repo: { full_name: 'kungfu-systems/kungfu' } },
+      },
+    },
+  };
+  assert.equal(shouldForceMacPullRequestSigning(request), true);
+  assert.equal(
+    shouldForceMacPullRequestSigning({
+      ...request,
+      event: {
+        pull_request: {
+          ...request.event.pull_request,
+          head: { repo: { full_name: 'untrusted/fork' } },
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    shouldForceMacPullRequestSigning({
+      ...request,
+      baseRef: 'dev/v4/v4.0',
+      event: {
+        pull_request: {
+          ...request.event.pull_request,
+          base: {
+            ...request.event.pull_request.base,
+            ref: 'dev/v4/v4.0',
+          },
+        },
+      },
+    }),
+    false,
   );
 });

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1243,11 +1243,10 @@ export function runInstalledKungfu({
   args,
   env,
 }) {
-  const result = spawnSync(kungfuBin, ['-H', home, ...args], {
+  const result = spawnInstalledKungfu(kungfuBin, ['-H', home, ...args], {
     cwd: installRoot,
     env,
     encoding: 'utf8',
-    shell: isWin,
   });
   if (result.status !== 0) {
     throw new Error(
@@ -1261,6 +1260,28 @@ export function runInstalledKungfu({
     );
   }
   return result.stdout || '';
+}
+
+export function installedKungfuInvocation(
+  kungfuBin,
+  args,
+  { platform = process.platform, comspec = process.env.ComSpec } = {},
+) {
+  if (platform !== 'win32') {
+    return { command: kungfuBin, args };
+  }
+  return {
+    command: comspec || 'cmd.exe',
+    args: ['/d', '/s', '/c', 'call', kungfuBin, ...args],
+  };
+}
+
+function spawnInstalledKungfu(kungfuBin, args, options) {
+  const invocation = installedKungfuInvocation(kungfuBin, args);
+  return spawnSync(invocation.command, invocation.args, {
+    ...options,
+    shell: false,
+  });
 }
 
 export function runInstalledCliSemanticSmoke({
@@ -1418,7 +1439,7 @@ function runInstalledKungfuKfdSmoke({
   extensionsRoot,
   env,
 }) {
-  const result = spawnSync(kungfuBin, ['kfd', 'status', '--json'], {
+  const result = spawnInstalledKungfu(kungfuBin, ['kfd', 'status', '--json'], {
     cwd: installRoot,
     env: {
       ...env,
@@ -1428,7 +1449,6 @@ function runInstalledKungfuKfdSmoke({
       KF_FIRST_PARTY_SOURCE_ROOT: extensionsRoot,
     },
     encoding: 'utf8',
-    shell: isWin,
   });
   if (result.status !== 0) {
     throw new Error(
@@ -1478,19 +1498,22 @@ function runInstalledKungfuActionSmoke({
       'utf8',
     );
     if (!isWin) fs.chmodSync(fakeNode, 0o755);
-    const result = spawnSync(kungfuBin, ['action', 'contract', '--json'], {
-      cwd: installRoot,
-      env: {
-        ...env,
-        KUNGFU_ACTION_ENTRY: actionEntry,
-        KUNGFU_NODE_FALLBACK_MARKER: marker,
-        PATH: [poisonDir, process.env.PATH || '']
-          .filter(Boolean)
-          .join(path.delimiter),
+    const result = spawnInstalledKungfu(
+      kungfuBin,
+      ['action', 'contract', '--json'],
+      {
+        cwd: installRoot,
+        env: {
+          ...env,
+          KUNGFU_ACTION_ENTRY: actionEntry,
+          KUNGFU_NODE_FALLBACK_MARKER: marker,
+          PATH: [poisonDir, process.env.PATH || '']
+            .filter(Boolean)
+            .join(path.delimiter),
+        },
+        encoding: 'utf8',
       },
-      encoding: 'utf8',
-      shell: isWin,
-    });
+    );
     if (result.status !== 0) {
       throw new Error(
         [
@@ -1541,7 +1564,7 @@ function runInstalledKungfuXinfaSmoke({ installRoot, kungfuBin, env }) {
   );
   const project = path.join(fixtureRoot, 'project.json');
   const atlasOutput = path.join(installRoot, 'xinfa-smoke-atlas');
-  const installed = spawnSync(
+  const installed = spawnInstalledKungfu(
     kungfuBin,
     [
       'xinfa',
@@ -1560,7 +1583,6 @@ function runInstalledKungfuXinfaSmoke({ installRoot, kungfuBin, env }) {
       cwd: installRoot,
       env,
       encoding: 'utf8',
-      shell: isWin,
     },
   );
   if (installed.status !== 0) {

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -13,6 +13,7 @@ import {
   cliArchiveLayout,
   desktopUpdaterArtifact,
   esbuildPlatformBinaryPath,
+  installedKungfuInvocation,
   kfxBundleExternalModules,
   requiresManagedEsbuildPlatform,
   stageXinfaContract,
@@ -50,6 +51,32 @@ test('CLI archive keeps the launcher distinct from its runtime tree', () => {
   });
   assert.match(cliLauncherContent('darwin'), /exec "\$here\/runtime\/kungfu"/);
   assert.match(cliLauncherContent('win32'), /%~dp0runtime\\kungfu\.exe/);
+});
+
+test('installed CLI launcher uses cmd.exe explicitly on Windows', () => {
+  assert.deepEqual(
+    installedKungfuInvocation('C:\\Kungfu Episodes\\kungfu.cmd', ['--help'], {
+      platform: 'win32',
+      comspec: 'C:\\Windows\\System32\\cmd.exe',
+    }),
+    {
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        'call',
+        'C:\\Kungfu Episodes\\kungfu.cmd',
+        '--help',
+      ],
+    },
+  );
+  assert.deepEqual(
+    installedKungfuInvocation('/opt/kungfu/kungfu', ['--help'], {
+      platform: 'linux',
+    }),
+    { command: '/opt/kungfu/kungfu', args: ['--help'] },
+  );
 });
 
 test('product observability ignores errors from sibling components', () => {

--- a/scripts/check-kfd-agent-runtime-boundary.mjs
+++ b/scripts/check-kfd-agent-runtime-boundary.mjs
@@ -96,6 +96,11 @@ assert.equal(
   manifest.suite.vectorRoot,
   'sha256:1e996b8c43b0b3e38630ccd58acf8a714cbc24b339d3794318347faab9057e5f',
 );
+assert.match(
+  workflow,
+  /KFD_SHA: 03deef6bbc6e2ac8aecfedc76f17f6c74a72b878/,
+  'the external conformance runner must use KFD v1.0.0-alpha.42 with the same Runtime 100 vector root',
+);
 
 process.stdout.write(
   `${JSON.stringify({

--- a/scripts/document-metadata-contract.mjs
+++ b/scripts/document-metadata-contract.mjs
@@ -285,6 +285,25 @@ function registryFields(values) {
   );
 }
 
+/** @param {string} root @param {string} commit */
+function ensureGitCommitAvailable(root, commit) {
+  const env = isolatedGitEnvironment();
+  const present = childProcess.spawnSync(
+    'git',
+    ['cat-file', '-e', `${commit}^{commit}`],
+    { cwd: root, env, encoding: 'utf8' },
+  );
+  if (present.status === 0) return;
+  const fetched = childProcess.spawnSync(
+    'git',
+    ['fetch', '--no-tags', '--depth=1', 'origin', commit],
+    { cwd: root, env, encoding: 'utf8' },
+  );
+  if (fetched.status !== 0) {
+    throw new Error(`cannot hydrate exact Git commit ${commit}`);
+  }
+}
+
 /** @param {string} root @param {MetadataContract} contract */
 function readLegacyAdrInventory(root, contract) {
   const identityContract = contract.adrIdentity;
@@ -325,6 +344,7 @@ function readLegacyAdrInventory(root, contract) {
     allowed.add(`${id}\0${recordPath}`);
   }
   if (identityContract.verifyCutoverTree) {
+    ensureGitCommitAvailable(root, inventory.cutoverCommit);
     const legacyRoot = path.posix.dirname(rel);
     const tree = childProcess.spawnSync(
       'git',

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -459,6 +459,80 @@ test('rejects a legacy inventory that differs from its fixed cutover tree', () =
   );
 });
 
+test('hydrates the exact legacy cutover commit in a shallow checkout', () => {
+  const source = fixture({
+    'adr/README.md': `${indexHeader}\n\n# ADRs\n\n| ADR | Status | Title |\n|---|---|---|\n| [ADR-0001](ADR-0001-example.md) | accepted | Example |\n`,
+    'adr/ADR-0001-example.md': `${adrHeader}\n\n# ADR-0001: Example\n\n- Status: accepted\n`,
+    'docs/document-metadata.registry.json': `${JSON.stringify({
+      schemaVersion: 1,
+      metadataSchema: 'kungfu.document-metadata/v1',
+      documents: {},
+    })}\n`,
+  });
+  git(source, ['init', '-q']);
+  git(source, ['config', 'user.name', 'Test']);
+  git(source, ['config', 'user.email', 'test@example.com']);
+  git(source, ['add', '.']);
+  git(source, [
+    '-c',
+    'core.hooksPath=/dev/null',
+    'commit',
+    '-q',
+    '-m',
+    'cutover',
+  ]);
+  const cutover = git(source, ['rev-parse', 'HEAD']);
+  fs.writeFileSync(
+    path.join(source, 'adr/legacy-identities.v1.json'),
+    `${JSON.stringify({
+      schema: 'kungfu.adr-legacy-identities/v1',
+      cutoverCommit: cutover,
+      records: [{ id: 'ADR-0001', path: 'adr/ADR-0001-example.md' }],
+    })}\n`,
+  );
+  git(source, ['add', '.']);
+  git(source, [
+    '-c',
+    'core.hooksPath=/dev/null',
+    'commit',
+    '-q',
+    '-m',
+    'inventory',
+  ]);
+
+  const remote = fixture({});
+  git(remote, ['init', '--bare', '-q']);
+  git(source, ['remote', 'add', 'origin', remote]);
+  git(source, ['push', '-q', 'origin', 'HEAD:main']);
+  git(remote, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  const shallowParent = fixture({});
+  const shallow = path.join(shallowParent, 'checkout');
+  git(shallowParent, ['clone', '-q', '--depth=1', `file://${remote}`, shallow]);
+  const missingCutover = childProcess.spawnSync(
+    'git',
+    ['cat-file', '-e', `${cutover}^{commit}`],
+    {
+      cwd: shallow,
+      encoding: 'utf8',
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+      ),
+    },
+  );
+  assert.notEqual(missingCutover.status, 0);
+
+  const selected = identityContract();
+  selected.adrIdentity.legacyCutoverCommit = cutover;
+  selected.adrIdentity.verifyCutoverTree = true;
+  const findings = validateDocumentMetadata({
+    root: shallow,
+    files: ['adr/ADR-0001-example.md', 'adr/README.md'],
+    contract: selected,
+  });
+  assert.equal(findings.length, 0);
+  assert.equal(git(shallow, ['cat-file', '-e', `${cutover}^{commit}`]), '');
+});
+
 test('accepts an ID-only UUIDv7 ADR without a shared index row', () => {
   const id = 'KF-ADR-019f8758-0efc-7011-a233-445566778899';
   const findings = run(


### PR DESCRIPTION
## Summary

Close the deterministic alpha qualification gaps proven by PR #1325:

- invoke installed Windows `.cmd` launchers through explicit `ComSpec` / `cmd.exe /d /s /c call`
- hydrate the exact pinned ADR legacy cutover commit when a locked Buildchain checkout is depth-1
- force electron-builder macOS signing only for same-repository alpha/release pull requests, after validating the event payload head and base repositories
- pin external KFD Runtime 100 conformance to published `v1.0.0-alpha.42` (`03deef6bbc6e2ac8aecfedc76f17f6c74a72b878`), aligned with vector root `sha256:1e996b8c43b0b3e38630ccd58acf8a714cbc24b339d3794318347faab9057e5f`

## Verification

- focused product, GUI launcher, metadata, and CLI qualification tests: 55/55 passed
- synthetic depth-1 remote fixture proves exact legacy cutover hydration
- same-repository/fork/dev macOS signing admission fixtures
- KFD Agent Runtime boundary and exact workflow pin passed
- workflow authority manifest refreshed and gate catalog passed
- Biome check passed
- full staged commit hook passed for all three commits

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Restore deterministic Windows CLI, shallow ADR, signed macOS, and KFD Runtime 100 alpha qualification"}
-->