### PR TITLE
fix(shifu): bypass adjacent quality target

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -185,6 +185,11 @@ test('Xinfa quality uses the source resolver and forwards one Windows mode', () 
     qualityIndex > routeIndex && qualityIndex < projectCutIndex,
     'Windows Xinfa quality target must stay adjacent to the route table',
   );
+  assert.match(
+    windows.slice(routeIndex, qualityIndex),
+    /goto projectcut\r?\n\s*$/u,
+    'ordinary Windows commands must bypass the adjacent quality target',
+  );
   assert.doesNotMatch(posixBlock, /xinfa\/tooling\/task\.mjs build/u);
   assert.doesNotMatch(windowsBlock, /xinfa\\tooling\\task\.mjs" build/u);
   assert.match(windowsBlock, /%~2/u);

--- a/shifu.cmd
+++ b/shifu.cmd
@@ -93,6 +93,7 @@ if /i "%~1"=="xinfa:standalone" goto xinfa
 if /i "%~1"=="xinfa:quality" goto xinfaquality
 if /i "%~1"=="docs:check:readonly" goto docsreadonly
 if /i "%~1"=="adr:release:gate" goto adrrelease
+goto projectcut
 
 :xinfaquality
 set "_XINFA_QUALITY_MODE=--check"


### PR DESCRIPTION
Restore ordinary Windows command dispatch after the `xinfa:quality` target was moved next to the route table. Without the explicit bypass, `shifu.cmd gate run ...` falls through into the quality argument parser.

This adds one `goto projectcut` and a regression assertion that preserves both routes.

Validation:
- Shifu entry/lifecycle contract tests
- `./shifu check:source`
- pre-commit gates
- failure reproduced from Windows merge-group run `30062072460`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restores existing Windows batch control flow and adds a regression assertion without changing architecture, runtime, protocol, qualification, or release contracts"
}
-->