### PR TITLE
fix(ci): bypass Shifu bootstrap in Alpha preflight

### DIFF
--- a/.github/workflows/alpha-promotion-preflight.yml
+++ b/.github/workflows/alpha-promotion-preflight.yml
@@ -116,7 +116,8 @@ jobs:
           PREFLIGHT_PLATFORM: ${{ matrix.platform }}
         run: |
           mkdir -p .buildchain/alpha-promotion-preflight
-          ./shifu alpha:promotion:preflight write-platform \
+          # shifu-entry-contract: allow receipt generation to bypass the platform-specific Shifu bootstrap
+          node scripts/alpha-promotion-preflight.mjs write-platform \
             --platform "$PREFLIGHT_PLATFORM" \
             --rustc "$(rustc --version)" \
             --cargo "$(cargo --version)" \
@@ -144,6 +145,10 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
       - name: Download platform receipts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -153,10 +158,12 @@ jobs:
 
       - name: Aggregate and self-verify receipt
         run: |
-          ./shifu alpha:promotion:preflight aggregate \
+          # shifu-entry-contract: allow receipt aggregation to bypass the platform-specific Shifu bootstrap
+          node scripts/alpha-promotion-preflight.mjs aggregate \
             --inputs .buildchain/alpha-promotion-preflight/platforms \
             --out .buildchain/alpha-promotion-preflight/receipt.json
-          ./shifu alpha:promotion:preflight verify \
+          # shifu-entry-contract: allow receipt verification to bypass the platform-specific Shifu bootstrap
+          node scripts/alpha-promotion-preflight.mjs verify \
             --receipt .buildchain/alpha-promotion-preflight/receipt.json \
             --source-commit "$SOURCE_SHA"
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -558,7 +558,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:b1391ec88a0b91f22576cbbb4ac1042e21670a8ec62e83ebd3d68245e5e309e8",
+          "definitionDigest": "sha256:abc30a30656d4db619b87736d5ef80f47b5e9bf62212b655f8a34bf1673ec7ee",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -568,6 +568,7 @@
           },
           "externalActions": [
             "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+            "actions/setup-node@v6.4.0",
             "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
             "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
           ],
@@ -580,18 +581,24 @@
             },
             {
               "index": 2,
-              "label": "name:Download platform receipts",
+              "label": "uses:actions/setup-node@v6.4.0",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:e51eaa740e84a1e0f754dce8b750d254726c181d59dcae007d2d7700e780c567"
+              "definitionDigest": "sha256:789e56d63991440fb89fffa3b2795c1cab043e6b7df6237a0c830c5c89759690"
             },
             {
               "index": 3,
-              "label": "name:Aggregate and self-verify receipt",
+              "label": "name:Download platform receipts",
               "authority": "qualification",
-              "definitionDigest": "sha256:6f8b0056662220807ac211b8b010f8c0c474405b0c0b23d8cfcbca16fb0c1690"
+              "definitionDigest": "sha256:e51eaa740e84a1e0f754dce8b750d254726c181d59dcae007d2d7700e780c567"
             },
             {
               "index": 4,
+              "label": "name:Aggregate and self-verify receipt",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:372e75cd9129f087d23c126beb5571844cb2bc15e4a720cdc54e274744f3c46d"
+            },
+            {
+              "index": 5,
               "label": "name:Upload reusable exact-source receipt",
               "authority": "evidence-publication",
               "definitionDigest": "sha256:b07646228dce4f9694d1a4ca2216a9baf32a06ba76f09fb1c3d86218d59ba8fb"
@@ -603,7 +610,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4c4c61ab18be85a0af5003d09eeec0f61e3f747a350a07db380bfb202ec3b49a",
+          "definitionDigest": "sha256:b8846a89708b7aaa7389a9786969e40c265efc1f222c180118780f160fc7df00",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -669,7 +676,7 @@
               "index": 9,
               "label": "name:Write platform receipt",
               "authority": "qualification",
-              "definitionDigest": "sha256:fd66af46357223bb1cb403cbca65d958f6a8fbfeb5d8125af044496f2d54255d"
+              "definitionDigest": "sha256:f8a22160c1ba7561bbdbb0da95195c20eb4a319e06ccbe4079edb5316a9000d7"
             },
             {
               "index": 10,

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -48,7 +48,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/affected-native-pr.yml` | `proof_probe` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/affected-native-pr.yml` | `shifu_workspace` | qualification | none | diagnostic | token:read | none | 8 |
 | `.github/workflows/affected-native-pr.yml` | `source_acceptance` | qualification | none | diagnostic | token:read | none | 0 |
-| `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
+| `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
 | `.github/workflows/build.yml` | `kungfu-phase-b` | qualification | none | qualifying | token:read | none | 0 |

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -96,17 +96,17 @@ test('automatic hosted preflight does not inherit a private Cargo mirror', () =>
   );
 });
 
-test('workflow passes preflight commands through Shifu without an extra separator', () => {
+test('workflow writes and aggregates receipts without bootstrapping Shifu', () => {
   const workflow = fs.readFileSync(
     path.join(process.cwd(), '.github/workflows/alpha-promotion-preflight.yml'),
     'utf8',
   );
-  assert.doesNotMatch(workflow, /\.\/shifu alpha:promotion:preflight --/u);
+  assert.doesNotMatch(workflow, /\.\/shifu alpha:promotion:preflight/u);
   for (const command of ['write-platform', 'aggregate', 'verify']) {
     assert.match(
       workflow,
       new RegExp(
-        String.raw`\.\/shifu alpha:promotion:preflight ${command}`,
+        String.raw`node scripts/alpha-promotion-preflight\.mjs ${command}`,
         'u',
       ),
     );


### PR DESCRIPTION
## Summary

- execute the pure Node receipt writer directly after `setup-node`
- pin Node 24 for aggregate/verify as well
- keep the platform probe credential-free and avoid Shifu toolchain bootstrap
- refresh the closed-world workflow authority projection

## Failure restored

After #1347 fixed the initial argv boundary, exact-source run https://github.com/kungfu-systems/kungfu/actions/runs/30012390934 exposed the next failure on Windows: Shifu attempted to bootstrap fnm and Git Bash tar could not extract the `C:` temporary path. macOS was then cancelled by fail-fast; Linux passed.

The receipt script itself has no package-manager dependency, so this patch enters it through the already-pinned Node 24 runtime on all hosted platforms.

## Verification

- `./shifu test:alpha-promotion-preflight` (10/10)
- direct platform receipt generation
- `./shifu gate:workflow-authority:refresh`
- `./shifu check:source`
- commit staged gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This restores the existing hosted Alpha preflight execution boundary without changing product or architecture contracts."
}
-->