### PR TITLE
fix(ci): accept Shifu argv separator in Alpha preflight

### DIFF
--- a/scripts/alpha-promotion-preflight.mjs
+++ b/scripts/alpha-promotion-preflight.mjs
@@ -258,8 +258,11 @@ export function verifyAggregateReceipt({
   return receipt;
 }
 
-function parse(argv) {
-  const [command, ...rest] = argv;
+export function parsePreflightArgs(argv) {
+  // Shifu forwards participant arguments through pnpm after a conventional
+  // `--` separator. Direct Node invocations do not include that boundary.
+  const normalized = argv[0] === '--' ? argv.slice(1) : argv;
+  const [command, ...rest] = normalized;
   const options = {};
   for (let index = 0; index < rest.length; index += 2) {
     const flag = rest[index];
@@ -276,7 +279,7 @@ function writeJson(file, value) {
 }
 
 function main(argv = process.argv.slice(2)) {
-  const { command, options } = parse(argv);
+  const { command, options } = parsePreflightArgs(argv);
   if (command === 'write-platform') {
     if (!options.platform || !options.out)
       throw new Error('write-platform requires --platform and --out');

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -10,6 +10,7 @@ import { test } from 'node:test';
 import {
   aggregatePlatformReceipts,
   buildPlatformReceipt,
+  parsePreflightArgs,
   verifyAggregateReceipt,
 } from './alpha-promotion-preflight.mjs';
 
@@ -82,6 +83,39 @@ test('early source contracts bypass the platform-specific Shifu bootstrap', () =
     workflow,
     /node --test[\s\S]*scripts\/alpha-promotion-preflight\.test\.mjs[\s\S]*product\/scripts\/cli-surface-qualification\.test\.mjs/u,
   );
+  for (const command of ['write-platform', 'aggregate', 'verify']) {
+    assert.match(
+      workflow,
+      new RegExp(
+        String.raw`\.\/shifu alpha:promotion:preflight -- ${command}`,
+        'u',
+      ),
+    );
+  }
+});
+
+test('preflight parser accepts direct and Shifu-forwarded argument boundaries', () => {
+  const direct = [
+    'write-platform',
+    '--platform',
+    'macos-arm64',
+    '--out',
+    'receipt.json',
+  ];
+  assert.deepEqual(parsePreflightArgs(direct), {
+    command: 'write-platform',
+    options: {
+      platform: 'macos-arm64',
+      out: 'receipt.json',
+    },
+  });
+  assert.deepEqual(parsePreflightArgs(['--', ...direct]), {
+    command: 'write-platform',
+    options: {
+      platform: 'macos-arm64',
+      out: 'receipt.json',
+    },
+  });
 });
 
 test('automatic hosted preflight does not inherit a private Cargo mirror', () => {


### PR DESCRIPTION
## Summary

- accept the leading `--` forwarded by `./shifu ... --`
- keep direct Node invocation behavior unchanged
- add workflow-contract and argv-equivalence regression coverage

## Failure restored

The dev push Alpha preflight run failed before any platform work because `node scripts/alpha-promotion-preflight.mjs -- write-platform ...` parsed `--` as the command (`invalid preflight option: write-platform`).

Failed run: https://github.com/kungfu-systems/kungfu/actions/runs/30009939293

## Verification

- `./shifu test:alpha-promotion-preflight` (10/10)
- real `./shifu alpha:promotion:preflight -- write-platform ...` receipt generation
- `./shifu check:source`
- `git diff --check`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This restores the existing Alpha preflight argument boundary without changing product or architecture contracts."
}
-->