### PR TITLE
fix(mission-control): authenticate native completion evidence

### DIFF
--- a/extensions/mission-control/mission-control-actions/domain/mission_control.py
+++ b/extensions/mission-control/mission-control-actions/domain/mission_control.py
@@ -2536,10 +2536,15 @@ def _tracked_completion_evidence(
         ),
         None,
     )
-    goal_record = (target_goal or {}).get("payload", {}).get("record", {})
+    goal_payload = (target_goal or {}).get("payload", {})
+    goal_record = goal_payload.get("record", {})
     expected_go_set = {goal_id}
     expected_go_set.update(
-        str(row.get("payload", {}).get("record", {}).get("goal_id") or "")
+        str(
+            row.get("payload", {}).get("record", {}).get("goal_id")
+            or row.get("payload", {}).get("record", {}).get("assignment_id")
+            or ""
+        )
         for row in state.get("goals", [])
         if (
             row.get("payload", {}).get("record", {}).get("parent_goal_id") == goal_id
@@ -2557,11 +2562,89 @@ def _tracked_completion_evidence(
             )
         )
     )
+    goal_subject = str((target_goal or {}).get("subject_key") or "")
+    owning_workspace_identity_root = str(
+        goal_record.get("owning_workspace_identity_root") or ""
+    )
+    expected_go_set.update(
+        str(
+            row.get("payload", {}).get("record", {}).get("goal_id")
+            or row.get("payload", {}).get("record", {}).get("assignment_id")
+            or ""
+        )
+        for row in state.get("goals", [])
+        if (
+            row.get("payload", {})
+            .get("record", {})
+            .get("parent_assignment_ref", {})
+            .get("subject")
+            == goal_subject
+            and row.get("payload", {})
+            .get("record", {})
+            .get("parent_assignment_ref", {})
+            .get("workspace_identity_root")
+            == owning_workspace_identity_root
+            and row.get("payload", {})
+            .get("record", {})
+            .get("owning_workspace_identity_root")
+            == owning_workspace_identity_root
+        )
+    )
     expected_go_set.discard("")
     if set(claim_record.get("go_set") or []) != expected_go_set:
         reject(
             "incomplete-parent-acceptance", "completion Go set omits or adds a child"
         )
+    request_root = str(goal_record.get("request_root") or "")
+    work_definition_root = str(goal_record.get("work_definition_root") or "")
+    work_definition = goal_record.get("work_definition")
+    source = goal_payload.get("source", {})
+    native_assignment = bool(
+        goal_subject == f"kungfu:{goal_id}"
+        and goal_record.get("goal_id") == goal_id
+        and (target_goal or {}).get("source_id")
+        in {USER_FACT_SOURCE_ID, AGENT_FACT_SOURCE_ID}
+        and source.get("authority_mode") == "kungfu-native"
+        and request_root
+        and work_definition_root
+        and isinstance(work_definition, dict)
+        and work_definition
+        and work_definition_root == _sha256_root(work_definition)
+        and not str(goal_record.get("project_cut_root") or "")
+    )
+    if native_assignment:
+        if claim_record.get("acceptance_root") != work_definition_root:
+            reject(
+                "acceptance-root-mismatch",
+                "claim acceptance_root differs from the Assignment work definition",
+            )
+        for claim_key in (
+            "input_atlas_root",
+            "result_atlas_root",
+            "project_cut_root",
+            "project_cut_receipt_root",
+        ):
+            if claim_record.get(claim_key):
+                reject(
+                    "legacy-authority-present",
+                    f"native Assignment claim must not set {claim_key}",
+                )
+        diagnostics.sort(key=lambda row: (row["code"], row["detail"]))
+        evidence = {
+            "schema": "kungfu.mission-control.tracked-completion-evidence/v1",
+            "authority": "kungfu-assignment-request",
+            "valid": not diagnostics,
+            "commit": commit,
+            "head_commit": head_commit,
+            "tree_oid": tree_oid,
+            "git_tree_root": expected_tree_root,
+            "request_root": request_root,
+            "work_definition_root": work_definition_root,
+            "cut": {},
+            "diagnostics": diagnostics,
+        }
+        evidence["evidence_root"] = _sha256_root(evidence)
+        return evidence
     for claim_key, goal_key, code in (
         ("acceptance_root", "acceptance_root", "acceptance-root-mismatch"),
         ("input_atlas_root", "input_atlas_root", "stale-atlas"),
@@ -2639,9 +2722,7 @@ def _tracked_completion_evidence(
         for row in (reconcile or {}).get("diagnostics", []):
             path = str(row.get("path") or "")
             if path in {"", "$"} or any(
-                path == prefix
-                or path.startswith(prefix + ":")
-                or path.startswith(prefix + "/")
+                path == prefix or path.startswith((prefix + ":", prefix + "/"))
                 for prefix in scoped_paths
                 if prefix
             ):
@@ -2770,7 +2851,9 @@ def claim_completion(
     availability = []
     for row in evidence_availability or []:
         if not isinstance(row, dict):
-            raise ValueError("evidence_availability rows must be objects")
+            raise ValueError(  # noqa: TRY004
+                "evidence_availability rows must be objects"
+            )
         acceptance = str(row.get("acceptance") or "").strip()
         level = str(row.get("level") or "").strip()
         availability_state = str(row.get("state") or "").strip()
@@ -3803,7 +3886,7 @@ def _bounded_followups(rows: list[dict[str, Any]] | None) -> list[dict[str, Any]
     result: list[dict[str, Any]] = []
     for row in rows or []:
         if not isinstance(row, dict):
-            raise ValueError("follow-up Go rows must be objects")
+            raise ValueError("follow-up Go rows must be objects")  # noqa: TRY004
         goal_id = _stable_id(str(row.get("goal_id") or ""), "followup.goal_id")
         title = str(row.get("title") or "").strip()
         objective = str(row.get("objective") or "").strip()

--- a/framework/core/tests/python/test_atlas_storage.py
+++ b/framework/core/tests/python/test_atlas_storage.py
@@ -1240,6 +1240,133 @@ def test_tracked_completion_selects_claimed_cut_in_multi_cut_commit(
     assert evidence["diagnostics"] == []
 
 
+def test_native_assignment_completion_review_does_not_require_project_cut(
+    tmp_path, monkeypatch
+):
+    commit = "1" * 40
+    tree = "2" * 40
+    request_root = "sha256:" + "a" * 64
+    work_definition = {"goal_id": "native-assignment", "objective": "verify"}
+    work_definition_root = mission_control._sha256_root(work_definition)
+    workspace_root = "sha256:" + "c" * 64
+
+    def fake_run(argv, **_kwargs):
+        if argv[0] == "node":
+            return subprocess.CompletedProcess(
+                argv, 0, json.dumps({"cuts": [], "diagnostics": []}), ""
+            )
+        if argv[:3] != ["git", "-C", str(tmp_path)]:
+            raise AssertionError(f"unexpected legacy verifier: {argv}")
+        values = {
+            "--show-toplevel": str(tmp_path),
+            f"{commit}^{{commit}}": commit,
+            "HEAD^{commit}": commit,
+            f"{commit}^{{tree}}": tree,
+        }
+        return subprocess.CompletedProcess(argv, 0, values[argv[-1]] + "\n", "")
+
+    monkeypatch.setattr(mission_control.subprocess, "run", fake_run)
+    state = {
+        "goals": [
+            {
+                "source_id": mission_control.USER_FACT_SOURCE_ID,
+                "subject_key": "kungfu:native-assignment",
+                "payload": {
+                    "record": {
+                        "goal_id": "native-assignment",
+                        "request_root": request_root,
+                        "work_definition": work_definition,
+                        "work_definition_root": work_definition_root,
+                        "owning_workspace_identity_root": workspace_root,
+                        "project_cut_root": "",
+                    },
+                    "source": {"authority_mode": "kungfu-native"},
+                },
+            },
+            {
+                "source_id": mission_control.AGENT_FACT_SOURCE_ID,
+                "subject_key": "kungfu:native-child",
+                "payload": {
+                    "record": {
+                        "goal_id": "native-child",
+                        "owning_workspace_identity_root": workspace_root,
+                        "parent_assignment_ref": {
+                            "subject": "kungfu:native-assignment",
+                            "workspace_identity_root": workspace_root,
+                        },
+                    },
+                    "source": {"authority_mode": "kungfu-native"},
+                },
+            },
+        ]
+    }
+    claim = {
+        "git_commit": commit,
+        "git_tree_root": mission_control._sha256_root(tree),
+        "go_set": ["native-assignment", "native-child"],
+        "acceptance_root": work_definition_root,
+        "input_atlas_root": "",
+        "result_atlas_root": "",
+        "project_cut_root": "",
+        "project_cut_receipt_root": "",
+    }
+
+    evidence = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+
+    assert evidence["valid"] is True
+    assert evidence["authority"] == "kungfu-assignment-request"
+    assert evidence["request_root"] == request_root
+    assert evidence["work_definition_root"] == work_definition_root
+    assert evidence["cut"] == {}
+    assert evidence["diagnostics"] == []
+
+    state["goals"][1]["payload"]["record"]["owning_workspace_identity_root"] = (
+        "sha256:" + "d" * 64
+    )
+    claim["go_set"] = ["native-assignment"]
+    cross_workspace_child = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert cross_workspace_child["valid"] is True
+
+    state["goals"][1]["payload"]["record"]["owning_workspace_identity_root"] = (
+        workspace_root
+    )
+    claim["go_set"] = ["native-assignment"]
+    omitted_child = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert omitted_child["valid"] is False
+    assert {row["code"] for row in omitted_child["diagnostics"]} == {
+        "incomplete-parent-acceptance"
+    }
+
+    claim["go_set"] = ["native-assignment", "native-child"]
+    state["goals"][0]["payload"]["record"]["work_definition"]["objective"] = "tampered"
+    mismatched_definition = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert mismatched_definition["valid"] is False
+    assert "project-cut-count-mismatch" in {
+        row["code"] for row in mismatched_definition["diagnostics"]
+    }
+
+    state["goals"][0]["payload"]["record"]["work_definition"] = {
+        "goal_id": "native-assignment",
+        "objective": "verify",
+    }
+    state["goals"][0]["source_id"] = mission_control.ATLAS_FACT_SOURCE_ID
+    foreign_authority = mission_control._tracked_completion_evidence(
+        str(tmp_path), state, "native-assignment", claim
+    )
+    assert foreign_authority["valid"] is False
+    assert "project-cut-count-mismatch" in {
+        row["code"] for row in foreign_authority["diagnostics"]
+    }
+
+
 def test_independent_completion_review_and_exact_continuation(tmp_path):
     runtime_dir = tmp_path / "runtime"
     _activate_mission_profile(runtime_dir)


### PR DESCRIPTION
## Summary
- authenticate native Assignment completion evidence from the sealed fact source and exact work-definition root
- include native child Assignments through workspace-scoped parent references
- reject legacy authority fields and cross-workspace or forged native projections

## Verification
- `./shifu check`
- focused Mission Control storage tests (2 passed)
- Ruff format and lint checks
- independent review: approved after all findings were resolved

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix enforces the existing native Assignment completion-review authority without changing an architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; this restores the existing contract)

Made with [Cursor](https://cursor.com)