### PR TITLE
fix(core): stabilize generated binding annotations

### DIFF
--- a/framework/core/.gyp/gen-stubs.js
+++ b/framework/core/.gyp/gen-stubs.js
@@ -19,6 +19,23 @@ const path = require('node:path');
 const glob = require('glob');
 const { shell } = require('../lib');
 
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function normalizeStubText(text) {
+  return (
+    text
+      .replace(/\r\n?/g, '\n')
+      .replace(/[ \t]+$/gm, '')
+      .replace(/\bfrom:/g, 'from_:')
+      // pybind11-stubgen can render an unresolved annotation as `...` on one
+      // host and `typing.Any` on another. Canonicalize only annotation positions;
+      // preserve ellipsis function bodies and default values.
+      .replace(/(:[ \t]*)\.\.\.(?=[ \t]*(?:[,)=]|$))/gm, '$1typing.Any')
+  );
+}
+
 function main() {
   const buildType = shell.getConfigValue('build_type') || 'Release';
   const buildDir = path.resolve('build', buildType);
@@ -70,12 +87,9 @@ function main() {
   for (const rel of glob.sync('**/*.pyi', { cwd: 'stubs/pykungfu' })) {
     const file = path.join('stubs', 'pykungfu', rel);
     const before = fs.readFileSync(file, 'utf8');
-    const after = before
-      .replace(/\r\n?/g, '\n')
-      .replace(/[ \t]+$/gm, '')
-      .replace(/\bfrom:/g, 'from_:');
+    const after = normalizeStubText(before);
     if (after !== before) fs.writeFileSync(file, after);
   }
 }
 
-module.exports = { main };
+module.exports = { main, normalizeStubText };

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -56,7 +56,7 @@
     "format:cpp": "node .gyp/run-format-cpp.js src",
     "format:python": "node .gyp/run-format-python.js . src src/*/*.spec .*/*.py",
     "kungfu": "node lib/kungfu-cli.js",
-    "test:tooling": "node --test tests/shell-exit-code.test.js tests/run-conan.test.js tests/sdk-core-build.test.js tests/episode-release-evidence.test.mjs",
+    "test:tooling": "node --test tests/shell-exit-code.test.js tests/run-conan.test.js tests/sdk-core-build.test.js tests/gen-stubs.test.js tests/episode-release-evidence.test.mjs",
     "test:storage-binding": "node --test tests/storage-node-binding.test.js",
     "dev:kungfu": "uv run --frozen python .devtools/kungfu_cli.py"
   },

--- a/framework/core/tests/gen-stubs.test.js
+++ b/framework/core/tests/gen-stubs.test.js
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { normalizeStubText } = require('../.gyp/gen-stubs');
+
+test('normalizes unresolved type annotations without changing ellipsis semantics', () => {
+  const generated = [
+    'def direct(value: ...) -> None:',
+    '    ...',
+    'def optional(value: ... = ...) -> ...:',
+    '    ...',
+    'def keyword(from: int) -> None:   ',
+    '    ...',
+    '',
+  ].join('\r\n');
+
+  assert.equal(
+    normalizeStubText(generated),
+    [
+      'def direct(value: typing.Any) -> None:',
+      '    ...',
+      'def optional(value: typing.Any = ...) -> ...:',
+      '    ...',
+      'def keyword(from_: int) -> None:',
+      '    ...',
+      '',
+    ].join('\n'),
+  );
+});


### PR DESCRIPTION
## Summary

- canonicalize host-dependent unresolved pybind11 stub annotations to `typing.Any`
- preserve function-body and default-value ellipses
- add the normalization case to the Core tooling suite

## Failure evidence

- alpha Build run `30058447310` built successfully but release verification failed because macOS stub generation changed tracked `runtime.pyi` from `typing.Any` to `...`
- the patch was checked against the exact dirty stub retained by that runner; normalization reproduces the committed canonical bytes

## Verification

- Core tooling tests: 19 passed
- `node node_modules/typescript/bin/tsc -p tsconfig.tools.json`
- `node --test framework/core/tests/gen-stubs.test.js`
- full `./shifu check:source` reached the final tooling type-check and the reported TS7006 was fixed and rechecked
- staged repository gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This makes an existing generated binding-stub representation deterministic across build hosts without changing the binding, public API, or architecture semantics."
}
-->