### PR TITLE
fix(core): canonicalize generated enum fields

### DIFF
--- a/framework/core/stubs/pykungfu/yijinjing/types.pyi
+++ b/framework/core/stubs/pykungfu/yijinjing/types.pyi
@@ -15,7 +15,7 @@ class AcceptedRangeRecorded:
     since: int
     source_id: String[str[128]]
     source_uid: int
-    status: ...
+    status: typing.Any
     until: int
     def __eq__(self, arg0: AcceptedRangeRecorded) -> bool:
         ...
@@ -415,7 +415,7 @@ class ImportManifestAccepted:
     source_id: String[str[128]]
     source_type: String[str[32]]
     source_uid: int
-    status: ...
+    status: typing.Any
     sync_root_algo: String[str[16]]
     sync_root_value: String[str[72]]
     def __eq__(self, arg0: ImportManifestAccepted) -> bool:
@@ -476,7 +476,7 @@ class ManifestEntryRecorded:
     location_uid: int
     manifest_uid: int
     payload_hash: String[str[72]]
-    payload_state: ...
+    payload_state: typing.Any
     schema_version: int
     source_path: String[str[256]]
     source_time: String[str[40]]
@@ -802,7 +802,7 @@ class SourceRegistered:
     __tag__: typing.ClassVar[int] = 10901
     coordinate: String[str[256]]
     head: String[str[128]]
-    kind: ...
+    kind: typing.Any
     location_uid: int
     register_time: int
     schema_version: int

--- a/framework/core/tests/gen-stubs.test.js
+++ b/framework/core/tests/gen-stubs.test.js
@@ -7,6 +7,7 @@ const { normalizeStubText } = require('../.gyp/gen-stubs');
 
 test('normalizes unresolved type annotations without changing ellipsis semantics', () => {
   const generated = [
+    'status: ...',
     'def direct(value: ...) -> None:',
     '    ...',
     'def optional(value: ... = ...) -> ...:',
@@ -19,6 +20,7 @@ test('normalizes unresolved type annotations without changing ellipsis semantics
   assert.equal(
     normalizeStubText(generated),
     [
+      'status: typing.Any',
       'def direct(value: typing.Any) -> None:',
       '    ...',
       'def optional(value: typing.Any = ...) -> ...:',


### PR DESCRIPTION
## Summary

- commit the canonical `typing.Any` form produced for four unresolved enum-backed fields
- extend stub normalization coverage to a class-field annotation
- eliminate the exact `types.pyi` drift that blocked alpha release qualification

## Failure evidence

- alpha Build run `30072005023` built successfully but Episode qualification rejected a dirty source tree
- the only tracked drift was `framework/core/stubs/pykungfu/yijinjing/types.pyi`
- the patched file matches the exact runner-generated output byte-for-byte

## Verification

- `node --test framework/core/tests/gen-stubs.test.js`
- `pnpm exec biome check --no-errors-on-unmatched framework/core/tests/gen-stubs.test.js`
- complete staged repository gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This commits the existing deterministic representation for unresolved generated enum-backed annotations without changing the binding, public API, or architecture semantics."
}
-->