### PR TITLE
fix(assignment): preserve native admission diagnostics

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -81,6 +81,18 @@ def _runtime(workspace_root="", home=False, operation_class="semantic-write"):
         }
     else:
         receipt = prepare_workspace_write(target, "assignment-orchestration")
+        target = resolve_workspace_target(
+            operation_class,
+            workspace_root or None,
+            home=home,
+            cwd=os.getcwd(),
+        )
+        identity = target.identity
+        if (
+            not identity.initialized
+            or identity.identity_root != receipt["workspace_identity_root"]
+        ):
+            raise RuntimeError("Assignment workspace identity did not stabilize")
     return identity, target.runtime_dir, receipt
 
 

--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -50,6 +50,8 @@ def _failure(code, error, next_actions=None):
 def _run(operation):
     try:
         return operation()
+    except click.exceptions.Exit:
+        raise
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         _failure("assignment-operation-failed", error)
         raise click.exceptions.Exit(2) from error

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime, timedelta, timezone
+import importlib
 import json
 from pathlib import Path
 import shutil
 from types import SimpleNamespace
 
+import click
 import kungfu
 import pytest
 
@@ -24,6 +26,7 @@ from kungfu.workspace_federation import (
 
 
 SOURCE = Path(__file__).resolve().parents[4] / "extensions" / "mission-control"
+ASSIGNMENT_CLI = importlib.import_module("kungfu.cli.commands.assignment")
 
 
 def _activate(runtime):
@@ -44,6 +47,17 @@ def _activate(runtime):
                 contract["decisionCard"], "approve", "test-owner"
             ),
         )
+
+
+def test_cli_run_preserves_an_intentional_machine_readable_exit(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(ASSIGNMENT_CLI, "_emit", emitted.append)
+
+    with pytest.raises(click.exceptions.Exit) as failure:
+        ASSIGNMENT_CLI._run(lambda: (_ for _ in ()).throw(click.exceptions.Exit(3)))
+
+    assert failure.value.exit_code == 3
+    assert emitted == []
 
 
 def test_source_root_recovers_checkout_from_assembled_binding(tmp_path):

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -60,6 +60,15 @@ def test_cli_run_preserves_an_intentional_machine_readable_exit(monkeypatch):
     assert emitted == []
 
 
+def test_cli_runtime_refreshes_a_new_workspace_identity(tmp_path):
+    identity, runtime_dir, receipt = ASSIGNMENT_CLI._runtime(str(tmp_path))
+
+    assert identity.initialized is True
+    assert identity.identity_state == "qualified"
+    assert identity.identity_root == receipt["workspace_identity_root"]
+    assert Path(runtime_dir).is_dir()
+
+
 def test_source_root_recovers_checkout_from_assembled_binding(tmp_path):
     checkout = tmp_path / "kungfu"
     checkout.mkdir()

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -60,7 +60,8 @@ def test_cli_run_preserves_an_intentional_machine_readable_exit(monkeypatch):
     assert emitted == []
 
 
-def test_cli_runtime_refreshes_a_new_workspace_identity(tmp_path):
+def test_cli_runtime_refreshes_a_new_workspace_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("KF_CONFIG_HOME", str(tmp_path / "config"))
     identity, runtime_dir, receipt = ASSIGNMENT_CLI._runtime(str(tmp_path))
 
     assert identity.initialized is True

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -3,6 +3,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -45,6 +46,50 @@ test('allows one explicitly justified implementation command', () => {
 
 test('current participant surfaces satisfy the contract', () => {
   assert.deepEqual(checkRoot(ROOT), []);
+});
+
+test('cold source Assignment failure remains machine-actionable', (t) => {
+  const temp = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-shifu-assignment-'),
+  );
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
+  const launcher = path.join(temp, 'shifu');
+  fs.copyFileSync(path.join(ROOT, 'shifu'), launcher);
+  fs.chmodSync(launcher, 0o755);
+
+  const result = spawnSync(launcher, ['assignment', 'status'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: temp,
+      XDG_CONFIG_HOME: path.join(temp, 'config'),
+    },
+  });
+  assert.equal(result.status, 127);
+  assert.equal(result.stderr, '');
+  assert.deepEqual(JSON.parse(result.stdout), {
+    schema: 'kungfu.assignment-orchestration.diagnosis/v1',
+    ok: false,
+    code: 'assignment-current-checkout-binding-missing',
+    message: 'Assignment admission requires pykungfu from the current checkout',
+    next_actions: [
+      {
+        action: 'build-core',
+        command: './shifu build:core',
+        description: 'Assemble pykungfu from the current checkout',
+      },
+    ],
+  });
+});
+
+test('Windows cold source Assignment failure carries the same diagnosis', () => {
+  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  assert.match(
+    windows,
+    /"code":"assignment-current-checkout-binding-missing"/u,
+  );
+  assert.match(windows, /"action":"build-core"/u);
+  assert.match(windows, /"command":"shifu\.cmd build:core"/u);
 });
 
 test('cache execution boundaries distinguish gate run and source acceptance', () => {

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -82,6 +82,28 @@ test('cold source Assignment failure remains machine-actionable', (t) => {
   });
 });
 
+test('partial Core assembly cannot masquerade as Assignment readiness', (t) => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-shifu-partial-'));
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
+  const launcher = path.join(temp, 'shifu');
+  const dist = path.join(temp, 'framework', 'core', 'dist', 'kungfu');
+  fs.mkdirSync(dist, { recursive: true });
+  fs.copyFileSync(path.join(ROOT, 'shifu'), launcher);
+  fs.chmodSync(launcher, 0o755);
+  fs.writeFileSync(path.join(dist, 'pykungfu.partial.so'), '');
+
+  const result = spawnSync(launcher, ['assignment', 'status'], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: temp },
+  });
+  assert.equal(result.status, 127);
+  assert.equal(result.stderr, '');
+  assert.equal(
+    JSON.parse(result.stdout).code,
+    'assignment-current-checkout-binding-missing',
+  );
+});
+
 test('Windows cold source Assignment failure carries the same diagnosis', () => {
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
   assert.match(
@@ -90,6 +112,7 @@ test('Windows cold source Assignment failure carries the same diagnosis', () => 
   );
   assert.match(windows, /"action":"build-core"/u);
   assert.match(windows, /"command":"shifu\.cmd build:core"/u);
+  assert.match(windows, /kungfubuildinfo\.json/u);
 });
 
 test('cache execution boundaries distinguish gate run and source acceptance', () => {

--- a/shifu
+++ b/shifu
@@ -269,11 +269,20 @@ if [ "${1:-}" = "assignment" ]; then
       exit 127
     fi
   fi
-  _kungfu_checkout_bin="./framework/core/dist/kungfu/kungfu"
-  if [ -x "$_kungfu_checkout_bin" ]; then
-    exec "$_kungfu_checkout_bin" assignment "$@"
+  _kungfu_checkout_binding=""
+  for _candidate in \
+    ./framework/core/dist/kungfu/pykungfu*.so \
+    ./framework/core/dist/kungfu/pykungfu*.pyd; do
+    if [ -f "$_candidate" ]; then
+      _kungfu_checkout_binding="$_candidate"
+      break
+    fi
+  done
+  if [ -n "$_kungfu_checkout_binding" ] && command -v uv >/dev/null 2>&1; then
+    cd ./framework/core
+    exec uv run --frozen python .devtools/kungfu_cli.py assignment "$@"
   fi
-  echo "shifu: assignment admission requires the current source CLI; run ./shifu build:core" >&2
+  printf '%s\n' '{"schema":"kungfu.assignment-orchestration.diagnosis/v1","ok":false,"code":"assignment-current-checkout-binding-missing","message":"Assignment admission requires pykungfu from the current checkout","next_actions":[{"action":"build-core","command":"./shifu build:core","description":"Assemble pykungfu from the current checkout"}]}'
   exit 127
 fi
 

--- a/shifu
+++ b/shifu
@@ -278,7 +278,10 @@ if [ "${1:-}" = "assignment" ]; then
       break
     fi
   done
-  if [ -n "$_kungfu_checkout_binding" ] && command -v uv >/dev/null 2>&1; then
+  _kungfu_checkout_build_info="./framework/core/dist/kungfu/kungfubuildinfo.json"
+  if [ -n "$_kungfu_checkout_binding" ] \
+    && [ -f "$_kungfu_checkout_build_info" ] \
+    && command -v uv >/dev/null 2>&1; then
     cd ./framework/core
     exec uv run --frozen python .devtools/kungfu_cli.py assignment "$@"
   fi

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -130,13 +130,15 @@ set "_KFC_ASSIGNMENT_ARGS=!_KFC_ASSIGNMENT_ARGS:* =!"
 if /i "%~2"=="capture" goto assignmentcapture
 if /i "%~2"=="cleanup" goto assignmentcapture
 if exist "%~dp0framework\core\dist\kungfu\pykungfu*.pyd" (
-  where uv >nul 2>nul
-  if not errorlevel 1 (
-    pushd "%~dp0framework\core"
-    uv run --frozen python .devtools\kungfu_cli.py assignment !_KFC_ASSIGNMENT_ARGS!
-    set "_KFC_ASSIGNMENT_ERROR=!errorlevel!"
-    popd
-    exit /b !_KFC_ASSIGNMENT_ERROR!
+  if exist "%~dp0framework\core\dist\kungfu\kungfubuildinfo.json" (
+    where uv >nul 2>nul
+    if not errorlevel 1 (
+      pushd "%~dp0framework\core"
+      uv run --frozen python .devtools\kungfu_cli.py assignment !_KFC_ASSIGNMENT_ARGS!
+      set "_KFC_ASSIGNMENT_ERROR=!errorlevel!"
+      popd
+      exit /b !_KFC_ASSIGNMENT_ERROR!
+    )
   )
 )
 echo {"schema":"kungfu.assignment-orchestration.diagnosis/v1","ok":false,"code":"assignment-current-checkout-binding-missing","message":"Assignment admission requires pykungfu from the current checkout","next_actions":[{"action":"build-core","command":"shifu.cmd build:core","description":"Assemble pykungfu from the current checkout"}]}

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -129,11 +129,17 @@ set "_KFC_ASSIGNMENT_ARGS=%*"
 set "_KFC_ASSIGNMENT_ARGS=!_KFC_ASSIGNMENT_ARGS:* =!"
 if /i "%~2"=="capture" goto assignmentcapture
 if /i "%~2"=="cleanup" goto assignmentcapture
-if exist "%~dp0framework\core\dist\kungfu\kungfu.exe" (
-  "%~dp0framework\core\dist\kungfu\kungfu.exe" assignment !_KFC_ASSIGNMENT_ARGS!
-  exit /b !errorlevel!
+if exist "%~dp0framework\core\dist\kungfu\pykungfu*.pyd" (
+  where uv >nul 2>nul
+  if not errorlevel 1 (
+    pushd "%~dp0framework\core"
+    uv run --frozen python .devtools\kungfu_cli.py assignment !_KFC_ASSIGNMENT_ARGS!
+    set "_KFC_ASSIGNMENT_ERROR=!errorlevel!"
+    popd
+    exit /b !_KFC_ASSIGNMENT_ERROR!
+  )
 )
-echo shifu: assignment admission requires the current source CLI; run shifu build:core 1>&2
+echo {"schema":"kungfu.assignment-orchestration.diagnosis/v1","ok":false,"code":"assignment-current-checkout-binding-missing","message":"Assignment admission requires pykungfu from the current checkout","next_actions":[{"action":"build-core","command":"shifu.cmd build:core","description":"Assemble pykungfu from the current checkout"}]}
 exit /b 127
 
 :assignmentcapture


### PR DESCRIPTION
## Summary
- route source Assignment commands through the current checkout's complete `pykungfu` assembly and keep cold-checkout failures machine-readable
- preserve intentional structured CLI exits instead of wrapping them as a second diagnosis
- refresh a newly initialized workspace identity before resolving local Assignment references

## Related issue

Native Initiative/Assignment admission qualification.

## Changes

- require both the binding and build metadata before source Assignment dispatch
- return one actionable JSON diagnosis for missing or partial assemblies
- isolate first-write regression tests from the developer workspace catalog

## Verification

- `./shifu test:shifu-xinfa-source` (26 passed)
- `PYTHONPATH=framework/core/build/Release:framework/core/src/python ./shifu exec -- uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_assignment_orchestration.py` (14 passed)
- `./shifu check:source`
- native dogfood: capture, current-checkout admission, claim, kickoff, and run gate
- independent review: approved after two findings were resolved

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores the existing native Assignment admission contract without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; diagnostics preserve the documented contract)

Made with [Cursor](https://cursor.com)