### PR TITLE
fix(cli): refresh catalog surface root authority

### DIFF
--- a/framework/core/src/python/kungfu/cli/catalog_projection.py
+++ b/framework/core/src/python/kungfu/cli/catalog_projection.py
@@ -13,10 +13,15 @@ from kungfu.cli import surface_contract
 
 
 _CATALOG_FILE = "cli_surface.catalog.json"
+_REGISTRY_FILE = "surface_contract.registry.json"
 
 
 def catalog_path() -> Path:
     return Path(__file__).resolve().parents[1] / "agent" / _CATALOG_FILE
+
+
+def registry_path() -> Path:
+    return Path(surface_contract.__file__).resolve().with_name(_REGISTRY_FILE)
 
 
 def _kfd3_linkage(row: dict[str, Any]) -> dict[str, Any]:
@@ -99,6 +104,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     target = catalog_path()
     if args.write:
+        contract = current()
+        if surface_contract.refresh_expected_surface_root(contract, registry_path()):
+            print(f"refreshed {registry_path()}")
         target.write_text(render(current()), encoding="utf-8")
         print(f"wrote {target}")
         return 0

--- a/framework/core/src/python/kungfu/cli/surface_contract.py
+++ b/framework/core/src/python/kungfu/cli/surface_contract.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import re
 from importlib import resources
+from pathlib import Path
 from typing import Any, Iterable
 
 import click
@@ -36,6 +37,31 @@ def contract_schema() -> dict[str, Any]:
 
 def _read_json(name: str) -> dict[str, Any]:
     return json.loads(resources.files(_PACKAGE).joinpath(name).read_text("utf-8"))
+
+
+def refresh_expected_surface_root(contract: dict[str, Any], target: Path) -> bool:
+    source = target.read_text(encoding="utf-8")
+    registry = json.loads(source)
+    projection = registry.get("catalogProjection")
+    expected = contract.get("surfaceRoot")
+    if not isinstance(projection, dict) or not isinstance(expected, str):
+        raise ValueError("CLI registry has no catalog surface-root projection")
+    current = projection.get("expectedSurfaceRoot")
+    if not isinstance(current, str):
+        raise ValueError("CLI registry expected surface root is missing")
+    if current == expected:
+        return False
+    current_literal = json.dumps(current)
+    if source.count(current_literal) != 1:
+        raise ValueError("CLI registry expected surface root is not uniquely writable")
+    updated = source.replace(current_literal, json.dumps(expected), 1)
+    if (
+        json.loads(updated).get("catalogProjection", {}).get("expectedSurfaceRoot")
+        != expected
+    ):
+        raise ValueError("CLI registry expected surface root refresh failed")
+    target.write_text(updated, encoding="utf-8")
+    return True
 
 
 def surface(**metadata: Any):

--- a/framework/core/tests/python/test_cli_surface_contract.py
+++ b/framework/core/tests/python/test_cli_surface_contract.py
@@ -315,6 +315,49 @@ def test_checked_in_catalog_is_the_deterministic_complete_projection(tmp_path):
     assert message == f"stale generated catalog: {stale}"
 
 
+def test_catalog_regeneration_refreshes_only_the_expected_surface_root(tmp_path):
+    target = tmp_path / "surface_contract.registry.json"
+    source = MODULE_PATH.with_name("surface_contract.registry.json").read_text(
+        encoding="utf-8"
+    )
+    registry = json.loads(source)
+    old_root = registry["catalogProjection"]["expectedSurfaceRoot"]
+    new_root = "sha256:" + "a" * 64
+    assert old_root != new_root
+    target.write_text(source, encoding="utf-8")
+
+    changed = surface_contract.refresh_expected_surface_root(
+        {"surfaceRoot": new_root}, target
+    )
+    assert changed is True
+    updated = target.read_text(encoding="utf-8")
+    assert updated == source.replace(json.dumps(old_root), json.dumps(new_root), 1)
+    assert (
+        surface_contract.refresh_expected_surface_root(
+            {"surfaceRoot": new_root}, target
+        )
+        is False
+    )
+
+
+def test_catalog_regeneration_fails_closed_on_ambiguous_registry_root(tmp_path):
+    target = tmp_path / "surface_contract.registry.json"
+    old_root = "sha256:" + "b" * 64
+    target.write_text(
+        json.dumps(
+            {
+                "catalogProjection": {"expectedSurfaceRoot": old_root},
+                "duplicate": old_root,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="not uniquely writable"):
+        surface_contract.refresh_expected_surface_root(
+            {"surfaceRoot": "sha256:" + "c" * 64}, target
+        )
+
+
 def test_agent_capabilities_embeds_the_exact_offline_surface_catalog(tmp_path):
     pytest.importorskip("pykungfu")
     from kungfu import agent as agent_pack

--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -77,7 +77,10 @@ const REGENERATIONS = [
   {
     command: './shifu fix:cli-catalog-parity',
     checkCommand: './shifu check:cli-catalog-parity',
-    paths: ['framework/core/src/python/kungfu/agent/cli_surface.catalog.json'],
+    paths: [
+      'framework/core/src/python/kungfu/cli/surface_contract.registry.json',
+      'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
+    ],
   },
   {
     command: './shifu core:architecture:write',

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -214,6 +214,11 @@ function fixture() {
   );
   write(
     root,
+    'framework/core/src/python/kungfu/cli/surface_contract.registry.json',
+    '{"summary":"ADR-0001"}\n',
+  );
+  write(
+    root,
     'framework/core/architecture/LAYERS.md',
     'Architecture authority for ADR-0001.\n',
   );
@@ -342,6 +347,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'crates/xinfa/qualification/context-quality-v1.json',
     'docs/qualification/gates/workflow-authority.json',
     'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
+    'framework/core/src/python/kungfu/cli/surface_contract.registry.json',
     'framework/core/architecture/LAYERS.md',
   ]) {
     assert.equal(
@@ -398,6 +404,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'docs/qualification/gates/workflow-authority.json',
   ]);
   assert.deepEqual(first.regenerations[3].paths, [
+    'framework/core/src/python/kungfu/cli/surface_contract.registry.json',
     'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
   ]);
   assert.deepEqual(first.regenerations[4].paths, [
@@ -425,7 +432,7 @@ test('keeps regeneration declarations immutable across plans', () => {
   );
   assert.equal(
     new Set(second.regenerations.flatMap((row) => row.paths)).size,
-    26,
+    27,
   );
 });
 


### PR DESCRIPTION
## Summary
- refresh the CLI registry expected surface root before catalog projection
- keep regeneration build-free and fail closed on ambiguous registry literals
- declare both CLI registry and catalog as generated ADR migration outputs

## Validation
- env -u KUNGFU_NATIVE_PATH ./shifu test:cli-surface-contract (19 passed, 10 skipped)
- KUNGFU_NATIVE_PATH=... ./shifu test:cli-surface-contract (29 passed)
- ./shifu adr:migrate:test (7 passed)
- ./shifu check:source (passed)

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Repair generated CLI catalog authority without changing an ADR record"}
-->