### PR TITLE
fix(ci): forward alpha preflight command arguments

### DIFF
--- a/.github/workflows/alpha-promotion-preflight.yml
+++ b/.github/workflows/alpha-promotion-preflight.yml
@@ -116,7 +116,7 @@ jobs:
           PREFLIGHT_PLATFORM: ${{ matrix.platform }}
         run: |
           mkdir -p .buildchain/alpha-promotion-preflight
-          ./shifu alpha:promotion:preflight -- write-platform \
+          ./shifu alpha:promotion:preflight write-platform \
             --platform "$PREFLIGHT_PLATFORM" \
             --rustc "$(rustc --version)" \
             --cargo "$(cargo --version)" \
@@ -153,10 +153,10 @@ jobs:
 
       - name: Aggregate and self-verify receipt
         run: |
-          ./shifu alpha:promotion:preflight -- aggregate \
+          ./shifu alpha:promotion:preflight aggregate \
             --inputs .buildchain/alpha-promotion-preflight/platforms \
             --out .buildchain/alpha-promotion-preflight/receipt.json
-          ./shifu alpha:promotion:preflight -- verify \
+          ./shifu alpha:promotion:preflight verify \
             --receipt .buildchain/alpha-promotion-preflight/receipt.json \
             --source-commit "$SOURCE_SHA"
 

--- a/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
+++ b/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0073
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1335, https://github.com/kungfu-systems/kungfu/pull/1340, https://github.com/kungfu-systems/kungfu/pull/1342]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1335, https://github.com/kungfu-systems/kungfu/pull/1340, https://github.com/kungfu-systems/kungfu/pull/1342, https://github.com/kungfu-systems/kungfu/pull/1347]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/731
 qualification_refs: [scripts/adr-release-gate.test.mjs, scripts/release-promotion-rehearsal.test.mjs, scripts/alpha-promotion-preflight.test.mjs]
 review_state: self-reviewed

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -558,7 +558,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:8afe059a474925dd88100dbc35ad97a8b97773910ec04e1cc0fbe3f25a889462",
+          "definitionDigest": "sha256:b1391ec88a0b91f22576cbbb4ac1042e21670a8ec62e83ebd3d68245e5e309e8",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -588,7 +588,7 @@
               "index": 3,
               "label": "name:Aggregate and self-verify receipt",
               "authority": "qualification",
-              "definitionDigest": "sha256:6ed1ecd8fcccd57b2dfd7bfca9b8d85280ee81c16563957f7a68ace661411eaf"
+              "definitionDigest": "sha256:6f8b0056662220807ac211b8b010f8c0c474405b0c0b23d8cfcbca16fb0c1690"
             },
             {
               "index": 4,
@@ -603,7 +603,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c3eca362c4e16d0567c5678e3cbf1005a701b99c266f47339ab0b494c32dc197",
+          "definitionDigest": "sha256:4c4c61ab18be85a0af5003d09eeec0f61e3f747a350a07db380bfb202ec3b49a",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -669,7 +669,7 @@
               "index": 9,
               "label": "name:Write platform receipt",
               "authority": "qualification",
-              "definitionDigest": "sha256:6ba6ad56b03b429ce0749e1702e6e03f912da179a79f0024ea5829761d51e59d"
+              "definitionDigest": "sha256:fd66af46357223bb1cb403cbca65d958f6a8fbfeb5d8125af044496f2d54255d"
             },
             {
               "index": 10,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -96,6 +96,23 @@ test('automatic hosted preflight does not inherit a private Cargo mirror', () =>
   );
 });
 
+test('workflow passes preflight commands through Shifu without an extra separator', () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), '.github/workflows/alpha-promotion-preflight.yml'),
+    'utf8',
+  );
+  assert.doesNotMatch(workflow, /\.\/shifu alpha:promotion:preflight --/u);
+  for (const command of ['write-platform', 'aggregate', 'verify']) {
+    assert.match(
+      workflow,
+      new RegExp(
+        String.raw`\.\/shifu alpha:promotion:preflight ${command}`,
+        'u',
+      ),
+    );
+  }
+});
+
 test('aggregate receipt binds the exact commit, tree and reusable roots', (t) => {
   const root = fixture(t);
   const receipt = aggregate(root);


### PR DESCRIPTION
Live Alpha preflight run 30007028822 proved public Cargo fetch on Linux and macOS, then failed at 1m14s while writing the first platform receipt. The workflow passed an extra `--` through the Shifu task, so the receipt script parsed the wrong command.

This follow-up removes the redundant separator from `write-platform`, `aggregate`, and `verify`, adds a source regression contract for all three calls, and locally executes the exact Shifu `write-platform` route to a qualifying receipt.

Verification:
- exact Shifu write-platform route produced a passed linux-x64 receipt
- staged repository gate passed
- Alpha/CLI contract tests: 10/10
- Gate catalog contract tests: 23/23
- documentation/rehearsal tests: 96/96
- actionlint passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0073"],
  "summary": "Forward exact Alpha preflight receipt commands through Shifu",
  "verification": ["source acceptance", "workflow authority", "live receipt-write fail-fast evidence"]
}
-->