### PR TITLE
feat(ci): require notarized macOS alpha artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   build:
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@2dcaabf7e4d64ac4849b4df26fa8822e74962343 # PR #1425 invariant Passport gate
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@f27b54bb89fcadca94a4fc0b549d7c71160bcf0e # macOS credential island train
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
@@ -52,6 +52,9 @@ jobs:
       artifact-name: kungfu
       artifact-paths: |
         product/release
+      credential-island-macos-app-path: product/dist/desktop/mac-arm64/Kungfu Episodes.app
+      credential-island-environment: alpha-macos-signing
+      credential-island-macos-platform-id: macos-arm64
       expected-artifacts-json: >-
         {"minFiles":8,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json","product/release/qualification/live-peer-continuity/report.json","product/release/qualification/live-peer-continuity/raw-logs.jsonl.gz","product/release/qualification/runtime-activation/report.json","product/release/qualification/runtime-activation/raw-logs.jsonl.gz","product/release/qualification/zero-burden-desktop/report.json","product/release/qualification/zero-burden-desktop/raw-logs.jsonl.gz","product/release/qualification/invariant-run.json"]}
       require-install: true
@@ -87,11 +90,10 @@ jobs:
       # On Linux it qualifies Episodes before running the ADR
       # release-admissibility gate.
       # shifu-entry-contract: allow cross-platform release qualification dispatch into the canonical shifu shim
-      # Pull requests into alpha/release remain fail-closed on the credential-
-      # bearing native signing/notarization campaign. Manual frozen-ref runs
-      # exercise the same functional and artifact Gates without importing
-      # production signing credentials into the ordinary build runner profile.
-      verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy ${{ github.event_name == 'pull_request' && 'required' || 'skip' }}
+      # Functional native qualification stays credential-free. Buildchain seals
+      # the exact unsigned macOS app after this lifecycle, then a separate
+      # protected GitHub-hosted credential island signs and notarizes it.
+      verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip
       release-candidate: true
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
       artifact-transfer-mode: s3-to-github-artifacts

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -52,10 +52,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2dcaabf7e4d64ac4849b4df26fa8822e74962343 # PR #1425 invariant Passport gate
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@f27b54bb89fcadca94a4fc0b549d7c71160bcf0e # macOS credential island train
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 2dcaabf7e4d64ac4849b4df26fa8822e74962343
+      buildchain-ref: f27b54bb89fcadca94a4fc0b549d7c71160bcf0e
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}
@@ -79,7 +79,7 @@ jobs:
       publish-package-set-order: as-provided
       trusted-publishing: false
       runner-preset: kungfu-v4-self-hosted
-      required-artifact-count: 3
+      required-artifact-count: 4
       release-passport: true
       release-passport-product-name: Kungfu Episodes
       release-passport-kfd-1-witness-jsons: |

--- a/docs/qualification/gates/macos-credential-island-policy.json
+++ b/docs/qualification/gates/macos-credential-island-policy.json
@@ -1,0 +1,24 @@
+{
+  "schema": "kungfu.macos-credential-island-policy/v1",
+  "repository": "kungfu-systems/kungfu",
+  "environment": "alpha-macos-signing",
+  "platformId": "macos-arm64-credential",
+  "manifestContract": "kungfu-buildchain-artifact",
+  "evidenceSchema": "buildchain.macos-credential-island-evidence/v1",
+  "app": {
+    "bundleId": "com.kungfu.app",
+    "architecture": "arm64"
+  },
+  "identity": {
+    "teamId": "ZDL5TK5LL4",
+    "certificateSha1": "31c5f3444a2b04870a9fcc78bafc49954cc55862"
+  },
+  "requiredVerifications": [
+    "codesignStrict",
+    "hardenedRuntime",
+    "appStaple",
+    "appGatekeeper",
+    "dmgStaple",
+    "dmgGatekeeper"
+  ]
+}

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -44,7 +44,7 @@ Each section is bound to the registry id by the catalog meta gate.
 <!-- gate-doc:release.artifact-admission -->
 ## Release artifact admission (`release.artifact-admission`)
 
-- **Problem:** Requires build status, three platform artifacts, release passport, and KFD witnesses.
+- **Problem:** Requires build status, three functional platform payloads, one authoritative signed and notarized macOS credential-island payload, release passport, and KFD witnesses.
 - **Protects:** release regressions from becoming an unexplained green profile or release claim.
 - **Action:** named handler `kungfu.buildchain.artifact-admission`; execution requires the declared remote controller capability.
 - **Dependencies:** `governance.promotion-rehearsal`.
@@ -60,7 +60,10 @@ Each section is bound to the registry id by the catalog meta gate.
 
 The handler executes once in the Linux promotion controller. Its admitted
 payload remains cross-platform: the controller still requires exact Linux,
-macOS, and Windows artifacts before the Gate passes.
+macOS, and Windows functional artifacts before the Gate passes. It separately
+requires the source-bound macOS credential-island DMG, ZIP, and accepted
+signing/notarization evidence; the signing credentials never enter a functional
+build runner.
 
 ### Continuity claim evidence boundary
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -558,7 +558,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:198f378802c7283b8ada6444460b0452811a49cb9453c38d3a284feebcc66787",
+          "definitionDigest": "sha256:db9bc13770f51b78811c720e08674d06485a05ccecd0bc32dbd4d4316df4b8dc",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -571,7 +571,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@2dcaabf7e4d64ac4849b4df26fa8822e74962343"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@f27b54bb89fcadca94a4fc0b549d7c71160bcf0e"
           ],
           "steps": []
         },
@@ -1611,7 +1611,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:a3843a83972e86a5f957c3067e1f3af764a3789b5ca8a442614fc594e772465b",
+          "definitionDigest": "sha256:a5f7ecf1eba69e7bdb82667eecd75a3e0ac9525e571b5e5fc0654385f5b98acc",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1624,7 +1624,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2dcaabf7e4d64ac4849b4df26fa8822e74962343"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@f27b54bb89fcadca94a4fc0b549d7c71160bcf0e"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -439,7 +439,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@2dcaabf7e4d64ac4849b4df26fa8822e74962343",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@f27b54bb89fcadca94a4fc0b549d7c71160bcf0e",
         "job": {
           "secrets": {
             "BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN": "${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}",
@@ -449,10 +449,13 @@
         },
         "with": {
           "runner-preset": "${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}",
+          "credential-island-macos-app-path": "product/dist/desktop/mac-arm64/Kungfu Episodes.app",
+          "credential-island-environment": "alpha-macos-signing",
+          "credential-island-macos-platform-id": "macos-arm64",
           "require-install": true,
           "require-build": true,
           "require-verify": true,
-          "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy ${{ github.event_name == 'pull_request' && 'required' || 'skip' }}",
+          "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip",
           "release-candidate": true,
           "publish-channel": "${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
           "artifact-transfer-mode": "s3-to-github-artifacts",
@@ -517,14 +520,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2dcaabf7e4d64ac4849b4df26fa8822e74962343",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@f27b54bb89fcadca94a4fc0b549d7c71160bcf0e",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "2dcaabf7e4d64ac4849b4df26fa8822e74962343",
+          "buildchain-ref": "f27b54bb89fcadca94a4fc0b549d7c71160bcf0e",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,
@@ -532,7 +535,7 @@
           "publication-consumer-predicate-id": "kungfu.release-admission/v1",
           "publish-command": "node scripts/buildchain-custom-publish-evidence.mjs",
           "runner-preset": "kungfu-v4-self-hosted",
-          "required-artifact-count": 3,
+          "required-artifact-count": 4,
           "release-passport": true,
           "release-passport-invariant-passport-command": "node scripts/kungfu-invariant.mjs --collect-evidence . --passport product/release/qualification/invariant-passport.json --json",
           "dry-run": "${{ github.event_name == 'workflow_dispatch' }}"

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "2dcaabf7e4d64ac4849b4df26fa8822e74962343",
+    "workflow_shell_sha": "f27b54bb89fcadca94a4fc0b549d7c71160bcf0e",
     "alpha": {
       "workflow_ref": "v2-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",
@@ -20,7 +20,7 @@
       "publish_dist_tag": "latest"
     },
     "required_status_check": "build",
-    "required_artifact_count": 3,
+    "required_artifact_count": 4,
     "required_surfaces": [
       "reusable-build",
       "release-candidate-promote",

--- a/scripts/buildchain-custom-publish-evidence.mjs
+++ b/scripts/buildchain-custom-publish-evidence.mjs
@@ -87,6 +87,9 @@ function main() {
   console.log(
     `buildchain custom publish admitted upgrade evidence for ${upgradeAdmission.platforms.join(', ')}`,
   );
+  console.log(
+    `buildchain custom publish admitted ${upgradeAdmission.credentialIsland.platformId} credential evidence from runtime ${upgradeAdmission.credentialIsland.runtimeSha}`,
+  );
   generateKfdEvidence();
   const requiredArtifactsPath =
     process.env.BUILDCHAIN_PUBLISH_REQUIRED_ARTIFACTS_PATH ||

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -752,8 +752,8 @@ test('every controller class has a structured adapter and input drift fails clos
     {
       id: 'release-admission',
       workflow: '.github/workflows/release-new-version.yml',
-      from: 'required-artifact-count: 3',
-      to: 'required-artifact-count: 2',
+      from: 'required-artifact-count: 4',
+      to: 'required-artifact-count: 3',
       drift: 'with.required-artifact-count',
     },
   ];

--- a/scripts/upgrade-publication-admission.mjs
+++ b/scripts/upgrade-publication-admission.mjs
@@ -3,6 +3,7 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { assertUpgradePublicationEligible } from '../product/scripts/upgrade-manifest.mjs';
 import { loadUpgradeQualificationContract } from './upgrade-qualification.mjs';
@@ -10,6 +11,13 @@ import { loadUpgradeQualificationContract } from './upgrade-qualification.mjs';
 const RELEASE_MANIFEST_SCHEMA = 'kungfu.product-upgrade.manifest/v1';
 const RELEASE_CANDIDATE_CONTRACT =
   'kungfu-buildchain-release-candidate-passport';
+const CREDENTIAL_POLICY_PATH =
+  'docs/qualification/gates/macos-credential-island-policy.json';
+const CREDENTIAL_EVIDENCE_FILE = 'credential-island-evidence.json';
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SHA1_PATTERN = /^[a-f0-9]{40}$/i;
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/i;
+const NOTARY_ID_PATTERN = /^[a-f0-9-]{36}$/i;
 
 function readJson(filePath, label) {
   try {
@@ -68,6 +76,288 @@ function canonical(value) {
 
 function sha256File(filePath) {
   return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function sha256Summary(files) {
+  const digest = createHash('sha256');
+  for (const file of files) {
+    digest.update(`${file.path}\0${file.size}\0${file.sha256}\n`);
+  }
+  return digest.digest('hex');
+}
+
+function credentialIslandPolicy() {
+  const policy = readJson(
+    path.join(ROOT, CREDENTIAL_POLICY_PATH),
+    'macOS credential-island policy',
+  );
+  if (policy.schema !== 'kungfu.macos-credential-island-policy/v1') {
+    throw new Error('macOS credential-island policy schema is unsupported');
+  }
+  if (
+    !policy.repository ||
+    !policy.environment ||
+    !policy.platformId ||
+    !policy.manifestContract ||
+    !policy.evidenceSchema ||
+    !policy.app?.bundleId ||
+    !['arm64', 'x64'].includes(policy.app?.architecture) ||
+    !/^[A-Z0-9]{10}$/.test(policy.identity?.teamId || '') ||
+    !SHA1_PATTERN.test(policy.identity?.certificateSha1 || '') ||
+    !Array.isArray(policy.requiredVerifications) ||
+    policy.requiredVerifications.length === 0
+  ) {
+    throw new Error('macOS credential-island policy is incomplete');
+  }
+  return policy;
+}
+
+function verifyManifestFileBytes(bundleRoot, file) {
+  if (
+    typeof file?.path !== 'string' ||
+    path.posix.isAbsolute(file.path) ||
+    file.path.split('/').includes('..') ||
+    !file.path.startsWith('product/release/')
+  ) {
+    throw new Error('credential manifest contains an unsafe output path');
+  }
+  const filePath = path.resolve(bundleRoot, file.path);
+  const relative = path.relative(path.resolve(bundleRoot), filePath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('credential manifest output escapes its payload bundle');
+  }
+  if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+    throw new Error(`credential manifest output is missing: ${file.path}`);
+  }
+  if (fs.lstatSync(filePath).isSymbolicLink()) {
+    throw new Error(
+      `credential manifest output is a symbolic link: ${file.path}`,
+    );
+  }
+  const realRelative = path.relative(
+    fs.realpathSync(bundleRoot),
+    fs.realpathSync(filePath),
+  );
+  if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
+    throw new Error('credential manifest output resolves outside its payload');
+  }
+  const size = fs.statSync(filePath).size;
+  if (size !== file.size) {
+    throw new Error(
+      `credential manifest size mismatch for ${file.path}: manifest ${file.size}, payload ${size}`,
+    );
+  }
+  const digest = sha256File(filePath);
+  if (digest !== file.sha256) {
+    throw new Error(
+      `credential manifest digest mismatch for ${file.path}: manifest ${file.sha256}, payload ${digest}`,
+    );
+  }
+  return filePath;
+}
+
+function verifyCredentialIslandBundle({
+  bundleRoot,
+  expectedVersion,
+  acceptedSources,
+  policy,
+}) {
+  const evidencePaths = filesNamed(bundleRoot, CREDENTIAL_EVIDENCE_FILE);
+  if (evidencePaths.length === 0) return null;
+  if (evidencePaths.length !== 1) {
+    throw new Error(
+      `credential payload ${bundleRoot} must contain exactly one ${CREDENTIAL_EVIDENCE_FILE}; found ${evidencePaths.length}`,
+    );
+  }
+  const manifestPaths = filesNamed(bundleRoot, 'manifest.json');
+  if (manifestPaths.length !== 1) {
+    throw new Error(
+      `credential payload ${bundleRoot} must contain exactly one manifest.json; found ${manifestPaths.length}`,
+    );
+  }
+  const manifest = readJson(
+    manifestPaths[0],
+    'macOS credential-island artifact manifest',
+  );
+  if (
+    manifest.schemaVersion !== 1 ||
+    manifest.contract !== policy.manifestContract
+  ) {
+    throw new Error('credential artifact manifest contract is unsupported');
+  }
+  if (
+    manifest.platform?.id !== policy.platformId ||
+    manifest.platform?.os !== 'macos' ||
+    manifest.platform?.arch !== policy.app.architecture
+  ) {
+    throw new Error(
+      'credential artifact platform identity is not authoritative',
+    );
+  }
+  if (
+    manifest.git?.repository !== policy.repository ||
+    !acceptedSources.has(manifest.git?.sha)
+  ) {
+    throw new Error(
+      'credential artifact source is not bound by the release-candidate passport',
+    );
+  }
+  if (
+    manifest.lifecycle?.stage !== 'credential-island' ||
+    manifest.lifecycle?.commandSource !== 'buildchain-action' ||
+    manifest.lifecycle?.executed !== true ||
+    manifest.expectedArtifacts?.ok !== true ||
+    manifest.expectedArtifacts?.source !== policy.evidenceSchema
+  ) {
+    throw new Error('credential artifact lifecycle did not qualify');
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length !== 3) {
+    throw new Error(
+      `credential artifact must contain exactly three authoritative files; found ${manifest.files?.length || 0}`,
+    );
+  }
+  const files = [...manifest.files].sort((left, right) =>
+    String(left.path).localeCompare(String(right.path)),
+  );
+  if (
+    new Set(files.map((file) => file.path)).size !== files.length ||
+    files.some(
+      (file) =>
+        !Number.isSafeInteger(file.size) ||
+        file.size < 1 ||
+        !/^[a-f0-9]{64}$/i.test(file.sha256 || ''),
+    )
+  ) {
+    throw new Error('credential artifact file inventory is invalid');
+  }
+  const filePaths = new Map(
+    files.map((file) => [
+      path.posix.basename(file.path),
+      verifyManifestFileBytes(bundleRoot, file),
+    ]),
+  );
+  if (
+    filePaths.size !== 3 ||
+    !filePaths.has(CREDENTIAL_EVIDENCE_FILE) ||
+    [...filePaths.keys()].filter((name) => name.endsWith('.dmg')).length !==
+      1 ||
+    [...filePaths.keys()].filter((name) => name.endsWith('.zip')).length !== 1
+  ) {
+    throw new Error(
+      'credential artifact must contain one evidence JSON, one DMG, and one ZIP',
+    );
+  }
+  const summary = manifest.summary;
+  const totalBytes = files.reduce((total, file) => total + file.size, 0);
+  if (
+    summary?.contract !== 'kungfu-buildchain-artifact-summary' ||
+    summary?.artifactName !== manifest.artifactName ||
+    JSON.stringify(canonical(summary?.platform)) !==
+      JSON.stringify(canonical(manifest.platform)) ||
+    summary?.fileCount !== files.length ||
+    summary?.totalBytes !== totalBytes ||
+    summary?.digest !== sha256Summary(files)
+  ) {
+    throw new Error(
+      'credential artifact summary does not bind exact payload bytes',
+    );
+  }
+
+  const evidence = readJson(
+    evidencePaths[0],
+    'macOS credential-island evidence',
+  );
+  if (
+    evidence.schema !== policy.evidenceSchema ||
+    evidence.status !== 'accepted'
+  ) {
+    throw new Error('credential-island evidence was not accepted');
+  }
+  if (
+    evidence.source?.repository !== policy.repository ||
+    evidence.source?.sha !== manifest.git.sha ||
+    !acceptedSources.has(evidence.source?.sha) ||
+    !SHA1_PATTERN.test(evidence.source?.treeSha || '')
+  ) {
+    throw new Error('credential-island evidence source binding is invalid');
+  }
+  if (
+    !SHA1_PATTERN.test(evidence.buildchain?.runtimeSha || '') ||
+    !SHA256_PATTERN.test(evidence.input?.manifestSha256 || '') ||
+    !SHA256_PATTERN.test(evidence.input?.archiveSha256 || '') ||
+    !Number.isSafeInteger(evidence.input?.archiveBytes) ||
+    evidence.input.archiveBytes < 1
+  ) {
+    throw new Error('credential-island sealed input binding is invalid');
+  }
+  if (
+    evidence.app?.bundleId !== policy.app.bundleId ||
+    evidence.app?.version !== expectedVersion ||
+    evidence.app?.architecture !== policy.app.architecture
+  ) {
+    throw new Error('credential-island application identity is invalid');
+  }
+  if (
+    String(evidence.identity?.certificateSha1 || '').toLowerCase() !==
+      policy.identity.certificateSha1.toLowerCase() ||
+    evidence.identity?.teamId !== policy.identity.teamId ||
+    !String(evidence.identity?.certificateSubject || '').startsWith(
+      'Developer ID Application:',
+    ) ||
+    !evidence.identity?.entitlementsProfile ||
+    !SHA256_PATTERN.test(evidence.identity?.entitlementsSha256 || '')
+  ) {
+    throw new Error('credential-island signing identity is invalid');
+  }
+  for (const label of ['application', 'diskImage']) {
+    if (
+      evidence.notarization?.[label]?.status !== 'Accepted' ||
+      !NOTARY_ID_PATTERN.test(evidence.notarization?.[label]?.id || '')
+    ) {
+      throw new Error(
+        `credential-island ${label} notarization was not accepted`,
+      );
+    }
+  }
+  for (const check of policy.requiredVerifications) {
+    if (evidence.verification?.[check] !== true) {
+      throw new Error(`credential-island verification did not pass: ${check}`);
+    }
+  }
+  const evidenceArtifacts = evidence.artifacts || [];
+  if (
+    evidenceArtifacts.length !== 2 ||
+    new Set(evidenceArtifacts.map((artifact) => artifact.kind)).size !== 2
+  ) {
+    throw new Error('credential-island evidence artifact inventory is invalid');
+  }
+  for (const kind of ['dmg', 'zip']) {
+    const artifact = evidenceArtifacts.find((item) => item.kind === kind);
+    const file = files.find((item) => item.path.endsWith(`.${kind}`));
+    if (
+      !artifact ||
+      !file ||
+      artifact.name !== path.posix.basename(file.path) ||
+      artifact.bytes !== file.size ||
+      artifact.sha256 !== `sha256:${file.sha256}`
+    ) {
+      throw new Error(
+        `credential-island ${kind.toUpperCase()} evidence does not bind the payload`,
+      );
+    }
+  }
+  return {
+    bundleRoot,
+    platformId: manifest.platform.id,
+    manifestPath: manifestPaths[0],
+    evidencePath: evidencePaths[0],
+    runtimeSha: evidence.buildchain.runtimeSha,
+    certificateSha1: evidence.identity.certificateSha1,
+    notarizationIds: [
+      evidence.notarization.application.id,
+      evidence.notarization.diskImage.id,
+    ],
+  };
 }
 
 function artifactFileName(artifact) {
@@ -220,6 +510,7 @@ export function verifyUpgradePublicationPayloads({
     throw new Error('expected publication version is required');
 
   const contract = loadUpgradeQualificationContract();
+  const credentialPolicy = credentialIslandPolicy();
   const evidenceFileName = contract.publication?.evidenceFileName;
   if (!evidenceFileName) {
     throw new Error(
@@ -247,6 +538,21 @@ export function verifyUpgradePublicationPayloads({
       }),
     )
     .filter(Boolean);
+  const credentialIsland = bundleRoots
+    .map((bundleRoot) =>
+      verifyCredentialIslandBundle({
+        bundleRoot,
+        expectedVersion,
+        acceptedSources,
+        policy: credentialPolicy,
+      }),
+    )
+    .filter(Boolean);
+  if (credentialIsland.length !== 1) {
+    throw new Error(
+      `upgrade publication requires exactly one authoritative macOS credential-island payload; found ${credentialIsland.length}`,
+    );
+  }
   const platformCounts = new Map();
   for (const item of admitted) {
     platformCounts.set(
@@ -286,5 +592,6 @@ export function verifyUpgradePublicationPayloads({
           `${right.platform}-${right.architecture}`,
         ),
       ),
+    credentialIsland: credentialIsland[0],
   };
 }

--- a/scripts/upgrade-publication-admission.test.mjs
+++ b/scripts/upgrade-publication-admission.test.mjs
@@ -15,6 +15,8 @@ import {
 
 const VERSION = '4.0.0-alpha.1';
 const SOURCE = 'a'.repeat(40);
+const RUNTIME = 'd'.repeat(40);
+const CERTIFICATE_SHA1 = '31c5f3444a2b04870a9fcc78bafc49954cc55862';
 const CONTRACT = loadUpgradeQualificationContract();
 
 function sha256(value) {
@@ -136,6 +138,159 @@ function platformFixture(root, platform, architecture) {
   };
 }
 
+function credentialManifest(root, bundleRoot, evidencePath, dmgPath, zipPath) {
+  const files = [dmgPath, evidencePath, zipPath]
+    .map((filePath) => ({
+      path: path.relative(bundleRoot, filePath).split(path.sep).join('/'),
+      size: fs.statSync(filePath).size,
+      sha256: sha256(fs.readFileSync(filePath)),
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+  const digest = createHash('sha256');
+  for (const file of files) {
+    digest.update(`${file.path}\0${file.size}\0${file.sha256}\n`);
+  }
+  const platform = {
+    id: 'macos-arm64-credential',
+    name: 'macos-arm64 credential island',
+    os: 'macos',
+    arch: 'arm64',
+  };
+  const artifactName = `kungfu-macos-credential-${SOURCE}`;
+  const manifest = {
+    schemaVersion: 1,
+    contract: 'kungfu-buildchain-artifact',
+    artifactName,
+    platform,
+    git: {
+      repository: 'kungfu-systems/kungfu',
+      sha: SOURCE,
+      ref: 'refs/heads/alpha/v4/v4.0',
+      runId: '123',
+      runAttempt: '1',
+    },
+    lifecycle: {
+      stage: 'credential-island',
+      commandSource: 'buildchain-action',
+      executed: true,
+    },
+    summary: {
+      contract: 'kungfu-buildchain-artifact-summary',
+      artifactName,
+      platform,
+      fileCount: files.length,
+      totalBytes: files.reduce((total, file) => total + file.size, 0),
+      digest: digest.digest('hex'),
+    },
+    expectedArtifacts: {
+      ok: true,
+      source: 'buildchain.macos-credential-island-evidence/v1',
+      checks: [
+        {
+          name: 'signed-output-count',
+          ok: true,
+          detail: '3 >= 3',
+        },
+      ],
+    },
+    files,
+  };
+  writeJson(path.join(bundleRoot, 'manifest.json'), manifest);
+}
+
+function credentialFixture(root) {
+  const bundleRoot = path.join(root, 'payloads', 'kungfu-macos-credential');
+  const releaseRoot = path.join(bundleRoot, 'product', 'release');
+  const dmgPath = path.join(
+    releaseRoot,
+    `Kungfu-Episodes-${VERSION}-macos-arm64.dmg`,
+  );
+  const zipPath = path.join(
+    releaseRoot,
+    `Kungfu-Episodes-${VERSION}-macos-arm64.zip`,
+  );
+  fs.mkdirSync(releaseRoot, { recursive: true });
+  fs.writeFileSync(dmgPath, 'signed-notarized-dmg');
+  fs.writeFileSync(zipPath, 'signed-notarized-zip');
+  const evidencePath = path.join(
+    releaseRoot,
+    'credential-island-evidence.json',
+  );
+  const evidence = {
+    schema: 'buildchain.macos-credential-island-evidence/v1',
+    status: 'accepted',
+    startedAt: '2026-07-23T00:00:00.000Z',
+    completedAt: '2026-07-23T00:01:00.000Z',
+    source: {
+      repository: 'kungfu-systems/kungfu',
+      sha: SOURCE,
+      treeSha: 'e'.repeat(40),
+    },
+    buildchain: { runtimeSha: RUNTIME },
+    input: {
+      manifestSha256: `sha256:${'1'.repeat(64)}`,
+      archiveSha256: `sha256:${'2'.repeat(64)}`,
+      archiveBytes: 4096,
+    },
+    app: {
+      bundleId: 'com.kungfu.app',
+      productName: 'Kungfu Episodes',
+      version: VERSION,
+      architecture: 'arm64',
+    },
+    identity: {
+      certificateSha1: CERTIFICATE_SHA1,
+      certificateSubject:
+        'Developer ID Application: Beijing Kungfu Technology Co., Ltd. (ZDL5TK5LL4)',
+      teamId: 'ZDL5TK5LL4',
+      entitlementsProfile: 'electron-desktop-v1',
+      entitlementsSha256: `sha256:${'3'.repeat(64)}`,
+    },
+    notarization: {
+      application: {
+        id: '11111111-1111-1111-1111-111111111111',
+        status: 'Accepted',
+      },
+      diskImage: {
+        id: '22222222-2222-2222-2222-222222222222',
+        status: 'Accepted',
+      },
+    },
+    verification: {
+      codesignStrict: true,
+      hardenedRuntime: true,
+      appStaple: true,
+      appGatekeeper: true,
+      dmgStaple: true,
+      dmgGatekeeper: true,
+    },
+    artifacts: [
+      {
+        kind: 'zip',
+        name: path.basename(zipPath),
+        bytes: fs.statSync(zipPath).size,
+        sha256: `sha256:${sha256(fs.readFileSync(zipPath))}`,
+      },
+      {
+        kind: 'dmg',
+        name: path.basename(dmgPath),
+        bytes: fs.statSync(dmgPath).size,
+        sha256: `sha256:${sha256(fs.readFileSync(dmgPath))}`,
+      },
+    ],
+    runner: { os: 'darwin', arch: 'arm64', image: 'macos-15-arm64' },
+  };
+  writeJson(evidencePath, evidence);
+  credentialManifest(root, bundleRoot, evidencePath, dmgPath, zipPath);
+  return {
+    bundleRoot,
+    dmgPath,
+    zipPath,
+    evidencePath,
+    manifestPath: path.join(bundleRoot, 'manifest.json'),
+  };
+}
+
 function fixture() {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-upgrade-publication-'),
@@ -154,11 +309,13 @@ function fixture() {
     linux: platformFixture(root, 'linux', 'x64'),
     win32: platformFixture(root, 'win32', 'x64'),
   };
+  const credential = credentialFixture(root);
   return {
     root,
     payloadRoot: path.join(root, 'payloads'),
     passportPath,
     platforms,
+    credential,
   };
 }
 
@@ -179,7 +336,7 @@ function withFixture(callback) {
   }
 }
 
-test('publication admission verifies three native payloads and exact desktop/CLI bytes', () => {
+test('publication admission verifies three native payloads plus authoritative signed macOS bytes', () => {
   withFixture((value) => {
     const admitted = verify(value);
     assert.deepEqual(admitted.platforms, [
@@ -198,6 +355,74 @@ test('publication admission verifies three native payloads and exact desktop/CLI
         path.isAbsolute(manifestPath),
       ),
       true,
+    );
+    assert.equal(
+      admitted.credentialIsland.platformId,
+      'macos-arm64-credential',
+    );
+    assert.equal(admitted.credentialIsland.runtimeSha, RUNTIME);
+    assert.equal(admitted.credentialIsland.certificateSha1, CERTIFICATE_SHA1);
+  });
+});
+
+test('publication admission rejects a missing credential-island payload', () => {
+  withFixture((value) => {
+    fs.rmSync(value.credential.bundleRoot, {
+      recursive: true,
+      force: true,
+    });
+    assert.throws(
+      () => verify(value),
+      /exactly one authoritative macOS credential-island payload; found 0/,
+    );
+  });
+});
+
+test('publication admission rejects signed DMG byte drift', () => {
+  withFixture((value) => {
+    fs.appendFileSync(value.credential.dmgPath, 'drift');
+    assert.throws(() => verify(value), /credential manifest size mismatch/);
+  });
+});
+
+test('publication admission rejects a non-authoritative signing identity', () => {
+  withFixture((value) => {
+    const evidence = JSON.parse(
+      fs.readFileSync(value.credential.evidencePath, 'utf8'),
+    );
+    evidence.identity.certificateSha1 = 'f'.repeat(40);
+    writeJson(value.credential.evidencePath, evidence);
+    credentialManifest(
+      value.root,
+      value.credential.bundleRoot,
+      value.credential.evidencePath,
+      value.credential.dmgPath,
+      value.credential.zipPath,
+    );
+    assert.throws(
+      () => verify(value),
+      /credential-island signing identity is invalid/,
+    );
+  });
+});
+
+test('publication admission rejects unaccepted notarization evidence', () => {
+  withFixture((value) => {
+    const evidence = JSON.parse(
+      fs.readFileSync(value.credential.evidencePath, 'utf8'),
+    );
+    evidence.notarization.diskImage.status = 'Invalid';
+    writeJson(value.credential.evidencePath, evidence);
+    credentialManifest(
+      value.root,
+      value.credential.bundleRoot,
+      value.credential.evidencePath,
+      value.credential.dmgPath,
+      value.credential.zipPath,
+    );
+    assert.throws(
+      () => verify(value),
+      /diskImage notarization was not accepted/,
     );
   });
 });

--- a/shifu.gates.json
+++ b/shifu.gates.json
@@ -536,7 +536,7 @@
     {
       "id": "release.artifact-admission",
       "title": "Release artifact admission",
-      "summary": "Requires build status, three platform artifacts, release passport, and KFD witnesses.",
+      "summary": "Requires build status, three functional platform payloads, one authoritative signed and notarized macOS credential-island payload, release passport, and KFD witnesses.",
       "category": "release",
       "documentation": "docs/qualification/gates/release-and-promotion.md",
       "dependencies": [


### PR DESCRIPTION
## Summary

Wire Kungfu alpha/release candidates to the immutable Buildchain macOS credential island. Functional builds remain credential-free; the exact unsigned macOS app is sealed, signed and notarized in a separate protected GitHub-hosted job, then admitted as a fourth release-candidate payload.

## Related issue

Buildchain PR kungfu-systems/buildchain#1570

## Changes

- pin the credential-island Buildchain train runtime
- seal `product/dist/desktop/mac-arm64/Kungfu Episodes.app` after the functional matrix
- replace the credential-bearing native campaign with credential-free functional qualification
- require the signed DMG/ZIP/evidence payload during promotion
- verify exact source, byte inventory, bundle/team/certificate identity, notarization, staple, and Gatekeeper evidence
- refresh closed-world workflow authority and Gate bindings

## Verification

- `./shifu check`
- `./shifu release:promotion:rehearse`
- 10 credential-island publication admission tests
- Gate catalog and closed-world workflow authority checks

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This implements the existing Buildchain credential-isolation boundary and does not alter a Kungfu product architecture contract."
}
-->

## Governance risk check

- [x] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow receives no credential values in the functional matrix. The protected `alpha-macos-signing` environment is consumed only by the isolated signing job; promotion reads byte-bound public evidence and no signing secret.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed