### PR TITLE
fix(ci): keep hosted Cargo preflight on public registry

### DIFF
--- a/.github/workflows/alpha-promotion-preflight.yml
+++ b/.github/workflows/alpha-promotion-preflight.yml
@@ -17,6 +17,10 @@ on:
         required: false
         type: boolean
         default: false
+      cargo-registry-index:
+        description: Optional explicit Cargo registry index for a diagnostic run.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -104,7 +108,7 @@ jobs:
               --manifest-path "crates/libwasm-spike/${engine}/Cargo.toml"
           done
         env:
-          BUILDCHAIN_CARGO_REGISTRY_INDEX: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
+          BUILDCHAIN_CARGO_REGISTRY_INDEX: ${{ inputs.cargo-registry-index }}
 
       - name: Write platform receipt
         shell: bash

--- a/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
+++ b/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0073
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1335, https://github.com/kungfu-systems/kungfu/pull/1340]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1335, https://github.com/kungfu-systems/kungfu/pull/1340, https://github.com/kungfu-systems/kungfu/pull/1342]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/731
 qualification_refs: [scripts/adr-release-gate.test.mjs, scripts/release-promotion-rehearsal.test.mjs, scripts/alpha-promotion-preflight.test.mjs]
 review_state: self-reviewed

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -551,7 +551,7 @@
     {
       "path": ".github/workflows/alpha-promotion-preflight.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:24f1e33cf0286487599af337db110bb24ae2a3cd7f537dee2cc141e6a8f1291a",
+      "definitionDigest": "sha256:b838f78fbae8723ea629dce882134a2cbff16ba0cdc72b70b6835e3fa448a515",
       "jobs": [
         {
           "id": "aggregate",
@@ -603,7 +603,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:3b0d19e516b63993cda60110b2cf32be55d09e476391740268ee1425688e5b48",
+          "definitionDigest": "sha256:c3eca362c4e16d0567c5678e3cbf1005a701b99c266f47339ab0b494c32dc197",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -663,7 +663,7 @@
               "index": 8,
               "label": "name:Fetch locked Rust dependencies serially",
               "authority": "qualification",
-              "definitionDigest": "sha256:38ccedf731fc31914ae61c984372bc42dacc18ed3c4d6d157b479f82a8db7f99"
+              "definitionDigest": "sha256:1c3b6dc51f01dd6c1d4dcc55267d2a149269e8638b264279c6feba754a290887"
             },
             {
               "index": 9,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -84,6 +84,18 @@ test('early source contracts bypass the platform-specific Shifu bootstrap', () =
   );
 });
 
+test('automatic hosted preflight does not inherit a private Cargo mirror', () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), '.github/workflows/alpha-promotion-preflight.yml'),
+    'utf8',
+  );
+  assert.doesNotMatch(workflow, /vars\.BUILDCHAIN_CARGO_REGISTRY_INDEX/u);
+  assert.match(
+    workflow,
+    /BUILDCHAIN_CARGO_REGISTRY_INDEX: \$\{\{ inputs\.cargo-registry-index \}\}/u,
+  );
+});
+
 test('aggregate receipt binds the exact commit, tree and reusable roots', (t) => {
   const root = fixture(t);
   const receipt = aggregate(root);


### PR DESCRIPTION
Live Alpha preflight run 30005181986 proved the Windows early-source repair, then failed at 2m05s because the GitHub-hosted runner inherited an office-only Cargo mirror at `192.168.100.222:8082`.

This follow-up makes automatic hosted preflight use the public Cargo registry. A mirror remains available only as an explicit `workflow_dispatch` input for a diagnostic run, so private infrastructure cannot leak into automatic public-runner qualification.

Verification:
- staged repository gate passed
- Alpha/CLI contract tests: 9/9
- Gate catalog contract tests: 23/23
- documentation/rehearsal tests: 96/96
- actionlint passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0073"],
  "summary": "Keep automatic hosted Alpha preflight on a publicly reachable Cargo registry",
  "verification": ["source acceptance", "workflow authority", "live private-mirror fail-fast evidence"]
}
-->