### PR TITLE
fix(mission-control): authenticate native completion evidence

### DIFF
--- a/extensions/mission-control/mission-control-actions/domain/mission_control.py
+++ b/extensions/mission-control/mission-control-actions/domain/mission_control.py
@@ -2536,18 +2536,101 @@ def _tracked_completion_evidence(
         ),
         None,
     )
-    goal_record = (target_goal or {}).get("payload", {}).get("record", {})
+    goal_payload = (target_goal or {}).get("payload", {})
+    goal_record = goal_payload.get("record", {})
     expected_go_set = {goal_id}
     expected_go_set.update(
-        str(row.get("payload", {}).get("record", {}).get("goal_id") or "")
+        str(
+            row.get("payload", {}).get("record", {}).get("goal_id")
+            or row.get("payload", {}).get("record", {}).get("assignment_id")
+            or ""
+        )
         for row in state.get("goals", [])
         if row.get("payload", {}).get("record", {}).get("parent_goal_id") == goal_id
+    )
+    goal_subject = str((target_goal or {}).get("subject_key") or "")
+    owning_workspace_identity_root = str(
+        goal_record.get("owning_workspace_identity_root") or ""
+    )
+    expected_go_set.update(
+        str(
+            row.get("payload", {}).get("record", {}).get("goal_id")
+            or row.get("payload", {}).get("record", {}).get("assignment_id")
+            or ""
+        )
+        for row in state.get("goals", [])
+        if (
+            row.get("payload", {})
+            .get("record", {})
+            .get("parent_assignment_ref", {})
+            .get("subject")
+            == goal_subject
+            and row.get("payload", {})
+            .get("record", {})
+            .get("parent_assignment_ref", {})
+            .get("workspace_identity_root")
+            == owning_workspace_identity_root
+            and row.get("payload", {})
+            .get("record", {})
+            .get("owning_workspace_identity_root")
+            == owning_workspace_identity_root
+        )
     )
     expected_go_set.discard("")
     if set(claim_record.get("go_set") or []) != expected_go_set:
         reject(
             "incomplete-parent-acceptance", "completion Go set omits or adds a child"
         )
+    request_root = str(goal_record.get("request_root") or "")
+    work_definition_root = str(goal_record.get("work_definition_root") or "")
+    work_definition = goal_record.get("work_definition")
+    source = goal_payload.get("source", {})
+    native_assignment = bool(
+        goal_subject == f"kungfu:{goal_id}"
+        and goal_record.get("goal_id") == goal_id
+        and (target_goal or {}).get("source_id")
+        in {USER_FACT_SOURCE_ID, AGENT_FACT_SOURCE_ID}
+        and source.get("authority_mode") == "kungfu-native"
+        and request_root
+        and work_definition_root
+        and isinstance(work_definition, dict)
+        and work_definition
+        and work_definition_root == _sha256_root(work_definition)
+        and not str(goal_record.get("project_cut_root") or "")
+    )
+    if native_assignment:
+        if claim_record.get("acceptance_root") != work_definition_root:
+            reject(
+                "acceptance-root-mismatch",
+                "claim acceptance_root differs from the Assignment work definition",
+            )
+        for claim_key in (
+            "input_atlas_root",
+            "result_atlas_root",
+            "project_cut_root",
+            "project_cut_receipt_root",
+        ):
+            if claim_record.get(claim_key):
+                reject(
+                    "legacy-authority-present",
+                    f"native Assignment claim must not set {claim_key}",
+                )
+        diagnostics.sort(key=lambda row: (row["code"], row["detail"]))
+        evidence = {
+            "schema": "kungfu.mission-control.tracked-completion-evidence/v1",
+            "authority": "kungfu-assignment-request",
+            "valid": not diagnostics,
+            "commit": commit,
+            "head_commit": head_commit,
+            "tree_oid": tree_oid,
+            "git_tree_root": expected_tree_root,
+            "request_root": request_root,
+            "work_definition_root": work_definition_root,
+            "cut": {},
+            "diagnostics": diagnostics,
+        }
+        evidence["evidence_root"] = _sha256_root(evidence)
+        return evidence
     for claim_key, goal_key, code in (
         ("acceptance_root", "acceptance_root", "acceptance-root-mismatch"),
         ("input_atlas_root", "input_atlas_root", "stale-atlas"),
@@ -2625,9 +2708,7 @@ def _tracked_completion_evidence(
         for row in (reconcile or {}).get("diagnostics", []):
             path = str(row.get("path") or "")
             if path in {"", "$"} or any(
-                path == prefix
-                or path.startswith(prefix + ":")
-                or path.startswith(prefix + "/")
+                path == prefix or path.startswith((prefix + ":", prefix + "/"))
                 for prefix in scoped_paths
                 if prefix
             ):
@@ -2756,7 +2837,9 @@ def claim_completion(
     availability = []
     for row in evidence_availability or []:
         if not isinstance(row, dict):
-            raise ValueError("evidence_availability rows must be objects")
+            raise ValueError(  # noqa: TRY004
+                "evidence_availability rows must be objects"
+            )
         acceptance = str(row.get("acceptance") or "").strip()
         level = str(row.get("level") or "").strip()
         availability_state = str(row.get("state") or "").strip()
@@ -3789,7 +3872,7 @@ def _bounded_followups(rows: list[dict[str, Any]] | None) -> list[dict[str, Any]
     result: list[dict[str, Any]] = []
     for row in rows or []:
         if not isinstance(row, dict):
-            raise ValueError("follow-up Go rows must be objects")
+            raise ValueError("follow-up Go rows must be objects")  # noqa: TRY004
         goal_id = _stable_id(str(row.get("goal_id") or ""), "followup.goal_id")
         title = str(row.get("title") or "").strip()
         objective = str(row.get("objective") or "").strip()

--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -81,6 +81,18 @@ def _runtime(workspace_root="", home=False, operation_class="semantic-write"):
         }
     else:
         receipt = prepare_workspace_write(target, "assignment-orchestration")
+        target = resolve_workspace_target(
+            operation_class,
+            workspace_root or None,
+            home=home,
+            cwd=os.getcwd(),
+        )
+        identity = target.identity
+        if (
+            not identity.initialized
+            or identity.identity_root != receipt["workspace_identity_root"]
+        ):
+            raise RuntimeError("Assignment workspace identity did not stabilize")
     return identity, target.runtime_dir, receipt
 
 

--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -50,6 +50,8 @@ def _failure(code, error, next_actions=None):
 def _run(operation):
     try:
         return operation()
+    except click.exceptions.Exit:
+        raise
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         _failure("assignment-operation-failed", error)
         raise click.exceptions.Exit(2) from error

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime, timedelta, timezone
+import importlib
 import json
 from pathlib import Path
 import shutil
 from types import SimpleNamespace
 
+import click
 import kungfu
 import pytest
 
@@ -24,6 +26,7 @@ from kungfu.workspace_federation import (
 
 
 SOURCE = Path(__file__).resolve().parents[4] / "extensions" / "mission-control"
+ASSIGNMENT_CLI = importlib.import_module("kungfu.cli.commands.assignment")
 
 
 def _activate(runtime):
@@ -44,6 +47,17 @@ def _activate(runtime):
                 contract["decisionCard"], "approve", "test-owner"
             ),
         )
+
+
+def test_cli_run_preserves_an_intentional_machine_readable_exit(monkeypatch):
+    emitted = []
+    monkeypatch.setattr(ASSIGNMENT_CLI, "_emit", emitted.append)
+
+    with pytest.raises(click.exceptions.Exit) as failure:
+        ASSIGNMENT_CLI._run(lambda: (_ for _ in ()).throw(click.exceptions.Exit(3)))
+
+    assert failure.value.exit_code == 3
+    assert emitted == []
 
 
 def test_source_root_recovers_checkout_from_assembled_binding(tmp_path):

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -60,6 +60,15 @@ def test_cli_run_preserves_an_intentional_machine_readable_exit(monkeypatch):
     assert emitted == []
 
 
+def test_cli_runtime_refreshes_a_new_workspace_identity(tmp_path):
+    identity, runtime_dir, receipt = ASSIGNMENT_CLI._runtime(str(tmp_path))
+
+    assert identity.initialized is True
+    assert identity.identity_state == "qualified"
+    assert identity.identity_root == receipt["workspace_identity_root"]
+    assert Path(runtime_dir).is_dir()
+
+
 def test_source_root_recovers_checkout_from_assembled_binding(tmp_path):
     checkout = tmp_path / "kungfu"
     checkout.mkdir()

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -60,7 +60,8 @@ def test_cli_run_preserves_an_intentional_machine_readable_exit(monkeypatch):
     assert emitted == []
 
 
-def test_cli_runtime_refreshes_a_new_workspace_identity(tmp_path):
+def test_cli_runtime_refreshes_a_new_workspace_identity(tmp_path, monkeypatch):
+    monkeypatch.setenv("KF_CONFIG_HOME", str(tmp_path / "config"))
     identity, runtime_dir, receipt = ASSIGNMENT_CLI._runtime(str(tmp_path))
 
     assert identity.initialized is True

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -1203,6 +1203,133 @@ def test_tracked_completion_selects_claimed_cut_in_multi_cut_commit(
     assert evidence["diagnostics"] == []
 
 
+def test_native_assignment_completion_review_does_not_require_project_cut(
+    tmp_path, monkeypatch
+):
+    commit = "1" * 40
+    tree = "2" * 40
+    request_root = "sha256:" + "a" * 64
+    work_definition = {"goal_id": "native-assignment", "objective": "verify"}
+    work_definition_root = mission_control._sha256_root(work_definition)
+    workspace_root = "sha256:" + "c" * 64
+
+    def fake_run(argv, **_kwargs):
+        if argv[0] == "node":
+            return subprocess.CompletedProcess(
+                argv, 0, json.dumps({"cuts": [], "diagnostics": []}), ""
+            )
+        if argv[:3] != ["git", "-C", str(tmp_path)]:
+            raise AssertionError(f"unexpected legacy verifier: {argv}")
+        values = {
+            "--show-toplevel": str(tmp_path),
+            f"{commit}^{{commit}}": commit,
+            "HEAD^{commit}": commit,
+            f"{commit}^{{tree}}": tree,
+        }
+        return subprocess.CompletedProcess(argv, 0, values[argv[-1]] + "\n", "")
+
+    monkeypatch.setattr(mission_control.subprocess, "run", fake_run)
+    state = {
+        "goals": [
+            {
+                "source_id": mission_control.USER_FACT_SOURCE_ID,
+                "subject_key": "kungfu:native-assignment",
+                "payload": {
+                    "record": {
+                        "goal_id": "native-assignment",
+                        "request_root": request_root,
+                        "work_definition": work_definition,
+                        "work_definition_root": work_definition_root,
+                        "owning_workspace_identity_root": workspace_root,
+                        "project_cut_root": "",
+                    },
+                    "source": {"authority_mode": "kungfu-native"},
+                },
+            },
+            {
+                "source_id": mission_control.AGENT_FACT_SOURCE_ID,
+                "subject_key": "kungfu:native-child",
+                "payload": {
+                    "record": {
+                        "goal_id": "native-child",
+                        "owning_workspace_identity_root": workspace_root,
+                        "parent_assignment_ref": {
+                            "subject": "kungfu:native-assignment",
+                            "workspace_identity_root": workspace_root,
+                        },
+                    },
+                    "source": {"authority_mode": "kungfu-native"},
+                },
+            },
+        ]
+    }
+    claim = {
+        "git_commit": commit,
+        "git_tree_root": mission_control._sha256_root(tree),
+        "go_set": ["native-assignment", "native-child"],
+        "acceptance_root": work_definition_root,
+        "input_atlas_root": "",
+        "result_atlas_root": "",
+        "project_cut_root": "",
+        "project_cut_receipt_root": "",
+    }
+
+    evidence = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+
+    assert evidence["valid"] is True
+    assert evidence["authority"] == "kungfu-assignment-request"
+    assert evidence["request_root"] == request_root
+    assert evidence["work_definition_root"] == work_definition_root
+    assert evidence["cut"] == {}
+    assert evidence["diagnostics"] == []
+
+    state["goals"][1]["payload"]["record"]["owning_workspace_identity_root"] = (
+        "sha256:" + "d" * 64
+    )
+    claim["go_set"] = ["native-assignment"]
+    cross_workspace_child = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert cross_workspace_child["valid"] is True
+
+    state["goals"][1]["payload"]["record"]["owning_workspace_identity_root"] = (
+        workspace_root
+    )
+    claim["go_set"] = ["native-assignment"]
+    omitted_child = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert omitted_child["valid"] is False
+    assert {row["code"] for row in omitted_child["diagnostics"]} == {
+        "incomplete-parent-acceptance"
+    }
+
+    claim["go_set"] = ["native-assignment", "native-child"]
+    state["goals"][0]["payload"]["record"]["work_definition"]["objective"] = "tampered"
+    mismatched_definition = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert mismatched_definition["valid"] is False
+    assert "project-cut-count-mismatch" in {
+        row["code"] for row in mismatched_definition["diagnostics"]
+    }
+
+    state["goals"][0]["payload"]["record"]["work_definition"] = {
+        "goal_id": "native-assignment",
+        "objective": "verify",
+    }
+    state["goals"][0]["source_id"] = mission_control.ATLAS_FACT_SOURCE_ID
+    foreign_authority = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert foreign_authority["valid"] is False
+    assert "project-cut-count-mismatch" in {
+        row["code"] for row in foreign_authority["diagnostics"]
+    }
+
+
 def test_independent_completion_review_and_exact_continuation(tmp_path):
     runtime_dir = tmp_path / "runtime"
     _activate_mission_profile(runtime_dir)

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -3,6 +3,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -45,6 +46,50 @@ test('allows one explicitly justified implementation command', () => {
 
 test('current participant surfaces satisfy the contract', () => {
   assert.deepEqual(checkRoot(ROOT), []);
+});
+
+test('cold source Assignment failure remains machine-actionable', (t) => {
+  const temp = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-shifu-assignment-'),
+  );
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
+  const launcher = path.join(temp, 'shifu');
+  fs.copyFileSync(path.join(ROOT, 'shifu'), launcher);
+  fs.chmodSync(launcher, 0o755);
+
+  const result = spawnSync(launcher, ['assignment', 'status'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: temp,
+      XDG_CONFIG_HOME: path.join(temp, 'config'),
+    },
+  });
+  assert.equal(result.status, 127);
+  assert.equal(result.stderr, '');
+  assert.deepEqual(JSON.parse(result.stdout), {
+    schema: 'kungfu.assignment-orchestration.diagnosis/v1',
+    ok: false,
+    code: 'assignment-current-checkout-binding-missing',
+    message: 'Assignment admission requires pykungfu from the current checkout',
+    next_actions: [
+      {
+        action: 'build-core',
+        command: './shifu build:core',
+        description: 'Assemble pykungfu from the current checkout',
+      },
+    ],
+  });
+});
+
+test('Windows cold source Assignment failure carries the same diagnosis', () => {
+  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  assert.match(
+    windows,
+    /"code":"assignment-current-checkout-binding-missing"/u,
+  );
+  assert.match(windows, /"action":"build-core"/u);
+  assert.match(windows, /"command":"shifu\.cmd build:core"/u);
 });
 
 test('cache execution boundaries distinguish gate run and source acceptance', () => {

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -82,6 +82,28 @@ test('cold source Assignment failure remains machine-actionable', (t) => {
   });
 });
 
+test('partial Core assembly cannot masquerade as Assignment readiness', (t) => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-shifu-partial-'));
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
+  const launcher = path.join(temp, 'shifu');
+  const dist = path.join(temp, 'framework', 'core', 'dist', 'kungfu');
+  fs.mkdirSync(dist, { recursive: true });
+  fs.copyFileSync(path.join(ROOT, 'shifu'), launcher);
+  fs.chmodSync(launcher, 0o755);
+  fs.writeFileSync(path.join(dist, 'pykungfu.partial.so'), '');
+
+  const result = spawnSync(launcher, ['assignment', 'status'], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: temp },
+  });
+  assert.equal(result.status, 127);
+  assert.equal(result.stderr, '');
+  assert.equal(
+    JSON.parse(result.stdout).code,
+    'assignment-current-checkout-binding-missing',
+  );
+});
+
 test('Windows cold source Assignment failure carries the same diagnosis', () => {
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
   assert.match(
@@ -90,6 +112,7 @@ test('Windows cold source Assignment failure carries the same diagnosis', () => 
   );
   assert.match(windows, /"action":"build-core"/u);
   assert.match(windows, /"command":"shifu\.cmd build:core"/u);
+  assert.match(windows, /kungfubuildinfo\.json/u);
 });
 
 test('cache execution boundaries distinguish gate run and source acceptance', () => {

--- a/shifu
+++ b/shifu
@@ -269,11 +269,20 @@ if [ "${1:-}" = "assignment" ]; then
       exit 127
     fi
   fi
-  _kungfu_checkout_bin="./framework/core/dist/kungfu/kungfu"
-  if [ -x "$_kungfu_checkout_bin" ]; then
-    exec "$_kungfu_checkout_bin" assignment "$@"
+  _kungfu_checkout_binding=""
+  for _candidate in \
+    ./framework/core/dist/kungfu/pykungfu*.so \
+    ./framework/core/dist/kungfu/pykungfu*.pyd; do
+    if [ -f "$_candidate" ]; then
+      _kungfu_checkout_binding="$_candidate"
+      break
+    fi
+  done
+  if [ -n "$_kungfu_checkout_binding" ] && command -v uv >/dev/null 2>&1; then
+    cd ./framework/core
+    exec uv run --frozen python .devtools/kungfu_cli.py assignment "$@"
   fi
-  echo "shifu: assignment admission requires the current source CLI; run ./shifu build:core" >&2
+  printf '%s\n' '{"schema":"kungfu.assignment-orchestration.diagnosis/v1","ok":false,"code":"assignment-current-checkout-binding-missing","message":"Assignment admission requires pykungfu from the current checkout","next_actions":[{"action":"build-core","command":"./shifu build:core","description":"Assemble pykungfu from the current checkout"}]}'
   exit 127
 fi
 

--- a/shifu
+++ b/shifu
@@ -278,7 +278,10 @@ if [ "${1:-}" = "assignment" ]; then
       break
     fi
   done
-  if [ -n "$_kungfu_checkout_binding" ] && command -v uv >/dev/null 2>&1; then
+  _kungfu_checkout_build_info="./framework/core/dist/kungfu/kungfubuildinfo.json"
+  if [ -n "$_kungfu_checkout_binding" ] \
+    && [ -f "$_kungfu_checkout_build_info" ] \
+    && command -v uv >/dev/null 2>&1; then
     cd ./framework/core
     exec uv run --frozen python .devtools/kungfu_cli.py assignment "$@"
   fi

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -130,13 +130,15 @@ set "_KFC_ASSIGNMENT_ARGS=!_KFC_ASSIGNMENT_ARGS:* =!"
 if /i "%~2"=="capture" goto assignmentcapture
 if /i "%~2"=="cleanup" goto assignmentcapture
 if exist "%~dp0framework\core\dist\kungfu\pykungfu*.pyd" (
-  where uv >nul 2>nul
-  if not errorlevel 1 (
-    pushd "%~dp0framework\core"
-    uv run --frozen python .devtools\kungfu_cli.py assignment !_KFC_ASSIGNMENT_ARGS!
-    set "_KFC_ASSIGNMENT_ERROR=!errorlevel!"
-    popd
-    exit /b !_KFC_ASSIGNMENT_ERROR!
+  if exist "%~dp0framework\core\dist\kungfu\kungfubuildinfo.json" (
+    where uv >nul 2>nul
+    if not errorlevel 1 (
+      pushd "%~dp0framework\core"
+      uv run --frozen python .devtools\kungfu_cli.py assignment !_KFC_ASSIGNMENT_ARGS!
+      set "_KFC_ASSIGNMENT_ERROR=!errorlevel!"
+      popd
+      exit /b !_KFC_ASSIGNMENT_ERROR!
+    )
   )
 )
 echo {"schema":"kungfu.assignment-orchestration.diagnosis/v1","ok":false,"code":"assignment-current-checkout-binding-missing","message":"Assignment admission requires pykungfu from the current checkout","next_actions":[{"action":"build-core","command":"shifu.cmd build:core","description":"Assemble pykungfu from the current checkout"}]}

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -129,11 +129,17 @@ set "_KFC_ASSIGNMENT_ARGS=%*"
 set "_KFC_ASSIGNMENT_ARGS=!_KFC_ASSIGNMENT_ARGS:* =!"
 if /i "%~2"=="capture" goto assignmentcapture
 if /i "%~2"=="cleanup" goto assignmentcapture
-if exist "%~dp0framework\core\dist\kungfu\kungfu.exe" (
-  "%~dp0framework\core\dist\kungfu\kungfu.exe" assignment !_KFC_ASSIGNMENT_ARGS!
-  exit /b !errorlevel!
+if exist "%~dp0framework\core\dist\kungfu\pykungfu*.pyd" (
+  where uv >nul 2>nul
+  if not errorlevel 1 (
+    pushd "%~dp0framework\core"
+    uv run --frozen python .devtools\kungfu_cli.py assignment !_KFC_ASSIGNMENT_ARGS!
+    set "_KFC_ASSIGNMENT_ERROR=!errorlevel!"
+    popd
+    exit /b !_KFC_ASSIGNMENT_ERROR!
+  )
 )
-echo shifu: assignment admission requires the current source CLI; run shifu build:core 1>&2
+echo {"schema":"kungfu.assignment-orchestration.diagnosis/v1","ok":false,"code":"assignment-current-checkout-binding-missing","message":"Assignment admission requires pykungfu from the current checkout","next_actions":[{"action":"build-core","command":"shifu.cmd build:core","description":"Assemble pykungfu from the current checkout"}]}
 exit /b 127
 
 :assignmentcapture


### PR DESCRIPTION
## Summary
- authenticate native Assignment completion evidence from the sealed fact source and exact work-definition root
- include native child Assignments through workspace-scoped parent references
- reject legacy authority fields and cross-workspace or forged native projections

## Verification
- `./shifu check`
- focused Mission Control storage tests (2 passed)
- Ruff format and lint checks
- independent review: approved after all findings were resolved

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix enforces the existing native Assignment completion-review authority without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; this restores the existing contract)

Made with [Cursor](https://cursor.com)