### PR TITLE
fix(adr): close invariant migration regeneration

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -83,6 +83,11 @@ const REGENERATIONS = [
     ],
   },
   {
+    command: './shifu invariant:verify -- --sync-roots --write --json',
+    checkCommand: './shifu invariant:verify -- --sync-roots --json',
+    paths: ['framework/invariant/kungfu-invariant.registry.json'],
+  },
+  {
     command: './shifu core:architecture:write',
     checkCommand: './shifu check:source',
     paths: [
@@ -340,6 +345,31 @@ function rewriteMode(rel) {
   return 'full';
 }
 
+/**
+ * @param {{cutoverCommit: string, identityTimestamp: number, id: string, path: string}} input
+ */
+export function deriveAdrMigrationMapping(input) {
+  const identity = classifyAdrIdentity(input.id);
+  if (identity?.kind !== 'legacy') {
+    throw new Error(`not a legacy ADR identity: ${input.id}`);
+  }
+  const random = crypto
+    .createHash('sha256')
+    .update(`${input.cutoverCommit}\0${input.id}\0${input.path}`)
+    .digest()
+    .subarray(0, 10);
+  const targetId = formatAdrIdentity(
+    identity.owner,
+    createUuidV7({ timestamp: input.identityTimestamp, random }),
+  );
+  return {
+    id: input.id,
+    path: input.path,
+    targetId,
+    targetPath: `docs/adr/${targetId}.md`,
+  };
+}
+
 /** @param {{root?: string, sourceCommit?: string}} [options] */
 export function createAdrMigrationPlan(options = {}) {
   const root = path.resolve(options.root || ROOT);
@@ -391,16 +421,12 @@ export function createAdrMigrationPlan(options = {}) {
       problems.push({ code: 'legacy-record-invalid', id, path: sourcePath });
       continue;
     }
-    const random = crypto
-      .createHash('sha256')
-      .update(`${cutoverCommit}\0${id}\0${sourcePath}`)
-      .digest()
-      .subarray(0, 10);
-    const targetId = formatAdrIdentity(
-      identity.owner,
-      createUuidV7({ timestamp: identityTimestamp, random }),
-    );
-    const targetPath = `docs/adr/${targetId}.md`;
+    const { targetId, targetPath } = deriveAdrMigrationMapping({
+      cutoverCommit,
+      identityTimestamp,
+      id,
+      path: sourcePath,
+    });
     if (targetIdentities.has(targetId)) {
       problems.push({ code: 'generated-identity-collision', id, targetId });
     }
@@ -768,6 +794,10 @@ function runRegenerationCheck(root, command) {
     ['./shifu xinfa:quality', ['xinfa:quality']],
     ['./shifu check:gate-catalog', ['check:gate-catalog']],
     ['./shifu check:cli-catalog-parity', ['check:cli-catalog-parity']],
+    [
+      './shifu invariant:verify -- --sync-roots --json',
+      ['invariant:verify', '--', '--sync-roots', '--json'],
+    ],
     ['./shifu check:source', ['check:source']],
   ]);
   const args = allowed.get(command);

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -224,6 +224,11 @@ function fixture() {
   );
   write(
     root,
+    'framework/invariant/kungfu-invariant.registry.json',
+    '{"decision":"ADR-0001"}\n',
+  );
+  write(
+    root,
     '.xinfa/baselines/sha256/example/atlas.json',
     '{"decision":"ADR-0000","related":"ADR-0001"}\n',
   );
@@ -349,6 +354,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
     'framework/core/src/python/kungfu/cli/surface_contract.registry.json',
     'framework/core/architecture/LAYERS.md',
+    'framework/invariant/kungfu-invariant.registry.json',
   ]) {
     assert.equal(
       preserved.get(rel),
@@ -368,6 +374,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
       './shifu node scripts/qualify-xinfa-context-quality.mjs --write',
       './shifu gate:workflow-authority:refresh',
       './shifu fix:cli-catalog-parity',
+      './shifu invariant:verify -- --sync-roots --write --json',
       './shifu core:architecture:write',
     ],
   );
@@ -378,6 +385,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
       './shifu xinfa:quality',
       './shifu check:gate-catalog',
       './shifu check:cli-catalog-parity',
+      './shifu invariant:verify -- --sync-roots --json',
       './shifu check:source',
     ],
   );
@@ -408,6 +416,9 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
   ]);
   assert.deepEqual(first.regenerations[4].paths, [
+    'framework/invariant/kungfu-invariant.registry.json',
+  ]);
+  assert.deepEqual(first.regenerations[5].paths, [
     'framework/core/architecture/LAYERS.md',
     'framework/core/architecture/TARGETS.cmake',
     'framework/core/architecture/PUBLIC_CONTRACTS.cmake',
@@ -424,7 +435,7 @@ test('keeps regeneration declarations immutable across plans', () => {
   first.regenerations[0].paths.pop();
 
   const second = createAdrMigrationPlan({ root });
-  assert.equal(second.regenerations.length, 5);
+  assert.equal(second.regenerations.length, 6);
   assert.equal(second.regenerations[0].paths.length, 17);
   assert.equal(
     second.regenerations.at(-1)?.checkCommand,
@@ -432,7 +443,7 @@ test('keeps regeneration declarations immutable across plans', () => {
   );
   assert.equal(
     new Set(second.regenerations.flatMap((row) => row.paths)).size,
-    27,
+    28,
   );
 });
 

--- a/scripts/check-kfd7-library-boundary.test.mjs
+++ b/scripts/check-kfd7-library-boundary.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 
+import { deriveAdrMigrationMapping } from './adr-migration.mjs';
 import { parseDumpbinExports } from './kfd7-public-symbols.mjs';
 import {
   assertBootstrapAdmission,
@@ -40,6 +41,7 @@ const releasePassport = readJson(
 );
 const symbolPolicyPath =
   'framework/core/architecture/libkungfu-symbol-policy.json';
+const legacyIdentityInventoryPath = 'docs/adr/legacy-identities.v1.json';
 const symbolPolicy = readJson(symbolPolicyPath);
 const consumerGuide = read('docs/guides/libkungfu-abi-consumer.md');
 const inventory = read('docs/architecture/kfd7-library-boundary.md');
@@ -54,6 +56,130 @@ const retiredSymbols = [
   'kungfu_embedding_get_api',
   'kungfu_native_storage_get_api',
 ];
+
+function exactMigrationDecisionRenames(
+  identityInventory,
+  identityTimestamp,
+  observedRenames,
+) {
+  return new Map(
+    identityInventory.records
+      .map((record) =>
+        deriveAdrMigrationMapping({
+          cutoverCommit: String(identityInventory.cutoverCommit),
+          identityTimestamp,
+          id: String(record.id),
+          path: String(record.path),
+        }),
+      )
+      .filter(
+        (mapping) => observedRenames.get(mapping.path) === mapping.targetPath,
+      )
+      .map((mapping) => [mapping.path, mapping.targetPath]),
+  );
+}
+
+function remapRenamedDecisionPaths(policy, revision) {
+  const changed = spawnSync(
+    'git',
+    ['diff', '--name-status', '--find-renames=90%', revision, '--', 'docs/adr'],
+    { encoding: 'utf8' },
+  );
+  if (changed.status !== 0) return policy;
+  const observedRenames = new Map(
+    changed.stdout
+      .trim()
+      .split('\n')
+      .map((line) => line.split('\t'))
+      .filter(
+        ([status, before, after]) => /^R\d+$/.test(status) && before && after,
+      )
+      .map(([, before, after]) => [before, after]),
+  );
+  const inventorySource = spawnSync(
+    'git',
+    ['show', `${revision}:${legacyIdentityInventoryPath}`],
+    { encoding: 'utf8' },
+  );
+  if (inventorySource.status !== 0) return policy;
+  const identityInventory = JSON.parse(inventorySource.stdout);
+  const timestampSource = spawnSync(
+    'git',
+    [
+      'show',
+      '-s',
+      '--format=%ct',
+      `${String(identityInventory.cutoverCommit)}^{commit}`,
+    ],
+    { encoding: 'utf8' },
+  );
+  if (timestampSource.status !== 0) return policy;
+  const identityTimestamp = Number(timestampSource.stdout.trim()) * 1000;
+  const renames = exactMigrationDecisionRenames(
+    identityInventory,
+    identityTimestamp,
+    observedRenames,
+  );
+  return {
+    ...policy,
+    bootstrapAdmission: {
+      ...policy.bootstrapAdmission,
+      entries: policy.bootstrapAdmission.entries.map((entry) => ({
+        ...entry,
+        decision: renames.get(entry.decision) ?? entry.decision,
+      })),
+    },
+  };
+}
+
+{
+  const identityInventory = {
+    cutoverCommit: 'a'.repeat(40),
+    records: [{ id: 'ADR-0001', path: 'docs/adr/ADR-0001-authorized.md' }],
+  };
+  const expected = deriveAdrMigrationMapping({
+    cutoverCommit: identityInventory.cutoverCommit,
+    identityTimestamp: 1_700_000_000_000,
+    ...identityInventory.records[0],
+  });
+  assert.equal(
+    exactMigrationDecisionRenames(
+      identityInventory,
+      1_700_000_000_000,
+      new Map([[expected.path, expected.targetPath]]),
+    ).get(expected.path),
+    expected.targetPath,
+  );
+  for (const target of [
+    'docs/adr/KF-ADR-018bcfe5-6800-7000-8000-000000000000.md',
+    'docs/adr/SHIFU-ADR-018bcfe5-6800-7000-8000-000000000000.md',
+    'docs/adr/KF-ADR-018bcfe5-6800-7000-8000-000000000001.md',
+  ]) {
+    assert.equal(
+      exactMigrationDecisionRenames(
+        identityInventory,
+        1_700_000_000_000,
+        new Map([[expected.path, target]]),
+      ).has(expected.path),
+      false,
+      `arbitrary ADR rename must not inherit authorization: ${target}`,
+    );
+  }
+  assert.equal(
+    exactMigrationDecisionRenames(
+      identityInventory,
+      1_700_000_000_000,
+      new Map([
+        [
+          'docs/adr/KF-ADR-018bcfe5-6800-7000-8000-000000000000.md',
+          'docs/adr/KF-ADR-018bcfe5-6800-7000-8000-000000000001.md',
+        ],
+      ]),
+    ).size,
+    0,
+    'canonical ADR renames must not inherit legacy authorization',
+  );
+}
 
 function baseSymbolPolicy() {
   const candidates = [
@@ -74,7 +200,9 @@ function baseSymbolPolicy() {
       ['show', `${revision}:${symbolPolicyPath}`],
       { encoding: 'utf8' },
     );
-    if (source.status === 0) return JSON.parse(source.stdout);
+    if (source.status === 0) {
+      return remapRenamedDecisionPaths(JSON.parse(source.stdout), revision);
+    }
   }
   throw new Error(
     'cannot resolve the target-branch bootstrap admission policy',
@@ -480,13 +608,23 @@ const surfaceFixture = () => ({
     () =>
       assertBootstrapDecisionDocuments(
         fixture.policy,
-        () => 'adr_id: ADR-9999\ndecision_status: proposed\n',
+        () => 'adr_id: ADR-0120\ndecision_status: proposed\n',
       ),
     /decision is not accepted/,
   );
   assert.throws(
     () => assertBootstrapDecisionDocuments(fixture.policy, () => null),
     /decision document is missing/,
+  );
+  assert.throws(
+    () =>
+      assertBootstrapDecisionDocuments(
+        fixture.policy,
+        () =>
+          'adr_id: KF-ADR-019f86da-4f90-7000-8000-000000000001\n' +
+          'decision_status: accepted\n',
+      ),
+    /decision path does not match its ADR identity/,
   );
 }
 

--- a/scripts/libkungfu-bootstrap-admission.mjs
+++ b/scripts/libkungfu-bootstrap-admission.mjs
@@ -2,6 +2,8 @@
 
 import assert from 'node:assert/strict';
 
+import { classifyAdrIdentity, inspectAdrRecordPath } from './adr-identity.mjs';
+
 const POLICY_SCHEMA = 'kungfu.libkungfu-symbol-policy/v2';
 const ADMISSION_MODE = 'closed-world';
 const ADMISSION_STATES = new Set(['authorized', 'qualified']);
@@ -171,10 +173,15 @@ export function assertBootstrapDecisionDocuments(policy, readDecision) {
       'string',
       `${entry.symbol} decision document is missing`,
     );
-    assert.match(
-      decision,
-      /^adr_id: ADR-\d{4}$/m,
+    const identity = /^adr_id: (\S+)$/m.exec(decision)?.[1] ?? '';
+    assert.ok(
+      classifyAdrIdentity(identity),
       `${entry.symbol} decision is not an ADR`,
+    );
+    assert.equal(
+      inspectAdrRecordPath(entry.decision, 'docs/adr').identity,
+      identity,
+      `${entry.symbol} decision path does not match its ADR identity`,
     );
     assert.match(
       decision,


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Close generated invariant-root regeneration and preserve KFD decision identity across the corpus rename"}
-->

## Summary
- declare invariant registry root synchronization in ADR migration plans
- verify the generated invariant registry before source completion
- bind KFD-7 preauthorization to the exact deterministic legacy-to-UUID migration mapping
- reject arbitrary ADR renames and decision path/identity drift

## Verification
- ./shifu adr:migrate:test
- ./shifu node --test scripts/check-kfd7-library-boundary.test.mjs
- ./shifu node --test scripts/kungfu-invariant.test.mjs
- ./shifu invariant:verify -- --sync-roots --json
- ./shifu check:source