### PR TITLE
fix(ci): write alpha preflight receipts with setup-node

### DIFF
--- a/.github/workflows/alpha-promotion-preflight.yml
+++ b/.github/workflows/alpha-promotion-preflight.yml
@@ -116,7 +116,8 @@ jobs:
           PREFLIGHT_PLATFORM: ${{ matrix.platform }}
         run: |
           mkdir -p .buildchain/alpha-promotion-preflight
-          ./shifu alpha:promotion:preflight write-platform \
+          # shifu-entry-contract: allow the dependency-free receipt writer to use setup-node before Windows Shifu bootstrap
+          node scripts/alpha-promotion-preflight.mjs write-platform \
             --platform "$PREFLIGHT_PLATFORM" \
             --rustc "$(rustc --version)" \
             --cargo "$(cargo --version)" \

--- a/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
+++ b/docs/adr/ADR-0073-buildchain-adr-release-admissibility.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: ADR-0073
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1335, https://github.com/kungfu-systems/kungfu/pull/1340, https://github.com/kungfu-systems/kungfu/pull/1342, https://github.com/kungfu-systems/kungfu/pull/1347]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/737, https://github.com/kungfu-systems/kungfu/pull/1335, https://github.com/kungfu-systems/kungfu/pull/1340, https://github.com/kungfu-systems/kungfu/pull/1342, https://github.com/kungfu-systems/kungfu/pull/1347, https://github.com/kungfu-systems/kungfu/pull/1351]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/731
 qualification_refs: [scripts/adr-release-gate.test.mjs, scripts/release-promotion-rehearsal.test.mjs, scripts/alpha-promotion-preflight.test.mjs]
 review_state: self-reviewed

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -603,7 +603,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4c4c61ab18be85a0af5003d09eeec0f61e3f747a350a07db380bfb202ec3b49a",
+          "definitionDigest": "sha256:4189238841d9cf2cebc6fb512da7837ffda933cd362f7cc41b81080139f8c8c0",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -669,7 +669,7 @@
               "index": 9,
               "label": "name:Write platform receipt",
               "authority": "qualification",
-              "definitionDigest": "sha256:fd66af46357223bb1cb403cbca65d958f6a8fbfeb5d8125af044496f2d54255d"
+              "definitionDigest": "sha256:5b678360852f9cf2cb9a5420effcde7369ef46e40f75bae11e227095ff5f9bcf"
             },
             {
               "index": 10,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -96,13 +96,21 @@ test('automatic hosted preflight does not inherit a private Cargo mirror', () =>
   );
 });
 
-test('workflow passes preflight commands through Shifu without an extra separator', () => {
+test('workflow uses setup-node for platform receipts and clean Shifu argv for aggregation', () => {
   const workflow = fs.readFileSync(
     path.join(process.cwd(), '.github/workflows/alpha-promotion-preflight.yml'),
     'utf8',
   );
   assert.doesNotMatch(workflow, /\.\/shifu alpha:promotion:preflight --/u);
-  for (const command of ['write-platform', 'aggregate', 'verify']) {
+  assert.match(
+    workflow,
+    /node scripts\/alpha-promotion-preflight\.mjs write-platform/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /\.\/shifu alpha:promotion:preflight write-platform/u,
+  );
+  for (const command of ['aggregate', 'verify']) {
     assert.match(
       workflow,
       new RegExp(


### PR DESCRIPTION
## Summary

- write dependency-free Alpha platform receipts with the workflow-pinned Node runtime
- avoid entering the Windows Shifu/fnm bootstrap after Cargo preflight succeeds
- preserve Shifu authority for aggregate and verify while testing the explicit exception

## Live evidence

Run https://github.com/kungfu-systems/kungfu/actions/runs/30012390934 reached public Cargo fetch on all three platforms and produced the Linux receipt, then Windows failed in Shifu's fnm bootstrap because Git Bash tar interpreted the `C:` path as a remote. This patch moves only the dependency-free receipt writer before that bootstrap boundary.

## Verification

- `node scripts/check-shifu-entry-contract.mjs`
- `node scripts/check-kungfu-gate-catalog.test.mjs`
- `node --test scripts/alpha-promotion-preflight.test.mjs product/scripts/cli-surface-qualification.test.mjs`
- `actionlint .github/workflows/alpha-promotion-preflight.yml`
- direct `write-platform` receipt generation
- full staged commit gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["ADR-0073"],
  "summary": "Write Alpha platform receipts with workflow-pinned Node before Windows Shifu bootstrap",
  "verification": ["source acceptance", "workflow authority", "live Windows receipt fail-fast evidence"]
}
-->
