### PR TITLE
fix(adr): close architecture projection regeneration

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -564,6 +564,18 @@ export function createAdrMigrationPlan(options = {}) {
         checkCommand: './shifu check:gate-catalog',
         paths: ['docs/qualification/gates/workflow-authority.json'],
       },
+      {
+        command: './shifu core:architecture:write',
+        checkCommand: './shifu check:source',
+        paths: [
+          'framework/core/architecture/LAYERS.md',
+          'framework/core/architecture/TARGETS.cmake',
+          'framework/core/architecture/PUBLIC_CONTRACTS.cmake',
+          'framework/core/architecture/ARCHITECTURE_INDEX.md',
+          'framework/core/architecture/ARCHITECTURE_HEALTH.md',
+          'framework/core/architecture/review-routes.json',
+        ],
+      },
     ],
     problems: problems.sort((left, right) =>
       Buffer.compare(
@@ -730,6 +742,7 @@ function runRegenerationCheck(root, command) {
     ['./shifu kfd:buildchain:check', ['kfd:buildchain:check']],
     ['./shifu xinfa:quality', ['xinfa:quality']],
     ['./shifu check:gate-catalog', ['check:gate-catalog']],
+    ['./shifu check:source', ['check:source']],
   ]);
   const args = allowed.get(command);
   if (!args) throw new Error(`unrecognized regeneration check: ${command}`);

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -306,6 +306,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
       './shifu kfd:buildchain',
       './shifu node scripts/qualify-xinfa-context-quality.mjs --write',
       './shifu gate:workflow-authority:refresh',
+      './shifu core:architecture:write',
     ],
   );
   assert.deepEqual(
@@ -314,6 +315,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
       './shifu kfd:buildchain:check',
       './shifu xinfa:quality',
       './shifu check:gate-catalog',
+      './shifu check:source',
     ],
   );
   assert.deepEqual(first.regenerations[0].paths, [
@@ -337,6 +339,14 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
   ]);
   assert.deepEqual(first.regenerations[2].paths, [
     'docs/qualification/gates/workflow-authority.json',
+  ]);
+  assert.deepEqual(first.regenerations[3].paths, [
+    'framework/core/architecture/LAYERS.md',
+    'framework/core/architecture/TARGETS.cmake',
+    'framework/core/architecture/PUBLIC_CONTRACTS.cmake',
+    'framework/core/architecture/ARCHITECTURE_INDEX.md',
+    'framework/core/architecture/ARCHITECTURE_HEALTH.md',
+    'framework/core/architecture/review-routes.json',
   ]);
 });
 


### PR DESCRIPTION
## Summary
Declare Core architecture projections as a closed ADR migration regeneration and require source acceptance before completion.

## Verification
- ./shifu adr:migrate:test
- ./shifu core:architecture:write
- ./shifu check:source
- git diff --check
- independent review: PASS

## ADR delivery / release declaration
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Migration completion closure for generated Core architecture projections; no architecture decision change"}
-->