### PR TITLE
fix(release): qualify installed CLI and Git history

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1276,6 +1276,29 @@ export function installedKungfuInvocation(
   };
 }
 
+export function runInstalledKungfuCommand(
+  { cli, args, env, cwd },
+  {
+    platform = process.platform,
+    comspec = process.env.ComSpec,
+    spawn = spawnSync,
+  } = {},
+) {
+  const invocation = installedKungfuInvocation(cli, args, {
+    platform,
+    comspec,
+  });
+  const result = spawn(invocation.command, invocation.args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    shell: false,
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
 function spawnInstalledKungfu(kungfuBin, args, options) {
   const invocation = installedKungfuInvocation(kungfuBin, args);
   return spawnSync(invocation.command, invocation.args, {
@@ -1915,6 +1938,7 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
             archiveSha256: sha256File(archivePath),
           },
           environment: smokeEnv,
+          runCommand: runInstalledKungfuCommand,
         });
         if (
           JSON.stringify(manifest.cliSurface) !==

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -16,6 +16,7 @@ import {
   installedKungfuInvocation,
   kfxBundleExternalModules,
   requiresManagedEsbuildPlatform,
+  runInstalledKungfuCommand,
   stageXinfaContract,
   verifyProductObservabilityEvents,
 } from './dist.mjs';
@@ -77,6 +78,45 @@ test('installed CLI launcher uses cmd.exe explicitly on Windows', () => {
     }),
     { command: '/opt/kungfu/kungfu', args: ['--help'] },
   );
+});
+
+test('installed CLI surface runner uses the Windows launcher invocation', () => {
+  let observed;
+  const result = runInstalledKungfuCommand(
+    {
+      cli: 'C:\\Kungfu Episodes\\kungfu.cmd',
+      args: ['--help-json'],
+      cwd: 'C:\\Kungfu Episodes',
+      env: { KUNGFU_HOME: 'C:\\Kungfu Home' },
+    },
+    {
+      platform: 'win32',
+      comspec: 'C:\\Windows\\System32\\cmd.exe',
+      spawn(command, args, options) {
+        observed = { command, args, options };
+        return { status: 0, stdout: '{}', stderr: '', signal: null };
+      },
+    },
+  );
+  assert.equal(result.status, 0);
+  assert.deepEqual(observed, {
+    command: 'C:\\Windows\\System32\\cmd.exe',
+    args: [
+      '/d',
+      '/s',
+      '/c',
+      'call',
+      'C:\\Kungfu Episodes\\kungfu.cmd',
+      '--help-json',
+    ],
+    options: {
+      cwd: 'C:\\Kungfu Episodes',
+      env: { KUNGFU_HOME: 'C:\\Kungfu Home' },
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+      shell: false,
+    },
+  });
 });
 
 test('product observability ignores errors from sibling components', () => {

--- a/scripts/run-release-qualification.mjs
+++ b/scripts/run-release-qualification.mjs
@@ -7,6 +7,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { prepareGateMeasurementHistory } from './prepare-gate-measurement-history.mjs';
 import {
   lifecycleEnvironment,
   runShifuWithCache,
@@ -298,6 +299,15 @@ export function releaseQualificationStages(
   return stages;
 }
 
+export function prepareReleaseQualificationHistory(
+  root = ROOT,
+  platform = process.platform,
+  prepare = prepareGateMeasurementHistory,
+) {
+  if (platform !== 'linux') return 'not-required';
+  return prepare(root);
+}
+
 function gitRevision() {
   return spawnSync('git', ['rev-parse', 'HEAD'], {
     cwd: ROOT,
@@ -415,6 +425,7 @@ function writeSummary(
 export function main(argv = process.argv.slice(2)) {
   const options = parseReleaseQualificationOptions(argv);
   const execution = loadExecutionProfile(options.executionProfile);
+  prepareReleaseQualificationHistory();
   const env = releaseQualificationEnvironment(
     ROOT,
     process.env,

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -11,6 +11,7 @@ import {
   loadExecutionProfile,
   parseExecutionProfile,
   parseReleaseQualificationOptions,
+  prepareReleaseQualificationHistory,
   releaseQualificationEnvironment,
   releaseQualificationStages,
 } from './run-release-qualification.mjs';
@@ -120,6 +121,27 @@ test('ADR admission follows Episode evidence only on the Linux release leg', () 
   );
   assert.ok(!names('darwin').includes('adr:release:gate'));
   assert.ok(!names('win32').includes('adr:release:gate'));
+});
+
+test('release qualification hydrates complete Git history only on Linux', () => {
+  const calls = [];
+  const prepare = (root) => {
+    calls.push(root);
+    return 'fetched-origin';
+  };
+  assert.equal(
+    prepareReleaseQualificationHistory('/source', 'linux', prepare),
+    'fetched-origin',
+  );
+  assert.equal(
+    prepareReleaseQualificationHistory('/source', 'darwin', prepare),
+    'not-required',
+  );
+  assert.equal(
+    prepareReleaseQualificationHistory('/source', 'win32', prepare),
+    'not-required',
+  );
+  assert.deepEqual(calls, ['/source']);
 });
 
 test('every platform runs the complete qualification stage sequence', () => {


### PR DESCRIPTION
## Summary
- invoke installed `kungfu.cmd` through the canonical explicit `cmd.exe /d /s /c call` adapter during CLI surface qualification
- hydrate the complete exact source history on the Linux release-qualification leg before ADR reachability auditing

## Evidence
- `node --test product/scripts/dist.test.mjs product/scripts/cli-surface-qualification.test.mjs scripts/run-release-qualification.test.mjs scripts/prepare-gate-measurement-history.test.mjs` (45 passed)
- full managed pre-commit hook passed

## Failure provenance
Repairs deterministic Windows CLI spawn and Linux shallow-history failures observed in alpha promotion PR #1330.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Restore deterministic Windows installed CLI and complete-history ADR alpha qualification"}
-->