### PR TITLE
fix(ci): pin S3 credential relay runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f # PR #1585 direct credential input upload
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@0484f4516d6d68a04b72d89a370df2f88cb9db4c # PR #1587 S3 credential input relay
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -52,10 +52,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f # PR #1585 direct credential input upload
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@0484f4516d6d68a04b72d89a370df2f88cb9db4c # PR #1587 S3 credential input relay
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 8aa540bc2bed4a94b3755c7328bef70ee40de80f
+      buildchain-ref: 0484f4516d6d68a04b72d89a370df2f88cb9db4c
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:30d081fa397c54c1bb6dbd96991c096d8f9ff3a9b99e25afc8f21411af3f3e21",
+          "definitionDigest": "sha256:819b4f4792fc7640b17be8de6690abc74bf97e9a3c62418c8164e70d4749a78a",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -744,7 +744,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@0484f4516d6d68a04b72d89a370df2f88cb9db4c"
           ],
           "steps": []
         },
@@ -1846,7 +1846,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:2cf0767324a89b78b69919c280a8254d32ff19dea2571a9bcfaf2c50cbec095a",
+          "definitionDigest": "sha256:38232e243890c21fd6ace2e59f98f482193f65f7035788db874cb28df6479187",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1859,7 +1859,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@0484f4516d6d68a04b72d89a370df2f88cb9db4c"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -439,7 +439,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@0484f4516d6d68a04b72d89a370df2f88cb9db4c",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -521,14 +521,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@8aa540bc2bed4a94b3755c7328bef70ee40de80f",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@0484f4516d6d68a04b72d89a370df2f88cb9db4c",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "8aa540bc2bed4a94b3755c7328bef70ee40de80f",
+          "buildchain-ref": "0484f4516d6d68a04b72d89a370df2f88cb9db4c",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "8aa540bc2bed4a94b3755c7328bef70ee40de80f",
+    "workflow_shell_sha": "0484f4516d6d68a04b72d89a370df2f88cb9db4c",
     "alpha": {
       "workflow_ref": "v2-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",


### PR DESCRIPTION
## Summary

- pin Build and release promotion to Buildchain `v2.14.18-alpha.1` runtime `0484f4516d6d68a04b72d89a370df2f88cb9db4c`
- refresh workflow authority digests and bindings
- bind the promotion rehearsal contract to the same immutable runtime

## Provenance

- Buildchain implementation: https://github.com/kungfu-systems/buildchain/pull/1586
- Buildchain alpha promotion: https://github.com/kungfu-systems/buildchain/pull/1587
- Buildchain promotion run: https://github.com/kungfu-systems/buildchain/actions/runs/30056198732

## Verification

- `./shifu gate:workflow-authority:refresh`
- `./shifu check:gate-catalog`
- `./shifu release:promotion:rehearse`
- `./shifu check:source`
- staged repository gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This updates an immutable Buildchain runtime pin and its generated workflow authority projections without changing Kungfu product or architecture semantics."
}
-->