### PR TITLE
fix(adr): preserve declared regeneration outputs

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -40,6 +40,74 @@ const SEMANTIC_LEGACY_FIXTURES = new Set([
   'scripts/adr-release-gate.test.mjs',
   'scripts/document-metadata-contract.test.mjs',
 ]);
+const REGENERATIONS = [
+  {
+    command: './shifu kfd:buildchain',
+    checkCommand: './shifu kfd:buildchain:check',
+    paths: [
+      '.buildchain/kfd/kfd-3/surfaces.json',
+      'developer/sdk/kfd/kfd-3-surfaces.json',
+      'developer/sdk/kfd/upstream-aggregate.json',
+      '.buildchain/kfd/kfd-1/contract-world.witness.json',
+      '.buildchain/kfd/kfd-1/release-gate.json',
+      '.buildchain/kfd/kfd-1/verify-result.json',
+      '.buildchain/kfd/kfd-2/claims/',
+      '.buildchain/kfd/kfd-2/release-claims.json',
+      'developer/sdk/kfd/kfd-1/contract-world.witness.json',
+      'developer/sdk/kfd/kfd-1/release-gate.json',
+      'developer/sdk/kfd/kfd-1/verify-result.json',
+      'developer/sdk/kfd/kfd-2/release-claims.json',
+      'developer/sdk/kfd/kfd-2/claims/',
+      '.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json',
+      '.buildchain/kfd/kfd-3/collaboration-interface.artifact.json',
+      '.buildchain/kfd/kfd-3/capability-query.json',
+      '.buildchain/kfd/buildchain-kfd-summary.json',
+    ],
+  },
+  {
+    command: './shifu node scripts/qualify-xinfa-context-quality.mjs --write',
+    checkCommand: './shifu xinfa:quality',
+    paths: [CURRENT_CONTEXT_QUALITY_QUALIFICATION],
+  },
+  {
+    command: './shifu gate:workflow-authority:refresh',
+    checkCommand: './shifu check:gate-catalog',
+    paths: ['docs/qualification/gates/workflow-authority.json'],
+  },
+  {
+    command: './shifu fix:cli-catalog-parity',
+    checkCommand: './shifu check:cli-catalog-parity',
+    paths: ['framework/core/src/python/kungfu/agent/cli_surface.catalog.json'],
+  },
+  {
+    command: './shifu core:architecture:write',
+    checkCommand: './shifu check:source',
+    paths: [
+      'framework/core/architecture/LAYERS.md',
+      'framework/core/architecture/TARGETS.cmake',
+      'framework/core/architecture/PUBLIC_CONTRACTS.cmake',
+      'framework/core/architecture/ARCHITECTURE_INDEX.md',
+      'framework/core/architecture/ARCHITECTURE_HEALTH.md',
+      'framework/core/architecture/review-routes.json',
+    ],
+  },
+];
+
+/** @param {string} rel */
+function isDeclaredRegenerationOutput(rel) {
+  return REGENERATIONS.some((regeneration) =>
+    regeneration.paths.some((output) =>
+      output.endsWith('/') ? rel.startsWith(output) : rel === output,
+    ),
+  );
+}
+
+function regenerationDeclarations() {
+  return REGENERATIONS.map((regeneration) => ({
+    ...regeneration,
+    paths: [...regeneration.paths],
+  }));
+}
 
 function gitEnv() {
   return Object.fromEntries(
@@ -95,6 +163,7 @@ function bytesDigest(value) {
 function lifecycle(rel) {
   if (SEMANTIC_LEGACY_FIXTURES.has(rel)) return 'semantic-fixture';
   if (rel === CURRENT_CONTEXT_QUALITY_CORPUS) return 'authored';
+  if (isDeclaredRegenerationOutput(rel)) return 'generated';
   if (
     rel === CURRENT_CONTEXT_QUALITY_QUALIFICATION ||
     (rel.startsWith('.buildchain/kfd/kfd-2/') &&
@@ -529,61 +598,7 @@ export function createAdrMigrationPlan(options = {}) {
         Buffer.compare(Buffer.from(left), Buffer.from(right)),
       ),
     ),
-    regenerations: [
-      {
-        command: './shifu kfd:buildchain',
-        checkCommand: './shifu kfd:buildchain:check',
-        paths: [
-          '.buildchain/kfd/kfd-3/surfaces.json',
-          'developer/sdk/kfd/kfd-3-surfaces.json',
-          'developer/sdk/kfd/upstream-aggregate.json',
-          '.buildchain/kfd/kfd-1/contract-world.witness.json',
-          '.buildchain/kfd/kfd-1/release-gate.json',
-          '.buildchain/kfd/kfd-1/verify-result.json',
-          '.buildchain/kfd/kfd-2/claims/',
-          '.buildchain/kfd/kfd-2/release-claims.json',
-          'developer/sdk/kfd/kfd-1/contract-world.witness.json',
-          'developer/sdk/kfd/kfd-1/release-gate.json',
-          'developer/sdk/kfd/kfd-1/verify-result.json',
-          'developer/sdk/kfd/kfd-2/release-claims.json',
-          'developer/sdk/kfd/kfd-2/claims/',
-          '.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json',
-          '.buildchain/kfd/kfd-3/collaboration-interface.artifact.json',
-          '.buildchain/kfd/kfd-3/capability-query.json',
-          '.buildchain/kfd/buildchain-kfd-summary.json',
-        ],
-      },
-      {
-        command:
-          './shifu node scripts/qualify-xinfa-context-quality.mjs --write',
-        checkCommand: './shifu xinfa:quality',
-        paths: [CURRENT_CONTEXT_QUALITY_QUALIFICATION],
-      },
-      {
-        command: './shifu gate:workflow-authority:refresh',
-        checkCommand: './shifu check:gate-catalog',
-        paths: ['docs/qualification/gates/workflow-authority.json'],
-      },
-      {
-        command: './shifu fix:cli-catalog-parity',
-        checkCommand: './shifu check:cli-catalog-parity',
-        paths: [
-          'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
-        ],
-      },
-      {
-        command: './shifu core:architecture:write',
-        checkCommand: './shifu check:source',
-        paths: [
-          'framework/core/architecture/LAYERS.md',
-          'framework/core/architecture/TARGETS.cmake',
-          'framework/core/architecture/PUBLIC_CONTRACTS.cmake',
-          'framework/core/architecture/ARCHITECTURE_INDEX.md',
-          'framework/core/architecture/ARCHITECTURE_HEALTH.md',
-          'framework/core/architecture/review-routes.json',
-        ],
-      },
-    ],
+    regenerations: regenerationDeclarations(),
     problems: problems.sort((left, right) =>
       Buffer.compare(
         Buffer.from(JSON.stringify(left)),

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -184,8 +184,38 @@ function fixture() {
   );
   write(
     root,
+    'framework/core/src/python/kungfu/agent/cli_surface.catalog.json.bak',
+    '{"evidence":"docs/adr/ADR-0001-first.md"}\n',
+  );
+  write(
+    root,
     'developer/sdk/kfd/kfd-2/release-claims.json',
     '{"evidence":"docs/adr/ADR-0001-first.md"}\n',
+  );
+  write(
+    root,
+    '.buildchain/kfd/kfd-3/surfaces.json',
+    '{"decision":"ADR-0001"}\n',
+  );
+  write(
+    root,
+    'crates/xinfa/qualification/context-quality-v1.json',
+    '{"decision":"ADR-0001"}\n',
+  );
+  write(
+    root,
+    'docs/qualification/gates/workflow-authority.json',
+    '{"decision":"ADR-0001"}\n',
+  );
+  write(
+    root,
+    'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
+    '{"summary":"ADR-0001"}\n',
+  );
+  write(
+    root,
+    'framework/core/architecture/LAYERS.md',
+    'Architecture authority for ADR-0001.\n',
   );
   write(
     root,
@@ -300,6 +330,31 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     preserved.get('developer/sdk/kfd/kfd-2/release-claims.json'),
     'generated',
   );
+  assert.equal(
+    transformed.has(
+      'framework/core/src/python/kungfu/agent/cli_surface.catalog.json.bak',
+    ),
+    true,
+    'a sibling of a declared output file must remain authored',
+  );
+  for (const rel of [
+    '.buildchain/kfd/kfd-3/surfaces.json',
+    'crates/xinfa/qualification/context-quality-v1.json',
+    'docs/qualification/gates/workflow-authority.json',
+    'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
+    'framework/core/architecture/LAYERS.md',
+  ]) {
+    assert.equal(
+      preserved.get(rel),
+      'generated',
+      `expected declared regeneration output to be generated: ${rel}`,
+    );
+    assert.equal(
+      transformed.has(rel),
+      false,
+      `declared regeneration output must not be a transformation: ${rel}`,
+    );
+  }
   assert.deepEqual(
     first.regenerations.map((row) => row.command),
     [
@@ -353,6 +408,25 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'framework/core/architecture/ARCHITECTURE_HEALTH.md',
     'framework/core/architecture/review-routes.json',
   ]);
+});
+
+test('keeps regeneration declarations immutable across plans', () => {
+  const root = fixture();
+  const first = createAdrMigrationPlan({ root });
+  first.regenerations.pop();
+  first.regenerations[0].paths.pop();
+
+  const second = createAdrMigrationPlan({ root });
+  assert.equal(second.regenerations.length, 5);
+  assert.equal(second.regenerations[0].paths.length, 17);
+  assert.equal(
+    second.regenerations.at(-1)?.checkCommand,
+    './shifu check:source',
+  );
+  assert.equal(
+    new Set(second.regenerations.flatMap((row) => row.paths)).size,
+    26,
+  );
 });
 
 test('applies a reviewed manifest idempotently and preserves historical bytes', () => {
@@ -459,7 +533,7 @@ test('completes only after declared regeneration checks and output closure', () 
     receipt.outputs.length,
     plan.regenerations.reduce((sum, row) => sum + row.paths.length, 0),
   );
-  fs.rmSync(path.join(root, plan.regenerations[0].paths[0]));
+  fs.rmSync(path.join(root, plan.regenerations[0].paths[1]));
   assert.throws(
     () =>
       completeAdrMigrationPlan(root, plan, plan.source.root, () => undefined),


### PR DESCRIPTION
## Summary
Treat every declared ADR migration regeneration output as generated from the same manifest authority, so completion validates the real regenerated artifact instead of a naive text-rewrite root.

Return isolated regeneration declarations for each plan so consumer mutation cannot weaken later manifests.

## Verification
- ./shifu adr:migrate:test (7/7)
- ./shifu check:source (549 tests: 539 pass, 10 skip; 41 Python; 114 runtime-upgrade; 69 desktop-update)
- pnpm exec biome check scripts/adr-migration.mjs scripts/adr-migration.test.mjs
- git diff --check
- independent review: PASS

## ADR delivery / release declaration
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","intent":"bugfix","reason":"Fail-closed lifecycle correction for already-declared ADR migration regeneration outputs; no architecture decision change"}
-->