### PR TITLE
fix(cli): refresh generated surface authority

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+        "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+        "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+        "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98",
+      "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+            "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "a68b65d81b311ef96df442d5f1a0f08edf5be187",
+    "sourceSha": "33722e46383d46a92647f8c8aa308e714ae5c4a9",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:d7e8812fc600f25b37fe5e58f0bc554135fb7f043294b95d21184fccd6405f5f"
   },

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+        "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+        "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+        "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98",
+      "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "30867ed7bfd5e3daaf09f23ee6c62128ba347c5be7303c4957dda075a745df98"
+            "sha256": "d00c400eec78ca59a20c8330ee3a72b6e2de3baae11dff4843b39932c2472740"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
+++ b/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
@@ -1,7 +1,7 @@
 {
-  "catalogRoot": "sha256:acc1643dce627fa10222da77f7cdaaf18e10a297d25035f7373c546e48b0482f",
+  "catalogRoot": "sha256:4f4b82c845d1fe144c94a33532eed9f17f03d42b4136251465aa10b704c2465c",
   "contractId": "kungfu-cli-surface",
-  "contractRoot": "sha256:62772a1a36f184c4ed560530302c11b4dff0169caf38969b827f20b80f04ee8c",
+  "contractRoot": "sha256:c53be7dedc6c191d64fd5e45562857b9e667c46a7c1b4383910b6d6dae41be4d",
   "kfd3Linkage": [
     {
       "apiIds": [],
@@ -2817,11 +2817,11 @@
       "kfd3Registry": "strict-link",
       "packagedInventory": "required-agent-pack-entry"
     },
-    "expectedSurfaceRoot": "sha256:61afbef227829a78743b9e8c8b28a88ed401b0afeeb52edf04e83bf3c8b3f9c1",
+    "expectedSurfaceRoot": "sha256:cb6096f63b1706d699baa13d3fb819aee789bc4b1088534bfe62eabd17ef615f",
     "regeneration": "./shifu fix:cli-catalog-parity",
     "validation": "./shifu check:cli-catalog-parity"
   },
-  "registryRoot": "sha256:a9f59bdcced68877c22bd3967b0932dd96fecebd5bdd453112e4c299038c0102",
+  "registryRoot": "sha256:6c2a48d7b55255c70afb9b53b9ec3460f4cd245566f54dc8effd969379e75de1",
   "schema": "kungfu.cli-surface-catalog/v1",
   "schemaRoot": "sha256:731eec25990d090067d59651d6c0793934124ac79df4111990bd905e03b605c4",
   "source": {
@@ -2834,7 +2834,7 @@
     "pathAuthority": "live-click-tree",
     "root": "kungfu"
   },
-  "surfaceRoot": "sha256:61afbef227829a78743b9e8c8b28a88ed401b0afeeb52edf04e83bf3c8b3f9c1",
+  "surfaceRoot": "sha256:cb6096f63b1706d699baa13d3fb819aee789bc4b1088534bfe62eabd17ef615f",
   "surfaces": [
     {
       "alias_diagnostics": [],
@@ -18179,6 +18179,17 @@
           "hidden": false,
           "kind": "option",
           "name": "depends_on",
+          "required": false,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--owning-workspace-identity-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "owning_workspace_identity_root",
           "required": false,
           "type": "text"
         },

--- a/framework/core/src/python/kungfu/cli/surface_contract.registry.json
+++ b/framework/core/src/python/kungfu/cli/surface_contract.registry.json
@@ -160,7 +160,7 @@
   "catalogProjection": {
     "artifact": "kungfu.agent/cli_surface.catalog.json",
     "authority": "runtime-fold",
-    "expectedSurfaceRoot": "sha256:61afbef227829a78743b9e8c8b28a88ed401b0afeeb52edf04e83bf3c8b3f9c1",
+    "expectedSurfaceRoot": "sha256:cb6096f63b1706d699baa13d3fb819aee789bc4b1088534bfe62eabd17ef615f",
     "consumers": {
       "agentCapabilities": "embed-complete",
       "agentCommands": "strict-link",


### PR DESCRIPTION
## Summary

- refresh the checked-in CLI surface catalog after the `create-go` option expansion
- refresh the exact projected surface root and dependent KFD evidence
- restore equality between installed human help roots and Agent capabilities

## Failure evidence

Alpha diagnostic Build run `30042835074` failed closed during product dist with `human help roots do not match the Agent catalog`; the credential-island signing job was safely skipped.

## Verification

- `./shifu check:cli-catalog-parity`
- live `help_projection` and Agent catalog root equality assertion
- `node --test product/scripts/cli-surface-qualification.test.mjs`
- `./shifu check:source`
- repository pre-commit `check:staged`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This refreshes generated CLI and KFD projections after an already-merged additive option; it does not change product or architecture semantics."
}
-->