### PR TITLE
fix(cli): refresh bootstrap verification surface

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+        "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+        "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+        "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203",
+      "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+            "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "15969006a1a6c4eac9c50dc636760dff90abb1e5",
+    "sourceSha": "de6fc09a1ce9b427c6850bfed7e6487497edb2c1",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:c293fa3821c9519f57320204586e1f16354847ed60d29ba21d097edf41b7ea6d"
   },

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+        "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+        "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+        "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203",
+      "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "b46b215cddf3323e5dbbe13bcb57bab904a11ed40b3a63e6217c36bd2fb81203"
+            "sha256": "56c303ee2052dcff155fc52e48f7cd48deed5e0984a2e9027446ad26afdee189"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
+++ b/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
@@ -1,7 +1,7 @@
 {
-  "catalogRoot": "sha256:8e94991495e55d85b7af7103105b6b68cd79147c57fde1d825a75b628a01fb5b",
+  "catalogRoot": "sha256:a19ac1ccba0aa1110126bf0efafba01297892050f043fd263dffba81f4cfd2cd",
   "contractId": "kungfu-cli-surface",
-  "contractRoot": "sha256:67be68da2203842bcaf077c922caeb725d037155a66478489fd88adfc73f598d",
+  "contractRoot": "sha256:bd93647322b2c5291a58ff81aec8074269f6ee0a52c8d50c5fa070a71ba1986d",
   "kfd3Linkage": [
     {
       "apiIds": [],
@@ -2448,6 +2448,12 @@
       "apiIds": [],
       "reason": "not-agent-visible",
       "state": "unlinked",
+      "surfaceId": "kungfu.cli.commands.update.bootstrap.verify"
+    },
+    {
+      "apiIds": [],
+      "reason": "not-agent-visible",
+      "state": "unlinked",
       "surfaceId": "kungfu.cli.commands.update.update.check"
     },
     {
@@ -2841,11 +2847,11 @@
       "kfd3Registry": "strict-link",
       "packagedInventory": "required-agent-pack-entry"
     },
-    "expectedSurfaceRoot": "sha256:5162361011274effcef397e31d91686c4740aea81a3c95514d521c49174df1eb",
+    "expectedSurfaceRoot": "sha256:788eaa4ba9d23ad617c37d6c9afe7cbc74e77e8a6c057ace6fb538c3062020ae",
     "regeneration": "./shifu fix:cli-catalog-parity",
     "validation": "./shifu check:cli-catalog-parity"
   },
-  "registryRoot": "sha256:0b97bde3757a57160263b8d2d8b31331deeb748751b883d869886b01780b7fe8",
+  "registryRoot": "sha256:e1b57345ff331c47839f7894ee2e62a9e2d524d9758c4be50c9b9722915a1662",
   "schema": "kungfu.cli-surface-catalog/v1",
   "schemaRoot": "sha256:731eec25990d090067d59651d6c0793934124ac79df4111990bd905e03b605c4",
   "source": {
@@ -2858,7 +2864,7 @@
     "pathAuthority": "live-click-tree",
     "root": "kungfu"
   },
-  "surfaceRoot": "sha256:5162361011274effcef397e31d91686c4740aea81a3c95514d521c49174df1eb",
+  "surfaceRoot": "sha256:788eaa4ba9d23ad617c37d6c9afe7cbc74e77e8a6c057ace6fb538c3062020ae",
   "surfaces": [
     {
       "alias_diagnostics": [],
@@ -30729,6 +30735,157 @@
       },
       "summary": "install a verified archive runtime without replacing live work",
       "visibility": "advanced"
+    },
+    {
+      "alias_diagnostics": [],
+      "aliases": [],
+      "approval_policy": {
+        "caller_confirmation_required": false,
+        "mode": "none",
+        "preconditions": []
+      },
+      "audience": [
+        "human",
+        "operator"
+      ],
+      "availability": {
+        "conditions": [
+          "source-runtime"
+        ],
+        "state": "available"
+      },
+      "canonical_path": "kungfu update bootstrap-verify",
+      "id": "kungfu.cli.commands.update.bootstrap.verify",
+      "kfd3_api_id": null,
+      "kfd3_api_ids": [],
+      "kind": "command",
+      "maturity": "stable",
+      "mutation_class": "plan",
+      "owner": "core",
+      "parameters": [
+        {
+          "arity": 1,
+          "kind": "argument",
+          "name": "channel_index",
+          "required": true,
+          "type": "file"
+        },
+        {
+          "arity": 1,
+          "kind": "argument",
+          "name": "candidate_archive",
+          "required": true,
+          "type": "file"
+        },
+        {
+          "arity": 1,
+          "kind": "argument",
+          "name": "candidate_root",
+          "required": true,
+          "type": "directory"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--channel"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "channel",
+          "required": true,
+          "type": "choice"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--platform"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "platform_name",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--architecture"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "architecture",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--version"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "version",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--manifest-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "manifest_root",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--artifact-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "artifact_root",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--platform-trust"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "platform_trust",
+          "required": true,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--trusted-key"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "trusted_keys",
+          "required": true,
+          "type": "text"
+        }
+      ],
+      "path_depth": 3,
+      "removal_gate": null,
+      "replacement": null,
+      "schema_refs": [],
+      "section": "internal",
+      "source": {
+        "familyPolicy": true,
+        "kind": "runtime-click",
+        "module": "kungfu.cli.commands.update",
+        "symbol": "bootstrap_verify"
+      },
+      "summary": "verify one staged bootstrap candidate before installation activation",
+      "visibility": "hidden-internal"
     },
     {
       "alias_diagnostics": [],

--- a/framework/core/src/python/kungfu/cli/surface_contract.registry.json
+++ b/framework/core/src/python/kungfu/cli/surface_contract.registry.json
@@ -160,7 +160,7 @@
   "catalogProjection": {
     "artifact": "kungfu.agent/cli_surface.catalog.json",
     "authority": "runtime-fold",
-    "expectedSurfaceRoot": "sha256:5162361011274effcef397e31d91686c4740aea81a3c95514d521c49174df1eb",
+    "expectedSurfaceRoot": "sha256:788eaa4ba9d23ad617c37d6c9afe7cbc74e77e8a6c057ace6fb538c3062020ae",
     "consumers": {
       "agentCapabilities": "embed-complete",
       "agentCommands": "strict-link",


### PR DESCRIPTION
## Summary

Refresh the generated CLI surface authority after the signed Alpha bootstrap added `kungfu update bootstrap-verify`. The stale projection blocked exact-source Linux product qualification because human help and the Agent catalog carried different contract roots.

## Related issue

None. Found by exact-source Hub Starter package qualification.

## Changes

- regenerate the complete CLI catalog and expected surface root
- refresh the dependent KFD-2 and KFD-3 evidence projections
- retain the fail-closed installed help/catalog parity check unchanged

## Verification

- `./shifu check:source`
- `./shifu test:cli-surface-qualification` (28 passed)
- `./shifu test:cli-surface-contract` with a compatible assembled native binding (29 passed)
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fix refreshes generated CLI and KFD projections for an already-declared command; it changes no architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates generated release evidence roots only; source acceptance, KFD evidence checks, and installed product qualification retain exact-root validation.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no authored behavior change)