### PR TITLE
fix(cli): infer installed Action layout

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/action.py
+++ b/framework/core/src/python/kungfu/cli/commands/action.py
@@ -32,6 +32,17 @@ def _resolve_action_entry():
     return None
 
 
+def _action_layout(entry):
+    if os.environ.get("KUNGFU_INSTALL_SOURCE"):
+        return "installed"
+    binding_dir = os.path.dirname(kungfu.__binding__.__file__)
+    installed_entries = {
+        os.path.realpath(os.path.join(binding_dir, "..", "action", "action.mjs")),
+        os.path.realpath(os.path.join(binding_dir, "action", "action.mjs")),
+    }
+    return "installed" if entry in installed_entries else "source"
+
+
 def _run_action(commands):
     entry = _resolve_action_entry()
     if not entry:
@@ -40,9 +51,7 @@ def _run_action(commands):
             "Resources/action, or set KUNGFU_ACTION_ENTRY to action.mjs"
         )
     os.environ["KUNGFU_ACTION_HOST"] = "embedded-libnode"
-    os.environ["KUNGFU_ACTION_LAYOUT"] = (
-        "installed" if os.environ.get("KUNGFU_INSTALL_SOURCE") else "source"
-    )
+    os.environ["KUNGFU_ACTION_LAYOUT"] = _action_layout(entry)
     status = kungfu.__binding__.libnode.run(sys.argv[0], entry, *commands)
     if isinstance(status, int) and status != 0:
         raise SystemExit(status)

--- a/framework/core/tests/python/test_action_command.py
+++ b/framework/core/tests/python/test_action_command.py
@@ -63,6 +63,19 @@ def test_installed_action_uses_embedded_libnode(tmp_path, monkeypatch):
     assert os.environ["KUNGFU_ACTION_LAYOUT"] == "installed"
 
 
+def test_packaged_action_infers_installed_layout(tmp_path, monkeypatch):
+    module, libnode = load_action_module(tmp_path, monkeypatch)
+    entry = tmp_path / "action" / "action.mjs"
+    entry.parent.mkdir()
+    entry.write_text("// fixture\n", encoding="utf-8")
+    monkeypatch.setenv("KUNGFU_ACTION_ENTRY", str(entry))
+    monkeypatch.delenv("KUNGFU_INSTALL_SOURCE", raising=False)
+    module._run_action(("contract", "--json"))
+    assert libnode.argv[1:] == (str(entry), "contract", "--json")
+    assert os.environ["KUNGFU_ACTION_HOST"] == "embedded-libnode"
+    assert os.environ["KUNGFU_ACTION_LAYOUT"] == "installed"
+
+
 def test_action_override_is_canonicalized_to_real_path(tmp_path, monkeypatch):
     module, libnode = load_action_module(tmp_path, monkeypatch)
     entry = tmp_path / "action.mjs"
@@ -76,7 +89,7 @@ def test_action_override_is_canonicalized_to_real_path(tmp_path, monkeypatch):
 
     monkeypatch.setattr(module.os.path, "realpath", fake_realpath)
     module._run_action(("contract", "--json"))
-    assert seen == [str(entry)]
+    assert seen[0] == str(entry)
     assert libnode.argv[1] == f"canonical:{entry}"
 
 


### PR DESCRIPTION
## Summary

- infer installed Action layout from the packaged binding/action directory relationship
- preserve the explicit KUNGFU_INSTALL_SOURCE compatibility path
- cover packaged archives without relying on ambient install metadata

## Failure evidence

The macOS Alpha build smoke in run 30016491923 packaged a valid embedded Action entry, but `kungfu action contract --json` reported `layout: source`. Product archive validation therefore failed before entering the credential island.

## Verification

- `./shifu test:action-kernel`
- `./shifu check:source`
- staged pre-commit gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This restores installed Action host provenance for packaged CLI archives without changing product or architecture contracts."
}
-->