### PR TITLE
fix(cli): refresh installed help catalog roots

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72",
+      "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+            "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "1da706aec59f25f078bb2151e8693f8387c97edf",
+    "sourceSha": "a68b65d81b311ef96df442d5f1a0f08edf5be187",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:d7e8812fc600f25b37fe5e58f0bc554135fb7f043294b95d21184fccd6405f5f"
   },

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72",
+      "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "e3630e7dade45625f6147a886a275bb7d9e1a22a575b3fa875db83ce63ad7e72"
+            "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
+++ b/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
@@ -1,7 +1,7 @@
 {
-  "catalogRoot": "sha256:e8e6084d52d321e9556e523b9fedc94631debc8da24e674d8a1a99c16955d84b",
+  "catalogRoot": "sha256:acc1643dce627fa10222da77f7cdaaf18e10a297d25035f7373c546e48b0482f",
   "contractId": "kungfu-cli-surface",
-  "contractRoot": "sha256:94c4c3893ad998599dd08ec08c8a4623e75d0746767d2886a9d95037eb3f8a24",
+  "contractRoot": "sha256:62772a1a36f184c4ed560530302c11b4dff0169caf38969b827f20b80f04ee8c",
   "kfd3Linkage": [
     {
       "apiIds": [],
@@ -2817,11 +2817,11 @@
       "kfd3Registry": "strict-link",
       "packagedInventory": "required-agent-pack-entry"
     },
-    "expectedSurfaceRoot": "sha256:069ed85336a4f4412a69145ad347cd2d661e92a4ab991edec7ea5f3e3be7f3ab",
+    "expectedSurfaceRoot": "sha256:61afbef227829a78743b9e8c8b28a88ed401b0afeeb52edf04e83bf3c8b3f9c1",
     "regeneration": "./shifu fix:cli-catalog-parity",
     "validation": "./shifu check:cli-catalog-parity"
   },
-  "registryRoot": "sha256:3b0152d670c8f57a60ed728ce6781f21662f7c323340b697cd16e52db10c4e78",
+  "registryRoot": "sha256:a9f59bdcced68877c22bd3967b0932dd96fecebd5bdd453112e4c299038c0102",
   "schema": "kungfu.cli-surface-catalog/v1",
   "schemaRoot": "sha256:731eec25990d090067d59651d6c0793934124ac79df4111990bd905e03b605c4",
   "source": {
@@ -2834,7 +2834,7 @@
     "pathAuthority": "live-click-tree",
     "root": "kungfu"
   },
-  "surfaceRoot": "sha256:069ed85336a4f4412a69145ad347cd2d661e92a4ab991edec7ea5f3e3be7f3ab",
+  "surfaceRoot": "sha256:61afbef227829a78743b9e8c8b28a88ed401b0afeeb52edf04e83bf3c8b3f9c1",
   "surfaces": [
     {
       "alias_diagnostics": [],
@@ -8952,7 +8952,7 @@
         "module": "kungfu.cli.commands.cut",
         "symbol": "cut"
       },
-      "summary": "inspect the current Project Cut, confidence, gaps, and next actions",
+      "summary": "inspect the current Cut using the active Domain Profile display name",
       "visibility": "advanced"
     },
     {

--- a/framework/core/src/python/kungfu/cli/surface_contract.registry.json
+++ b/framework/core/src/python/kungfu/cli/surface_contract.registry.json
@@ -160,7 +160,7 @@
   "catalogProjection": {
     "artifact": "kungfu.agent/cli_surface.catalog.json",
     "authority": "runtime-fold",
-    "expectedSurfaceRoot": "sha256:069ed85336a4f4412a69145ad347cd2d661e92a4ab991edec7ea5f3e3be7f3ab",
+    "expectedSurfaceRoot": "sha256:61afbef227829a78743b9e8c8b28a88ed401b0afeeb52edf04e83bf3c8b3f9c1",
     "consumers": {
       "agentCapabilities": "embed-complete",
       "agentCommands": "strict-link",


### PR DESCRIPTION
## Summary

- refresh the generated CLI surface catalog for the current `cut` and `update` help summaries
- propagate the resulting catalog digest through KFD-2 release claims and KFD-3 prebuild evidence
- restore packaged `--help-json` parity with `agent capabilities --json`
- replace #1365 with a single linear commit because the dev merge queue uses `REBASE`; #1365 had a correct final tree but its merge-resolution history was rejected as `merge_conflict`

## Evidence

The real macOS Alpha build run `30022985357` completed product packaging but failed product CLI qualification because the packaged live Click tree and checked-in Agent catalog had different contract roots. The exact drift was limited to existing command summaries.

## Validation

- native-backed `./shifu test:cli-surface-contract` (29 passed)
- `./shifu kfd:buildchain`
- `./shifu check:source`
- staged commit gate
- linear history: exactly one commit above current `dev/v4/v4.0`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This refreshes generated CLI surface and KFD evidence after existing command help changes without changing product or architecture contracts."
}
-->