### PR TITLE
fix(shifu): keep Windows quality dispatch reachable

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -171,10 +171,20 @@ test('Xinfa quality uses the source resolver and forwards one Windows mode', () 
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
   const posixBlock = posix.match(/xinfa:quality\)[\s\S]*?;;/u)?.[0];
   const windowsBlock = windows.match(
-    /:xinfaquality[\s\S]*?:docsreadonly/u,
+    /:xinfaquality[\s\S]*?(?=\r?\n:projectcut\r?\n)/u,
   )?.[0];
+  const routeIndex = windows.indexOf(
+    'if /i "%~1"=="xinfa:quality" goto xinfaquality',
+  );
+  const qualityIndex = windows.indexOf('\n:xinfaquality\n');
+  const projectCutIndex = windows.indexOf('\n:projectcut\n');
   assert.ok(posixBlock, 'POSIX Xinfa quality block is missing');
   assert.ok(windowsBlock, 'Windows Xinfa quality block is missing');
+  assert.ok(routeIndex >= 0, 'Windows Xinfa quality route is missing');
+  assert.ok(
+    qualityIndex > routeIndex && qualityIndex < projectCutIndex,
+    'Windows Xinfa quality target must stay adjacent to the route table',
+  );
   assert.doesNotMatch(posixBlock, /xinfa\/tooling\/task\.mjs build/u);
   assert.doesNotMatch(windowsBlock, /xinfa\\tooling\\task\.mjs" build/u);
   assert.match(windowsBlock, /%~2/u);

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -94,6 +94,36 @@ if /i "%~1"=="xinfa:quality" goto xinfaquality
 if /i "%~1"=="docs:check:readonly" goto docsreadonly
 if /i "%~1"=="adr:release:gate" goto adrrelease
 
+:xinfaquality
+set "_XINFA_QUALITY_MODE=--check"
+if "%~2"=="" goto xinfaqualityrun
+if /i "%~2"=="--check" goto xinfaqualityargs
+if /i "%~2"=="--write" (
+  set "_XINFA_QUALITY_MODE=--write"
+  goto xinfaqualityargs
+)
+echo shifu: usage: shifu.cmd xinfa:quality [--check^|--write] 1>&2
+exit /b 1
+
+:xinfaqualityargs
+if not "%~3"=="" (
+  echo shifu: usage: shifu.cmd xinfa:quality [--check^|--write] 1>&2
+  exit /b 1
+)
+
+:xinfaqualityrun
+where fnm >nul 2>nul && (
+  fnm install >nul 2>nul
+  fnm exec --using-file -- node "%~dp0scripts\qualify-xinfa-context-quality.mjs" "%_XINFA_QUALITY_MODE%"
+  exit /b !errorlevel!
+)
+where node >nul 2>nul && (
+  node "%~dp0scripts\qualify-xinfa-context-quality.mjs" "%_XINFA_QUALITY_MODE%"
+  exit /b !errorlevel!
+)
+echo shifu: xinfa quality qualification needs node 1>&2
+exit /b 127
+
 :projectcut
 if /i not "%~1"=="project-cut" goto sourceacceptance
 where fnm >nul 2>nul && (
@@ -245,36 +275,6 @@ where node >nul 2>nul && (
   exit /b !errorlevel!
 )
 echo shifu: xinfa tasks need node -- install fnm or any system node 1>&2
-exit /b 127
-
-:xinfaquality
-set "_XINFA_QUALITY_MODE=--check"
-if "%~2"=="" goto xinfaqualityrun
-if /i "%~2"=="--check" goto xinfaqualityargs
-if /i "%~2"=="--write" (
-  set "_XINFA_QUALITY_MODE=--write"
-  goto xinfaqualityargs
-)
-echo shifu: usage: shifu.cmd xinfa:quality [--check^|--write] 1>&2
-exit /b 1
-
-:xinfaqualityargs
-if not "%~3"=="" (
-  echo shifu: usage: shifu.cmd xinfa:quality [--check^|--write] 1>&2
-  exit /b 1
-)
-
-:xinfaqualityrun
-where fnm >nul 2>nul && (
-  fnm install >nul 2>nul
-  fnm exec --using-file -- node "%~dp0scripts\qualify-xinfa-context-quality.mjs" "%_XINFA_QUALITY_MODE%"
-  exit /b !errorlevel!
-)
-where node >nul 2>nul && (
-  node "%~dp0scripts\qualify-xinfa-context-quality.mjs" "%_XINFA_QUALITY_MODE%"
-  exit /b !errorlevel!
-)
-echo shifu: xinfa quality qualification needs node 1>&2
 exit /b 127
 
 :docsreadonly


### PR DESCRIPTION
Restore the Windows `xinfa:quality` dispatch used by the required merge-queue workspace check. The implementation block is mechanically moved next to the route table, and the entry contract now preserves that placement.

Validation:
- `./shifu xinfa:quality --check`
- Shifu entry/lifecycle contract tests
- `./shifu check:source`
- pre-commit gates

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repositions an existing Windows batch dispatch target and adds a regression assertion without changing architecture, runtime, protocol, qualification, or release contracts"
}
-->