### PR TITLE
fix(adr): close contract policy migration regeneration

### DIFF
--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -2036,6 +2036,7 @@ function contractPolicy(options) {
   const repoRoot = locateRepoRoot(process.cwd());
   const policyPaths = canonicalPolicyPaths(repoRoot);
   const policyPath = path.resolve(repoRoot, policyPaths.source);
+  const policyArtifactPath = path.resolve(repoRoot, policyPaths.artifact);
   const policy = buildCanonicalPolicy(repoRoot);
   const rendered = renderJson(policy);
   if (options.check && options.write) {
@@ -2045,16 +2046,28 @@ function contractPolicy(options) {
     const previousHash = fs.existsSync(policyPath)
       ? sha256File(policyPath)
       : '';
+    const previousArtifactHash = fs.existsSync(policyArtifactPath)
+      ? sha256File(policyArtifactPath)
+      : '';
     fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+    fs.mkdirSync(path.dirname(policyArtifactPath), { recursive: true });
     fs.writeFileSync(policyPath, rendered);
+    fs.writeFileSync(policyArtifactPath, rendered);
     printContractCommand(
       {
         schema: 'kungfu.sdk.contract-policy-write/v1',
         ok: true,
         source: policyPaths.source,
+        artifact: policyPaths.artifact,
         previousHash,
+        previousArtifactHash,
         hash: sha256File(policyPath),
-        changed: !previousHash || previousHash !== sha256File(policyPath),
+        artifactHash: sha256File(policyArtifactPath),
+        changed:
+          !previousHash ||
+          previousHash !== sha256File(policyPath) ||
+          !previousArtifactHash ||
+          previousArtifactHash !== sha256File(policyArtifactPath),
       },
       options,
       [
@@ -2068,12 +2081,22 @@ function contractPolicy(options) {
     const existing = fs.existsSync(policyPath)
       ? fs.readFileSync(policyPath, 'utf8')
       : '';
+    const existingArtifact = fs.existsSync(policyArtifactPath)
+      ? fs.readFileSync(policyArtifactPath, 'utf8')
+      : '';
     const data = {
       schema: 'kungfu.sdk.contract-policy-check/v1',
-      ok: existing === rendered,
-      status: existing === rendered ? 'current' : 'mismatched',
+      ok: existing === rendered && existingArtifact === rendered,
+      status:
+        existing === rendered && existingArtifact === rendered
+          ? 'current'
+          : 'mismatched',
       source: policyPaths.source,
+      artifact: policyPaths.artifact,
       hash: fs.existsSync(policyPath) ? sha256File(policyPath) : '',
+      artifactHash: fs.existsSync(policyArtifactPath)
+        ? sha256File(policyArtifactPath)
+        : '',
       renderedHash: `sha256:${createHash('sha256').update(rendered).digest('hex')}`,
     };
     printContractCommand(data, options, [

--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -42,6 +42,16 @@ const SEMANTIC_LEGACY_FIXTURES = new Set([
 ]);
 const REGENERATIONS = [
   {
+    command:
+      './shifu node developer/sdk/src/sdk.js contract policy --write --json',
+    checkCommand:
+      './shifu node developer/sdk/src/sdk.js contract policy --check --json',
+    paths: [
+      'framework/contract/kungfu-agent-first-canonical-policy.json',
+      'config/kungfu-agent-first-canonical-policy.json',
+    ],
+  },
+  {
     command: './shifu kfd:buildchain',
     checkCommand: './shifu kfd:buildchain:check',
     paths: [
@@ -788,8 +798,19 @@ function generatedPathRoot(root, rel) {
 }
 
 /** @param {string} root @param {string} command */
-function runRegenerationCheck(root, command) {
+export function regenerationCheckArgs(command) {
   const allowed = new Map([
+    [
+      './shifu node developer/sdk/src/sdk.js contract policy --check --json',
+      [
+        'node',
+        'developer/sdk/src/sdk.js',
+        'contract',
+        'policy',
+        '--check',
+        '--json',
+      ],
+    ],
     ['./shifu kfd:buildchain:check', ['kfd:buildchain:check']],
     ['./shifu xinfa:quality', ['xinfa:quality']],
     ['./shifu check:gate-catalog', ['check:gate-catalog']],
@@ -802,6 +823,12 @@ function runRegenerationCheck(root, command) {
   ]);
   const args = allowed.get(command);
   if (!args) throw new Error(`unrecognized regeneration check: ${command}`);
+  return [...args];
+}
+
+/** @param {string} root @param {string} command */
+function runRegenerationCheck(root, command) {
+  const args = regenerationCheckArgs(command);
   const result = childProcess.spawnSync('./shifu', args, {
     cwd: root,
     env: gitEnv(),

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -12,6 +12,7 @@ import {
   applyAdrMigrationPlan,
   completeAdrMigrationPlan,
   createAdrMigrationPlan,
+  regenerationCheckArgs,
 } from './adr-migration.mjs';
 
 const roots = [];
@@ -199,6 +200,16 @@ function fixture() {
   );
   write(
     root,
+    'framework/contract/kungfu-agent-first-canonical-policy.json',
+    '{"decision":"ADR-0001"}\n',
+  );
+  write(
+    root,
+    'config/kungfu-agent-first-canonical-policy.json',
+    '{"decision":"ADR-0001"}\n',
+  );
+  write(
+    root,
     'crates/xinfa/qualification/context-quality-v1.json',
     '{"decision":"ADR-0001"}\n',
   );
@@ -348,6 +359,8 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     'a sibling of a declared output file must remain authored',
   );
   for (const rel of [
+    'framework/contract/kungfu-agent-first-canonical-policy.json',
+    'config/kungfu-agent-first-canonical-policy.json',
     '.buildchain/kfd/kfd-3/surfaces.json',
     'crates/xinfa/qualification/context-quality-v1.json',
     'docs/qualification/gates/workflow-authority.json',
@@ -370,6 +383,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
   assert.deepEqual(
     first.regenerations.map((row) => row.command),
     [
+      './shifu node developer/sdk/src/sdk.js contract policy --write --json',
       './shifu kfd:buildchain',
       './shifu node scripts/qualify-xinfa-context-quality.mjs --write',
       './shifu gate:workflow-authority:refresh',
@@ -381,6 +395,7 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
   assert.deepEqual(
     first.regenerations.map((row) => row.checkCommand),
     [
+      './shifu node developer/sdk/src/sdk.js contract policy --check --json',
       './shifu kfd:buildchain:check',
       './shifu xinfa:quality',
       './shifu check:gate-catalog',
@@ -390,6 +405,10 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     ],
   );
   assert.deepEqual(first.regenerations[0].paths, [
+    'framework/contract/kungfu-agent-first-canonical-policy.json',
+    'config/kungfu-agent-first-canonical-policy.json',
+  ]);
+  assert.deepEqual(first.regenerations[1].paths, [
     '.buildchain/kfd/kfd-3/surfaces.json',
     'developer/sdk/kfd/kfd-3-surfaces.json',
     'developer/sdk/kfd/upstream-aggregate.json',
@@ -408,17 +427,17 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
     '.buildchain/kfd/kfd-3/capability-query.json',
     '.buildchain/kfd/buildchain-kfd-summary.json',
   ]);
-  assert.deepEqual(first.regenerations[2].paths, [
+  assert.deepEqual(first.regenerations[3].paths, [
     'docs/qualification/gates/workflow-authority.json',
   ]);
-  assert.deepEqual(first.regenerations[3].paths, [
+  assert.deepEqual(first.regenerations[4].paths, [
     'framework/core/src/python/kungfu/cli/surface_contract.registry.json',
     'framework/core/src/python/kungfu/agent/cli_surface.catalog.json',
   ]);
-  assert.deepEqual(first.regenerations[4].paths, [
+  assert.deepEqual(first.regenerations[5].paths, [
     'framework/invariant/kungfu-invariant.registry.json',
   ]);
-  assert.deepEqual(first.regenerations[5].paths, [
+  assert.deepEqual(first.regenerations[6].paths, [
     'framework/core/architecture/LAYERS.md',
     'framework/core/architecture/TARGETS.cmake',
     'framework/core/architecture/PUBLIC_CONTRACTS.cmake',
@@ -435,15 +454,22 @@ test('keeps regeneration declarations immutable across plans', () => {
   first.regenerations[0].paths.pop();
 
   const second = createAdrMigrationPlan({ root });
-  assert.equal(second.regenerations.length, 6);
-  assert.equal(second.regenerations[0].paths.length, 17);
+  assert.equal(second.regenerations.length, 7);
+  assert.equal(second.regenerations[0].paths.length, 2);
   assert.equal(
     second.regenerations.at(-1)?.checkCommand,
     './shifu check:source',
   );
   assert.equal(
     new Set(second.regenerations.flatMap((row) => row.paths)).size,
-    28,
+    30,
+  );
+  for (const regeneration of second.regenerations) {
+    assert.ok(regenerationCheckArgs(regeneration.checkCommand).length > 0);
+  }
+  assert.throws(
+    () => regenerationCheckArgs('./shifu unknown:regeneration-check'),
+    /unrecognized regeneration check/,
   );
 });
 
@@ -551,7 +577,12 @@ test('completes only after declared regeneration checks and output closure', () 
     receipt.outputs.length,
     plan.regenerations.reduce((sum, row) => sum + row.paths.length, 0),
   );
-  fs.rmSync(path.join(root, plan.regenerations[0].paths[1]));
+  const preservedPaths = new Set(plan.preserved.map((row) => row.path));
+  const missingOutput = plan.regenerations
+    .flatMap((regeneration) => regeneration.paths)
+    .find((output) => !output.endsWith('/') && !preservedPaths.has(output));
+  assert.ok(missingOutput);
+  fs.rmSync(path.join(root, missingOutput));
   assert.throws(
     () =>
       completeAdrMigrationPlan(root, plan, plan.source.root, () => undefined),

--- a/scripts/check-kfd7-library-boundary.test.mjs
+++ b/scripts/check-kfd7-library-boundary.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 
+import { identityFromAdrPath } from './adr-identity.mjs';
 import { deriveAdrMigrationMapping } from './adr-migration.mjs';
 import { parseDumpbinExports } from './kfd7-public-symbols.mjs';
 import {
@@ -604,11 +605,15 @@ const surfaceFixture = () => ({
 
 {
   const fixture = surfaceFixture();
+  const decisionIdentity = identityFromAdrPath(
+    fixture.policy.bootstrapAdmission.entries[0].decision,
+  );
+  assert.ok(decisionIdentity);
   assert.throws(
     () =>
       assertBootstrapDecisionDocuments(
         fixture.policy,
-        () => 'adr_id: ADR-0120\ndecision_status: proposed\n',
+        () => `adr_id: ${decisionIdentity}\ndecision_status: proposed\n`,
       ),
     /decision is not accepted/,
   );


### PR DESCRIPTION
<!-- kungfu-adr-release:v1\n{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Close canonical contract-policy regeneration and preserve KFD decision-status fixture semantics across ADR identity cutover"}\n-->\n\n## Summary\n\n- regenerate the canonical KFD contract policy before KFD evidence and close both source/artifact bytes\n- allowlist the exact policy verification command in ADR migration completion\n- keep the KFD decision-status negative fixture valid before and after identity cutover\n\n## Verification\n\n- [source-acceptance] revision=fdf23fb8126817761dcd6e96cdad4ee94fc0b93c base=origin/dev/v4/v4.0@e4e9b2a70b54bda7973abfa16132b03a00d4fc7e
[source-acceptance] changed files: 4

[source-acceptance] diff hygiene
[source-acceptance] $ git diff --check

[source-acceptance] no Bash scripts
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/no-bash-guard.mjs

[source-acceptance] Shifu entry contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-shifu-entry-contract.mjs
[shifu-entry] participant-facing commands use Shifu

[source-acceptance] Shifu cache contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-shifu-cache-contract.mjs
[shifu-cache] contract=docs/shifu/cache-contract.json valid=3 rejected=2

[source-acceptance] Shifu Documentation Protocol
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-shifu-documentation-contract.mjs
[shifu-docs] contract=docs/shifu/documentation-contract.json providers=7 routes=2 surfaces=401 rejected=6 schema=passed

[source-acceptance] documentation material lane
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/run-documentation-material-tests.mjs
documentation KFD-1 witness current
[freeze] restored witnessed Documentation Atlas material from tracked gzip: atlas.json
✔ installed reader verifies and reads the exact offline Xinfa pack (1066.705333ms)
✔ tampered product bytes fail closed before any read (210.009ms)
✔ freeze assembly stages the selected verified Atlas into the product (0.397375ms)
✔ freeze materializes Mission Control dependency links (5.386459ms)
✔ freeze restores an ignored product Atlas body from a tracked gzip bundle without Git (15.316875ms)
✔ final documentation matrix binds product and multi-consumer roots (1866.836667ms)
✔ a second compiler or selector authority fails qualification (0.143834ms)
✔ an unbounded compatibility alias fails qualification (0.078458ms)
ℹ tests 8
ℹ suites 0
ℹ pass 8
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1922.751875

[source-acceptance] Shifu Gate contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-shifu-gate-contract.mjs
[shifu-gate] contract=docs/shifu/gate-contract.json valid=1 rejected=5 schema=passed

[source-acceptance] Kungfu Gate catalog
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-kungfu-gate-catalog.mjs
[kungfu-gates] 38 gates, 6 profiles, 25 structured invocations and 18 closed-world workflows aligned

[source-acceptance] Xinfa standalone boundary
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node crates/xinfa/tooling/check-boundary.mjs
[xinfa-boundary] linked component boundary passed

[source-acceptance] carrier/action envelope
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-carrier-action-envelope.mjs
[carrier-action] envelope gate passed

[source-acceptance] runtime greenfield
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-runtime-greenfield.mjs
[runtime-greenfield] gate passed

[source-acceptance] trademark public-use gate
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-trademark-public-use.mjs
[trademark-public-use] contract=framework/release/kungfu-trademark-public-use.contract.json state=pre-release class9-core=6 valid=true

[source-acceptance] schema authority
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-schema-authority.mjs
[schema-authority] single-owner, JSON-edge, and projection-route gates passed

[source-acceptance] core architecture contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node framework/core/architecture/check-layers.mjs
OK: 316 first-party C/C++ files have one component owner; public contracts, the layer map and internal target graph are current.

[source-acceptance] core architecture negative fixtures
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node framework/core/architecture/check-layers.mjs --self-test
  ok: clean contract passes
  ok: target without CMake evidence fails
  ok: unclassified source fails
  ok: multiple ownership fails
  ok: component budget overflow fails
  ok: forbidden reverse include fails
  ok: resolved internal reverse include fails
  ok: undeclared resolved dependency fails
  ok: declared reverse dependency fails
  ok: reverse target dependency fails
  ok: component dependency cycle fails
  ok: internal target dependency cycle fails
  ok: target edge outside component graph fails
  ok: contract test without CMake evidence fails
  ok: source without internal target fails
  ok: source with multiple internal targets fails
  ok: missing responsibility token fails
  ok: forbidden responsibility token fails
  ok: source responsibility budget fails
  ok: clean public contract inventory passes
  ok: unclassified public header fails
  ok: multiply classified public header fails
  ok: stable symbol drift fails
  ok: binding parity drift fails
  ok: missing retained layout fixture fails
  ok: incomplete deprecation ledger fails
OK: core architecture negative fixtures fail for the intended reasons.

[source-acceptance] core architecture query and health contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node framework/core/architecture/query-health.mjs
[core-architecture] components=12 authority=sha256:101dfc1c09e69455d7fbfce001fdeac0bd5180e968bb6f259c1694d8575d258f findings=0

[source-acceptance] core architecture query negative and navigation fixtures
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node framework/core/architecture/query-health.mjs --self-test
  ok: legacy and canonical ADR record paths resolve exactly
  ok: path:framework/core/src/libkungfu/src/runtime/storage/query_render.cpp -> runtime-storage-services
  ok: symbol:kungfu_get_api -> core-composition-bindings
  ok: error:unsupported api version -> core-composition-bindings
  ok: capability:live -> runtime-live-services
  ok: profile:journal -> yijinjing-schema
  ok: unknown capability fails closed
  ok: missing owner fails closed
  ok: component cycle is visible
  ok: health regression fails closed
  ok: advisory regression stays visible without blocking

[source-acceptance] core build capability contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node framework/core/architecture/check-build-capabilities.mjs
[core-build-capabilities] 5 profiles; default=full; supported=journal,embedded-minimal,embedded-sqlite,full

[source-acceptance] core build capability negative fixtures
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node framework/core/architecture/check-build-capabilities.mjs --self-test
  ok: unknown profile component fails
  ok: incomplete component closure fails
  ok: planned default fails closed
  ok: unknown target dependency fails
  ok: unmapped architecture component fails
[core-build-capabilities] negative fixtures passed
[core-build-capabilities] 5 profiles; default=full; supported=journal,embedded-minimal,embedded-sqlite,full

[source-acceptance] core affected-native negative fixtures
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/run-core-affected-native.mjs --self-test
  ok: deterministic implementation plan
  ok: unrelated root package task does not schedule SDK qualification
  ok: SDK root package task change schedules qualification
  ok: unknown root package impact fails closed
  ok: public ABI and gate authority schedule SDK qualification
  ok: partition set is deterministic, disjoint, and complete
  ok: native contract JSON fixture selects qualification tests
  ok: cross-language Core qualification expands globally
  ok: outside-Core change emits a required-check-safe tier-none plan
  ok: Python source changes do not invent native work
  ok: runtime packaging changes do not invent native work
  ok: generated native binding stubs force full native coverage
  ok: unclassified source fails closed
  ok: native source outside tracked_roots is outside the authority
  ok: Core test fixtures and qualification harness expand globally
  ok: Core slice qualification harness remains non-native
  ok: unknown qualification source expands globally
  ok: authority dependency change expands globally
  ok: Core native build support changes expand globally
  ok: core build definition change expands globally
  ok: public header propagates to consumers
  ok: target deletion fails closed
  ok: test mapping loss fails closed
  ok: receipt drift fails closed
  ok: receipt partition drift fails closed
  ok: source-bound plan verifies before execution
  ok: source-bound plan digest drift fails closed
[core-affected] 27 negative/determinism fixtures passed

[source-acceptance] journal authority boundary
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-journal-authority-boundary.mjs
[journal-authority] Session/legacy CLI retired; Storage/Episode authority boundary clean

[source-acceptance] live runtime terminology
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-live-runtime-terminology.mjs
[live-runtime-terminology] live/reactor/peer/coordinator vocabulary clean; wire-v1 adapter isolated

[source-acceptance] runtime activation contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-runtime-contract.mjs
[runtime-contract] contract=framework/runtime/kungfu-runtime.contract.json valid=5 rejected=7 schema=passed

[source-acceptance] runtime upgrade contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-upgrade-contract.mjs
[upgrade-contract] contract=framework/upgrade/kungfu-upgrade.contract.json states=12 reasons=14 fixtures=6

[source-acceptance] product upgrade qualification
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-upgrade-qualification.mjs
[upgrade-qualification] contract=framework/upgrade/kungfu-upgrade-qualification.contract.json fixtures=29 messages=19 platforms=3

[source-acceptance] agent session contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-agent-session-contract.mjs
[agent-session-contract] contract=framework/agent-session/kungfu-agent-session.contract.json valid=7 rejected=8 schema=passed

[source-acceptance] CLI catalog parity
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-cli-catalog-parity.mjs
ok (generated CLI catalog and all declared consumers are current)

[source-acceptance] Project Cut contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-project-cut-contract.mjs
[project-cut-contract] schema=sha256:3c4193cab90f3b1b48f504033b4d842b721d48c10259bd4ece8ea62a2fd9a055 protocol=sha256:d47894a6d80d6f406488bc0731440773cb902385e5711546ff9855aec27482b9 cut=sha256:11c1806ceab489c78cb3ccb8865497c52cd3f7eec8e059165bb1d87b068e4561 receipt=sha256:13c6a9c870ead0d73bb1ccdcaccc0875f6aa50bd6a95108a56596b07b75c0b7a schemas=4 schema-validation=passed schema-fixtures=5 negative=12

[source-acceptance] Project Cut settlement contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-project-cut-settlement.mjs
[project-cut-settlement] schema=sha256:2f87355a9fb4ef44221f21806e87422ea914d6d3bcafa780627f63aaf3269041 contract=sha256:5bfc42e0a4955d2f75b94278b2308f556baad4fe2c730168b39074f1ea880f57 schemas=4 schema-validation=compiled

[source-acceptance] Project Cut history contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-project-cut-history.mjs
[project-cut-history] schema=sha256:5fcd30c3fcbe4720d1ce10ea3c9ebbbd46dba497e6276b5489d94deb8455dd96 contract=sha256:01ff866029f7b19e2a18ba97a96cf1cc75844d145103abdda9a4c6c7420c8720 schemas=2 schema-validation=compiled

[source-acceptance] Project Cut composition contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-project-cut-composition.mjs
[project-cut-composition] schema=sha256:e89bee1dccfc5599b1684818ca5173b22843d5bc3d6773b1c818cbb601edd6be contract=sha256:1f72d31af0b5addcad97f9da90ab5068c4b1301a6791d417b52561bcba19ddaa schemas=1

[source-acceptance] Project Cut scoped composition admission
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-project-cut-composition-gate.mjs
[project-cut-composition] no changed Cut manifests; scoped gate skipped

[source-acceptance] workspace continuation contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-workspace-continuation.mjs
[workspace-continuation] contract=sha256:f2977d2b85cd368da3fc66f4768d982851629f1a4da5a588c3b868014e6720ca states=4 actions=5

[source-acceptance] Episode Admission contract
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-episode-admission-contract.mjs
[episode-admission] contract=sha256:e91ea5549a2d4be1b4ed3d53ee96abb69d5ff927279ed4cc3004dfc1234923cb actions=7 transports=3 states=9

[source-acceptance] durability production-candidate admission
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/check-durability-production-candidate.mjs
[durability-admission] passed-current-hardware-production-candidate; inputs=6; production_eligible=false

[source-acceptance] Buildchain KFD release evidence
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/buildchain-kfd-evidence.mjs --check
[kfd] ok: KFD-1 witness, 4 KFD-2 claim(s), 144 KFD-3 surface(s)

[source-acceptance] Shifu version sync
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/sync-shifu-version.mjs --check

[source-acceptance] layered SDK projections
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/generate-layered-sdk.mjs --check
[layered-sdk] generated projections are current

[source-acceptance] documentation contracts
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/run-docs-source-check.mjs
[docs:source] Markdown structure
markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Finding: **/*.md !.buildchain/runtime/** !.buildchain/tmp/** !framework/core/.deps/** !**/node_modules/** !**/.venv*/** !**/build/** !**/dist/** !**/out/**
Linting: 360 file(s)
Summary: 0 error(s)
[docs:source] local links, anchors, and contracts
[docs] checked 359 Markdown files; local links, anchors, and documentation contracts passed
[docs:source] documentation contract fixtures
✔ admits fully qualified Core and Shifu records under one policy (7.975416ms)
✔ reports status debt by default and fails strict or stable qualification (0.192833ms)
✔ fails on structural findings even when release obligations are admitted (0.094125ms)
✔ excludes terminal decisions from stable obligations (0.088083ms)
✔ creates canonical UUIDv7 identities without shared sequence state (0.578833ms)
✔ resolves unique human prefixes without creating a second identity (0.316792ms)
✔ creates 100 unique identities at one fixed timestamp (0.42675ms)
✔ classifies only canonical new and grandfatherable legacy identities (0.488875ms)
✔ extracts the complete identity from UUIDv7 filenames (0.204958ms)
✔ classifies only direct lowercase Markdown ADR record paths as canonical (1.036542ms)
✔ plans deterministic ID-only renames from an exact Git tree (513.349375ms)
✔ keeps regeneration declarations immutable across plans (480.104042ms)
✔ applies a reviewed manifest idempotently and preserves historical bytes (446.409292ms)
✔ completes only after declared regeneration checks and output closure (459.637458ms)
✔ fails closed on expected-root or working-file drift (353.2905ms)
✔ fails closed unless the legacy publication pattern occurs exactly once (896.623583ms)
✔ fails closed when revision rewriting changes a target ADR root again (446.188875ms)
✔ plans an ADR without allocating a number or updating a shared index (0.783708ms)
✔ keeps the deprecated slug input out of the canonical path (0.189667ms)
✔ independent writers create distinct files and leave README untouched (1.519541ms)
✔ refuses to overwrite an existing ADR (1.866625ms)
✔ two ADR branches merge in either order without identity or index conflict (689.983334ms)
✔ fails closed when ADR identity authority reports a structural finding (3.254625ms)
✔ validates the repository ADR authority without injected findings (6249.002458ms)
✔ release loading fails closed on identity-looking noncanonical paths (4.187084ms)
✔ parses exactly one JSON manifest from the PR body (0.385875ms)
✔ hydrates exact promotion boundaries in a shallow build checkout (788.891167ms)
✔ feature dev PR requires a stage-ready or implemented delivery (1.882875ms)
✔ implemented dev intent needs a staged/implemented qualified ADR (1.356ms)
✔ ADR-neutral bugfix remains available outside feature branches (1.760791ms)
✔ alpha settlement must match a changed ADR projection (1.581583ms)
✔ alpha allows an explicit no-ADR-progress settlement (1.547542ms)
✔ alpha rejects changed accepted ADRs omitted from settlement (1.694875ms)
✔ stable blocks every unaccounted accepted ADR (10.083667ms)
✔ stable admits an exact-release, exact-condition admin waiver (1.556542ms)
✔ stable rejects stale, unauthorized, and broader waivers (1.387875ms)
✔ implemented ADR without qualification evidence still blocks stable (1.3005ms)
✔ rejects mutable documentation Action refs (3.158209ms)
✔ accepts local files, cross-file anchors, images, and external links (7.192333ms)
✔ rejects missing local targets with source coordinates (9.134958ms)
✔ rejects missing cross-file anchors (1.57ms)
✔ rejects local-link case mismatches on case-insensitive filesystems (1.27925ms)
✔ tracks GitHub duplicate-heading suffixes (1.4275ms)
✔ rejects missing canonical entry pointers (1.369333ms)
✔ rejects repository-escaping local links (1.601042ms)
✔ rejects unreachable public documents (1.456375ms)
✔ admits declared implicit collection members without per-file index edits (1.894542ms)
✔ enforces a canonical docs hierarchy with entry-only root Markdown (2.032792ms)
✔ rejects every undeclared root Markdown document (3.203292ms)
✔ rejects Markdown under every retired documentation root (2.699167ms)
✔ rejects undeclared executable examples (1.331208ms)
✔ rejects declared executable examples outside the safe argv allowlist (1.098625ms)
To /var/folders/lh/63dh4_t12tl7smhvvcr9wwlr0000gn/T/kungfu-cutover-Hvu06C/remote.git
 * [new branch]      main -> main
Cloning into '/var/folders/lh/63dh4_t12tl7smhvvcr9wwlr0000gn/T/kungfu-cutover-Hvu06C/checkout'...
Automatic merge went well; stopped before committing as requested
✔ hydrates the exact ADR cutover commit in a shallow checkout (695.001625ms)
✔ accepts typed public metadata and aligned ADR projections (4.725542ms)
✔ rejects deleting or weakening the repository ADR identity policy (4.699542ms)
✔ cannot bypass ADR routing with external schemas or profile order (10.299ms)
✔ rejects a new sequential ADR outside the exact legacy inventory (2.261166ms)
✔ rejects a legacy inventory that differs from its fixed cutover tree (211.633167ms)
✔ hydrates the exact legacy cutover commit in a shallow checkout (779.861167ms)
✔ accepts an ID-only UUIDv7 ADR without a shared index row (3.585916ms)
✔ rejects duplicate UUIDs and heading or owner-prefix drift (2.31025ms)
✔ routes every non-index ADR Markdown file through identity validation (7.055333ms)
✔ rejects copying a grandfathered identity to a different path (2.129416ms)
✔ accepts reciprocal acyclic ADR supersession metadata (1.649958ms)
✔ rejects one-sided and cyclic ADR supersession graphs (2.073458ms)
✔ rejects missing required public registry metadata (0.986084ms)
✔ rejects the ambiguous legacy status field (1.140625ms)
✔ rejects visible frontmatter when the registry is authoritative (1.259292ms)
✔ rejects undeclared maintenance attribution in registry metadata (1.433417ms)
✔ rejects orphaned registry entries (0.882167ms)
✔ rejects ADR body status drift (1.813375ms)
✔ rejects ADR index status drift (1.635417ms)
✔ rejects implementation detail in the ADR index status column (1.44125ms)
✔ preserves independently consumed frontmatter schemas (1.474959ms)
✔ accepts reachable full-SHA implementation and closure evidence (368.437334ms)
✔ pins PR evidence reachability to the source-acceptance base SHA (0.749209ms)
✔ runs Git-sensitive documentation fixtures serially in both gates (0.566291ms)
✔ accepts a merge preview by default but rejects PR-only evidence against its base (674.572917ms)
✔ accepts stable PR implementation and closure evidence (363.948292ms)
✔ rejects closure PR evidence outside the canonical repository (224.834625ms)
✔ rejects malformed implementation commit evidence (224.232458ms)
✔ rejects implementation evidence on a not-started ADR (287.9425ms)
✔ rejects pull-request evidence outside the canonical repository (281.396375ms)
✔ rejects a legacy exemption after evidence becomes complete (272.813917ms)
✔ the committed Buildchain promotion consumer contract is coherent (2.898958ms)
✔ alpha and stable promotion fixtures cover admission and fail-closed paths (16.49525ms)
✔ promotion workflow drift is rejected before Buildchain promotion (0.857458ms)
✔ release qualification rejects ADR admission before Episode evidence (0.470792ms)
✔ promotion preflight owns no release credentials or side-effect commands (0.200917ms)
✔ the full rehearsal preserves tracked files, branches, and tags (6222.336708ms)
✔ a non-promotion GitHub event does not become ADR admission (6586.903833ms)
✔ an actual GitHub promotion event traverses the ADR gate CLI (12724.955208ms)
✔ an actual stable event fails closed on the current ADR balance sheet (12611.345916ms)
✔ accepts a registry aligned with the public vocabulary reference (3.219208ms)
✔ rejects canonical heading drift (1.975291ms)
✔ rejects duplicate canonical terms and missing governed roots (9.753625ms)
✔ projects canonical terms and prose rules into disposable Vale styles (5.838084ms)
ℹ tests 97
ℹ suites 0
ℹ pass 97
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 54587.187084
[docs:source] ADR release contract
[adr-release] contract and waiver ledger are valid
[docs:source] ADR authority audit
[adr-audit] canonical authority: docs/adr
[adr-audit] records=150 kungfu=141 shifu=9
[adr-audit] structural=0 debt=88 stable-admitted=40 stable-blocked=97
[adr-audit] result=pass
[docs:source] immutable documentation toolchain
[docs:toolchain] immutable action, container, and archive pins passed
[docs:source] build-free documentation gate passed

[source-acceptance] source-acceptance contract tests
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node --test scripts/buildchain-install.test.mjs scripts/run-shifu-lifecycle.test.mjs scripts/check-typescript-files.test.mjs scripts/source-acceptance.test.mjs scripts/check-shifu-entry-contract.test.mjs scripts/check-shifu-cache-contract.test.mjs scripts/check-health-diagnostics-contract.test.mjs scripts/shifu-cache-runtime.test.mjs scripts/shifu-conan-publish.test.mjs scripts/shifu-uv-cache-adapter.test.mjs scripts/shifu-gate-runtime.test.mjs scripts/shifu-gate-executor.test.mjs scripts/shifu-documentation-runtime.test.mjs scripts/shifu-documentation-surfaces.test.mjs scripts/shifu-documentation-consumers.test.mjs scripts/kungfu-xinfa-consumer.test.mjs scripts/check-kungfu-gate-catalog.test.mjs scripts/affected-native-proof.test.mjs scripts/verify-kungfu-release-admission.test.mjs crates/xinfa/tooling/check-boundary.test.mjs scripts/check-schema-authority.test.mjs scripts/check-runtime-contract.test.mjs scripts/check-trademark-public-use.test.mjs scripts/check-upgrade-contract.test.mjs scripts/probe-cpp-cmake-contract.test.mjs scripts/check-upgrade-qualification.test.mjs scripts/upgrade-publication-admission.test.mjs scripts/check-agent-session-contract.test.mjs scripts/check-cli-catalog-parity.test.mjs scripts/check-fact-cut-kernel-contract.test.mjs scripts/check-exit-bundle-contract.test.mjs scripts/check-fact-root-canonical.test.mjs scripts/kungfu-invariant.test.mjs scripts/check-kfd7-library-boundary.test.mjs scripts/check-layered-api-encoding-boundary.test.mjs scripts/check-kfd-agent-runtime-boundary.mjs scripts/check-fact-root-canonical.test.mjs scripts/check-project-cut-contract.test.mjs scripts/check-git-episode-provider.test.mjs scripts/check-project-cut-settlement.test.mjs scripts/check-project-cut-history.test.mjs scripts/check-project-cut-composition.test.mjs scripts/project-cut-merge-queue-admission.test.mjs scripts/check-workspace-continuation.test.mjs framework/assignment-capture/assignment-capture.test.mjs scripts/run-continuity-pilot.test.mjs scripts/check-episode-admission-contract.test.mjs framework/agent-session/tests/capsule-host.test.mjs framework/agent-session/tests/peer-transport.test.mjs framework/agent-session/tests/runtime-port.test.mjs framework/agent-session/tests/provider-adapters.test.mjs framework/agent-session/tests/interaction-port.test.mjs framework/agent-session/tests/codex-app-server-contract.test.mjs framework/agent-session/tests/codex-app-server-interaction.test.mjs framework/agent-session/tests/codex-app-server-recovery.test.mjs framework/agent-session/tests/codex-app-server-runtime.test.mjs framework/agent-session/tests/codex-app-server-product.test.mjs framework/agent-session/tests/product-surface.test.mjs framework/agent-session/tests/product-detached-host.test.mjs extensions/terminal/tests/agent-session-snapshot.test.ts framework/core/tests/qualification/runtime-activation/run.test.mjs framework/core/tests/qualification/durability/run.test.mjs framework/core/tests/qualification/durability/powercut_plan.test.mjs framework/core/tests/qualification/durability/fault_campaign.test.mjs framework/core/tests/qualification/durability/candidate_evidence.test.mjs framework/core/tests/qualification/durability/retained_evidence.test.mjs framework/core/tests/qualification/durability/institutional_evidence.test.mjs framework/core/tests/qualification/durability/product_contract.test.mjs framework/core/tests/qualification/durability/slo_evidence.test.mjs framework/core/tests/qualification/durability/offhost_evidence.test.mjs framework/core/tests/qualification/durability/clean_restart_evidence.test.mjs framework/core/tests/qualification/durability/production_candidate_admission.test.mjs scripts/run-durability-powercut-qemu.test.mjs scripts/prepare-durability-powercut-qemu.test.mjs scripts/run-durability-fault-campaign.test.mjs scripts/run-durability-institutional-qemu.test.mjs scripts/run-durability-slo.test.mjs scripts/run-durability-offhost-restore.test.mjs scripts/run-durability-clean-host-restart.test.mjs
✔ current Xinfa source satisfies the linked component boundary (22.088167ms)
✔ pure core rejects filesystem access while test-only access is ignored (2.25975ms)
✔ trunk dependency direction is exact and one-way (0.3985ms)
✔ non-registry and non-allowlisted dependencies are rejected (0.240666ms)
✔ private host-product imports are rejected (0.695459ms)
(node:80695) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/dkr/Worktrees/kungfu/fix/adr-migration-contract-policy-regeneration/extensions/terminal/tests/agent-session-snapshot.test.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/dkr/Worktrees/kungfu/fix/adr-migration-contract-policy-regeneration/extensions/terminal/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
✔ renders retained PTY transcript lines (0.493833ms)
✔ renders structured-session status without requiring a terminal snapshot (0.07ms)
✔ renders the waiting state before a snapshot arrives (0.064083ms)
✔ VT snapshot preserves the active text grid without presenting escape bytes (0.937833ms)
✔ VT snapshot reconstructs absolute columns, whole-line erase, and saved cursor (0.138958ms)
✔ bounded output emits an explicit gap while the VT snapshot remains current (3.847125ms)
✔ input is idempotent and fenced by attempt, generation, epoch and process identity (1.193292ms)
✔ provider exit closes input before any later write can reach a shell (0.541167ms)
✔ resize and signal target only the current process identity (6.988959ms)
✔ PTY readiness failure is exposed before provider spawn (0.1635ms)
✔ pinned stable schema manifest has a self-recomputing deterministic bundle digest (10.712ms)
✔ contract gate pins CLI, stable schema and non-experimental capability shape (2.947667ms)
✔ positive fixtures map only typed provider events without retaining raw payloads (3.020583ms)
✔ negative fixtures fail closed on method, direction, envelope and identity drift (2.55975ms)
✔ contract preserves provider-specific authority and recovery limits (0.264958ms)
✔ turn identity comes from turn/started and has one terminal boundary (13.654542ms)
✔ approval control is exact-targeted and defaults to deny (1.682ms)
✔ non-approval controls deny by default and require explicit allow results (0.937708ms)
✔ steer and interrupt plans require the exact active provider turn (2.732417ms)
✔ usage, error and unknown item types stay typed without raw retention (3.16275ms)
✔ event gaps, stale processes and plan mutation fail closed (0.9355ms)
✔ CLI and Agent consumers produce the same deterministic plan root (1.192375ms)
✔ production route freezes the exact Codex app-server stdio launch (1.006083ms)
✔ product policy defaults Codex to structured with an explicit PTY rollback (0.113084ms)
✔ feature flag off and non-Codex providers retain the PTY plan (12.177625ms)
✔ GUI CLI and Agent share one frozen structured route and exact controls (141.749542ms)
✔ durable admission precedes provider write and exact duplicates reuse one receipt (20.750833ms)
✔ a crash window rehydrates as duplicate unknown and never writes twice (4.705459ms)
✔ runtime exit and request rejection converge on one unknown receipt (5.260083ms)
✔ approval controls retain exact request identity, default deny and deduplicate (1.865917ms)
✔ runtime loss marks unresolved input and controls unknown before closing attempt (1.3165ms)
✔ resume and read bind an exact old boundary without replaying old input (3.176291ms)
✔ backpressure, fence drift and ledger corruption fail before provider write (6.6165ms)
✔ PTY fallback preserves the old structured receipts and requires a new attempt (2.078708ms)
✔ continuous reader exposes turn identity before a late turn/start response (88.851834ms)
✔ malformed and unknown frames fail closed and freeze admission (154.7425ms)
✔ bounded queue freezes before the hard bound and reports overflow without growth (72.789791ms)
✔ thread and turn identities remain isolated across concurrent notifications (83.471375ms)
✔ server requests correlate exactly and stale writers are rejected (65.564375ms)
✔ slow or failing consumers cannot block stdout draining (63.652958ms)
✔ stderr content is never retained or surfaced (71.550541ms)
✔ stdout pipe loss terminates the provider with an unknown attempt boundary (8.4095ms)
✔ unexpected provider exit is visible and never claims a terminal outcome (70.743917ms)
✔ version drift fails before spawn (0.940917ms)
✔ ready instruction is one idempotent atomic paste and proves no outcome (4.699042ms)
✔ Claude instruction submits paste and Enter as separately idempotent writes (1.290292ms)
✔ busy queue flushes only after a supported ready signature (0.634625ms)
✔ approval and unknown modal states never auto-deliver or auto-queue (0.616916ms)
✔ interrupt mode sends one fenced signal then waits for ready before text (0.518708ms)
✔ sendKey is manual-only, deduplicated, and never implies approval outcome (0.369625ms)
✔ provider exit and opaque shell fallback fail closed (0.416209ms)
✔ adapter version drift is visible and cannot write through a ready-looking screen (0.258625ms)
✔ bounded queue rejects overflow without dropping or writing hidden input (0.359584ms)
✔ multiple readers recover by journal cursor even when notices are lost (9.464125ms)
✔ AgentSession declares process loss as lost-control instead of fake PTY recovery (0.834584ms)
✔ one controller wins, duplicate input is idempotent, and stale authority fails closed (0.727333ms)
✔ interrupt signal is idempotent and uses the same controller and foreground fencing (0.358542ms)
✔ explicit takeover and resize coalescing retain one auditable winner (0.628083ms)
✔ Coordinator re-registration preserves stream epoch and controller lease (0.283167ms)
✔ Capsule continuity consumes the Core runtime authority schema and fences regressions (0.102ms)
✔ Supervisor adoption requires exact runtime, generation and process identity (0.245792ms)
✔ slow reader gets an explicit gap and VT snapshot without blocking output (1.060333ms)
✔ bounded journal transport has no per-reader output fanout in the writer path (30.788959ms)
✔ detached endpoint is stable per runtime root and contains no main pid (1.3135ms)
✔ a new main client reconnects to one worker and worker loss never fakes continuity (183.766833ms)
✔ independent clients serialize first worker startup (129.836875ms)
✔ product state hides process topology and reserves action-required for unsafe recovery (1.031417ms)
✔ Core resolves one primary WorkConsole for a generic WorkRef (0.591834ms)
✔ GUI, CLI, and KFD-3 produce the exact same reviewed start plan (9.431708ms)
✔ one Go action starts once, auto-attaches, and later views reuse the Capsule (16.17725ms)
✔ all clients see one Hub projection and presentation detach never ends the provider (10.922583ms)
✔ a provider restart creates a new attempt under the same primary WorkConsole (1.315334ms)
✔ the durable Core registry migrates view-owned v1 data without presentation authority (82.086625ms)
✔ Terminal persistence contains presentation references but no Console authority (12.023417ms)
✔ Terminal WorkRef launch remains Profile-neutral and rejects partial identity (18.625209ms)
✔ the published v2 schema admits the Core registry and excludes presentation (65.35525ms)
✔ provider exit metadata remains visible without retaining terminal output (0.791583ms)
✔ controller lease has one winner and transfers only after exact release (3.495125ms)
✔ Agent instruction uses the shared plan and receipt without claiming work outcome (0.869709ms)
✔ approval state holds shared automatic instruction and stale plans fail closed (0.783125ms)
✔ the product runtime executes a reviewed plan through the real Capsule host (0.700084ms)
✔ the local product RPC preserves the same action and error envelopes (22.236042ms)
✔ codex adapter classifies only versioned redacted fixtures (4.938458ms)
✔ claude adapter classifies only versioned redacted fixtures (4.444125ms)
✔ version drift and foreground mismatch fail visibly to raw human fallback (0.122125ms)
✔ Claude volatile state uses the latest bounded signature and fails closed on a later modal (1.43175ms)
✔ Claude current VT grid supersedes erased volatile states (0.184417ms)
✔ instruction encoding uses each provider bounded paste submit sequence (0.399ms)
✔ version probe returns metadata only and never claims private-state inspection (0.240084ms)
✔ native port uses action envelopes on one public journal writer (1.063041ms)
✔ reader follows a Peer public journal and reconstructs cursor frames (0.329042ms)
✔ native queue overflow becomes an explicit gap (0.110042ms)
✔ capture round-trips the complete historical Atlas card field set (18.092875ms)
✔ capture target order matches workspace.py capture-only resolution (198.575833ms)
✔ expiry cleanup is dry-run-first and retains captured bytes (14.54725ms)
✔ cleanup fails closed for request material without a valid receipt (5.725334ms)
✔ Shifu source entry captures without compiled Kungfu artifacts (147.739375ms)
✔ retained v2 campaign is complete, immutable, and hardware-bounded (121.64325ms)
✔ retained canary cannot be promoted into qualification evidence (112.905917ms)
✔ current Linux process evidence retains every raw suite log (459.342459ms)
✔ institutional drill proves same-host recovery without widening claims (76.455917ms)
✔ retained clean-restart reports are exact machine artifacts (6.178916ms)
✔ clean host restart preserves authority and cannot widen its claim (4.112291ms)
✔ fault campaign freezes three complete seeded device-model cycles (13.879375ms)
✔ fault campaign order is deterministic and claims stay bounded (2.225833ms)
✔ fault campaign rejects profile cardinality drift (1.305125ms)
✔ institutional evidence binds every correctness tier (0.85975ms)
✔ institutional evidence cannot imply physical or production qualification (0.089291ms)
✔ retained off-host reports are exact machine artifacts (5.145833ms)
✔ off-host restore preserves authoritative facts and stays bounded (4.189125ms)
✔ power-cut plan is dry-run-only and names every fault boundary (2.371584ms)
✔ plan limits writes and termination to disposable run identities (0.421958ms)
✔ unsafe workspace or command inputs fail closed (0.249125ms)
✔ checkpoint publication before directory sync remains an allowed range (0.141ms)
✔ product capability authority is bound to retained evidence (5.643458ms)
✔ product capability fails closed outside its named envelope (0.178458ms)
✔ production-candidate admission is digest-bound and fail-closed (371.725333ms)
✔ retained three-platform process evidence is complete and immutable (1121.280584ms)
✔ all platform profiles are schema-valid and cover both receipt profiles (80.105ms)
✔ the dry run plans only local Shifu commands and makes no claim (26.766084ms)
✔ Windows qualification commands enter Shifu through cmd.exe (0.254125ms)
✔ Windows Episode workers preserve Path and declare the source runtime boundary (0.121708ms)
✔ passing suites qualify only the declared process-crash envelope (22.243583ms)
✔ dirty source or platform facts fail closed without rewriting suite evidence (26.221834ms)
✔ a failed or marker-incomplete suite fails the report and its fault coverage (56.150875ms)
✔ retained agent-120 SLO index is immutable and profile-bound (2.51125ms)
✔ candidate SLO evidence cannot widen hardware or production claims (0.305542ms)
✔ failed suites print only a bounded normalized log tail (0.600375ms)
✔ default evidence survives Core build-directory cleanup (0.290792ms)
✔ dry-run plans every Shifu-owned qualification step without claims (40.682083ms)
✔ product verification checks the distribution outputs without rebuilding them (0.533291ms)
✔ only source-tree Python suites allow the hosted qualification interpreter (0.16375ms)
✔ Windows suites invoke the repository Shifu shim through ComSpec (0.241875ms)
✔ Windows suite invocation rejects cmd expansion syntax (0.225ms)
✔ clean passing source qualifies exact product artifacts with bounded claims (48.015542ms)
✔ omitted products and dirty source fail closed as unqualified (28.080167ms)
✔ one failed suite fails its coverage and every supported claim (26.007625ms)
✔ raw logs are retained as a checksummed gzip bundle beside the report (4.645083ms)
✔ commit rewrites reuse only when the exact tree, base, and plan projection match (4.277875ms)
✔ complete partition evidence seals and verifies against the exact producer (5.327167ms)
✔ missing, tampered, or stale proof evidence fails closed (7.306541ms)
✔ tree, producer, and unsuccessful receipt drift cannot reuse proof (6.016625ms)
✔ lookup admits one current same-repository successful PR artifact (0.612208ms)
✔ lookup degrades duplicate, fork, failed, and expired artifacts to full run (0.191834ms)
✔ workflow keeps one required context while staging authoritative queue builds (2.662042ms)
✔ source install provisions only build-free tools from wheels (0.6405ms)
✔ source install fails closed off GitHub-hosted Linux in CI (0.251458ms)
✔ verify install preserves the existing Shifu lifecycle (0.834541ms)
✔ agent-session contract accepts positive fixtures and rejects all named safety failures (110.223459ms)
✔ contract keeps PTY delivery separate from semantic work authority (0.104875ms)
✔ coordinator and session stream epochs remain independent (0.417958ms)
✔ unknown modal state cannot admit an automatic semantic instruction (0.0855ms)
✔ repository CLI catalog parity is current (32.481541ms)
✔ catalog root drift fails closed (25.94825ms)
✔ a hand-edited and re-rooted catalog still fails the registry fence (58.430667ms)
✔ orphan and mismatched consumer entries fail closed (26.080375ms)
✔ standalone command routes require an explicit live Click target (22.591625ms)
✔ orphan runtime API and packaged omission fail closed (24.542709ms)
✔ Episode Admission contract and public projections stay aligned (3.381459ms)
✔ removing destination authority fails closed (12.980834ms)
✔ widening the simulated remote adapter fails closed (18.21075ms)
✔ registers one packaged KFD-1 Exit Bundle contract (2.4065ms)
✔ embedded schemas validate the exact contract and full fixture (111.488583ms)
✔ public compatibility policy is bounded by exact retained evidence (0.171417ms)
✔ machine inventory stays bound to current domain authorities (1.239459ms)
✔ full and thin semantics remain mutually exclusive (0.097916ms)
✔ positive and negative corpus pins fail-closed diagnostics (154.41825ms)
✔ ADR maturity and public Mission schema references cannot drift (1.346792ms)
✔ composition authority never absorbs member domain semantics (0.145834ms)
✔ registers one accepted contract with the native writer stage implemented (1.116791ms)
✔ keeps Fact lifecycle claims aligned with current implementation evidence (3.203042ms)
✔ the embedded Draft 2020-12 schema validates the exact contract (63.11975ms)
✔ separates every authoritative role and freezes the Cut root inputs (0.160417ms)
✔ declares one owner for closed metadata, typed bodies, bytes, and projections (0.075333ms)
✔ accepts the positive fixtures (0.271917ms)
✔ every declared falsifier fails for the declared reason (0.171375ms)
✔ the machine contract contains no product workflow vocabulary (0.656167ms)
✔ KFR2 freezes a library-independent closed typed protocol (1.062292ms)
✔ the independent Python implementation reproduces every byte and rejection (104.954459ms)
✔ the machine registry welds ordered C++ and Python schema projections (87.145208ms)
✔ Fact mutation requests have an exact closed-field projection (0.594208ms)
✔ the C++ authority exposes KFR2 as writer and retains the exact legacy reader (0.500083ms)
✔ the writer authority passport welds migration, rollback and exact candidate gates (0.123208ms)
✔ the corpus carries the adversarial cross-language boundary cases (0.140292ms)
✔ public schemas close producer bytes without claiming the native root (88.837833ms)
✔ seals one immutable JSONL segment and re-import is idempotent (119.605375ms)
✔ projects valid int63 Episode identities to lossless decimal strings (2.134333ms)
✔ provider export/import preserves both roots across workspaces (168.648291ms)
✔ different Episodes have independent leases; the same Episode rejects a second writer (113.125875ms)
✔ crash before rename is bounded and leaves no published segment (140.831917ms)
✔ torn tail, duplicate, out-of-order, hash drift, and unknown schema fail visibly (404.094542ms)
✔ raw runtime material and unqualified roots are rejected (0.261ms)
✔ qualification preimage drift fails visibly (95.9675ms)
✔ an existing workspace ignore must retain every private/runtime exclusion (6.059084ms)
✔ capability matrix keeps native authority separate from Git shadow storage (0.110083ms)
✔ diagnostics contract is registered with stable statuses and exits (0.848916ms)
✔ every problem template is actionable and never embeds execute (0.156125ms)
✔ command preflight profiles are fresh, bounded, and explicit (0.127209ms)
✔ recovery classifications bind only fenced authority operations (0.079542ms)
✔ unified recovery defaults to plan-only and requires exact execution identity (0.22275ms)
✔ high-value command paths declare the registered preflight profiles (0.321584ms)
✔ fast mode contract excludes fsck and health source has no mutation calls (0.212875ms)
✔ full-profile CI requires native health and preflight performance qualification (0.552125ms)
{"schema":"kungfu.kfd-agent-runtime.boundary-check/v1","ok":true,"publicHeaders":["kungfu/api.h"],"linkedTarget":"${LIBKUNGFU_NAME}","suiteRoot":"sha256:1e996b8c43b0b3e38630ccd58acf8a714cbc24b339d3794318347faab9057e5f"}
✔ scripts/check-kfd-agent-runtime-boundary.mjs (63.269875ms)
KFD-7 library boundary contract: ok
✔ scripts/check-kfd7-library-boundary.test.mjs (397.703334ms)
✔ the single required dev workflow is merge-queue compatible (1.115084ms)
✔ dev candidate heavy work is queue-only and depends on both preflights (0.450708ms)
✔ focused measurement bootstrap is exact and fail-closed (0.53075ms)
✔ current Kungfu catalog, docs, matrix, actions, and workflows align (346.996125ms)
✔ an omitted workflow dependency stays required and distinctly bound (434.7415ms)
✔ workflow authority rejects unknown workflows, jobs, steps, and activation drift (390.082083ms)
✔ refreshing digests cannot authorize a mutable action in an authority-bearing workflow (137.319292ms)
✔ refreshing digests cannot give qualification jobs inherited secrets or an Environment (243.954916ms)
✔ matrix rendering is deterministic and includes every profile (0.811959ms)
✔ a new Gate requires complete source-bound measurement coverage (229.819541ms)
✔ the frozen unmeasured baseline cannot absorb a new Gate (74.091208ms)
✔ missing platforms and stale Gate definitions fail measurement coverage (143.738167ms)
✔ dirty, unsuccessful, and duration-drifted receipts fail measurement coverage (79.883833ms)
✔ handler Gate measurements require an intact controller binding receipt (106.497417ms)
✔ matrix, gate document, and workflow drift each fail closed (501.932792ms)
✔ execution parameter and reuse tuple drift fail closed (133.955875ms)
✔ document facts and workflow entrypoints fail closed (294.166792ms)
✔ every controller class has a structured adapter and input drift fails closed (897.006792ms)
✔ rogue, duplicate, missing, and invalid controller adapters fail closed (636.255958ms)
✔ direct Gate invocations are discovered from YAML and must have one binding (241.651ms)
✔ direct Gate arguments and profile inputs fail closed on drift (356.584292ms)
✔ schema v2 rejects missing invocation contracts and legacy snippets (100.639417ms)
✔ Gate and profile mismatch or dynamic ids fail closed (580.393292ms)
✔ the layered API contract projects one public ABI waist (1.882542ms)
✔ identity protocols retain their existing canonical preimages (1.190959ms)
✔ FlatBuffers carrier identity is not confused with logical identity (0.206958ms)
✔ the L1 SDK pilot is generated for all four language consumers (3.515959ms)
✔ Xinfa keeps JSON evidence dependencies and no FlatBuffers authority (31.792792ms)
✔ Work lifecycle publishes one generated operation set through the same waist (2.200458ms)
Switched to a new branch 'candidate'
Automatic merge went well; stopped before committing as requested
Automatic merge went well; stopped before committing as requested
Switched to a new branch 'preview'
Switched to a new branch 'moving-main'
Switched to branch 'feature-a'
Rebasing (1/2)
Rebasing (2/2)
Successfully rebased and updated refs/heads/feature-a.
Switched to branch 'feature-b'
Rebasing (1/2)
Rebasing (2/2)
Successfully rebased and updated refs/heads/feature-b.
Switched to branch 'feature-c'
Rebasing (1/2)
Rebasing (2/2)
Successfully rebased and updated refs/heads/feature-c.
Switched to a new branch 'moving-main'
Switched to branch 'iterative-feature'
Rebasing (1/4)
Rebasing (2/4)
Rebasing (3/4)
Rebasing (4/4)
Successfully rebased and updated refs/heads/iterative-feature.
Switched to a new branch 'candidate'
Switched to a new branch 'candidate'
Switched to a new branch 'candidate'
Switched to a new branch 'candidate'
Switched to a new branch 'candidate'
✔ composition contract is rooted without changing Project Cut v1 (70.987667ms)
✔ two concurrent disjoint Cuts compose into one qualified N:M receipt (6684.454917ms)
✔ a Cut first published by a merge commit has a deterministic publication (2946.265083ms)
✔ a merge preview reuses the publication from its identical side parent (3742.244667ms)
✔ three concurrent Cuts survive a moving-main merge and clean-clone rebuild (9678.357333ms)
✔ an exact successor anchors superseded Cut publications after queue rebase (6606.433958ms)
✔ a squash-published Cut chain replays independent of sibling order (6136.787667ms)
✔ a self-consistent Cut with the wrong source root still fails closed (1683.594166ms)
✔ resolved overlap stays incomplete until integration evidence is admitted (2698.631625ms)
✔ resolved overlap qualifies with a tracked admitted Integration Episode (3871.697166ms)
✔ a qualified Integration Cut remains valid after forward evolution (7779.651584ms)
✔ self-consistent forged Episode evidence cannot admit an overlap (3791.716042ms)
✔ receipt-only and Episode-only evidence deletion enter the scoped gate (3052.053833ms)
✔ multiple project identities receive separate candidate projections (2894.737083ms)
✔ missing parent manifest and missing receipt fail closed (1495.732875ms)
✔ tampering is rejected and empty scopes remain distinct from global audit (790.093083ms)
✔ Project Cut contract, schema bundle, golden roots, and negative fixtures are welded (113.78525ms)
✔ object field order cannot change semantic or serialization roots (1.179292ms)
✔ cut root, serialization root, artifact digest, and receipt root are separate identities (0.945584ms)
✔ publication coordinates are not admitted into a Project Cut root preimage (0.7685ms)
✔ canonical JSON rejects ambiguous text and number encodings (0.904125ms)
✔ lossless Episode-edge parsing preserves uint64 tokens without widening Project Cut roots (0.2135ms)
✔ semantic parent availability is independent of Git ancestry (1.258334ms)
✔ receipt verification detects artifact-byte drift without changing semantic identity (2.071916ms)
Automatic merge went well; stopped before committing as requested
✔ history schemas and operation matrix are rooted (111.904542ms)
✔ history inventory retains legacy cut.json compatibility (772.77275ms)
✔ history CLI emits stable JSON envelopes for observe and reconcile (952.227458ms)
✔ rewrite operations preserve sealed roots and unqualified rewrites fail visibly (2325.7025ms)
✔ merge, revert, recovery, empty, and ref contention have explicit semantics (2912.666792ms)
✔ orphan and archive reconciliation are visible and concurrent worktrees need no global lock (1854.839541ms)
✔ reconcile skips excluded baseline bytes while retaining protocol evidence (0.569041ms)
✔ prepare is deterministic, dry-run does not mutate, and explicit staging is exact (2610.559917ms)
✔ explicit empty Episode delta prepares, publishes, and reconciles without an Episode (1683.944875ms)
✔ commit projection chunks aggregate blob reads beyond one bounded batch (1994.534625ms)
✔ commit observe preserves sealed-unpublished state, then proves publication (4595.858958ms)
✔ source drift, private input, and a commit without a cut fail visibly (1713.045875ms)
✔ partial staging remains explicit and abandonment requires execute (1217.097125ms)
✔ baseline material stays out of Git and missing material fails visibly (2136.939334ms)
✔ tracked witnesses are validated from the exact index and commit (2940.103458ms)
✔ thin hooks verify and observe through the public settlement core (1205.950291ms)
✔ CLI emits one stable JSON envelope and requires the agent-first flag (766.951ms)
✔ public CLI seals a qualified Episode only on execute and stages exact outputs (429.612167ms)
✔ public CLI matches a lossless int63 bundle to decimal-string fsck evidence (172.420709ms)
✔ runtime contract accepts positive fixtures and rejects all safety failures (136.6815ms)
✔ process diagnostics do not upgrade a handle without a durable cut (0.142666ms)
✔ process placement is explicit while semantic host and embedded remain non-claims (0.447583ms)
✔ operation registry classifies daemonless and live-required work from one authority (0.10875ms)
✔ the existing Profile action registry references the runtime operation authority (6.628166ms)
✔ standalone readiness and lease targets enforce their local invariants (4.823458ms)
✔ valid typed view, opaque body, and foreign JSON edge are not authorities (3.182875ms)
✔ one semantic identity cannot have Hana and FlatBuffers owners (1.243541ms)
✔ JSON cannot become a core semantic service surface (0.514958ms)
✔ projection route is exclusive to its schema owner (0.812ms)
✔ repository inventory matches production sources (45.443167ms)
✔ cache contract schemas accept valid fixtures and reject unsafe policy (188.620834ms)
✔ shifu exposes the exact checked-in contract (59.807875ms)
✔ shifu exposes the exact checked-in profile schema (65.961083ms)
✔ shifu exposes the exact checked-in resolution schema (81.059083ms)
✔ shifu exposes the exact checked-in diagnostic schema (77.186791ms)
✔ shifu exposes the exact checked-in config plan schema (67.453667ms)
✔ unknown cache schema fails with usage (73.065041ms)
✔ shifu validates a profile through its runtime authority (75.12075ms)
✔ cache apply is transparent when no profile projection is configured (117.006625ms)
✔ cache status is local-only and distinguishes absent from partial configuration (6.866ms)
✔ cache use is dry-run by default and manages only its delimited block (22.862958ms)
✔ cache use refuses to overwrite an Atlas controller projection (6.21375ms)
✔ cache doctor resolves configured profiles while leaving hit evidence unproven (11.224791ms)
✔ cache doctor probes selected HTTP endpoints only when requested (63.449959ms)
✔ cache doctor uses the lightweight devpi API for legacy Python profiles (13.174708ms)
✔ HTTP probe retries a transient timeout and succeeds (0.166084ms)
✔ HTTP probe keeps persistent timeouts failed at the attempt bound (0.122917ms)
✔ HTTP probe retries 5xx but accepts a reachable 4xx without retry (0.093459ms)
✔ cache profile runtime rejects probe attempts above the schema bound (6.281042ms)
✔ cache status CLI emits the diagnostic receipt as JSON (68.9525ms)
✔ shell shim keeps cache on L2 when native task execution is forced (116.079958ms)
✔ ordinary shell task auto-applies a projected profile exactly once (1298.643667ms)
✔ explicit runner projection overrides user-global development config (912.476875ms)
✔ shell gate run applies a projected profile once at the outer boundary (1305.91075ms)
✔ active child and absent projection bypass automatic cache application (1681.192875ms)
✔ active child does not reload developer bindings omitted by its cache profile (709.070333ms)
✔ partial projection reaches the resolver and fails closed (766.007041ms)
✔ accepts Shifu commands in participant documentation (1.709833ms)
✔ rejects direct package-manager commands in participant documentation (0.197208ms)
✔ rejects direct node in a workflow run block (0.142417ms)
✔ allows one explicitly justified implementation command (0.087333ms)
✔ current participant surfaces satisfy the contract (7.035083ms)
✔ cache execution boundaries distinguish gate run and source acceptance (0.486208ms)
✔ Xinfa product tasks bypass unrelated Kungfu dependency caches (0.321041ms)
✔ Xinfa source entry prefers hash-pinned wasm and preserves native fallback (0.357ms)
✔ Xinfa quality uses the source resolver and forwards one Windows mode (0.818208ms)
✔ Windows source-fresh launcher retries one transient build failure (0.267125ms)
✔ Windows local environment parsing is inline and label-free (0.186125ms)
✔ source-fresh launchers pin nested Shifu entry to the resolved binary (0.215667ms)
✔ cold source acquisition copies the binary from its isolated Cargo target (0.564958ms)
✔ Windows launchers dispatch after resolution blocks and preserve arguments (0.358375ms)
✔ runtime guard rejects a direct task and accepts Shifu provenance (136.019583ms)
✔ package manager cannot run a guarded root task without Shifu (712.196125ms)
(node:81107) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/dkr/Worktrees/kungfu/fix/adr-migration-contract-policy-regeneration/framework/gui/src/main/product-identity.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/dkr/Worktrees/kungfu/fix/adr-migration-contract-policy-regeneration/framework/gui/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
✔ the current pre-release state is truthful and complete (23.481083ms)
✔ the GUI About projection preserves product and version identity (0.216667ms)
✔ registered symbols and unsupported registration claims are rejected (14.525458ms)
✔ removing a source product surface or its runtime wiring is rejected (13.990083ms)
✔ renaming the product or removing an exact-mark surface is rejected (5.026791ms)
✔ renaming protected technical identifiers or packages is rejected (25.645667ms)
✔ preview or staging cannot satisfy the first real release gate (2.588416ms)
✔ released use requires source-bound public evidence for one exact release (7.326292ms)
✔ released use requires evidence for every core Class 9 identification (3.322584ms)
✔ conditional Class 9 items require released evidence when selected (1.6725ms)
✔ file-scoped type check reports only diagnostics owned by requested files (1321.592334ms)
✔ upgrade contract weld and state fixtures stay complete (1.333583ms)
✔ every reason keeps one complete user message (17.360708ms)
✔ activation authority drift fails closed (6.063125ms)
✔ runtime upgrade tests enter pinned uv through Shifu (0.623ms)
✔ runtime upgrade tests use the welded Windows Shifu entry (0.108541ms)
✔ upgrade qualification contract keeps messages, docs, and platform claims welded (2.109958ms)
✔ native campaign evidence signs every retained artifact without persisting a private key (21.0285ms)
✔ upgrade qualification fixture: qualified-native-evidence (1.144292ms)
✔ upgrade qualification fixture: missing-evidence (1.009708ms)
✔ upgrade qualification fixture: source-only-tier (0.470375ms)
✔ upgrade qualification fixture: source-mismatch (0.421ms)
✔ upgrade qualification fixture: surface-missing (0.377416ms)
✔ upgrade qualification fixture: runtime-churn-insufficient (0.414958ms)
✔ upgrade qualification fixture: messages-unqualified (0.422084ms)
✔ upgrade qualification fixture: docs-unqualified (0.450834ms)
✔ upgrade qualification fixture: signature-missing (2.152ms)
✔ upgrade qualification fixture: signature-invalid (0.53875ms)
✔ upgrade qualification fixture: artifact-digest-mismatch (0.457791ms)
✔ upgrade qualification fixture: campaign-missing (0.318125ms)
✔ upgrade qualification fixture: campaign-source-mismatch (0.372834ms)
✔ upgrade qualification fixture: campaign-channel-root-missing (1.048708ms)
✔ upgrade qualification fixture: campaign-artifact-root-mismatch (0.574917ms)
✔ upgrade qualification fixture: campaign-passport-mismatch (0.37225ms)
✔ upgrade qualification fixture: campaign-previous-public-invalid (0.352542ms)
✔ upgrade qualification fixture: campaign-platform-mismatch (0.330042ms)
✔ upgrade qualification fixture: campaign-owner-mismatch (0.49825ms)
✔ upgrade qualification fixture: campaign-command-mismatch (0.347708ms)
✔ upgrade qualification fixture: campaign-confirmation-unbounded (0.357875ms)
✔ upgrade qualification fixture: campaign-result-mismatch (0.342959ms)
✔ upgrade qualification fixture: campaign-smoke-missing (0.350375ms)
✔ upgrade qualification fixture: campaign-activation-mismatch (0.489375ms)
✔ upgrade qualification fixture: campaign-fault-missing (0.354917ms)
✔ upgrade qualification fixture: campaign-nonclaim-mismatch (0.335583ms)
✔ upgrade qualification fixture: campaign-docs-missing (0.40325ms)
✔ upgrade qualification fixture: campaign-simulated (0.31225ms)
✔ upgrade qualification fixture: campaign-stale (0.30525ms)
✔ workspace continuation contract and public projections stay aligned (4.242792ms)
✔ missing explicit continuation action fails closed (32.032333ms)
✔ checker command resolution uses the native Windows shifu launcher (0.614667ms)
✔ checker diagnostics prefer stderr, remove control codes, and redact the repository root (0.1735ms)
✔ checker timeout terminates the complete Windows process tree (0.497792ms)
✔ checker failures expose bounded stdout and stderr diagnostics (0.196083ms)
✔ Fact native harness preserves its source qualification boundary on Windows (0.233833ms)
✔ Windows invariant checker delegates Fact native execution to the shared harness (0.173375ms)
✔ Fact characterization fixtures use an explicit cross-platform encoding (0.599917ms)
✔ meta-contract freezes orthogonal stability, maturity, verdict, and layer vocabularies (0.175334ms)
✔ registry validates, has no root drift, and binds strong invariants to models and refinements (74.124166ms)
✔ the public source runner discovers and verifies both domains without native prerequisites (338.202917ms)
✔ source drift, unknown checker, and missing strong-model bindings fail closed (30.453125ms)
✔ implementation passport verifies a complete three-platform matrix and rejects omission, falsification, staleness, and tamper (4816.235791ms)
✔ release evidence aggregation preserves the built source identity and rejects mixed sources (378.228333ms)
✔ Exit migration release claims bind exact installed witnesses and fail closed on every declared downgrade (9.623583ms)
✔ Episode object receipt is stable, separate from admission, and honest for sealed, open, damaged, and changed objects (84.382208ms)
✔ successor gate rejects silent semantic change and requires model/refinement impact for strong invariants (20.901917ms)
✔ schemas reject unknown verdicts and tampered receipt roots (106.996167ms)
✔ Kungfu materializes Human, Agent, and GUI views without owning compiler semantics (1023.740583ms)
✔ preparation remains dry-run and run-scoped by default (1.014666ms)
✔ preparation implementation has no workflow or host-service authority (1.088459ms)
✔ the C++ probe searches the Windows libkungfu archive output directory (1.864625ms)
✔ the C++ probe compiles public Core headers as UTF-8 on MSVC (0.19925ms)
✔ the C++ probe links the separate Windows yijinjing archive (1.102458ms)
✔ the C++ probe links the Windows yijinjing xxHash dependency (0.397292ms)
✔ the SDK resolves the real uv base interpreter for Windows CMake builds (0.465792ms)
✔ the SDK pins multi-config C++ probe artifacts to the declared dist directory (0.341208ms)
✔ synthetic replay matches the tree produced by a real rebase (1924.309583ms)
✔ merge conflicts are deterministic repair-required admissions (939.941625ms)
✔ source drift is rejected before merge queue entry (4083.196917ms)
✔ a source-only candidate with no Cut delta is qualified (791.959875ms)
✔ runs one bounded preparatory pilot and generates animation inputs (52.526625ms)
✔ rejects hidden transcript injection (46.438875ms)
✔ rejects different task trees (26.714916ms)
✔ rejects missing baseline identity and missing oracle (19.895083ms)
✔ rejects fabricated public metrics (26.750542ms)
✔ rejects smoke evidence presented as FO10 (23.489833ms)
✔ clean-restart plan is frozen, sentinel-protected, and two-phase (3.925625ms)
✔ unsafe run identities and phases fail before any host operation (0.41475ms)
✔ Node architecture names normalize to the frozen Linux vocabulary (0.093292ms)
✔ runner contains no CI, deletion, or host-control authority (0.362209ms)
✔ campaign dry run names the full bounded mutation surface (10.891625ms)
✔ canary is one named trial and cannot claim qualification (1.519542ms)
✔ QEMU device envelopes are explicit and do not widen hardware claims (0.113791ms)
✔ campaign source records every failure and preserves the workspace (0.284042ms)
✔ institutional QEMU qualification remains local and disposable (0.628292ms)
✔ institutional evidence includes ENOSPC, restart, fsck, and restore (0.10825ms)
✔ off-host plan is frozen, build-local, sentinel-protected, and delete-free (1.257333ms)
✔ unsafe run identities fail before any host operation (0.498792ms)
✔ Node architecture names normalize to the frozen Linux hardware vocabulary (0.094042ms)
✔ runner contains no self-hosted CI, deletion, or host-service authority (0.468458ms)
✔ QEMU execution arguments isolate root and raw durability devices (1.450666ms)
✔ execution remains explicit (0.7025ms)
✔ profile freezes both profiles, rollover, throughput, and two 15-minute soaks (1.811125ms)
✔ dry-run plan is project-local and cannot dispatch GitHub CI (0.28975ms)
✔ correctness is a knockout and absolute ceilings do not move (0.287291ms)
✔ aggregate report passes only the exact named host and NVMe/ext4 envelope (1.704417ms)
✔ implementation contains no GitHub or host-control authority (0.33225ms)
✔ wraps an arbitrary child command in one cache projection (0.966125ms)
✔ an active cache projection is reused without acquiring a second partition (0.101833ms)
✔ an inactive lifecycle enters the cache projection exactly once (0.089292ms)
✔ copies the lifecycle environment without mutating the caller (0.130208ms)
✔ adds retained upgrade evidence only to dist (0.176875ms)
✔ preserves release evidence supplied by the build environment (0.073833ms)
✔ wraps a lifecycle task in cache apply without a shell command (0.074208ms)
✔ runs the Unix shim without a shell (171.057667ms)
✔ Windows reuses a selected native launcher without a nested cmd shim (25.391666ms)
✔ quotes a Windows shim payload and rejects expansion syntax (3.323666ms)
✔ enters a Windows batch shim with one Node-quoted cmd payload (0.206375ms)
﹣ Windows preserves a multi-argument Shifu batch invocation (0.073958ms) # SKIP
﹣ Windows cold, warm, explicit, and cache-applied launchers dispatch ordinary commands (0.0685ms) # SKIP
﹣ Windows lifecycle dispatch reaches an ordinary pnpm command (0.036666ms) # SKIP
✔ Windows cache re-entry leaves the welded shim token unquoted (0.669625ms)
✔ Conan storage partitions are stable per execution principal and isolated across principals (0.433541ms)
✔ validates exact bytes and applies only environment bindings (1.051542ms)
✔ origin-only registry endpoints do not gain a trailing slash (0.246792ms)
✔ fails closed on digest mismatch and secret-like environment keys (0.425292ms)
✔ rejects endpoint credentials, query strings, and unknown fields (0.549042ms)
shifu cache: Python effective lock unavailable; using declared public fallback
shifu cache: managed Conan storage is already in use; timed out waiting for the same partition
shifu cache: reclaimed a managed Conan lock whose owner is no longer running
✔ resolves an HTTP reference and emits a redacted schema receipt (102.814917ms)
✔ cache apply injects bindings and writes a receipt (70.349917ms)
✔ cache apply strips inherited uv transport when the profile has no Python index (75.906334ms)
✔ strict Python cache uses a disposable effective lock and redacted receipt (2363.999875ms)
✔ strict Python cache fails before starting the child when effective lock rebinding fails (584.304042ms)
✔ development Python cache records declared fallback when effective lock is unavailable (1006.065417ms)
✔ cache apply overrides Cargo and isolates Conan without mutating persistent config (2998.542833ms)
✔ cache apply cleans config overlays after a failing child (82.262583ms)
✔ nested cache apply preserves the original tool PATH instead of wrapping a wrapper (148.665084ms)
✔ nested Gate task re-entry does not acquire Conan storage when Conan is unused (755.07875ms)
✔ a non-Conan child does not contend with an occupied Conan partition (66.2915ms)
✔ a Conan child waits boundedly and preserves a live same-partition lock (587.991042ms)
✔ a Conan child reclaims a lock whose recorded process is dead (894.387625ms)
✔ cache apply is a transparent pass-through when no profile is configured (46.605583ms)
✔ matrix contract covers the required three platforms (1.06675ms)
✔ dry-run plan keeps publisher credentials out of Buildchain (3.449375ms)
✔ package revision read-back requires exact recipe and package revisions (0.26025ms)
✔ execute fails closed outside Shifu before invoking Conan (76.62175ms)
✔ two non-Kungfu consumer shapes compile through one Xinfa authority (2580.131583ms)
✔ documentation contract accepts Kungfu inputs and rejects every negative fixture (235.009916ms)
✔ shifu exposes the exact checked-in documentation contract (75.736375ms)
✔ shifu exposes the exact checked-in documentation submission schema (68.133458ms)
✔ shifu exposes the exact checked-in documentation receipt schema (83.603959ms)
✔ validate emits a non-qualifying, non-self-certified receipt (101.388667ms)
✔ show emits deterministic roots independent of collection order (77.3015ms)
✔ unknown fields and public routing of private providers fail visibly (0.818ms)
✔ CLI JSON diagnostics are stable for the same invalid fixture (201.514667ms)
✔ stdin validation rejects malformed JSON without executing anything (67.002167ms)
✔ Shifu delegates Atlas compilation and verification to the public Xinfa CLI (1362.085125ms)
✔ surface inventory closes tracked prose (115.616791ms)
﹣ surface inventory emits an exact Xinfa project (0.093541ms) # requires a built Xinfa binary
﹣ human surface inventory and Xinfa submission are deterministic (0.445541ms) # requires a built Xinfa binary
﹣ Xinfa derives semantic nodes and rejects an unverified inventory root (0.0635ms) # requires a built Xinfa binary
✔ Xinfa Agent discovery closes repository, installed-pack, and dual-first routes (2.865333ms)
﹣ a one-sided dual-first parity group fails closed (0.06425ms) # requires a built Xinfa binary
﹣ documentation context stays a thin Xinfa delegation with the declared parity group (0.059042ms) # requires a built Xinfa binary
﹣ documentation final-ready binds KFD-1 impact and dual-first projections (0.0455ms) # requires a built Xinfa binary
﹣ implementation revision drift is preserved as a Xinfa document dependency mismatch (0.048209ms) # requires a built Xinfa binary
✔ authoring impact classifies review obligations and blocks historical deletion (639.035542ms)
✔ an eligible surface without a classification fails closed (3.582041ms)
✔ explicit multi-gate runs close and deduplicate shared dependencies (203.196292ms)
✔ explicit diagnostic runs can omit one declared dependency without becoming qualifying (52.067ms)
✔ dependency omission rejects qualifying, explicit, and unrelated Gates (1.391208ms)
✔ a clean complete profile produces a current qualifying receipt (325.064083ms)
✔ receipt integrity binds the effective execution parameters (313.161708ms)
✔ advisory failures remain visible without blocking required qualification (137.517125ms)
✔ required failures keep a copyable single-gate reproduction argv (104.745958ms)
✔ task failure reasons retain a bounded diagnostic output tail (92.016958ms)
✔ task output above the legacy 16 MiB buffer remains executable (106.440292ms)
✔ required gate-specific evidence is enforced without embedding its content (87.963042ms)
✔ unsafe evidence refs and inherited environment values cannot enter receipts (3.332916ms)
✔ a required handler skip is non-successful and non-qualifying (1.602875ms)
✔ handler reasons are bounded and redact paths, URLs and secret-like assignments (1.316875ms)
✔ timeouts are bounded and recorded as errors (1006.31675ms)
✔ task actions re-enter an existing lightweight Shifu task beside an active qualification (9693.289333ms)
✔ stale source, changed definitions and incomplete coverage fail receipt reuse (168.864083ms)
✔ task invocation uses the native Shifu entrypoint on POSIX and cmd.exe on Windows (0.248584ms)
✔ gate contract accepts the valid fixture and rejects every semantic failure class (136.622584ms)
✔ shifu exposes the exact checked-in Gate contract (64.702417ms)
✔ shifu exposes the exact checked-in Gate registry schema (86.904083ms)
✔ shifu exposes the exact checked-in Gate plan schema (85.879875ms)
✔ shifu exposes the exact checked-in Gate receipt schema (56.704375ms)
✔ validate remains available when the selected registry is invalid (79.392708ms)
✔ list, show, explain and matrix have versioned deterministic JSON (426.265916ms)
✔ plan closes dependencies into deterministic parallel groups (100.869708ms)
✔ explicit diagnostic selection is non-qualifying and still closes dependencies (72.946ms)
✔ required unsupported gates fail the plan without pretending to skip (65.734709ms)
✔ explicit gate execution emits a non-qualifying unified receipt (860.837125ms)
✔ the legacy rich-command error still rejects unrelated unknown commands (48.134167ms)
✔ official PyPI lock policy rejects private and alternate hosts (1.397083ms)
✔ transport URL rebinding preserves the uv lock semantic digest (0.621834ms)
✔ effective lock and environment stay outside the canonical checkout (950.63075ms)
✔ type baseline covers every Python surface declared by [tool.mypy] (2148.335084ms)
✔ release verification reuses the exact mypy tool lane without project sync (0.667416ms)
✔ Python source checks use uvx when a bare ruff is unavailable (0.48425ms)
✔ Python source checks use uv tool run when the uvx shim is absent (0.080292ms)
✔ C++ source checks use the exact ambient formatter when it matches the repository pin (0.156459ms)
✔ C++ source checks isolate an incompatible ambient formatter behind pinned uvx (0.130042ms)
✔ Python type checks use the pinned CI mypy when it is healthy (0.079666ms)
✔ Python type checks isolate a broken ambient mypy behind pinned uvx (0.071625ms)
✔ Python type checks use pinned uv tool run without a uvx shim (0.076917ms)
✔ source plan covers representative source-only checks (721.769792ms)
✔ clang-format falls back to pinned uv tool run without a uvx shim (0.165417ms)
✔ generated Xinfa and Project Cut evidence is not treated as web source (0.140625ms)
✔ Conan recipe Python is linted without widening into the product type baseline (14.60575ms)
✔ changed GUI TypeScript receives a file-scoped semantic check (0.202209ms)
✔ RocksDB source archive keeps an explicit tar filename (0.214791ms)
✔ source plan cannot enter build, compiler, artifact, or release lifecycles (0.580416ms)
✔ reusable workflow is bound to source mode and the pinned stable runtime (0.226833ms)
✔ manual package build is welded to the reviewed Phase B consumer (0.500208ms)
✔ the native membrane matrix is a promotion gate, not a dev PR gate (0.140375ms)
✔ documentation lint excludes the checked-out Buildchain runtime (0.903917ms)
✔ publication admission verifies three native payloads plus authoritative signed macOS bytes (67.734875ms)
✔ publication admission rejects a missing credential-island payload (43.82125ms)
✔ publication admission rejects signed DMG byte drift (45.313583ms)
✔ publication admission rejects a non-authoritative signing identity (61.003459ms)
✔ publication admission rejects unaccepted notarization evidence (40.335083ms)
✔ publication admission rejects missing retained qualification evidence (20.622375ms)
✔ publication admission rejects payload byte drift after manifest creation (34.693167ms)
✔ publication admission rejects source identity outside the RC passport (33.864208ms)
✔ publication admission rejects campaign evidence bound to a different RC passport (35.1165ms)
✔ publication admission rejects an incomplete platform matrix (43.362084ms)
✔ publication admission rejects divergent duplicate release manifests (42.6765ms)
✔ Kungfu independently accepts only a current sealed qualifying capability (243.730791ms)
✔ Kungfu rejects missing platform evidence and replayed or stale admission (128.069208ms)
✔ Kungfu rejects policy, runner, control-plane, and artifact substitution (97.932875ms)
✔ Kungfu consumer qualification seals only an exact current handoff (25.745625ms)
ℹ tests 569
ℹ suites 0
ℹ pass 559
ℹ fail 0
ℹ cancelled 0
ℹ skipped 10
ℹ todo 0
ℹ duration_ms 64351.906542

[source-acceptance] Phase B package identity contract tests
[source-acceptance] $ python3 -m unittest scripts.test_prepare_kungfu_phase_b_package
{"consumer": {"commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "ref": "v1.2.4-alpha.28", "repository": "kungfu-systems/build-images"}, "package": {"filename": "kungfu-episodes-cli-linux-x64.tar.gz", "platform": "linux-x64", "sha256": "4c0e52e82dbdd31e64e70bf61554556ac5145347f2e21434592a31265b2aa4b5", "sizeBytes": 422, "sourceCommit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "version": "4.0.0-alpha.1"}, "schema": "kungfu.phase-b-package-identity/v1"}

[source-acceptance] agent work state contract and CLI parity
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/run-agent-work-state-tests.mjs
✔ registers one layered Agent Work contract with bounded claims (1.499417ms)
✔ validates Profile shape and cross-object semantics from one contract (169.742833ms)
✔ separates Action Geometry from the Agent Work Domain Profile by exact roots (1.509375ms)
✔ proves context payload alone cannot determine action validity (27.805208ms)
✔ publishes every invalid inference and P17 check (0.360041ms)
✔ separates continuity smoke, comparison, and public projection evidence (13.269792ms)
✔ human and agent routes point to the same contract authority (0.493708ms)
ℹ tests 7
ℹ suites 0
ℹ pass 7
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 297.546834
.........................................                                [100%]
41 passed in 5.47s

[source-acceptance] runtime upgrade control-plane tests
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/run-runtime-upgrade-tests.mjs
........................................................................ [ 63%]
..........................................                               [100%]
114 passed in 6.56s

[source-acceptance] desktop update adapter tests
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node scripts/run-desktop-update-tests.mjs
✔ passes Windows ESM entrypoints as file URLs (0.556458ms)
✔ upgrade manifest generation runs after runtime mutation hooks (0.168417ms)
✔ preserves an explicit certificate hash for duplicate named identities (0.511875ms)
✔ falls back to the identity resolved by electron-builder (0.095917ms)
✔ recognizes thin and universal Mach-O headers (0.12ms)
✔ skips ordinary resources without skipping native runtime code (0.107667ms)
✔ fails closed when a candidate cannot be inspected (0.0735ms)
✔ preserves existing string, array, and function ignore rules (0.07725ms)
✔ returns one function so osx-sign does not discard the ignore option (0.054667ms)
✔ both desktop builders resolve the signing hook from the GUI project (0.374375ms)
✔ production provider construction disables implicit updater actions (1.305084ms)
✔ bundled reconciliation rejects unqualified manifests before Core (0.970542ms)
✔ electron-updater adapter disables implicit download and install (5.191459ms)
✔ release-manifest resolution errors stay on the adapter event surface (0.659792ms)
✔ published manifest resolver binds updater version and platform (1.091292ms)
✔ unqualified remote manifests fail closed before download (0.351459ms)
✔ manifest resolver rejects a cross-platform release identity (0.138166ms)
✔ CLI bridge stays inside runtime upgrade and carries stale-plan fences (3.949875ms)
✔ desktop installer handoff requires a Core download plan (1.542667ms)
✔ installer handoff replans after download before restarting the app (0.359042ms)
✔ update-not-available revokes stale download authority (0.471167ms)
✔ an unsolicited available event cannot grant transport authority (0.105958ms)
✔ a stale available event cannot replace an active download (0.55675ms)
✔ a delayed available plan cannot replace Core reconciliation (0.410583ms)
✔ a delayed available-plan failure cannot erase Core reconciliation (0.21725ms)
✔ a second check invalidates an earlier pending available plan (0.164208ms)
✔ an unsolicited downloaded event cannot grant installer authority (0.193ms)
✔ stale progress cannot revive a revoked download (0.221375ms)
✔ a failed update check clears previous transport authority (0.241208ms)
✔ a failed updater download revokes transport authority (0.213583ms)
✔ an updater error event revokes transport authority (0.18575ms)
✔ stale updater events cannot erase an active Core receipt (0.2785ms)
✔ a failed installer handoff revokes transport authority (0.267916ms)
✔ a restarted check returns to idle without stale authority (0.0705ms)
✔ a restarted downloaded update must re-enter the updater download path (0.281667ms)
✔ a restarted in-progress download becomes an explicit retry (0.06625ms)
✔ a persisted available update requires a fresh updater check (0.112791ms)
✔ an incoherent restarted download fails closed (0.059666ms)
✔ an interrupted installer handoff is never replayed automatically (0.0945ms)
✔ event persistence failure becomes a recoverable in-memory error (0.176042ms)
✔ download does not start when its state cannot be persisted (0.153042ms)
✔ concurrent reconciliation of one release stages only once (0.253083ms)
✔ concurrent reconciliation rejects a different release identity (0.159292ms)
✔ reentrant reconciliation during install joins the active release (0.134583ms)
✔ an update check cannot replace active runtime reconciliation (0.145833ms)
✔ an update check cannot overlap an active download (0.131291ms)
✔ runtime reconciliation cannot overlap an active download (0.130667ms)
✔ startup reconciliation activates only an idle Core plan (0.116334ms)
✔ active incompatible work defers without staging or killing work (0.110708ms)
✔ readiness failure is reconciled through the Core rollback receipt (0.118459ms)
✔ a readiness probe crash is reconciled as a failed readiness check (0.607334ms)
✔ a bundled runtime install failure revokes stale update authority (0.191833ms)
✔ a Core reconcile failure preserves the current recovery receipt (0.252125ms)
✔ a persisted reconciling receipt resumes without staging again (0.109625ms)
✔ a staged receipt cannot cross a changed release identity (0.12375ms)
✔ a stale downloaded target cannot replace the current Core plan (0.145417ms)
✔ a downloaded manifest must preserve the exact planned release identity (0.094834ms)
✔ release identity comparison ignores JSON object key order (0.109709ms)
✔ a failed Core plan becomes recoverable controller state (3.34225ms)
✔ saved desktop update state round-trips through the canonical file (2.235959ms)
✔ a truncated canonical state recovers as an explainable error (1.643917ms)
✔ a schema-valid but incomplete state cannot regain update authority (1.022667ms)
✔ an interrupted temporary write cannot replace canonical state (1.50325ms)
✔ bundled manifest binds exact runtime bytes and source product identity (3.067208ms)
✔ bundled manifest binds internal symlinks and rejects tree escape (13.176125ms)
✔ desktop finalization binds installer bytes and stays fail-closed locally (7.555625ms)
✔ external manifest asset names are deterministic and platform-specific (0.099459ms)
✔ CLI finalization adds an exact archive without losing desktop evidence (3.992041ms)
✔ both desktop builders retain the bundled upgrade identity outside runtime (0.738917ms)
ℹ tests 69
ℹ suites 0
ℹ pass 69
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 270.956792

[source-acceptance] tooling type check
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node node_modules/typescript/bin/tsc -p tsconfig.tools.json

[source-acceptance] changed web source format and lint
[source-acceptance] $ /Users/dkr/.local/opt/node-v24.16.0-darwin-arm64/bin/node node_modules/@biomejs/biome/bin/biome check --no-errors-on-unmatched developer/sdk/src/sdk.js scripts/adr-migration.mjs scripts/adr-migration.test.mjs scripts/check-kfd7-library-boundary.test.mjs
Checked 4 files in 59ms. No fixes applied.

[source-acceptance] build-free source gate passed\n- TAP version 13
# Subtest: plans deterministic ID-only renames from an exact Git tree
ok 1 - plans deterministic ID-only renames from an exact Git tree
  ---
  duration_ms: 593.557333
  type: 'test'
  ...
# Subtest: keeps regeneration declarations immutable across plans
ok 2 - keeps regeneration declarations immutable across plans
  ---
  duration_ms: 515.054791
  type: 'test'
  ...
# Subtest: applies a reviewed manifest idempotently and preserves historical bytes
ok 3 - applies a reviewed manifest idempotently and preserves historical bytes
  ---
  duration_ms: 478.664417
  type: 'test'
  ...
# Subtest: completes only after declared regeneration checks and output closure
ok 4 - completes only after declared regeneration checks and output closure
  ---
  duration_ms: 439.196542
  type: 'test'
  ...
# Subtest: fails closed on expected-root or working-file drift
ok 5 - fails closed on expected-root or working-file drift
  ---
  duration_ms: 370.668083
  type: 'test'
  ...
# Subtest: fails closed unless the legacy publication pattern occurs exactly once
ok 6 - fails closed unless the legacy publication pattern occurs exactly once
  ---
  duration_ms: 901.794166
  type: 'test'
  ...
# Subtest: fails closed when revision rewriting changes a target ADR root again
ok 7 - fails closed when revision rewriting changes a target ADR root again
  ---
  duration_ms: 426.984875
  type: 'test'
  ...
1..7
# tests 7
# suites 0
# pass 7
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 3784.047542\n- TAP version 13
# KFD-7 library boundary contract: ok
# Subtest: scripts/check-kfd7-library-boundary.test.mjs
ok 1 - scripts/check-kfd7-library-boundary.test.mjs
  ---
  duration_ms: 176.15
  type: 'test'
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 180.954417\n- {
  "schema": "kungfu.sdk.contract-policy-write/v1",
  "ok": true,
  "source": "framework/contract/kungfu-agent-first-canonical-policy.json",
  "artifact": "config/kungfu-agent-first-canonical-policy.json",
  "previousHash": "sha256:e77be4fdea188eac89bcf697992e6e82cdf66c0324eeebdd50825fece5251fef",
  "previousArtifactHash": "sha256:e77be4fdea188eac89bcf697992e6e82cdf66c0324eeebdd50825fece5251fef",
  "hash": "sha256:e77be4fdea188eac89bcf697992e6e82cdf66c0324eeebdd50825fece5251fef",
  "artifactHash": "sha256:e77be4fdea188eac89bcf697992e6e82cdf66c0324eeebdd50825fece5251fef",
  "changed": false
}\n- {
  "schema": "kungfu.sdk.contract-policy-check/v1",
  "ok": true,
  "status": "current",
  "source": "framework/contract/kungfu-agent-first-canonical-policy.json",
  "artifact": "config/kungfu-agent-first-canonical-policy.json",
  "hash": "sha256:e77be4fdea188eac89bcf697992e6e82cdf66c0324eeebdd50825fece5251fef",
  "artifactHash": "sha256:e77be4fdea188eac89bcf697992e6e82cdf66c0324eeebdd50825fece5251fef",
  "renderedHash": "sha256:e77be4fdea188eac89bcf697992e6e82cdf66c0324eeebdd50825fece5251fef"
}\n- staged pre-commit gate