### PR TITLE
fix(ci): pin direct macOS credential upload runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4 # PR #1582 credential input upload transport
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f # PR #1585 direct credential input upload
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -52,10 +52,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4 # PR #1582 credential input upload transport
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f # PR #1585 direct credential input upload
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4
+      buildchain-ref: 8aa540bc2bed4a94b3755c7328bef70ee40de80f
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:dc237d6d053fd4ae904848f08850fdcb46a80356ec549def4275b6aeb1d74dcf",
+          "definitionDigest": "sha256:30d081fa397c54c1bb6dbd96991c096d8f9ff3a9b99e25afc8f21411af3f3e21",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -744,7 +744,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f"
           ],
           "steps": []
         },
@@ -1846,7 +1846,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:eace38e984318a0faef83cd6508554eba900c2f47ed96715c51de0e5040533e0",
+          "definitionDigest": "sha256:2cf0767324a89b78b69919c280a8254d32ff19dea2571a9bcfaf2c50cbec095a",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1859,7 +1859,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -439,7 +439,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -521,14 +521,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
+          "buildchain-ref": "8aa540bc2bed4a94b3755c7328bef70ee40de80f",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "69a8c14f2d5c50af6fd0295393f43aaaeee6a0b4",
+    "workflow_shell_sha": "8aa540bc2bed4a94b3755c7328bef70ee40de80f",
     "alpha": {
       "workflow_ref": "v2-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",


### PR DESCRIPTION
## Summary

- pin the alpha Build and release-promotion consumers to Buildchain `v2.14.18-alpha.0` (`8aa540bc2bed4a94b3755c7328bef70ee40de80f`)
- adopt the direct single-file credential-island upload transport from Buildchain PR #1584/#1585
- refresh the source-bound workflow authority, workflow bindings, and promotion rehearsal contract

## Failure evidence

Mac-only Build run `30046454214` failed twice while streaming the redundant outer artifact archive (`write EPIPE`); the sealed unsigned ZIP had already been built and verified, and the signer job did not start.

## Verification

- `./shifu check:gate-catalog`
- `node --test scripts/release-promotion-rehearsal.test.mjs` (9/9)
- `./shifu check:source`
- repository pre-commit `check:staged`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This updates an immutable Buildchain runtime pin and its generated workflow authority projections without changing Kungfu product or architecture semantics."
}
-->