### PR TITLE
fix(ci): consume credential upload workflow shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@b89d903a87ca67041216c0f46b3f0912063789f8 # PR #1572 matrix fail-fast policy
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4 # PR #1582 credential input upload transport
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -52,10 +52,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@b89d903a87ca67041216c0f46b3f0912063789f8 # PR #1572 matrix fail-fast policy
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4 # PR #1582 credential input upload transport
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: b89d903a87ca67041216c0f46b3f0912063789f8
+      buildchain-ref: 69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:f86482b6bfa82d603635ad59a2e6b6cd213abfba7a28cef4ebcd73639f3b355a",
+          "definitionDigest": "sha256:dc237d6d053fd4ae904848f08850fdcb46a80356ec549def4275b6aeb1d74dcf",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -744,7 +744,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@b89d903a87ca67041216c0f46b3f0912063789f8"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4"
           ],
           "steps": []
         },
@@ -1846,7 +1846,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:263b5abc01b69c715fe4994642d0913fa6a6826bf781b4759995b00a4f44ddbb",
+          "definitionDigest": "sha256:eace38e984318a0faef83cd6508554eba900c2f47ed96715c51de0e5040533e0",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1859,7 +1859,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@b89d903a87ca67041216c0f46b3f0912063789f8"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -439,7 +439,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@b89d903a87ca67041216c0f46b3f0912063789f8",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -521,14 +521,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@b89d903a87ca67041216c0f46b3f0912063789f8",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "b89d903a87ca67041216c0f46b3f0912063789f8",
+          "buildchain-ref": "69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "b89d903a87ca67041216c0f46b3f0912063789f8",
+    "workflow_shell_sha": "69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
     "alpha": {
       "workflow_ref": "v2-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",

--- a/scripts/affected-native-proof.mjs
+++ b/scripts/affected-native-proof.mjs
@@ -9,7 +9,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
-export const IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v2';
+export const IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v3';
 export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v1';
 export const WORKFLOW_PATH = '.github/workflows/affected-native-pr.yml';
 export const DEFAULT_MAX_AGE_SECONDS = 6 * 60 * 60;
@@ -100,6 +100,17 @@ function validateNativeToolchain(toolchain, requireHosted = false) {
   return toolchain;
 }
 
+export function nativeToolchainIdentity(toolchain, requireHosted = false) {
+  validateNativeToolchain(toolchain, requireHosted);
+  const { imageVersion: _imageVersion, ...runner } = toolchain.runner;
+  return {
+    compiler: toolchain.compiler,
+    cmake: toolchain.cmake,
+    ninja: toolchain.ninja,
+    runner,
+  };
+}
+
 export function validatePlan(plan) {
   if (plan?.schema !== 'kungfu.core-affected-native-plan/v1') {
     throw new Error('unsupported affected-native plan schema');
@@ -145,7 +156,7 @@ export function createProofDescriptor(
     planProjectionDigest: digest(projection),
     partitionCount,
     platformTier: plan.platformTier,
-    toolchain,
+    toolchain: nativeToolchainIdentity(toolchain, nativeRequired),
   };
   const proofId = digest(identity).slice('sha256:'.length);
   return {
@@ -230,7 +241,7 @@ export function validateCoreReceipt(receipt, descriptor) {
     }
     validateNativeToolchain(receipt.toolchain, true);
     if (
-      stableJson(receipt.toolchain) !==
+      stableJson(nativeToolchainIdentity(receipt.toolchain, true)) !==
       stableJson(descriptor.identity.toolchain)
     ) {
       throw new Error('affected-native receipt toolchain identity drift');

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import {
   createProofDescriptor,
   digest,
+  nativeToolchainIdentity,
   sealProof,
   selectReusableArtifact,
   verifyProofBundle,
@@ -179,13 +180,52 @@ test('descriptor binds the exact tree, base, plan projection, and toolchain', ()
       compiler: 'g++-14 changed',
     }).proofId,
   );
-  assert.notEqual(
+  assert.equal(
     first.proofId,
     createProofDescriptor(plan(HEAD), TREE, 2, {
       ...TOOLCHAIN,
       runner: { ...TOOLCHAIN.runner, imageVersion: '20260721.2.0' },
     }).proofId,
   );
+  assert.notEqual(
+    first.proofId,
+    createProofDescriptor(plan(HEAD), TREE, 2, {
+      ...TOOLCHAIN,
+      runner: { ...TOOLCHAIN.runner, imageOS: 'ubuntu26' },
+    }).proofId,
+  );
+  assert.deepEqual(
+    first.identity.toolchain,
+    nativeToolchainIdentity(TOOLCHAIN),
+  );
+});
+
+test('hosted image rollout preserves proof compatibility and receipt facts', () => {
+  const value = fixture();
+  const descriptor = createProofDescriptor(value.value, TREE, 2, TOOLCHAIN);
+  const receiptPath = path.join(value.inputs, 'partition-1', 'receipt.json');
+  const rolled = receipt(value.value, 1);
+  rolled.toolchain = {
+    ...TOOLCHAIN,
+    runner: { ...TOOLCHAIN.runner, imageVersion: '20260721.2.0' },
+  };
+  fs.writeFileSync(receiptPath, `${JSON.stringify(rolled, null, 2)}\n`);
+  const proof = sealProof(descriptor, value.inputs, producer());
+  assert.equal(
+    proof.partitions[1].toolchain.runner.imageVersion,
+    '20260721.2.0',
+  );
+
+  rolled.toolchain = {
+    ...TOOLCHAIN,
+    runner: { ...TOOLCHAIN.runner, imageOS: 'ubuntu26' },
+  };
+  fs.writeFileSync(receiptPath, `${JSON.stringify(rolled, null, 2)}\n`);
+  assert.throws(
+    () => sealProof(descriptor, value.inputs, producer()),
+    /toolchain identity drift/,
+  );
+  fs.rmSync(value.root, { recursive: true, force: true });
 });
 
 test('complete partition evidence seals and verifies against the exact producer', () => {
@@ -517,6 +557,6 @@ test('workflow keeps one required context while staging authoritative queue buil
   assert.match(verifier, /run\?\.head_sha === headSha/u);
   assert.match(
     verifier,
-    /stableJson\(receipt\.toolchain\) !==\s+stableJson\(descriptor\.identity\.toolchain/u,
+    /stableJson\(nativeToolchainIdentity\(receipt\.toolchain, true\)\) !==\s+stableJson\(descriptor\.identity\.toolchain/u,
   );
 });


### PR DESCRIPTION
## Summary

- pin Build and release promotion to the reviewed Buildchain `v2.14.17-alpha.9` workflow shell
- consume the credential-island input upload transport fix from Buildchain PR #1582
- refresh the closed-world workflow authority and binding contracts atomically
- admit GitHub-hosted runner image rollouts without weakening OS, architecture, compiler, CMake, or Ninja identity checks

## Queue finding

The first authoritative queue run, `30038897328`, completed both affected-native partitions successfully, then exposed a nondeterministic cross-job identity mismatch: the probe job ran image `20260720.247.2`, while both partition jobs ran image `20260714.240.1`. GitHub can assign independent jobs from adjacent hosted image rollout revisions.

The v3 proof identity excludes only volatile `runner.imageVersion` from cross-job compatibility. Every partition receipt still retains the observed image version, and stable runner/toolchain drift remains fail-closed. The actual failed-run artifacts replayed successfully with proof root `sha256:bea38fe2a86460abf1af5a275bd12a212aa02e828357b02832d21a1e2c007dd5`.

## Verification

- `./shifu check:gate-catalog`
- `node --test scripts/release-promotion-rehearsal.test.mjs`
- `node --test scripts/affected-native-proof.test.mjs` (8/8)
- replay of both real partition receipts from queue run `30038897328`
- `./shifu check:source`
- repository pre-commit `check:staged`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This updates one reviewed immutable Buildchain workflow shell and corrects volatile hosted-runner proof identity without changing Kungfu product or architecture contracts."
}
-->