### PR TITLE
fix(ci): run alpha preflight contracts directly on Windows

### DIFF
--- a/.github/workflows/alpha-promotion-preflight.yml
+++ b/.github/workflows/alpha-promotion-preflight.yml
@@ -69,7 +69,11 @@ jobs:
 
       - name: Verify early source contracts
         shell: bash
-        run: ./shifu test:alpha-promotion-preflight
+        run: |
+          # shifu-entry-contract: allow setup-node to bypass the Windows Shifu bootstrap before native preparation
+          node --test \
+            scripts/alpha-promotion-preflight.test.mjs \
+            product/scripts/cli-surface-qualification.test.mjs
 
       - name: Verify ADR cutover history is locally available
         if: ${{ runner.os == 'Linux' }}

--- a/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
+++ b/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0073
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1331]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1335, https://github.com/kungfu-systems/kungfu/pull/1340]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/731
 qualification_refs: [scripts/adr-release-gate.test.mjs, scripts/release-promotion-rehearsal.test.mjs, scripts/alpha-promotion-preflight.test.mjs]
 review_state: self-reviewed

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -603,7 +603,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:f806bd229b2d20d93271e5a489830459db65726c25709d09833c6690e1b2aa27",
+          "definitionDigest": "sha256:3b0d19e516b63993cda60110b2cf32be55d09e476391740268ee1425688e5b48",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -639,7 +639,7 @@
               "index": 4,
               "label": "name:Verify early source contracts",
               "authority": "qualification",
-              "definitionDigest": "sha256:64dd9fcc010e0ef0eb70ac08cea4c0d65f65bfccd91ad6f06c242a10f4e10b23"
+              "definitionDigest": "sha256:11c7cfe93dce2aeb5fbc3ea1cbf16705f1636505938a1368f87910011043ce25"
             },
             {
               "index": 5,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -68,6 +68,22 @@ function aggregate(root, generatedAt = '2026-07-23T00:00:00.000Z') {
   });
 }
 
+test('early source contracts bypass the platform-specific Shifu bootstrap', () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), '.github/workflows/alpha-promotion-preflight.yml'),
+    'utf8',
+  );
+  assert.doesNotMatch(
+    workflow,
+    /run: \.\/shifu test:alpha-promotion-preflight/u,
+  );
+  assert.doesNotMatch(workflow, /scripts\/require-shifu\.mjs/u);
+  assert.match(
+    workflow,
+    /node --test[\s\S]*scripts\/alpha-promotion-preflight\.test\.mjs[\s\S]*product\/scripts\/cli-surface-qualification\.test\.mjs/u,
+  );
+});
+
 test('aggregate receipt binds the exact commit, tree and reusable roots', (t) => {
   const root = fixture(t);
   const receipt = aggregate(root);


### PR DESCRIPTION
The live exact-source Alpha preflight run 30002186983 proved the new fail-fast boundary but exposed a Windows bootstrap defect: the early source-only contract step entered through `./shifu`, so Git Bash tar interpreted the Windows drive prefix as a remote host.

This follow-up runs the two dependency-free source contract suites through the workflow-pinned `actions/setup-node` runtime, keeps the Shifu entry exception explicit and machine-audited, refreshes workflow authority, and adds a regression assertion that prevents the Windows-specific bootstrap path from returning.

Verification:
- staged repository gate passed
- Alpha/CLI contract tests: 8/8
- Gate catalog contract tests: 23/23
- documentation/rehearsal tests: 96/96
- actionlint passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0073"],
  "summary": "Route the exact-source Alpha preflight test through setup-node on Windows",
  "verification": ["source acceptance", "workflow authority", "live Windows fail-fast evidence"]
}
-->