### PR TITLE
fix(ci): bind macOS signer to caller environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@2e57d4000c5ad4e410ae5495867570eeb2adb73d # PR #1612 macOS signer bundle runtime
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@5481e48220aedfafc5dc3ac29748fdaae5718c74 # PR #1617 caller-owned macOS signing
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
@@ -85,7 +85,7 @@ jobs:
       artifact-paths: |
         product/release
       credential-island-macos-app-path: product/dist/desktop/mac-arm64/Kungfu Episodes.app
-      credential-island-environment: alpha-macos-signing
+      credential-island-caller-owned: true
       credential-island-macos-platform-id: macos-arm64
       expected-artifacts-json: >-
         {"minFiles":8,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json","product/release/qualification/live-peer-continuity/report.json","product/release/qualification/live-peer-continuity/raw-logs.jsonl.gz","product/release/qualification/runtime-activation/report.json","product/release/qualification/runtime-activation/raw-logs.jsonl.gz","product/release/qualification/zero-burden-desktop/report.json","product/release/qualification/zero-burden-desktop/raw-logs.jsonl.gz","product/release/qualification/invariant-run.json"]}
@@ -143,6 +143,85 @@ jobs:
       buildchain-contract-lock-path: .buildchain/contract-lock.json
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking
+
+  credential-island-macos:
+    name: Sign and notarize sealed macOS application
+    needs: build
+    if: ${{ needs.build.result == 'success' }}
+    runs-on: macos-15
+    timeout-minutes: 90
+    environment:
+      name: alpha-macos-signing
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      artifact-name: ${{ steps.names.outputs.artifact-name }}
+      manifest-artifact-name: ${{ steps.names.outputs.manifest-artifact-name }}
+      evidence-path: ${{ steps.credential-island.outputs.evidence-path }}
+    steps:
+      - name: Resolve signed artifact names
+        id: names
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ needs.build.outputs.publish-source-sha }}
+        run: |
+          {
+            echo "artifact-name=kungfu-macos-credential-${SOURCE_SHA}"
+            echo "manifest-artifact-name=kungfu-manifest-macos-credential-${SOURCE_SHA}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Download immutable credential-island runtime
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kungfu-credential-island-runtime-${{ needs.build.outputs.buildchain-runtime-sha }}
+          path: .buildchain/runtime/actions/macos-credential-island
+
+      - name: Download source-bound sealed application input
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kungfu-credential-island-input-macos-arm64-${{ needs.build.outputs.publish-source-sha }}
+          path: .buildchain/credential-island-input
+
+      - name: Sign, notarize, staple, and verify
+        id: credential-island
+        uses: ./.buildchain/runtime/actions/macos-credential-island
+        with:
+          input-root: .buildchain/credential-island-input
+          output-root: .buildchain/credential-island-output
+          source-repository: ${{ github.repository }}
+          source-sha: ${{ needs.build.outputs.publish-source-sha }}
+          source-tree-sha: ${{ needs.build.outputs.publish-source-tree-sha }}
+          source-ref: ${{ needs.build.outputs.publish-source-ref || github.ref }}
+          buildchain-runtime-sha: ${{ needs.build.outputs.buildchain-runtime-sha }}
+          artifact-name: ${{ steps.names.outputs.artifact-name }}
+          platform-id: macos-arm64-credential
+          artifact-relative-output: product/release
+          expected-bundle-id: ${{ vars.BUILDCHAIN_MACOS_EXPECTED_BUNDLE_ID }}
+          expected-team-id: ${{ vars.BUILDCHAIN_MACOS_EXPECTED_TEAM_ID }}
+          certificate-sha1: ${{ vars.BUILDCHAIN_MACOS_CERTIFICATE_SHA1 }}
+          certificate-p12-base64: ${{ secrets.BUILDCHAIN_MACOS_CERTIFICATE_P12_BASE64 }}
+          certificate-password: ${{ secrets.BUILDCHAIN_MACOS_CERTIFICATE_PASSWORD }}
+          notary-api-key-p8-base64: ${{ secrets.BUILDCHAIN_MACOS_NOTARY_API_KEY_P8_BASE64 }}
+          notary-api-key-id: ${{ secrets.BUILDCHAIN_MACOS_NOTARY_API_KEY_ID }}
+          notary-api-issuer: ${{ secrets.BUILDCHAIN_MACOS_NOTARY_API_ISSUER }}
+
+      - name: Upload authoritative signed macOS payload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.names.outputs.artifact-name }}
+          path: ${{ steps.credential-island.outputs.artifact-root }}
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+
+      - name: Upload authoritative signed macOS manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.names.outputs.manifest-artifact-name }}
+          path: ${{ steps.credential-island.outputs.manifest-path }}
+          if-no-files-found: error
+          retention-days: 14
 
   phase-b-package:
     name: Prepare Kungfu Phase B package

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -52,10 +52,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e57d4000c5ad4e410ae5495867570eeb2adb73d # PR #1612 macOS signer bundle runtime
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@5481e48220aedfafc5dc3ac29748fdaae5718c74 # PR #1617 caller-owned macOS signing
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 2e57d4000c5ad4e410ae5495867570eeb2adb73d
+      buildchain-ref: 5481e48220aedfafc5dc3ac29748fdaae5718c74
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -723,7 +723,7 @@
     },
     {
       "path": ".github/workflows/build.yml",
-      "authority": "qualification",
+      "authority": "product-publication",
       "definitionDigest": "sha256:c9f4f9751fcc77457775c5d49e66e577731e825a1ca40009be9410b36e5d6012",
       "jobs": [
         {
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:b0825c876ec71c43b4bda7fd01c9618bd3c8c911772842c9e60b5085c3054858",
+          "definitionDigest": "sha256:596c770d0706ffd3724ee1c69cd6f4f7a2a0885f8ee59e6cdbefeedba343d06e",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -744,9 +744,73 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@2e57d4000c5ad4e410ae5495867570eeb2adb73d"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@5481e48220aedfafc5dc3ac29748fdaae5718c74"
           ],
           "steps": []
+        },
+        {
+          "id": "credential-island-macos",
+          "authority": "product-publication",
+          "publication": "product",
+          "receipt": "none",
+          "definitionDigest": "sha256:d4b3ff09b7e84fbdd02b867bdc8c1982fb80861b8f3279315b60c122c72d73f2",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [
+              "BUILDCHAIN_MACOS_CERTIFICATE_P12_BASE64",
+              "BUILDCHAIN_MACOS_CERTIFICATE_PASSWORD",
+              "BUILDCHAIN_MACOS_NOTARY_API_ISSUER",
+              "BUILDCHAIN_MACOS_NOTARY_API_KEY_ID",
+              "BUILDCHAIN_MACOS_NOTARY_API_KEY_P8_BASE64"
+            ],
+            "inheritedSecrets": false,
+            "environment": "alpha-macos-signing"
+          },
+          "externalActions": [
+            "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+            "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+          ],
+          "steps": [
+            {
+              "index": 1,
+              "label": "id:names",
+              "authority": "qualification",
+              "definitionDigest": "sha256:01b1f7aa2f15fc40027213990c6a68030808ae41638da8e9726e1563d4c72b62"
+            },
+            {
+              "index": 2,
+              "label": "name:Download immutable credential-island runtime",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:bd21b7bbcf426ab9015845dfe1c39a8ac9107e5baff34374a1b9f9ba5bc008d1"
+            },
+            {
+              "index": 3,
+              "label": "name:Download source-bound sealed application input",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:fca5f1dd321b9ee9c209e6ebe7d83d83f7bcdc03460633a6aed741f427c2089e"
+            },
+            {
+              "index": 4,
+              "label": "id:credential-island",
+              "authority": "product-publication",
+              "definitionDigest": "sha256:b2196e22eceaa0476e4d55bac814c5d34783e340b03341e8d84a778c097fb141"
+            },
+            {
+              "index": 5,
+              "label": "name:Upload authoritative signed macOS payload",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:77a17288c5d96117623cac499cc6fe79186d07c479f5140c5a6eb8df15c7a3dc"
+            },
+            {
+              "index": 6,
+              "label": "name:Upload authoritative signed macOS manifest",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:a41f8263042a7679a2140cc228d4ea1bdc2c2713cf76f7bb298493e2b8e02a14"
+            }
+          ]
         },
         {
           "id": "kungfu-phase-b",
@@ -1846,7 +1910,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:6b125a885fd941987a2803b8d785e9ec599dcb756ae47ffd048f7fb27b8c646f",
+          "definitionDigest": "sha256:7726b00c9c0ae48760c3da4f51185b4f6f303e6f2430d718bf49569466f857b0",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1859,7 +1923,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e57d4000c5ad4e410ae5495867570eeb2adb73d"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@5481e48220aedfafc5dc3ac29748fdaae5718c74"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -51,6 +51,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
+| `.github/workflows/build.yml` | `credential-island-macos` | product-publication | product | none | token:read, repo-secret:BUILDCHAIN_MACOS_CERTIFICATE_P12_BASE64+BUILDCHAIN_MACOS_CERTIFICATE_PASSWORD+BUILDCHAIN_MACOS_NOTARY_API_ISSUER+BUILDCHAIN_MACOS_NOTARY_API_KEY_ID+BUILDCHAIN_MACOS_NOTARY_API_KEY_P8_BASE64 | `alpha-macos-signing` | 6 |
 | `.github/workflows/build.yml` | `kungfu-phase-b` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `phase-b-package` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/build.yml` | `preflight` | qualification | none | diagnostic | token:write, oidc | none | 2 |

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -439,7 +439,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@2e57d4000c5ad4e410ae5495867570eeb2adb73d",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@5481e48220aedfafc5dc3ac29748fdaae5718c74",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -451,7 +451,7 @@
         "with": {
           "runner-preset": "${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}",
           "credential-island-macos-app-path": "product/dist/desktop/mac-arm64/Kungfu Episodes.app",
-          "credential-island-environment": "alpha-macos-signing",
+          "credential-island-caller-owned": true,
           "credential-island-macos-platform-id": "macos-arm64",
           "require-install": true,
           "require-build": true,
@@ -521,14 +521,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e57d4000c5ad4e410ae5495867570eeb2adb73d",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@5481e48220aedfafc5dc3ac29748fdaae5718c74",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "2e57d4000c5ad4e410ae5495867570eeb2adb73d",
+          "buildchain-ref": "5481e48220aedfafc5dc3ac29748fdaae5718c74",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "2e57d4000c5ad4e410ae5495867570eeb2adb73d",
+    "workflow_shell_sha": "5481e48220aedfafc5dc3ac29748fdaae5718c74",
     "alpha": {
       "workflow_ref": "v2-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",


### PR DESCRIPTION
## Summary

- select Buildchain caller-owned credential-island mode at exact alpha runtime `5481e48220aedfafc5dc3ac29748fdaae5718c74`
- run the credential-bearing macOS signer as a Kungfu top-level job bound directly to `alpha-macos-signing`
- preserve the no-checkout boundary while downloading only the immutable signer runtime and source-bound sealed application input
- keep release promotion and workflow authority projections aligned with the same runtime

## Why

The cross-repository reusable workflow could bind the deployment environment but GitHub did not expose its environment secrets to the called workflow job. The live diagnostic failed closed before keychain import with a missing notarization input. This change keeps those secrets exclusively in the consumer environment instead of widening them to repository secrets.

## Verification

- `./shifu gate:workflow-authority:refresh`
- `./shifu check:gate-catalog`
- `./shifu release:promotion:rehearse`
- `./shifu check:source`
- staged repository gate during commit

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This CI bug fix changes only credential routing and exact Buildchain runtime binding; it does not alter a product architecture contract."
}
-->

## Governance risk check

- [x] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The credential boundary is verified by the no-checkout caller-owned signing job and closed-world workflow authority. No credential values are present in the repository or PR.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed