### PR TITLE
fix(adr): close native source formatting in migration

### DIFF
--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -39,6 +39,7 @@ const FORMAT_CACHE = new Map();
 const FORMAT_CONFIG_PATHS = new Map();
 const FORMAT_CONFIG_DIRS = new Set();
 const FORMAT_BINARY_VERSIONS = new Map();
+const FORMAT_TOOL_COMMANDS = new Map();
 const CONTENT_ROOT_BOUND_ARTIFACTS = [
   '.xinfa/manifests/legacy-atlas-roots.json',
 ];
@@ -203,18 +204,50 @@ function lockedPythonToolVersion(lock, packageName) {
   return match[1];
 }
 
-/** @param {string} root @param {string} tool @param {string[]} args @param {string} input */
-function runLockedPythonTool(root, tool, args, input) {
+/** @param {string} root @param {string} tool @param {string} expectedVersion */
+function lockedPythonToolCommand(root, tool, expectedVersion) {
+  const key = `${ROOT}:${tool}:${expectedVersion}`;
+  if (FORMAT_TOOL_COMMANDS.has(key)) return FORMAT_TOOL_COMMANDS.get(key);
+  const candidates = [
+    { command: tool, prefix: [] },
+    {
+      command: 'uv',
+      prefix: [
+        'run',
+        '--project',
+        path.join(ROOT, 'framework/core'),
+        '--frozen',
+        tool,
+      ],
+    },
+  ];
+  const observed = [];
+  for (const candidate of candidates) {
+    const result = childProcess.spawnSync(
+      candidate.command,
+      [...candidate.prefix, '--version'],
+      { cwd: root, encoding: 'utf8', timeout: 30_000 },
+    );
+    const match = new RegExp(`${tool}(?: version)? (\\d+\\.\\d+\\.\\d+)`).exec(
+      `${result.stdout || ''}${result.stderr || ''}`,
+    );
+    if (match) observed.push(match[1]);
+    if (result.status === 0 && match?.[1] === expectedVersion) {
+      FORMAT_TOOL_COMMANDS.set(key, candidate);
+      return candidate;
+    }
+  }
+  throw new Error(
+    `ADR migration ${tool} version drift: expected ${expectedVersion}, got ${observed.join(', ') || '<unknown>'}`,
+  );
+}
+
+/** @param {string} root @param {string} tool @param {string[]} args @param {string} input @param {string} expectedVersion */
+function runLockedPythonTool(root, tool, args, input, expectedVersion) {
+  const selected = lockedPythonToolCommand(root, tool, expectedVersion);
   return childProcess.spawnSync(
-    'uv',
-    [
-      'run',
-      '--project',
-      path.join(ROOT, 'framework/core'),
-      '--frozen',
-      tool,
-      ...args,
-    ],
+    selected.command,
+    [...selected.prefix, ...args],
     {
       cwd: root,
       env: { ...process.env, NO_COLOR: '1' },
@@ -330,23 +363,6 @@ function formatRewrittenSource(root, rel, text, mode, formatting) {
   );
   if (FORMAT_CACHE.has(cacheKey)) return FORMAT_CACHE.get(cacheKey);
   if (mode === 'ruff' || mode === 'clang-format') {
-    const versionKey = `uv:${ROOT}:${mode}`;
-    let actualVersion = FORMAT_BINARY_VERSIONS.get(versionKey);
-    if (!actualVersion) {
-      const versionResult = runLockedPythonTool(root, mode, ['--version'], '');
-      const versionMatch = new RegExp(
-        `${mode}(?: version)? (\\d+\\.\\d+\\.\\d+)`,
-      ).exec(`${versionResult.stdout || ''}${versionResult.stderr || ''}`);
-      if (versionResult.status === 0 && versionMatch) {
-        actualVersion = versionMatch[1];
-        FORMAT_BINARY_VERSIONS.set(versionKey, actualVersion);
-      }
-    }
-    if (actualVersion !== policy.version) {
-      throw new Error(
-        `ADR migration ${mode} version drift: expected ${policy.version}, got ${actualVersion || '<unknown>'}`,
-      );
-    }
     const configPath = materializeFormatterConfig(
       policy.config,
       mode === 'ruff' ? 'pyproject.toml' : '.clang-format',
@@ -355,7 +371,7 @@ function formatRewrittenSource(root, rel, text, mode, formatting) {
       mode === 'ruff'
         ? ['format', '--config', configPath, '--stdin-filename', rel, '-']
         : [`-style=file:${configPath}`, `--assume-filename=${rel}`];
-    const result = runLockedPythonTool(root, mode, args, text);
+    const result = runLockedPythonTool(root, mode, args, text, policy.version);
     if (result.status !== 0) {
       throw new Error(
         `${mode} could not format rewritten ADR source ${rel}: ${String(result.stderr || result.stdout || '').trim()}`,

--- a/scripts/adr-migration.mjs
+++ b/scripts/adr-migration.mjs
@@ -33,6 +33,8 @@ const CURRENT_CONTEXT_QUALITY_CORPUS =
 const CURRENT_CONTEXT_QUALITY_QUALIFICATION =
   'crates/xinfa/qualification/context-quality-v1.json';
 const WEB_SOURCE = /\.(?:ts|tsx|js|jsx|mjs|cjs|json|jsonc|css)$/;
+const PYTHON_SOURCE = /\.py$/;
+const CPP_SOURCE = /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/;
 const FORMAT_CACHE = new Map();
 const FORMAT_CONFIG_PATHS = new Map();
 const FORMAT_CONFIG_DIRS = new Set();
@@ -186,17 +188,52 @@ function bytesDigest(value) {
 
 /** @param {string} rel */
 function sourceFormatMode(rel) {
-  return WEB_SOURCE.test(rel) ? 'biome' : 'none';
+  if (WEB_SOURCE.test(rel)) return 'biome';
+  if (PYTHON_SOURCE.test(rel)) return 'ruff';
+  if (CPP_SOURCE.test(rel)) return 'clang-format';
+  return 'none';
 }
 
-/** @param {Buffer} config */
-function materializeBiomeConfig(config) {
-  const root = bytesDigest(config);
+/** @param {Buffer} lock @param {string} packageName */
+function lockedPythonToolVersion(lock, packageName) {
+  const match = new RegExp(
+    `(?:^|\\n)name = "${packageName}"\\nversion = "([^"]+)"(?:\\n|$)`,
+  ).exec(lock.toString('utf8'));
+  if (!match) throw new Error(`uv.lock does not pin ${packageName}`);
+  return match[1];
+}
+
+/** @param {string} root @param {string} tool @param {string[]} args @param {string} input */
+function runLockedPythonTool(root, tool, args, input) {
+  return childProcess.spawnSync(
+    'uv',
+    [
+      'run',
+      '--project',
+      path.join(ROOT, 'framework/core'),
+      '--frozen',
+      tool,
+      ...args,
+    ],
+    {
+      cwd: root,
+      env: { ...process.env, NO_COLOR: '1' },
+      input,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 30_000,
+    },
+  );
+}
+
+/** @param {Buffer} config @param {string} [name] */
+function materializeFormatterConfig(config, name = 'biome.json') {
+  const root = bytesDigest(Buffer.concat([Buffer.from(`${name}\0`), config]));
   if (FORMAT_CONFIG_PATHS.has(root)) return FORMAT_CONFIG_PATHS.get(root);
   const dir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-adr-migration-biome-'),
   );
-  const file = path.join(dir, 'biome.json');
+  const file = path.join(dir, name);
   fs.writeFileSync(file, config);
   FORMAT_CONFIG_DIRS.add(dir);
   FORMAT_CONFIG_PATHS.set(root, file);
@@ -271,24 +308,65 @@ process.once('exit', () => {
  * @param {string} root
  * @param {string} rel
  * @param {string} text
- * @param {'biome' | 'none'} mode
- * @param {Buffer} config
- * @param {string} expectedVersion
+ * @param {'biome' | 'ruff' | 'clang-format' | 'none'} mode
+ * @param {{biome: {config: Buffer, version: string}, ruff: {config: Buffer, version: string}, clangFormat: {config: Buffer, version: string}}} formatting
  */
-function formatRewrittenSource(root, rel, text, mode, config, expectedVersion) {
+function formatRewrittenSource(root, rel, text, mode, formatting) {
   if (mode === 'none') return text;
-  if (mode !== 'biome') throw new Error(`unknown source format mode: ${mode}`);
-  if (!Buffer.isBuffer(config) || config.length === 0) {
-    throw new Error('Biome configuration is missing from the source snapshot');
-  }
+  if (!['biome', 'ruff', 'clang-format'].includes(mode))
+    throw new Error(`unknown source format mode: ${mode}`);
+  const policy =
+    mode === 'clang-format' ? formatting.clangFormat : formatting[mode];
+  if (!Buffer.isBuffer(policy?.config) || policy.config.length === 0)
+    throw new Error(
+      `${mode} configuration is missing from the source snapshot`,
+    );
   const cacheKey = bytesDigest(
     Buffer.concat([
-      config,
-      Buffer.from(`\0${rel}\0`, 'utf8'),
+      policy.config,
+      Buffer.from(`\0${mode}\0${policy.version}\0${rel}\0`, 'utf8'),
       Buffer.from(text, 'utf8'),
     ]),
   );
   if (FORMAT_CACHE.has(cacheKey)) return FORMAT_CACHE.get(cacheKey);
+  if (mode === 'ruff' || mode === 'clang-format') {
+    const versionKey = `uv:${ROOT}:${mode}`;
+    let actualVersion = FORMAT_BINARY_VERSIONS.get(versionKey);
+    if (!actualVersion) {
+      const versionResult = runLockedPythonTool(root, mode, ['--version'], '');
+      const versionMatch = new RegExp(
+        `${mode}(?: version)? (\\d+\\.\\d+\\.\\d+)`,
+      ).exec(`${versionResult.stdout || ''}${versionResult.stderr || ''}`);
+      if (versionResult.status === 0 && versionMatch) {
+        actualVersion = versionMatch[1];
+        FORMAT_BINARY_VERSIONS.set(versionKey, actualVersion);
+      }
+    }
+    if (actualVersion !== policy.version) {
+      throw new Error(
+        `ADR migration ${mode} version drift: expected ${policy.version}, got ${actualVersion || '<unknown>'}`,
+      );
+    }
+    const configPath = materializeFormatterConfig(
+      policy.config,
+      mode === 'ruff' ? 'pyproject.toml' : '.clang-format',
+    );
+    const args =
+      mode === 'ruff'
+        ? ['format', '--config', configPath, '--stdin-filename', rel, '-']
+        : [`-style=file:${configPath}`, `--assume-filename=${rel}`];
+    const result = runLockedPythonTool(root, mode, args, text);
+    if (result.status !== 0) {
+      throw new Error(
+        `${mode} could not format rewritten ADR source ${rel}: ${String(result.stderr || result.stdout || '').trim()}`,
+      );
+    }
+    const formatted = String(result.stdout);
+    FORMAT_CACHE.set(cacheKey, formatted);
+    return formatted;
+  }
+  const config = policy.config;
+  const expectedVersion = policy.version;
   const binary = biomeBinary(root);
   const actualVersion = biomeVersion(binary);
   if (!expectedVersion || actualVersion !== expectedVersion) {
@@ -301,7 +379,7 @@ function formatRewrittenSource(root, rel, text, mode, config, expectedVersion) {
     [
       'format',
       '--config-path',
-      materializeBiomeConfig(config),
+      materializeFormatterConfig(config),
       '--vcs-enabled=false',
       '--stdin-file-path',
       rel,
@@ -339,9 +417,8 @@ function formatRewrittenSource(root, rel, text, mode, config, expectedVersion) {
  * @param {Map<string, {id: string, path: string, targetId: string, targetPath: string}>} mappings
  * @param {string} rewriteModeValue
  * @param {{beforeRoot: string, afterRoot: string}[]} revisions
- * @param {'biome' | 'none'} formatMode
- * @param {Buffer} config
- * @param {string} expectedVersion
+ * @param {'biome' | 'ruff' | 'clang-format' | 'none'} formatMode
+ * @param {{biome: {config: Buffer, version: string}, ruff: {config: Buffer, version: string}, clangFormat: {config: Buffer, version: string}}} formatting
  */
 function rewriteAndFormat(
   root,
@@ -351,16 +428,14 @@ function rewriteAndFormat(
   rewriteModeValue,
   revisions,
   formatMode,
-  config,
-  expectedVersion,
+  formatting,
 ) {
   return formatRewrittenSource(
     root,
     rel,
     rewriteForMode(text, mappings, rewriteModeValue, revisions),
     formatMode,
-    config,
-    expectedVersion,
+    formatting,
   );
 }
 
@@ -592,6 +667,22 @@ export function createAdrMigrationPlan(options = {}) {
       `package.json does not pin an exact Biome version in ${commit}`,
     );
   }
+  const pythonConfig = snapshot.get('framework/core/pyproject.toml');
+  const pythonLock = snapshot.get('framework/core/uv.lock');
+  const clangConfig = snapshot.get('.clang-format');
+  if (!pythonConfig || !pythonLock || !clangConfig) {
+    throw new Error(`native formatter policy is missing from ${commit}`);
+  }
+  const ruffVersion = lockedPythonToolVersion(pythonLock, 'ruff');
+  const clangFormatVersion = lockedPythonToolVersion(
+    pythonLock,
+    'clang-format',
+  );
+  const formatting = {
+    biome: { config: biomeConfig, version: biomeVersion },
+    ruff: { config: pythonConfig, version: ruffVersion },
+    clangFormat: { config: clangConfig, version: clangFormatVersion },
+  };
   if (!files.includes(INVENTORY)) {
     throw new Error(`${INVENTORY} is missing from ${commit}`);
   }
@@ -678,8 +769,7 @@ export function createAdrMigrationPlan(options = {}) {
             'full',
             [],
             sourceFormatMode(row.path),
-            biomeConfig,
-            biomeVersion,
+            formatting,
           ),
         ),
       };
@@ -710,8 +800,7 @@ export function createAdrMigrationPlan(options = {}) {
             rewriteMode(rel),
             [],
             sourceFormatMode(rel),
-            biomeConfig,
-            biomeVersion,
+            formatting,
           ),
         ),
       };
@@ -786,8 +875,7 @@ export function createAdrMigrationPlan(options = {}) {
       rel,
       rewritten,
       formatMode,
-      biomeConfig,
-      biomeVersion,
+      formatting,
     );
     const row = {
       path: rel,
@@ -852,6 +940,14 @@ export function createAdrMigrationPlan(options = {}) {
       webSourceFormatting: {
         mode: 'biome-stdin-repository-policy-v1',
         version: biomeVersion,
+      },
+      pythonSourceFormatting: {
+        mode: 'ruff-stdin-repository-policy-v1',
+        version: ruffVersion,
+      },
+      cppSourceFormatting: {
+        mode: 'clang-format-stdin-repository-policy-v1',
+        version: clangFormatVersion,
       },
     },
     mappings: [...mappings.values()].sort((left, right) =>
@@ -958,6 +1054,20 @@ export function applyAdrMigrationPlan(root, plan, expectedSourceRoot = '') {
   if (String(git(root, ['status', '--porcelain'])).trim()) {
     throw new Error('working checkout must be clean before migration apply');
   }
+  const formatting = {
+    biome: {
+      config: fs.readFileSync(path.join(root, 'biome.json')),
+      version: String(plan.policy?.webSourceFormatting?.version || ''),
+    },
+    ruff: {
+      config: fs.readFileSync(path.join(root, 'framework/core/pyproject.toml')),
+      version: String(plan.policy?.pythonSourceFormatting?.version || ''),
+    },
+    clangFormat: {
+      config: fs.readFileSync(path.join(root, '.clang-format')),
+      version: String(plan.policy?.cppSourceFormatting?.version || ''),
+    },
+  };
   for (const row of plan.transformations) {
     const source = path.join(root, row.path);
     const target = path.join(root, row.targetPath);
@@ -972,8 +1082,7 @@ export function applyAdrMigrationPlan(root, plan, expectedSourceRoot = '') {
         ...(plan.artifactRevisionMappings || []),
       ],
       row.formatMode || 'none',
-      fs.readFileSync(path.join(root, 'biome.json')),
-      String(plan.policy?.webSourceFormatting?.version || ''),
+      formatting,
     );
     if (bytesDigest(rewritten) !== row.afterRoot) {
       throw new Error(`migration algorithm drifted for ${row.path}`);

--- a/scripts/adr-migration.test.mjs
+++ b/scripts/adr-migration.test.mjs
@@ -79,6 +79,17 @@ function fixture() {
     'package.json',
     `${JSON.stringify({ devDependencies: { '@biomejs/biome': '1.9.4' } }, null, 2)}\n`,
   );
+  write(
+    root,
+    'framework/core/pyproject.toml',
+    '[tool.ruff]\nline-length = 88\n[tool.ruff.format]\nquote-style = "double"\n',
+  );
+  write(
+    root,
+    'framework/core/uv.lock',
+    'name = "clang-format"\nversion = "20.1.8"\n\nname = "ruff"\nversion = "0.15.20"\n',
+  );
+  write(root, '.clang-format', 'BasedOnStyle: Google\nColumnLimit: 120\n');
   const records = [
     { id: 'ADR-0001', path: 'docs/adr/ADR-0001-first.md' },
     { id: 'SHIFU-ADR-0002', path: 'docs/adr/SHIFU-ADR-0002-second.md' },
@@ -181,6 +192,16 @@ function fixture() {
     root,
     'scripts/format-sensitive.mjs',
     "console.error('ADR-0001 boundary violation must remain source-formatted after identity migration');\n",
+  );
+  write(
+    root,
+    'scripts/format-sensitive.py',
+    '@command(help="ADR-0001 boundary violation must remain source-formatted after identity migration")\ndef run():\n    pass\n',
+  );
+  write(
+    root,
+    'framework/core/format-sensitive.cpp',
+    'void fail() { throw Error("ADR-0001 boundary violation must remain source-formatted after identity migration"); }\n',
   );
   write(root, '.gitignore', '# ADR-0001\n');
   write(root, 'shifu', '# ADR-0001; docs/adr/ADR-0001-first.md\n');
@@ -347,6 +368,18 @@ test('plans deterministic ID-only renames from an exact Git tree', () => {
       (row) => row.path === 'scripts/format-sensitive.mjs',
     )?.formatMode,
     'biome',
+  );
+  assert.equal(
+    first.transformations.find(
+      (row) => row.path === 'scripts/format-sensitive.py',
+    )?.formatMode,
+    'ruff',
+  );
+  assert.equal(
+    first.transformations.find(
+      (row) => row.path === 'framework/core/format-sensitive.cpp',
+    )?.formatMode,
+    'clang-format',
   );
   const preserved = new Map(
     first.preserved.map((row) => [row.path, row.lifecycle]),


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Close deterministic Python and C/C++ source formatting inside ADR migration plan and apply roots"}
-->

## Summary

- bind ADR migration Python formatting to the source snapshot Ruff lock and pyproject policy
- bind C/C++ formatting to the source snapshot clang-format lock and style policy
- support exact preinstalled CI formatters with a locked uv fallback
- include formatted Python/C++ bytes in deterministic afterRoot closure
- add migration fixtures covering both source families

## Verification

- `./shifu adr:migrate:test` (9/9)
- direct preinstalled Ruff/clang-format test lane (9/9)
- two byte-identical real-repository migration plans, 0 problems
- `./shifu check:source`

ADR-neutral migration tooling fix.