### PR TITLE
fix(ci): defer macOS signature verification to credential island

### DIFF
--- a/scripts/probe-release-platform.mjs
+++ b/scripts/probe-release-platform.mjs
@@ -14,14 +14,24 @@ import {
 } from './document-metadata-contract.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CREDENTIAL_ISLAND_POLICY =
+  'docs/qualification/gates/macos-credential-island-policy.json';
+const REQUIRED_FINAL_VERIFICATIONS = [
+  'codesignStrict',
+  'hardenedRuntime',
+  'appStaple',
+  'appGatekeeper',
+  'dmgStaple',
+  'dmgGatekeeper',
+];
 
 function fail(message) {
   throw new Error(`[release-platform-probe] ${message}`);
 }
 
-function run(command, args) {
+function run(command, args, root = ROOT) {
   const result = childProcess.spawnSync(command, args, {
-    cwd: ROOT,
+    cwd: root,
     encoding: 'utf8',
   });
   if (result.error || result.status !== 0) {
@@ -47,9 +57,56 @@ function findApplications(root) {
   return matches;
 }
 
+function credentialIslandPolicy(root) {
+  const policyPath = path.join(root, CREDENTIAL_ISLAND_POLICY);
+  if (!fs.existsSync(policyPath)) return null;
+  let policy;
+  try {
+    policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+  } catch (error) {
+    fail(
+      `failed to read macOS credential-island policy: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  if (
+    policy.schema !== 'kungfu.macos-credential-island-policy/v1' ||
+    !policy.repository ||
+    !policy.environment ||
+    !policy.platformId ||
+    !policy.app?.bundleId ||
+    !['arm64', 'x64'].includes(policy.app?.architecture) ||
+    !/^[A-Z0-9]{10}$/.test(policy.identity?.teamId || '') ||
+    !/^[a-f0-9]{40}$/i.test(policy.identity?.certificateSha1 || '') ||
+    !Array.isArray(policy.requiredVerifications) ||
+    REQUIRED_FINAL_VERIFICATIONS.some(
+      (verification) => !policy.requiredVerifications.includes(verification),
+    )
+  ) {
+    fail('macOS credential-island policy is incomplete');
+  }
+  return policy;
+}
+
+function assertCredentialIslandApplication(application) {
+  const contents = path.join(application, 'Contents');
+  const infoPlist = path.join(contents, 'Info.plist');
+  const executableDirectory = path.join(contents, 'MacOS');
+  if (!fs.existsSync(infoPlist) || !fs.statSync(infoPlist).isFile())
+    fail('credential-island application is missing Contents/Info.plist');
+  if (
+    !fs.existsSync(executableDirectory) ||
+    !fs.statSync(executableDirectory).isDirectory() ||
+    fs.readdirSync(executableDirectory).length === 0
+  )
+    fail('credential-island application is missing Contents/MacOS payload');
+}
+
 export function probeReleasePlatform({
   root = ROOT,
   platform = process.platform,
+  runCommand = (command, args) => run(command, args, root),
 }) {
   if (platform === 'darwin') {
     const applications = findApplications(
@@ -59,7 +116,16 @@ export function probeReleasePlatform({
       fail(
         `expected one packaged macOS application, found ${applications.length}`,
       );
-    run('codesign', [
+    if (credentialIslandPolicy(root)) {
+      assertCredentialIslandApplication(applications[0]);
+      return {
+        platform,
+        check: 'credential-island-application-structure',
+        finalSignature: 'deferred',
+        status: 'passed',
+      };
+    }
+    runCommand('codesign', [
       '--verify',
       '--deep',
       '--strict',

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -7,6 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 
+import { probeReleasePlatform } from './probe-release-platform.mjs';
 import {
   loadExecutionProfile,
   parseExecutionProfile,
@@ -15,6 +16,60 @@ import {
   releaseQualificationEnvironment,
   releaseQualificationStages,
 } from './run-release-qualification.mjs';
+
+function writeMacApplication(root) {
+  const application = path.join(
+    root,
+    'product',
+    'dist',
+    'desktop',
+    'mac-arm64',
+    'Kungfu Episodes.app',
+  );
+  fs.mkdirSync(path.join(application, 'Contents', 'MacOS'), {
+    recursive: true,
+  });
+  fs.writeFileSync(path.join(application, 'Contents', 'Info.plist'), 'plist\n');
+  fs.writeFileSync(
+    path.join(application, 'Contents', 'MacOS', 'Kungfu Episodes'),
+    'binary\n',
+  );
+  return application;
+}
+
+function writeCredentialIslandPolicy(root, overrides = {}) {
+  const policyPath = path.join(
+    root,
+    'docs',
+    'qualification',
+    'gates',
+    'macos-credential-island-policy.json',
+  );
+  fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+  fs.writeFileSync(
+    policyPath,
+    JSON.stringify({
+      schema: 'kungfu.macos-credential-island-policy/v1',
+      repository: 'kungfu-systems/kungfu',
+      environment: 'alpha-macos-signing',
+      platformId: 'macos-arm64',
+      app: { bundleId: 'com.kungfu.app', architecture: 'arm64' },
+      identity: {
+        teamId: 'AAAAAAAAAA',
+        certificateSha1: 'a'.repeat(40),
+      },
+      requiredVerifications: [
+        'codesignStrict',
+        'hardenedRuntime',
+        'appStaple',
+        'appGatekeeper',
+        'dmgStaple',
+        'dmgGatekeeper',
+      ],
+      ...overrides,
+    }),
+  );
+}
 
 test('qualification temp state is repository scoped on every platform', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-release-env-'));
@@ -45,6 +100,73 @@ test('cheap platform probe runs before every expensive qualification stage', () 
       releaseQualificationStages(platform)[0][0],
       'release:probe:platform',
     );
+  }
+});
+
+test('macOS platform probe defers final signature authority to the credential island', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-macos-probe-'));
+  try {
+    writeMacApplication(root);
+    writeCredentialIslandPolicy(root);
+    let codesignCalls = 0;
+    const report = probeReleasePlatform({
+      root,
+      platform: 'darwin',
+      runCommand: () => {
+        codesignCalls += 1;
+      },
+    });
+    assert.deepEqual(report, {
+      platform: 'darwin',
+      check: 'credential-island-application-structure',
+      finalSignature: 'deferred',
+      status: 'passed',
+    });
+    assert.equal(codesignCalls, 0);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('macOS platform probe keeps codesign verification without credential-island policy', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-macos-probe-'));
+  try {
+    const application = writeMacApplication(root);
+    const calls = [];
+    const report = probeReleasePlatform({
+      root,
+      platform: 'darwin',
+      runCommand: (...args) => calls.push(args),
+    });
+    assert.deepEqual(report, {
+      platform: 'darwin',
+      check: 'codesign-structure',
+      status: 'passed',
+    });
+    assert.deepEqual(calls, [
+      [
+        'codesign',
+        ['--verify', '--deep', '--strict', '--verbose=2', application],
+      ],
+    ]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('macOS platform probe fails closed on incomplete credential-island policy', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-macos-probe-'));
+  try {
+    writeMacApplication(root);
+    writeCredentialIslandPolicy(root, {
+      requiredVerifications: ['codesignStrict'],
+    });
+    assert.throws(
+      () => probeReleasePlatform({ root, platform: 'darwin' }),
+      /macOS credential-island policy is incomplete/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary

- treat the declared macOS credential island as the final signature authority
- keep the pre-sign release probe structural and fail closed on incomplete policy
- preserve local codesign verification when no credential-island policy is declared

## Verification

- `node --test scripts/run-release-qualification.test.mjs`
- `node --test scripts/alpha-promotion-preflight.test.mjs product/scripts/cli-surface-qualification.test.mjs scripts/upgrade-publication-admission.test.mjs`
- repository pre-commit `check:staged`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This restores the declared credential-island verification boundary without changing product or architecture contracts."
}
-->