### PR TITLE
fix(adr): close CLI catalog regeneration

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -565,6 +565,13 @@ export function createAdrMigrationPlan(options = {}) {
         paths: ['docs/qualification/gates/workflow-authority.json'],
       },
       {
+        command: './shifu fix:cli-catalog-parity',
+        checkCommand: './shifu check:cli-catalog-parity',
+        paths: [
+          'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
+        ],
+      },
+      {
         command: './shifu core:architecture:write',
         checkCommand: './shifu check:source',
         paths: [
@@ -742,6 +749,7 @@ function runRegenerationCheck(root, command) {
     ['./shifu kfd:buildchain:check', ['kfd:buildchain:check']],
     ['./shifu xinfa:quality', ['xinfa:quality']],
     ['./shifu check:gate-catalog', ['check:gate-catalog']],
+    ['./shifu check:cli-catalog-parity', ['check:cli-catalog-parity']],
     ['./shifu check:source', ['check:source']],
   ]);
   const args = allowed.get(command);

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -306,6 +306,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
       './shifu kfd:buildchain',
       './shifu node scripts/qualify-xinfa-context-quality.mjs --write',
       './shifu gate:workflow-authority:refresh',
+      './shifu fix:cli-catalog-parity',
       './shifu core:architecture:write',
     ],
   );
@@ -315,6 +316,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
       './shifu kfd:buildchain:check',
       './shifu xinfa:quality',
       './shifu check:gate-catalog',
+      './shifu check:cli-catalog-parity',
       './shifu check:source',
     ],
   );
@@ -341,6 +343,9 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'docs/qualification/gates/workflow-authority.json',
   ]);
   assert.deepEqual(first.regenerations[3].paths, [
+    'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
+  ]);
+  assert.deepEqual(first.regenerations[4].paths, [
     'framework/core/architecture/LAYERS.md',
     'framework/core/architecture/TARGETS.cmake',
     'framework/core/architecture/PUBLIC_CONTRACTS.cmake',


### PR DESCRIPTION
## Summary
Declare the generated CLI surface catalog as a closed ADR migration regeneration before final source acceptance.

## Verification
- ./shifu adr:migrate:test
- ./shifu fix:cli-catalog-parity
- ./shifu check:cli-catalog-parity
- ./shifu check:source
- git diff --check
- independent review: PASS

## ADR delivery / release declaration
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Migration completion closure for the generated CLI surface catalog; no architecture decision change"}
-->