### PR TITLE
feat(workspace): close federated work projection

### DIFF
--- a/docs/adr/KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3.md
+++ b/docs/adr/KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1341]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1341, https://github.com/kungfu-systems/kungfu/pull/1423]
 qualification_refs: [framework/workspace-federation/workspace-federation.contract.json, framework/workspace-federation/qualification/2026-07-23-home-two-repositories.json, framework/core/tests/python/test_workspace.py, framework/core/tests/python/test_workspace_federation.py, framework/core/tests/python/test_assignment_orchestration.py]
 review_state: self-reviewed
 sensitivity: public
@@ -13,7 +13,7 @@ period: 2026-07-23
 theme: workspace-federation-assignment-graph
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-07-23
+last_reviewed: 2026-07-24
 ai_provenance: GPT-5 via Codex on 2026-07-23; based on the current Kungfu workspace, Mission Control, Fact, Assignment orchestration, Profile, and Project Cut implementations plus the captured Assignment work definition; no claim about unobserved installed runtimes or future cross-machine transport
 ---
 
@@ -91,6 +91,21 @@ availability, staleness, and failures. Unavailable Catalog entries and
 unresolved references remain visible. Reads never create Home, initialize a
 project, import evidence, establish relations, or claim an atomic global cut.
 
+The global projection composes one authority-qualified identity index before
+resolving references. Observations fold only when an exact shared version root
+proves that they are replicas. Equal human labels under distinct authorities
+remain distinct; divergent versions under one authority remain a conflict.
+The default human view shows one row per canonical Work object, while component
+observations, replicas, label collisions, conflicts, exclusions, and unresolved
+references remain available through progressive detail and the JSON envelope.
+
+Catalog membership has an explicit local lifecycle. Active entries are
+required by default; retired, test-only, and quarantined entries stay retained
+and counted but are excluded by declared policy. Lifecycle maintenance is
+exact-entry and dry-run-first, binds the observed Catalog cut, emits a durable
+before/after receipt, and never rewrites a workspace authority. A Catalog
+change during a query yields a marked retry result rather than a hybrid view.
+
 Global completion remains false until an independent continuation Decision
 accepts the result and the applicable Project Cut root plus settlement receipt
 are evidenced. Execution exit, stage-ready, claim, review, decision, and
@@ -105,6 +120,10 @@ pending settlement remain distinct Portfolio states.
   because the workspace identity root is part of every graph reference.
 - Discovery is bounded by explicit Catalog evidence; v1 intentionally does not
   discover arbitrary sibling repositories or remote machines.
+- Canonical Work count and component observation count are intentionally
+  different measures. Strict mode also reports replicas, conflicts, stale,
+  unavailable, excluded, unresolved, proof, and zero-write evidence rather than
+  using a clean display to erase degraded truth.
 - Cross-machine locator exchange and historical migration require later,
   explicit protocols. Existing uninitialized workspaces qualify their identity
   on first semantic write; no big-bang history rewrite is performed.

--- a/framework/core/src/python/kungfu/assignment_orchestration.py
+++ b/framework/core/src/python/kungfu/assignment_orchestration.py
@@ -661,6 +661,85 @@ def verify_sealed_state(state_file: str | Path) -> dict[str, Any]:
     }
 
 
+def list_sealed_assignment_states(
+    workspace_root: str | Path,
+) -> dict[str, Any]:
+    """Read the bounded worktree-deletion-safe Assignment seal index."""
+
+    root = Path(workspace_root).expanduser().resolve()
+    storage_root, storage_kind = _sealed_state_storage(root)
+    index_root = storage_root / "assignment-states" / "sha256"
+    states: list[dict[str, Any]] = []
+    unqualified: list[dict[str, Any]] = []
+    issues: list[dict[str, Any]] = []
+    for state_path in sorted(index_root.glob("*/*/state.json")):
+        try:
+            snapshot = json.loads(state_path.read_text(encoding="utf-8"))
+            verification = verify_sealed_state(state_path)
+            assignment = snapshot.get("assignment") or {}
+            subject = str(snapshot.get("assignment_subject") or "")
+            owning_root = str(assignment.get("owning_workspace_identity_root") or "")
+            query_root = str(snapshot.get("query_proof_root") or "")
+            if not verification["ok"]:
+                raise ValueError("sealed Assignment state does not verify")
+            if (
+                not subject
+                or not re.fullmatch(r"sha256:[0-9a-f]{64}", owning_root)
+                or not re.fullmatch(r"sha256:[0-9a-f]{64}", query_root)
+            ):
+                unqualified.append(
+                    {
+                        "assignment_subject": subject,
+                        "state_root": verification["state_root"],
+                        "phase": snapshot.get("phase"),
+                        "reason": "legacy-seal-lacks-portable-work-coordinate",
+                    }
+                )
+                continue
+            states.append(
+                {
+                    "schema": "kungfu.assignment-orchestration.sealed-work-coordinate/v1",
+                    "assignment_subject": subject,
+                    "workspace_identity_root": owning_root,
+                    "state_root": verification["state_root"],
+                    "query_proof_root": query_root,
+                    "phase": snapshot.get("phase"),
+                    "settled": snapshot.get("phase") == "continuation-decided",
+                    "storage_kind": storage_kind,
+                }
+            )
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            issues.append(
+                {
+                    "code": "sealed-assignment-state-invalid",
+                    "path": str(state_path.relative_to(storage_root)),
+                    "message": str(error),
+                }
+            )
+    states.sort(
+        key=lambda row: (
+            str(row["assignment_subject"]),
+            str(row["workspace_identity_root"]),
+            str(row["state_root"]),
+        )
+    )
+    unqualified.sort(
+        key=lambda row: (
+            str(row["assignment_subject"]),
+            str(row["state_root"]),
+        )
+    )
+    body = {
+        "schema": "kungfu.assignment-orchestration.sealed-work-index/v1",
+        "states": states,
+        "unqualified_states": unqualified,
+        "issues": issues,
+        "storage_kind": storage_kind,
+        "writes": [],
+    }
+    return {**body, "index_root": semantic_root(body)}
+
+
 def _root(value: Any, field: str, *, optional: bool = False) -> str:
     text = str(value or "")
     if optional and not text:

--- a/framework/core/src/python/kungfu/cli/commands/workspace.py
+++ b/framework/core/src/python/kungfu/cli/commands/workspace.py
@@ -16,6 +16,7 @@ from kungfu.workspace import (
     inspect_workspace,
     load_workspace_catalog,
     load_workspace_registry,
+    maintain_workspace_catalog,
     rebuild_workspace_catalog,
     rebind_workspace_locator,
     request_full_evidence,
@@ -40,6 +41,20 @@ from kungfu.workspace_guidance import (
 
 def _json(payload):
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _human_work_line(row, width):
+    display = row["display"]
+    state = display.get("portfolio_state") or display.get("status") or "unknown"
+    conflict = " !conflict" if row["conflict"] else ""
+    replicas = f" x{row['replica_count'] + 1}" if row["replica_count"] else ""
+    suffix = f" [{state}]{conflict}{replicas} {row['canonical_root'][7:15]}"
+    prefix = f"{row['object_kind']} "
+    available = max(8, width - len(prefix) - len(suffix))
+    title = str(display["title"])
+    if len(title) > available:
+        title = title[: max(1, available - 1)] + "…"
+    return f"{prefix}{title}{suffix}"
 
 
 def _identity_or_error(path: str | None, home: bool):
@@ -343,6 +358,56 @@ def catalog_rebind(identity_root, path, as_json):
 
 
 @workspace.command(
+    name="catalog-maintain",
+    help="plan or execute explicit reversible Catalog lifecycle transitions",
+)
+@click.option(
+    "--entry-key",
+    "entry_keys",
+    multiple=True,
+    required=True,
+    help="exact identity_root or locator_key; repeat for a bounded batch",
+)
+@click.option(
+    "--action",
+    type=click.Choice(["retire", "test-only", "quarantine", "restore"]),
+    required=True,
+)
+@click.option("--reason", required=True, help="auditable lifecycle reason")
+@click.option(
+    "--execute",
+    is_flag=True,
+    help="write the exact dry-run transition and durable receipt",
+)
+@click.option("--json", "as_json", is_flag=True, help="machine-readable output")
+def catalog_maintain(entry_keys, action, reason, execute, as_json):
+    try:
+        payload = maintain_workspace_catalog(
+            list(entry_keys),
+            action,
+            reason,
+            execute=execute,
+        )
+    except (OSError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    if as_json:
+        _json(payload)
+        return
+    verb = "updated" if payload["executed"] else "would update"
+    click.echo(
+        f"{verb} {len(payload['changes'])} Catalog entries "
+        f"{payload['catalog_cut_before']} -> {payload['catalog_cut_after']}"
+    )
+    for change in payload["changes"]:
+        click.echo(
+            f"{change['entry_key']} "
+            f"{change['before']['lifecycle']['state']} -> "
+            f"{change['after']['lifecycle']['state']} "
+            f"{change.get('locator') or 'Home'}"
+        )
+
+
+@workspace.command(
     name="work",
     help="query local or federated Initiative/Assignment work without writes",
 )
@@ -378,6 +443,25 @@ def catalog_rebind(identity_root, path, as_json):
     help="exit nonzero unless every component and proof is complete",
 )
 @click.option(
+    "--include-settled",
+    is_flag=True,
+    help="include completed, archived, and closed canonical Work",
+)
+@click.option(
+    "--include-excluded",
+    is_flag=True,
+    help="include policy-excluded Catalog components in raw component details",
+)
+@click.option(
+    "--details",
+    type=click.Choice(
+        ["summary", "components", "replicas", "conflicts", "unresolved", "proof"]
+    ),
+    default="summary",
+    show_default=True,
+    help="select progressive-disclosure detail for human output",
+)
+@click.option(
     "--gate-phase",
     type=click.Choice(["kickoff", "stage-ready", "closeout"]),
     help="emit a proof-bound installed-controller dogfood receipt",
@@ -391,6 +475,9 @@ def work(
     direction,
     relation_types,
     strict,
+    include_settled,
+    include_excluded,
+    details,
     gate_phase,
     as_json,
 ):
@@ -411,6 +498,8 @@ def work(
             start_ref=start_ref,
             direction=direction,
             relation_types=relation_types or None,
+            include_excluded=include_excluded,
+            include_settled=include_settled,
         )
         if gate_phase:
             payload["dogfood_gate_receipt"] = build_dogfood_gate_receipt(
@@ -430,22 +519,69 @@ def work(
         if strict and (not payload["aggregate"]["complete"] or not gate_verified):
             raise SystemExit(2)
         return
-    for component in payload["components"]:
-        workspace_row = component["workspace"]
+    projection = payload["global_work"]
+    aggregate = payload["aggregate"]
+    if aggregate["state"] != "complete":
         click.echo(
-            f"{workspace_row['workspace_id']} {component['availability']} "
-            f"initiatives={len(component['initiatives'])} "
-            f"assignments={len(component['assignments'])}"
+            f"global Work is {aggregate['state']}; "
+            f"required unknown={aggregate['unknown_component_count']} "
+            f"conflicts={aggregate['conflict_count']} "
+            f"unresolved={aggregate['unresolved_reference_count']}",
+            err=True,
+        )
+    for row in projection["visible_work"]:
+        width = max(40, click.get_current_context().terminal_width or 80)
+        click.echo(_human_work_line(row, width))
+    if details == "components":
+        for component in payload["components"]:
+            workspace_row = component["workspace"]
+            click.echo(
+                f"component {workspace_row['workspace_id']} "
+                f"{component['availability']} cut={component.get('cut_root') or '-'}"
+            )
+    elif details == "replicas":
+        for row in projection["canonical_work"]:
+            if row["replica_count"]:
+                click.echo(
+                    f"replica-set {row['canonical_root']} "
+                    f"observations={row['observation_count']}"
+                )
+    elif details == "conflicts":
+        for row in projection["canonical_work"]:
+            if row["conflict"]:
+                click.echo(
+                    f"conflict {row['canonical_root']} "
+                    f"{','.join(row['conflict_reasons'])}"
+                )
+    elif details == "unresolved":
+        for row in projection["reference_resolution"]["unresolved"]:
+            click.echo(f"unresolved {row['code']} {row.get('dependency_id') or ''}")
+    elif details == "proof":
+        click.echo(
+            f"catalog-cut={payload['proof']['catalog_cut']} "
+            f"query-proof={payload['proof']['proof_root']} "
+            f"projection={projection['projection_root']} "
+            f"verified={payload['verification']['ok']}"
         )
     if payload["proof"]["unresolved_references"]:
         click.echo(
             f"unresolved={len(payload['proof']['unresolved_references'])}",
             err=True,
         )
-    aggregate = payload["aggregate"]
     click.echo(
-        f"global={aggregate['state']} assignments={aggregate['known_assignment_count']} "
-        f"unknown-components={aggregate['unknown_component_count']}"
+        f"global={aggregate['state']} visible={projection['visible_work_count']} "
+        f"canonical={aggregate['canonical_work_count']} "
+        f"observations={aggregate['work_observation_count']} "
+        f"components={aggregate['component_observation_count']} "
+        f"replicas={aggregate['replica_count']} conflicts={aggregate['conflict_count']} "
+        f"label-collisions={aggregate['label_collision_count']} "
+        f"retained-seals={aggregate['retained_assignment_state_count']} "
+        f"legacy-seals={aggregate['unqualified_retained_assignment_state_count']} "
+        f"unavailable={aggregate['unavailable_component_count']} "
+        f"stale={aggregate['stale_component_count']} "
+        f"excluded={aggregate['excluded_component_count']} "
+        f"unresolved={aggregate['unresolved_reference_count']} "
+        f"proof={'ok' if aggregate['proof_ok'] else 'failed'} writes=0"
     )
     if aggregate["false_zero_guard"] == "unknown-not-empty":
         click.echo(

--- a/framework/core/src/python/kungfu/workspace.py
+++ b/framework/core/src/python/kungfu/workspace.py
@@ -523,6 +523,7 @@ def load_workspace_catalog(
     """Read the locator Catalog without creating or repairing it."""
 
     path = workspace_catalog_path(config_home, env=env)
+    payload: dict[str, Any]
     if not os.path.exists(path):
         payload = {
             "schema": CATALOG_SCHEMA,
@@ -532,15 +533,16 @@ def load_workspace_catalog(
         return _loaded_catalog(payload, path)
     try:
         with open(path, encoding="utf-8") as stream:
-            payload = json.load(stream)
+            loaded_payload = json.load(stream)
         if (
-            not isinstance(payload, dict)
-            or payload.get("schema") != CATALOG_SCHEMA
-            or not isinstance(payload.get("entries"), list)
+            not isinstance(loaded_payload, dict)
+            or loaded_payload.get("schema") != CATALOG_SCHEMA
+            or not isinstance(loaded_payload.get("entries"), list)
         ):
             raise ValueError("Catalog contract mismatch")
+        payload = loaded_payload
         persisted_cut = _catalog_cut(payload)
-        entries = []
+        entries: list[dict[str, Any]] = []
         for entry in payload["entries"]:
             if (
                 not isinstance(entry, dict)

--- a/framework/core/src/python/kungfu/workspace.py
+++ b/framework/core/src/python/kungfu/workspace.py
@@ -27,6 +27,9 @@ REGISTRY_SCHEMA = "kungfu.workspace.registry/v1"
 CATALOG_SCHEMA = "kungfu.workspace.locator-catalog/v1"
 CATALOG_ENTRY_SCHEMA = "kungfu.workspace.locator-entry/v1"
 CATALOG_VERIFICATION_SCHEMA = "kungfu.workspace.locator-verification/v1"
+CATALOG_CUT_SCHEMA = "kungfu.workspace.locator-catalog-cut/v1"
+CATALOG_LIFECYCLE_PLAN_SCHEMA = "kungfu.workspace.catalog-lifecycle-plan/v1"
+CATALOG_LIFECYCLE_RECEIPT_SCHEMA = "kungfu.workspace.catalog-lifecycle-receipt/v1"
 ENSURE_RECEIPT_SCHEMA = "kungfu.workspace.ensure-receipt/v1"
 TARGET_RECEIPT_SCHEMA = "kungfu.workspace.target-receipt/v1"
 CONTINUATION_STATUS_SCHEMA = "kungfu.workspace.continuation-status/v1"
@@ -60,6 +63,13 @@ OperationClass = Literal[
     "migration",
     "destructive",
 ]
+CatalogLifecycleState = Literal["active", "retired", "test-only", "quarantined"]
+
+_CATALOG_EXCLUSION_POLICY = {
+    "retired": "explicit-retirement",
+    "test-only": "isolated-test-fixture",
+    "quarantined": "explicit-quarantine",
+}
 
 
 @dataclass(frozen=True)
@@ -514,12 +524,12 @@ def load_workspace_catalog(
 
     path = workspace_catalog_path(config_home, env=env)
     if not os.path.exists(path):
-        return {
+        payload = {
             "schema": CATALOG_SCHEMA,
             "entries": [],
-            "issues": [],
-            "catalog_path": path,
+            "epoch": 0,
         }
+        return _loaded_catalog(payload, path)
     try:
         with open(path, encoding="utf-8") as stream:
             payload = json.load(stream)
@@ -529,6 +539,7 @@ def load_workspace_catalog(
             or not isinstance(payload.get("entries"), list)
         ):
             raise ValueError("Catalog contract mismatch")
+        persisted_cut = _catalog_cut(payload)
         entries = []
         for entry in payload["entries"]:
             if (
@@ -547,17 +558,35 @@ def load_workspace_catalog(
                 identity_root or not _ROOT.fullmatch(locator_key)
             ):
                 raise ValueError("Catalog locator candidate is invalid")
-            entries.append(dict(entry))
+            lifecycle = _catalog_lifecycle(entry)
+            entries.append(
+                {
+                    **dict(entry),
+                    "provenance": _catalog_provenance(entry),
+                    "lifecycle": lifecycle,
+                    "retained": True,
+                    "required": lifecycle["state"] not in _CATALOG_EXCLUSION_POLICY,
+                    "exclusion_policy": _CATALOG_EXCLUSION_POLICY.get(
+                        lifecycle["state"]
+                    ),
+                }
+            )
         return {
             **payload,
             "entries": entries,
+            "epoch": int(payload.get("epoch") or 0),
             "issues": [],
             "catalog_path": path,
+            "catalog_cut": persisted_cut,
         }
     except (OSError, ValueError, json.JSONDecodeError) as error:
-        return {
+        fallback = {
             "schema": CATALOG_SCHEMA,
             "entries": [],
+            "epoch": 0,
+        }
+        return {
+            **fallback,
             "issues": [
                 {
                     "code": "catalog-invalid",
@@ -566,6 +595,7 @@ def load_workspace_catalog(
                 }
             ],
             "catalog_path": path,
+            "catalog_cut": _catalog_cut(fallback),
         }
 
 
@@ -583,7 +613,25 @@ def observe_workspace_locator(
             "invalid Workspace Locator Catalog must be repaired explicitly"
         )
     observed_at = _now()
-    entry = _catalog_entry(identity, observed_at)
+    entry = _catalog_entry(
+        identity,
+        observed_at,
+        provenance={
+            "source": "explicit-observation",
+            "registration_reason": identity.resolution_reason,
+        },
+    )
+    existing = next(
+        (
+            row
+            for row in catalog["entries"]
+            if _catalog_entry_key(row) == _catalog_entry_key(entry)
+        ),
+        None,
+    )
+    if existing is not None:
+        entry["lifecycle"] = _catalog_lifecycle(existing)
+        entry["provenance"] = _catalog_provenance(existing)
     entries = [
         row
         for row in catalog["entries"]
@@ -597,11 +645,17 @@ def observe_workspace_locator(
     payload = {
         "schema": CATALOG_SCHEMA,
         "entries": entries,
+        "epoch": int(catalog.get("epoch") or 0) + 1,
         "updated_at": observed_at,
     }
     path = workspace_catalog_path(config_home, env=env)
     _write_json_atomic(path, payload)
-    return {**payload, "catalog_path": path, "observed": entry}
+    return {
+        **payload,
+        "catalog_path": path,
+        "catalog_cut": _catalog_cut(payload),
+        "observed": entry,
+    }
 
 
 def rebuild_workspace_catalog(
@@ -658,11 +712,27 @@ def rebuild_workspace_catalog(
     observed_at = _now()
     by_key: dict[str, dict[str, Any]] = {}
     for identity in identities:
-        entry = _catalog_entry(identity, observed_at)
+        entry = _catalog_entry(
+            identity,
+            observed_at,
+            provenance={
+                "source": next(
+                    (
+                        row["source"]
+                        for row in sources
+                        if row["workspace_id"] == identity.workspace_id
+                    ),
+                    "catalog-rebuild",
+                ),
+                "registration_reason": identity.resolution_reason,
+            },
+        )
         by_key[_catalog_entry_key(entry)] = entry
     payload = {
         "schema": CATALOG_SCHEMA,
         "entries": [by_key[key] for key in sorted(by_key)],
+        "epoch": int(load_workspace_catalog(config_home, env=env).get("epoch") or 0)
+        + 1,
         "updated_at": observed_at,
     }
     path = workspace_catalog_path(config_home, env=env)
@@ -670,6 +740,7 @@ def rebuild_workspace_catalog(
     return {
         **payload,
         "catalog_path": path,
+        "catalog_cut": _catalog_cut(payload),
         "sources": sources,
         "filesystem_scan": False,
         "authority": False,
@@ -716,10 +787,144 @@ def verify_workspace_catalog(
         "schema": CATALOG_VERIFICATION_SCHEMA,
         "ok": ok,
         "catalog_path": catalog["catalog_path"],
+        "catalog_cut": catalog["catalog_cut"],
+        "epoch": catalog["epoch"],
         "issues": catalog["issues"],
         "entries": results,
         "authority": False,
         "writes": [],
+    }
+
+
+def maintain_workspace_catalog(
+    entry_keys: list[str],
+    action: Literal["retire", "test-only", "quarantine", "restore"],
+    reason: str,
+    *,
+    execute: bool = False,
+    config_home: str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Plan or execute explicit, reversible Catalog lifecycle transitions.
+
+    The Catalog contains locators only. This operation never touches a
+    workspace, its ``.kungfu`` authority, or any Work evidence. Dry-run is the
+    default and the execute path is bound to the exact Catalog cut it planned.
+    """
+
+    reason = reason.strip()
+    if action not in {"retire", "test-only", "quarantine", "restore"}:
+        raise ValueError("unsupported Catalog lifecycle action")
+    if not reason:
+        raise ValueError("Catalog lifecycle maintenance requires a reason")
+    requested = set(entry_keys)
+    if not requested:
+        raise ValueError("Catalog lifecycle maintenance requires an entry key")
+    catalog = load_workspace_catalog(config_home, env=env)
+    if catalog["issues"]:
+        raise ValueError("invalid Workspace Locator Catalog must be repaired first")
+    by_key = {_catalog_entry_key(row): row for row in catalog["entries"]}
+    missing = sorted(requested - set(by_key))
+    if missing:
+        raise ValueError(f"Catalog entry key not found: {missing[0]}")
+
+    target_state: CatalogLifecycleState = {
+        "restore": "active",
+        "retire": "retired",
+        "test-only": "test-only",
+        "quarantine": "quarantined",
+    }[action]  # type: ignore[assignment]
+    transitioned_at = _now()
+    changes: list[dict[str, Any]] = []
+    persisted_entries: list[dict[str, Any]] = []
+    for row in catalog["entries"]:
+        before = _persisted_catalog_entry(row)
+        key = _catalog_entry_key(row)
+        if key not in requested:
+            persisted_entries.append(before)
+            continue
+        after = {
+            **before,
+            "lifecycle": {
+                "state": target_state,
+                "reason": reason,
+                "transitioned_at": transitioned_at,
+                "previous_state": _catalog_lifecycle(row)["state"],
+            },
+        }
+        changes.append(
+            {
+                "entry_key": key,
+                "workspace_id": row.get("workspace_id"),
+                "identity_root": row.get("identity_root"),
+                "locator": row.get("locator"),
+                "before": before,
+                "after": after,
+            }
+        )
+        persisted_entries.append(after)
+
+    next_payload = {
+        "schema": CATALOG_SCHEMA,
+        "entries": persisted_entries,
+        "epoch": int(catalog.get("epoch") or 0) + 1,
+        "updated_at": transitioned_at,
+    }
+    plan = {
+        "schema": CATALOG_LIFECYCLE_PLAN_SCHEMA,
+        "action": action,
+        "reason": reason,
+        "catalog_path": catalog["catalog_path"],
+        "catalog_cut_before": catalog["catalog_cut"],
+        "catalog_cut_after": _catalog_cut(next_payload),
+        "epoch_before": int(catalog.get("epoch") or 0),
+        "epoch_after": next_payload["epoch"],
+        "changes": changes,
+        "workspace_writes": 0,
+        "authority_writes": 0,
+        "rollback": "restore each before entry from this receipt at the recorded cut",
+    }
+    plan_root = _semantic_root(
+        {key: value for key, value in plan.items() if key != "catalog_path"}
+    )
+    if not execute:
+        return {
+            **plan,
+            "plan_root": plan_root,
+            "executed": False,
+            "writes": [],
+        }
+
+    current = load_workspace_catalog(config_home, env=env)
+    if current["catalog_cut"] != plan["catalog_cut_before"]:
+        raise ValueError("Catalog changed after planning; retry from a fresh dry-run")
+    _write_json_atomic(catalog["catalog_path"], next_payload)
+    receipt_body = {
+        "schema": CATALOG_LIFECYCLE_RECEIPT_SCHEMA,
+        "plan_root": plan_root,
+        "action": action,
+        "reason": reason,
+        "catalog_cut_before": plan["catalog_cut_before"],
+        "catalog_cut_after": plan["catalog_cut_after"],
+        "epoch_before": plan["epoch_before"],
+        "epoch_after": plan["epoch_after"],
+        "changes": changes,
+        "workspace_writes": 0,
+        "authority_writes": 0,
+    }
+    receipt = {**receipt_body, "receipt_root": _semantic_root(receipt_body)}
+    receipt_path = os.path.join(
+        os.path.dirname(catalog["catalog_path"]),
+        "receipts",
+        receipt["receipt_root"].removeprefix("sha256:") + ".json",
+    )
+    _write_json_atomic(receipt_path, receipt)
+    return {
+        **plan,
+        "plan_root": plan_root,
+        "executed": True,
+        "receipt": {**receipt, "receipt_path": receipt_path},
+        "writes": [catalog["catalog_path"], receipt_path],
     }
 
 
@@ -1208,6 +1413,8 @@ def _qualified_identity(identity: WorkspaceIdentity) -> WorkspaceIdentity:
 def _catalog_entry(
     identity: WorkspaceIdentity,
     observed_at: str,
+    *,
+    provenance: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     locator_key = _semantic_root(
         {
@@ -1227,11 +1434,87 @@ def _catalog_entry(
         "data_home": identity.data_home,
         "available": _workspace_available(identity),
         "observed_at": observed_at,
+        "provenance": dict(
+            provenance
+            or {
+                "source": "explicit-observation",
+                "registration_reason": identity.resolution_reason,
+            }
+        ),
+        "lifecycle": {
+            "state": "active",
+            "reason": "observed",
+            "transitioned_at": observed_at,
+            "previous_state": None,
+        },
     }
 
 
 def _catalog_entry_key(entry: Mapping[str, Any]) -> str:
     return str(entry.get("identity_root") or entry.get("locator_key") or "")
+
+
+def _catalog_cut(payload: Mapping[str, Any]) -> str:
+    body = {
+        "schema": CATALOG_CUT_SCHEMA,
+        "catalog": {
+            "schema": payload.get("schema"),
+            "entries": list(payload.get("entries") or []),
+            "epoch": int(payload.get("epoch") or 0),
+            "updated_at": payload.get("updated_at"),
+        },
+    }
+    return _semantic_root(body)
+
+
+def _loaded_catalog(payload: Mapping[str, Any], path: str) -> dict[str, Any]:
+    return {
+        **dict(payload),
+        "entries": list(payload.get("entries") or []),
+        "epoch": int(payload.get("epoch") or 0),
+        "issues": [],
+        "catalog_path": path,
+        "catalog_cut": _catalog_cut(payload),
+    }
+
+
+def _catalog_provenance(entry: Mapping[str, Any]) -> dict[str, str]:
+    value = entry.get("provenance")
+    if isinstance(value, Mapping):
+        source = str(value.get("source") or "legacy")
+        reason = str(value.get("registration_reason") or "legacy-observation")
+    else:
+        source = "legacy"
+        reason = "legacy-observation"
+    return {"source": source, "registration_reason": reason}
+
+
+def _catalog_lifecycle(entry: Mapping[str, Any]) -> dict[str, Any]:
+    value = entry.get("lifecycle")
+    state = str((value or {}).get("state") or "active")
+    if state not in {"active", "retired", "test-only", "quarantined"}:
+        raise ValueError("Catalog entry lifecycle state is invalid")
+    return {
+        "state": state,
+        "reason": str((value or {}).get("reason") or "legacy-default-active"),
+        "transitioned_at": str(
+            (value or {}).get("transitioned_at") or entry.get("observed_at") or ""
+        ),
+        "previous_state": (value or {}).get("previous_state"),
+    }
+
+
+def _persisted_catalog_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in entry.items()
+        if key
+        not in {
+            "retained",
+            "required",
+            "exclusion_policy",
+        }
+    }
 
 
 def _canonical_path(value: str) -> str:
@@ -1246,11 +1529,21 @@ def _workspace_config_home(env: Mapping[str, str] | None = None) -> str:
     default beginning with ``~`` must instead use that mapping's ``HOME``.
     """
 
+    process_environment = env is None
     env = os.environ if env is None else env
     resolution = load_config_contract(env=env)["resolution"]
-    configured = str(
-        env.get(str(resolution["configHomeEnv"])) or resolution["defaultConfigHome"]
-    )
+    config_home_env = str(resolution["configHomeEnv"])
+    configured_value = env.get(config_home_env)
+    if (
+        process_environment
+        and not configured_value
+        and os.environ.get("PYTEST_CURRENT_TEST")
+    ):
+        configured_value = os.environ.get("KF_PYTEST_CONFIG_HOME") or os.path.join(
+            tempfile.gettempdir(),
+            f"kungfu-pytest-config-{os.getpid()}",
+        )
+    configured = str(configured_value or resolution["defaultConfigHome"])
     mapped_home = env.get("HOME")
     if mapped_home and (configured == "~" or configured.startswith("~/")):
         configured = (

--- a/framework/core/src/python/kungfu/workspace_federation.py
+++ b/framework/core/src/python/kungfu/workspace_federation.py
@@ -34,6 +34,13 @@ COMPONENT_ENVELOPE_SCHEMA = "kungfu.workspace-federation.component-envelope/v1"
 QUERY_SCHEMA = "kungfu.workspace-federation.query/v1"
 QUERY_PROOF_SCHEMA = "kungfu.workspace-federation.query-proof/v1"
 QUERY_VERIFICATION_SCHEMA = "kungfu.workspace-federation.query-verification/v1"
+GLOBAL_WORK_PROJECTION_SCHEMA = "kungfu.workspace-federation.global-work/v1"
+CANONICAL_WORK_SCHEMA = "kungfu.workspace-federation.canonical-work/v1"
+CANONICAL_WORK_IDENTITY_SCHEMA = (
+    "kungfu.workspace-federation.canonical-work-identity/v1"
+)
+WORK_OBSERVATION_SCHEMA = "kungfu.workspace-federation.work-observation/v1"
+REFERENCE_RESOLUTION_SCHEMA = "kungfu.workspace-federation.reference-resolution/v1"
 DOGFOOD_GATE_RECEIPT_SCHEMA = "kungfu.workspace-federation.dogfood-gate-receipt/v1"
 DOGFOOD_GATE_VERIFICATION_SCHEMA = (
     "kungfu.workspace-federation.dogfood-gate-verification/v1"
@@ -345,6 +352,8 @@ def query_federation(
     config_home: str | None = None,
     env: Mapping[str, str] | None = None,
     loader: WorkspaceLoader | None = None,
+    include_excluded: bool = False,
+    include_settled: bool = False,
 ) -> dict[str, Any]:
     """Read local, related, or all known work without mutating any workspace."""
 
@@ -360,10 +369,19 @@ def query_federation(
         key = identity.identity_root or identity.workspace_id
         identities.setdefault(key, identity)
 
-    include(current)
+    excluded_entries = [
+        entry for entry in catalog["entries"] if not entry.get("required", True)
+    ]
+    excluded_roots = {
+        str(entry.get("identity_root") or "") for entry in excluded_entries
+    }
+    if scope != "all" or current.identity_root not in excluded_roots:
+        include(current)
     if scope == "all":
         include(inspect_workspace(home=True, env=env))
         for entry in catalog["entries"]:
+            if not entry.get("required", True):
+                continue
             if entry.get("workspace_kind") == "home":
                 include(inspect_workspace(home=True, env=env))
             else:
@@ -378,6 +396,8 @@ def query_federation(
             for endpoint in (relation.get("source", {}), relation.get("target", {}))
         }
         for entry in catalog["entries"]:
+            if not entry.get("required", True):
+                continue
             if entry.get("identity_root") not in related_roots:
                 continue
             include(_identity_from_catalog_entry(entry, env=env))
@@ -385,45 +405,16 @@ def query_federation(
             _safe_component(identity, loader) for identity in identities.values()
         ]
 
-    known_roots = {
-        component["workspace"]["identity_root"]
-        for component in components
-        if component["workspace"].get("identity_root")
-    }
-    unresolved: list[dict[str, Any]] = []
-    for component in components:
-        for relation in component.get("relations", []):
-            for side in ("source", "target"):
-                endpoint = relation.get(side) or {}
-                root = str(endpoint.get("workspace_identity_root") or "")
-                if root and root not in known_roots:
-                    unresolved.append(
-                        {
-                            "relation_root": relation.get("relation_root"),
-                            "side": side,
-                            "workspace_identity_root": root,
-                        }
-                    )
-        for problem in component.get("problems", []):
-            if problem.get("code") != "unresolved-assignment-dependency":
-                continue
-            unresolved.append(
-                {
-                    "code": problem["code"],
-                    "workspace_identity_root": component["workspace"].get(
-                        "identity_root"
-                    ),
-                    "assignment_subject": problem.get("assignment_subject"),
-                    "dependency_id": problem.get("dependency_id"),
-                }
-            )
-
     if scope == "all":
         projected_roots = {
             component["workspace"].get("identity_root") for component in components
         }
         for entry in catalog["entries"]:
-            if entry["identity_root"] in projected_roots:
+            if not entry.get("required", True):
+                if include_excluded:
+                    components.append(_excluded_component(entry))
+                continue
+            if entry.get("identity_root") in projected_roots:
                 continue
             components.append(_unavailable_component(entry))
 
@@ -433,10 +424,44 @@ def query_federation(
             str(row["workspace"].get("workspace_id") or ""),
         )
     )
+    projection = _compose_global_work(
+        components,
+        include_settled=include_settled,
+    )
+    unresolved = projection["reference_resolution"]["unresolved"]
+    component_problems = [
+        {
+            "workspace_identity_root": (component.get("workspace") or {}).get(
+                "identity_root"
+            ),
+            **dict(problem),
+        }
+        for component in components
+        for problem in component.get("problems") or []
+        if problem.get("code") != "unresolved-assignment-dependency"
+        and component.get("availability") != "excluded"
+    ]
+    catalog_after = load_workspace_catalog(config_home, env=env)
+    catalog_changed = catalog_after["catalog_cut"] != catalog["catalog_cut"]
+    catalog_issues = list(catalog["issues"])
+    if catalog_changed:
+        catalog_issues.append(
+            {
+                "code": "catalog-changed-during-query",
+                "catalog_cut_before": catalog["catalog_cut"],
+                "catalog_cut_after": catalog_after["catalog_cut"],
+                "next_action": "retry against a fresh Catalog cut",
+            }
+        )
     observed_at = _now()
     proof = {
         "schema": QUERY_PROOF_SCHEMA,
         "scope": scope,
+        "catalog_cut": catalog["catalog_cut"],
+        "catalog_cut_after": catalog_after["catalog_cut"],
+        "catalog_epoch": catalog["epoch"],
+        "catalog_epoch_after": catalog_after["epoch"],
+        "catalog_changed_during_query": catalog_changed,
         "component_cuts": [
             {
                 "workspace_identity_root": row["workspace"].get("identity_root"),
@@ -449,7 +474,22 @@ def query_federation(
             }
             for row in components
         ],
-        "catalog_issues": catalog["issues"],
+        "catalog_issues": catalog_issues,
+        "component_problems": component_problems,
+        "excluded_entries": [
+            {
+                "entry_key": str(
+                    entry.get("identity_root") or entry.get("locator_key") or ""
+                ),
+                "identity_root": entry.get("identity_root"),
+                "workspace_id": entry.get("workspace_id"),
+                "lifecycle": entry.get("lifecycle"),
+                "exclusion_policy": entry.get("exclusion_policy"),
+                "observed_at": entry.get("observed_at"),
+            }
+            for entry in excluded_entries
+        ],
+        "global_work_projection_root": projection["projection_root"],
         "unresolved_references": unresolved,
         "atomic_global_cut": False,
     }
@@ -458,6 +498,7 @@ def query_federation(
         "scope": scope,
         "observed_at": observed_at,
         "components": components,
+        "global_work": projection,
         "proof": {**proof, "proof_root": semantic_root(proof)},
         "authority": "component-workspace-authorities",
         "atomic_global_cut": False,
@@ -476,9 +517,12 @@ def query_federation(
         ),
     }
     verification = verify_federation_query(result)
-    known_assignments = sum(
-        len(component.get("assignments", [])) for component in components
-    )
+    observation_count = projection["observation_count"]
+    known_assignments = projection["assignment_observation_count"]
+    canonical_count = projection["canonical_work_count"]
+    replica_count = projection["replica_count"]
+    conflict_count = projection["conflict_count"]
+    label_collision_count = projection["label_collision_count"]
     available = sum(
         component.get("availability") == "available" for component in components
     )
@@ -488,8 +532,30 @@ def query_federation(
     unavailable = sum(
         component.get("availability") == "unavailable" for component in components
     )
-    unknown = degraded + unavailable
-    residual = len(catalog["issues"]) + len(unresolved) + len(verification["issues"])
+    stale = sum(
+        bool(component.get("stale"))
+        and component.get("availability") not in {"excluded"}
+        for component in components
+    )
+    excluded = len(excluded_entries)
+    tombstoned = sum(
+        str((entry.get("lifecycle") or {}).get("state") or "")
+        in {"retired", "test-only", "quarantined"}
+        for entry in excluded_entries
+    )
+    unknown = sum(
+        component.get("availability") in {"degraded", "unavailable"}
+        or bool(component.get("stale"))
+        for component in components
+        if component.get("availability") != "excluded"
+    )
+    residual = (
+        len(catalog_issues)
+        + len(component_problems)
+        + len(unresolved)
+        + conflict_count
+        + len(verification["issues"])
+    )
     complete = unknown == 0 and residual == 0
     state = "complete" if complete else "partial" if components else "unavailable"
     next_actions: list[str] = []
@@ -503,6 +569,14 @@ def query_federation(
         )
     if unresolved:
         next_actions.append("resolve retained cross-workspace Work references")
+    if component_problems:
+        next_actions.append("repair or explicitly exclude invalid component evidence")
+    if conflict_count:
+        next_actions.append(
+            "resolve ambiguous or conflicting canonical Work identities"
+        )
+    if catalog_changed:
+        next_actions.append("retry against a stable Catalog cut")
     if verification["issues"]:
         next_actions.append(
             "reject unverified component envelopes and re-run strict mode"
@@ -511,21 +585,417 @@ def query_federation(
         "state": state,
         "complete": complete,
         "component_count": len(components),
+        "component_observation_count": len(components),
+        "work_observation_count": observation_count,
+        "canonical_work_count": canonical_count,
+        "replica_count": replica_count,
+        "conflict_count": conflict_count,
+        "label_collision_count": label_collision_count,
+        "retained_assignment_state_count": projection[
+            "retained_assignment_state_count"
+        ],
+        "unqualified_retained_assignment_state_count": projection[
+            "unqualified_retained_assignment_state_count"
+        ],
         "available_component_count": available,
         "degraded_component_count": degraded,
         "unavailable_component_count": unavailable,
+        "stale_component_count": stale,
+        "excluded_component_count": excluded,
+        "tombstoned_component_count": tombstoned,
         "unknown_component_count": unknown,
         "known_assignment_count": known_assignments,
+        "unresolved_reference_count": len(unresolved),
+        "component_problem_count": len(component_problems),
+        "proof_ok": verification["ok"],
+        "writes": 0,
         "residual_error_count": residual,
         "false_zero_guard": (
             "unknown-not-empty"
-            if known_assignments == 0 and unknown > 0
+            if known_assignments == 0 and (unknown > 0 or residual > 0)
             else "not-applicable"
         ),
         "next_actions": next_actions,
     }
     result["verification"] = verification
     return result
+
+
+def _compose_global_work(
+    components: Iterable[Mapping[str, Any]],
+    *,
+    include_settled: bool = False,
+) -> dict[str, Any]:
+    """Compose root-bound observations into conservative canonical Work rows."""
+
+    component_rows = list(components)
+    observations: list[dict[str, Any]] = []
+    authority_nodes: dict[str, list[dict[str, Any]]] = {}
+    for component in component_rows:
+        workspace = component.get("workspace") or {}
+        envelope = component.get("envelope") or {}
+        for kind, field in (
+            ("initiative", "initiatives"),
+            ("assignment", "assignments"),
+        ):
+            for record in component.get(field) or []:
+                reference = parse_work_ref((record or {}).get("work_ref") or {})
+                display = {
+                    "title": str(
+                        record.get("title")
+                        or record.get("assignment_id")
+                        or record.get("initiative_id")
+                        or reference.subject
+                    ),
+                    "status": str(record.get("status") or ""),
+                    "portfolio_state": str(
+                        (record.get("lifecycle") or {}).get("portfolio_state") or ""
+                    ),
+                    "next_actions": list(
+                        (record.get("lifecycle") or {}).get("next_actions") or []
+                    ),
+                }
+                body = {
+                    "schema": WORK_OBSERVATION_SCHEMA,
+                    "work_ref": reference.as_dict(),
+                    "workspace_id": workspace.get("workspace_id"),
+                    "workspace_identity_root": reference.workspace_identity_root,
+                    "component_cut_root": component.get("cut_root"),
+                    "component_envelope_root": envelope.get("envelope_root"),
+                    "profile_root": envelope.get("profile_root"),
+                    "availability": component.get("availability"),
+                    "stale": bool(component.get("stale")),
+                    "display": display,
+                }
+                observation = {**body, "observation_root": semantic_root(body)}
+                observations.append(observation)
+                authority_nodes.setdefault(reference.node_key, []).append(observation)
+
+    fold_groups: dict[str, list[dict[str, Any]]] = {}
+    for node_key, rows in authority_nodes.items():
+        versions = sorted(
+            {str(row["work_ref"].get("version_root") or "") for row in rows}
+        )
+        reference = rows[0]["work_ref"]
+        fold_key = (
+            f"replica|{reference['object_kind']}|{reference['subject']}|{versions[0]}"
+            if len(versions) == 1
+            else f"authority|{node_key}"
+        )
+        fold_groups.setdefault(fold_key, []).extend(rows)
+
+    provisional: list[dict[str, Any]] = []
+    for rows in fold_groups.values():
+        rows.sort(key=lambda row: row["observation_root"])
+        references = [parse_work_ref(row["work_ref"]) for row in rows]
+        authority_roots = sorted(
+            {reference.workspace_identity_root for reference in references}
+        )
+        version_roots = sorted({reference.version_root for reference in references})
+        reference = references[0]
+        provisional.append(
+            {
+                "schema": CANONICAL_WORK_SCHEMA,
+                "object_kind": reference.object_kind,
+                "subject": reference.subject,
+                "authority_roots": authority_roots,
+                "version_roots": version_roots,
+                "equivalence": (
+                    {
+                        "state": "proven-replica",
+                        "witness": "shared-version-root",
+                        "version_root": version_roots[0],
+                    }
+                    if len(authority_roots) > 1 and len(version_roots) == 1
+                    else {
+                        "state": "authority-qualified",
+                        "witness": "workspace-identity-root",
+                    }
+                ),
+                "observation_roots": [str(row["observation_root"]) for row in rows],
+                "observations": rows,
+                "observation_count": len(rows),
+                "replica_count": max(0, len(rows) - len(version_roots)),
+                "display": rows[0]["display"],
+                "conflict": len(version_roots) > 1,
+                "conflict_reasons": (
+                    ["same-authority-divergent-version"]
+                    if len(version_roots) > 1
+                    else []
+                ),
+            }
+        )
+
+    by_label: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for row in provisional:
+        by_label.setdefault((row["object_kind"], row["subject"]), []).append(row)
+
+    canonical_rows: list[dict[str, Any]] = []
+    node_to_canonical: dict[str, str] = {}
+    subject_to_canonical: dict[tuple[str, str], set[str]] = {}
+    for row in provisional:
+        identity_body = {
+            "schema": CANONICAL_WORK_IDENTITY_SCHEMA,
+            "object_kind": row["object_kind"],
+            "subject": row["subject"],
+            "authority_roots": row["authority_roots"],
+            "version_roots": row["version_roots"],
+            "equivalence": row["equivalence"],
+        }
+        canonical_root = semantic_root(identity_body)
+        canonical_body = {
+            **dict(row),
+            "canonical_root": canonical_root,
+        }
+        canonical = {
+            **canonical_body,
+            "canonical_projection_root": semantic_root(canonical_body),
+        }
+        canonical_rows.append(canonical)
+        subject_to_canonical.setdefault(
+            (canonical["object_kind"], canonical["subject"]), set()
+        ).add(canonical_root)
+        for observation in canonical["observations"]:
+            node_to_canonical[parse_work_ref(observation["work_ref"]).node_key] = (
+                canonical_root
+            )
+    canonical_rows.sort(
+        key=lambda row: (
+            row["object_kind"],
+            row["subject"],
+            row["canonical_root"],
+        )
+    )
+    canonical_by_root = {str(row["canonical_root"]): row for row in canonical_rows}
+    label_collisions = [
+        {
+            "object_kind": object_kind,
+            "subject": subject,
+            "canonical_roots": sorted(
+                row["canonical_root"]
+                for row in canonical_rows
+                if row["object_kind"] == object_kind and row["subject"] == subject
+            ),
+            "state": "authority-distinct",
+            "strict_effect": "ambiguous-only-when-used-by-unqualified-reference",
+        }
+        for (object_kind, subject), rows in sorted(by_label.items())
+        if len(rows) > 1
+    ]
+    retained_states = {
+        str(state.get("state_root") or ""): dict(state)
+        for component in component_rows
+        for state in component.get("retained_assignment_states") or []
+        if state.get("state_root")
+    }
+    unqualified_retained_states = {
+        str(state.get("state_root") or ""): dict(state)
+        for component in component_rows
+        for state in component.get("unqualified_retained_assignment_states") or []
+        if state.get("state_root")
+    }
+    retained_subjects: dict[str, list[dict[str, Any]]] = {}
+    for state in retained_states.values():
+        if state.get("settled") is True:
+            retained_subjects.setdefault(
+                str(state.get("assignment_subject") or ""), []
+            ).append(state)
+    for rows in retained_subjects.values():
+        rows.sort(key=lambda row: str(row.get("state_root") or ""))
+
+    resolved: list[dict[str, Any]] = []
+    unresolved: list[dict[str, Any]] = []
+    relations = [
+        relation
+        for component in component_rows
+        for relation in component.get("relations") or []
+    ]
+    for relation in relations:
+        for side in ("source", "target"):
+            reference = parse_work_ref((relation or {}).get(side) or {})
+            target_root = node_to_canonical.get(reference.node_key)
+            if target_root:
+                resolved.append(
+                    {
+                        "kind": "typed-relation-endpoint",
+                        "relation_root": relation.get("relation_root"),
+                        "side": side,
+                        "work_ref": reference.as_dict(),
+                        "canonical_root": target_root,
+                    }
+                )
+            else:
+                unresolved.append(
+                    {
+                        "code": "missing-reference",
+                        "kind": "typed-relation-endpoint",
+                        "relation_root": relation.get("relation_root"),
+                        "side": side,
+                        "work_ref": reference.as_dict(),
+                        "next_action": "register and read the referenced workspace authority",
+                    }
+                )
+
+    for component in component_rows:
+        workspace = component.get("workspace") or {}
+        for problem in component.get("problems") or []:
+            if problem.get("code") != "unresolved-assignment-dependency":
+                continue
+            dependency_id = str(problem.get("dependency_id") or "")
+            dependency_subject = (
+                dependency_id
+                if dependency_id.startswith("kungfu:")
+                else f"kungfu:{dependency_id}"
+            )
+            candidates = sorted(
+                subject_to_canonical.get(("assignment", dependency_subject), set())
+            )
+            retained_candidates = retained_subjects.get(dependency_subject, [])
+            unqualified_candidates = [
+                row
+                for row in unqualified_retained_states.values()
+                if row.get("assignment_subject") == dependency_subject
+            ]
+            base = {
+                "kind": "legacy-assignment-dependency",
+                "workspace_identity_root": workspace.get("identity_root"),
+                "assignment_subject": problem.get("assignment_subject"),
+                "dependency_id": dependency_id,
+                "dependency_subject": dependency_subject,
+            }
+            if (
+                len(candidates) == 1
+                and not canonical_by_root[candidates[0]]["conflict"]
+            ):
+                resolved.append({**base, "canonical_root": candidates[0]})
+            elif not candidates and len(retained_candidates) == 1:
+                retained = retained_candidates[0]
+                resolved.append(
+                    {
+                        **base,
+                        "resolution": "retained-sealed-assignment-state",
+                        "sealed_state_root": retained["state_root"],
+                        "work_ref": {
+                            "schema": WORK_REF_SCHEMA,
+                            "workspace_identity_root": retained[
+                                "workspace_identity_root"
+                            ],
+                            "object_kind": "assignment",
+                            "subject": dependency_subject,
+                            "version_root": retained["state_root"],
+                            "cut_root": retained["query_proof_root"],
+                        },
+                    }
+                )
+            else:
+                code = (
+                    "missing-reference"
+                    if not candidates
+                    and not retained_candidates
+                    and not unqualified_candidates
+                    else (
+                        "conflicting-reference"
+                        if len(candidates) == 1 and not retained_candidates
+                        else (
+                            "incompatible-retained-reference"
+                            if not candidates
+                            and not retained_candidates
+                            and unqualified_candidates
+                            else "ambiguous-reference"
+                        )
+                    )
+                )
+                unresolved.append(
+                    {
+                        **base,
+                        "code": code,
+                        "candidate_canonical_roots": candidates,
+                        "candidate_sealed_state_roots": [
+                            row["state_root"] for row in retained_candidates
+                        ],
+                        "candidate_unqualified_state_roots": [
+                            row["state_root"] for row in unqualified_candidates
+                        ],
+                        "next_action": (
+                            "register the dependency authority"
+                            if code == "missing-reference"
+                            else "replace the legacy dependency id with one exact WorkRef"
+                        ),
+                    }
+                )
+
+    relation_qualification = qualify_assignment_graph(relations)
+    for issue in relation_qualification["issues"]:
+        unresolved.append(
+            {
+                "code": (
+                    "cyclic-reference"
+                    if issue.get("code") == "relation-cycle"
+                    else "invalid-reference"
+                ),
+                "qualification_issue": issue,
+                "next_action": "repair the source relation and publish a new component cut",
+            }
+        )
+    resolved.sort(key=lambda row: semantic_root(row))
+    unresolved.sort(key=lambda row: semantic_root(row))
+    resolution_body = {
+        "schema": REFERENCE_RESOLUTION_SCHEMA,
+        "resolved": resolved,
+        "unresolved": unresolved,
+        "relation_qualification_root": relation_qualification["qualification_root"],
+    }
+    reference_resolution = {
+        **resolution_body,
+        "resolution_root": semantic_root(resolution_body),
+    }
+    visible_work = [
+        row
+        for row in canonical_rows
+        if include_settled
+        or (
+            str(row["display"].get("portfolio_state") or "") != "completed"
+            and str(row["display"].get("status") or "").lower()
+            not in {"completed", "archived", "closed"}
+        )
+    ]
+    body = {
+        "schema": GLOBAL_WORK_PROJECTION_SCHEMA,
+        "canonical_work": canonical_rows,
+        "label_collisions": label_collisions,
+        "retained_assignment_states": [
+            retained_states[root] for root in sorted(retained_states)
+        ],
+        "unqualified_retained_assignment_states": [
+            unqualified_retained_states[root]
+            for root in sorted(unqualified_retained_states)
+        ],
+        "visible_work": visible_work,
+        "filter": {
+            "include_settled": include_settled,
+            "default": "active-and-attention",
+        },
+        "reference_resolution": reference_resolution,
+        "canonical_work_count": len(canonical_rows),
+        "visible_work_count": len(visible_work),
+        "initiative_count": sum(
+            row["object_kind"] == "initiative" for row in canonical_rows
+        ),
+        "assignment_count": sum(
+            row["object_kind"] == "assignment" for row in canonical_rows
+        ),
+        "observation_count": len(observations),
+        "assignment_observation_count": sum(
+            row["work_ref"]["object_kind"] == "assignment" for row in observations
+        ),
+        "replica_count": sum(row["replica_count"] for row in canonical_rows),
+        "conflict_count": sum(bool(row["conflict"]) for row in canonical_rows),
+        "label_collision_count": len(label_collisions),
+        "retained_assignment_state_count": len(retained_states),
+        "unqualified_retained_assignment_state_count": len(unqualified_retained_states),
+        "writes": 0,
+    }
+    return {**body, "projection_root": semantic_root(body)}
 
 
 def verify_federation_query(value: Mapping[str, Any]) -> dict[str, Any]:
@@ -593,6 +1063,15 @@ def verify_federation_query(value: Mapping[str, Any]) -> dict[str, Any]:
                 issues.append(
                     {"code": "component-runtime-incompatible", "index": index}
                 )
+        retained_states = component.get("retained_assignment_states") or []
+        retained_root = str(component.get("retained_state_index_root") or "")
+        if retained_root and (
+            not _ROOT.fullmatch(retained_root)
+            or _retained_state_projection_root(retained_states) != retained_root
+        ):
+            issues.append(
+                {"code": "component-retained-state-index-root", "index": index}
+            )
         for kind in ("initiatives", "assignments"):
             rows = component.get(kind)
             if not isinstance(rows, list):
@@ -606,6 +1085,23 @@ def verify_federation_query(value: Mapping[str, Any]) -> dict[str, Any]:
                         {"code": "component-work-ref-invalid", "index": index}
                     )
                     break
+    projection = value.get("global_work")
+    if not isinstance(projection, Mapping):
+        issues.append({"code": "global-work-projection-missing"})
+    else:
+        declared_projection_root = str(projection.get("projection_root") or "")
+        projection_body = dict(projection)
+        projection_body.pop("projection_root", None)
+        if (
+            projection.get("schema") != GLOBAL_WORK_PROJECTION_SCHEMA
+            or not _ROOT.fullmatch(declared_projection_root)
+            or semantic_root(projection_body) != declared_projection_root
+        ):
+            issues.append({"code": "global-work-projection-root"})
+        if (value.get("proof") or {}).get(
+            "global_work_projection_root"
+        ) != declared_projection_root:
+            issues.append({"code": "query-proof-global-work-mismatch"})
     proof_components = (value.get("proof") or {}).get("component_cuts")
     expected_proof_components = [
         {
@@ -899,6 +1395,30 @@ def _load_component(identity: WorkspaceIdentity) -> dict[str, Any]:
     workspace through the controller's active Mission Control Profile.
     """
 
+    from kungfu import assignment_orchestration
+
+    sealed_index = (
+        assignment_orchestration.list_sealed_assignment_states(identity.workspace_root)
+        if identity.workspace_root
+        else {
+            "schema": "kungfu.assignment-orchestration.sealed-work-index/v1",
+            "states": [],
+            "unqualified_states": [],
+            "issues": [],
+            "storage_kind": "none",
+            "writes": [],
+            "index_root": semantic_root(
+                {
+                    "schema": "kungfu.assignment-orchestration.sealed-work-index/v1",
+                    "states": [],
+                    "unqualified_states": [],
+                    "issues": [],
+                    "storage_kind": "none",
+                    "writes": [],
+                }
+            ),
+        }
+    )
     runtime_dir = os.path.join(identity.data_home, "runtime")
     if not os.path.isdir(runtime_dir):
         body = {
@@ -919,7 +1439,14 @@ def _load_component(identity: WorkspaceIdentity) -> dict[str, Any]:
             "initiatives": [],
             "assignments": [],
             "relations": [],
-            "problems": [],
+            "problems": list(sealed_index["issues"]),
+            "retained_assignment_states": sealed_index["states"],
+            "unqualified_retained_assignment_states": sealed_index[
+                "unqualified_states"
+            ],
+            "retained_state_index_root": _retained_state_projection_root(
+                sealed_index["states"]
+            ),
             "reader_runtime": _reader_runtime_identity(),
             "workspace_runtime": _workspace_runtime_identity(identity),
             "profile_binding": _empty_profile_binding(),
@@ -1043,7 +1570,12 @@ def _load_component(identity: WorkspaceIdentity) -> dict[str, Any]:
         "initiatives": projected_initiatives,
         "assignments": projected_assignments,
         "relations": [relations[root] for root in sorted(relations)],
-        "problems": problems,
+        "problems": [*problems, *sealed_index["issues"]],
+        "retained_assignment_states": sealed_index["states"],
+        "unqualified_retained_assignment_states": sealed_index["unqualified_states"],
+        "retained_state_index_root": _retained_state_projection_root(
+            sealed_index["states"]
+        ),
         "reader_runtime": _reader_runtime_identity(),
         "workspace_runtime": _workspace_runtime_identity(identity),
         "profile_binding": profile_binding,
@@ -1199,6 +1731,13 @@ def _bind_component_envelope(component: dict[str, Any]) -> dict[str, Any]:
         "errors": errors,
         "known_initiative_count": len(component.get("initiatives") or []),
         "known_assignment_count": len(component.get("assignments") or []),
+        "retained_assignment_state_count": len(
+            component.get("retained_assignment_states") or []
+        ),
+        "unqualified_retained_assignment_state_count": len(
+            component.get("unqualified_retained_assignment_states") or []
+        ),
+        "retained_state_index_root": component.get("retained_state_index_root") or "",
         "relation_roots": sorted(
             str(row.get("relation_root") or "")
             for row in component.get("relations") or []
@@ -1221,7 +1760,23 @@ def _component_result_material(component: Mapping[str, Any]) -> dict[str, Any]:
         "assignments": list(component.get("assignments") or []),
         "relations": list(component.get("relations") or []),
         "problems": list(component.get("problems") or []),
+        "retained_assignment_states": list(
+            component.get("retained_assignment_states") or []
+        ),
+        "unqualified_retained_assignment_states": list(
+            component.get("unqualified_retained_assignment_states") or []
+        ),
+        "retained_state_index_root": component.get("retained_state_index_root") or "",
     }
+
+
+def _retained_state_projection_root(states: Iterable[Mapping[str, Any]]) -> str:
+    return semantic_root(
+        {
+            "schema": "kungfu.workspace-federation.retained-assignment-states/v1",
+            "states": [dict(row) for row in states],
+        }
+    )
 
 
 def _record_projection(
@@ -1366,6 +1921,44 @@ def _unavailable_component(entry: Mapping[str, Any]) -> dict[str, Any]:
             "problems": [
                 {
                     "code": "workspace-unavailable",
+                    "locator": entry.get("locator"),
+                }
+            ],
+        }
+    )
+
+
+def _excluded_component(entry: Mapping[str, Any]) -> dict[str, Any]:
+    workspace = {
+        "schema": "kungfu.workspace.identity/v1",
+        "workspace_id": entry.get("workspace_id"),
+        "identity_root": entry.get("identity_root"),
+        "identity_state": entry.get("identity_state") or "qualified",
+        "workspace_kind": entry.get("workspace_kind"),
+        "workspace_root": entry.get("locator"),
+        "display_path": entry.get("locator") or "Home",
+        "data_home": entry.get("data_home"),
+        "initialized": False,
+        "state": "excluded",
+        "resolution_reason": "catalog-lifecycle-policy",
+    }
+    return _bind_component_envelope(
+        {
+            "workspace": workspace,
+            "availability": "excluded",
+            "observed_at": _now(),
+            "catalog_observed_at": entry.get("observed_at"),
+            "stale": not bool(entry.get("available")),
+            "cut_root": "",
+            "query_proof_root": "",
+            "initiatives": [],
+            "assignments": [],
+            "relations": [],
+            "problems": [
+                {
+                    "code": "workspace-excluded",
+                    "lifecycle": entry.get("lifecycle"),
+                    "exclusion_policy": entry.get("exclusion_policy"),
                     "locator": entry.get("locator"),
                 }
             ],

--- a/framework/core/src/python/kungfu/workspace_federation.py
+++ b/framework/core/src/python/kungfu/workspace_federation.py
@@ -16,7 +16,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Any, Callable, Iterable, Literal, Mapping
+from typing import Any, Callable, Iterable, Literal, Mapping, cast
 
 from kungfu.workspace import (
     WorkspaceIdentity,
@@ -1419,6 +1419,7 @@ def _load_component(identity: WorkspaceIdentity) -> dict[str, Any]:
             ),
         }
     )
+    sealed_states = cast(list[dict[str, Any]], sealed_index["states"])
     runtime_dir = os.path.join(identity.data_home, "runtime")
     if not os.path.isdir(runtime_dir):
         body = {
@@ -1440,13 +1441,11 @@ def _load_component(identity: WorkspaceIdentity) -> dict[str, Any]:
             "assignments": [],
             "relations": [],
             "problems": list(sealed_index["issues"]),
-            "retained_assignment_states": sealed_index["states"],
+            "retained_assignment_states": sealed_states,
             "unqualified_retained_assignment_states": sealed_index[
                 "unqualified_states"
             ],
-            "retained_state_index_root": _retained_state_projection_root(
-                sealed_index["states"]
-            ),
+            "retained_state_index_root": _retained_state_projection_root(sealed_states),
             "reader_runtime": _reader_runtime_identity(),
             "workspace_runtime": _workspace_runtime_identity(identity),
             "profile_binding": _empty_profile_binding(),
@@ -1571,11 +1570,9 @@ def _load_component(identity: WorkspaceIdentity) -> dict[str, Any]:
         "assignments": projected_assignments,
         "relations": [relations[root] for root in sorted(relations)],
         "problems": [*problems, *sealed_index["issues"]],
-        "retained_assignment_states": sealed_index["states"],
+        "retained_assignment_states": sealed_states,
         "unqualified_retained_assignment_states": sealed_index["unqualified_states"],
-        "retained_state_index_root": _retained_state_projection_root(
-            sealed_index["states"]
-        ),
+        "retained_state_index_root": _retained_state_projection_root(sealed_states),
         "reader_runtime": _reader_runtime_identity(),
         "workspace_runtime": _workspace_runtime_identity(identity),
         "profile_binding": profile_binding,

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -356,6 +356,48 @@ def test_sealed_state_survives_git_worktree_deletion(tmp_path):
     assert assignment_orchestration.verify_sealed_state(state_file)["ok"] is True
 
 
+def test_sealed_state_index_retains_exact_work_coordinate(tmp_path):
+    common = tmp_path / "repo.git"
+    administration = common / "worktrees" / "assignment-index"
+    administration.mkdir(parents=True)
+    (administration / "commondir").write_text("../..\n", encoding="utf-8")
+    workspace = tmp_path / "worktree"
+    workspace.mkdir()
+    (workspace / ".git").write_text(f"gitdir: {administration}\n", encoding="utf-8")
+    owning_root = "sha256:" + "b" * 64
+    status = {
+        "initiative_subject": "kungfu:initiative-a",
+        "assignment_subject": "kungfu:assignment-a",
+        "assignment": {
+            "assignment_id": "assignment-a",
+            "owning_workspace_identity_root": owning_root,
+        },
+        "phase": "continuation-decided",
+        "active_lease": None,
+        "query_proof_root": "sha256:" + "a" * 64,
+    }
+    plan = assignment_orchestration.sealed_state_plan(workspace, status)
+    assignment_orchestration.apply_sealed_state(plan, plan["state_root"])
+
+    index = assignment_orchestration.list_sealed_assignment_states(workspace)
+
+    assert index["issues"] == []
+    assert index["writes"] == []
+    assert index["index_root"].startswith("sha256:")
+    assert index["states"] == [
+        {
+            "schema": "kungfu.assignment-orchestration.sealed-work-coordinate/v1",
+            "assignment_subject": "kungfu:assignment-a",
+            "workspace_identity_root": owning_root,
+            "state_root": plan["state_root"],
+            "query_proof_root": status["query_proof_root"],
+            "phase": "continuation-decided",
+            "settled": True,
+            "storage_kind": "git-common-dir",
+        }
+    ]
+
+
 def test_assignment_relation_handshake_is_workspace_routed_and_fact_backed(
     tmp_path,
 ):
@@ -679,10 +721,16 @@ def test_unresolved_dependency_shorthand_remains_visible_without_fake_work_ref(
     ]
     assert result["proof"]["unresolved_references"] == [
         {
-            "code": "unresolved-assignment-dependency",
+            "kind": "legacy-assignment-dependency",
+            "code": "missing-reference",
             "workspace_identity_root": identity.identity_root,
             "assignment_subject": "kungfu:current",
             "dependency_id": "historical-assignment",
+            "dependency_subject": "kungfu:historical-assignment",
+            "candidate_canonical_roots": [],
+            "candidate_sealed_state_roots": [],
+            "candidate_unqualified_state_roots": [],
+            "next_action": "register the dependency authority",
         }
     ]
 

--- a/framework/core/tests/python/test_workspace.py
+++ b/framework/core/tests/python/test_workspace.py
@@ -14,6 +14,7 @@ from kungfu.workspace import (
     inspect_workspace,
     load_workspace_catalog,
     load_workspace_registry,
+    maintain_workspace_catalog,
     prepare_workspace_write,
     rebuild_workspace_catalog,
     rebind_workspace_locator,
@@ -181,6 +182,73 @@ def test_catalog_damage_degrades_discovery_without_changing_workspace_authority(
     assert rebuilt["filesystem_scan"] is False
     assert rebuilt["entries"][0]["identity_root"] == qualified.identity_root
     assert verify_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})["ok"]
+
+
+def test_catalog_lifecycle_is_dry_run_reversible_and_retains_authority(tmp_path):
+    config_home = tmp_path / "config"
+    identity = inspect_workspace(str(tmp_path / "repo"), env={"HOME": str(tmp_path)})
+    assert identity is None or identity.identity_state == "locator-candidate"
+    repo = tmp_path / "cataloged"
+    repo.mkdir()
+    candidate = inspect_workspace(str(repo), env={"HOME": str(tmp_path)})
+    assert candidate is not None
+    ensure_workspace_data_home(candidate, "catalog-lifecycle-fixture")
+    qualified = inspect_workspace(str(repo), env={"HOME": str(tmp_path)})
+    assert qualified is not None
+    select_workspace(
+        qualified, config_home=str(config_home), env={"HOME": str(tmp_path)}
+    )
+    before = load_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})
+    entry_key = before["entries"][0]["identity_root"]
+
+    plan = maintain_workspace_catalog(
+        [entry_key],
+        "retire",
+        "fixture retired",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+    )
+
+    assert plan["executed"] is False
+    assert plan["writes"] == []
+    assert (
+        load_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})[
+            "catalog_cut"
+        ]
+        == before["catalog_cut"]
+    )
+
+    applied = maintain_workspace_catalog(
+        [entry_key],
+        "retire",
+        "fixture retired",
+        execute=True,
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+    )
+    retired = load_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})
+
+    assert applied["receipt"]["receipt_root"].startswith("sha256:")
+    assert retired["entries"][0]["lifecycle"]["state"] == "retired"
+    assert retired["entries"][0]["required"] is False
+    assert retired["entries"][0]["retained"] is True
+    assert (repo / ".kungfu" / "workspace-identity.json").exists()
+
+    restored = maintain_workspace_catalog(
+        [entry_key],
+        "restore",
+        "fixture restored",
+        execute=True,
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+    )
+    assert restored["receipt"]["catalog_cut_before"] == retired["catalog_cut"]
+    assert (
+        load_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})[
+            "entries"
+        ][0]["lifecycle"]["state"]
+        == "active"
+    )
 
 
 def test_tracked_settled_shadow_is_readable_without_runtime_initialization(tmp_path):

--- a/framework/core/tests/python/test_workspace_federation.py
+++ b/framework/core/tests/python/test_workspace_federation.py
@@ -10,6 +10,7 @@ import pytest
 from kungfu.workspace import (
     ensure_workspace_data_home,
     inspect_workspace,
+    maintain_workspace_catalog,
     observe_workspace_locator,
     select_workspace,
 )
@@ -26,6 +27,7 @@ from kungfu.workspace_federation import (
     verify_federation_query,
     verify_dogfood_gate_receipt,
 )
+from kungfu.cli.commands.workspace import _human_work_line
 
 
 ROOT_A = "sha256:" + "a" * 64
@@ -61,6 +63,26 @@ def _ref(identity, subject, version=ROOT_A, cut=ROOT_B):
     )
 
 
+def _component_fixture(identity, assignments):
+    return {
+        "availability": "available",
+        "stale": False,
+        "cut_root": ROOT_D,
+        "query_proof_root": ROOT_D,
+        "initiatives": [],
+        "assignments": assignments.get(identity.identity_root, []),
+        "relations": [],
+        "problems": [],
+        "profile_root": ROOT_A,
+        "reader_runtime": {"runtime_root": ROOT_B},
+        "workspace_runtime": {"runtime_root": ROOT_C},
+        "compatibility": {
+            "state": "compatible",
+            "protocol": "kungfu.fact-material-read/v1",
+        },
+    }
+
+
 def test_public_contract_matches_runtime_relation_vocabulary():
     contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
 
@@ -82,6 +104,32 @@ def test_public_contract_matches_runtime_relation_vocabulary():
         "closeout",
     ]
     assert contract["catalog"]["filesystemScan"] is False
+    assert contract["catalog"]["maintenanceDryRunDefault"] is True
+    assert contract["query"]["globalWorkProjection"]["humanAndJsonShareProjection"]
+
+
+def test_human_projection_is_stable_at_realistic_scale_and_narrow_width():
+    rows = [
+        {
+            "object_kind": "assignment",
+            "display": {
+                "title": f"Work item {index:02d} with a deliberately descriptive title",
+                "portfolio_state": "open" if index % 3 else "awaiting-review",
+            },
+            "conflict": index == 17,
+            "replica_count": 1 if index in {4, 21} else 0,
+            "canonical_root": f"sha256:{index + 1:064x}",
+        }
+        for index in range(35)
+    ]
+
+    snapshot = [_human_work_line(row, 60) for row in rows]
+
+    assert len(snapshot) == 35
+    assert all(len(line) <= 60 for line in snapshot)
+    assert len(set(snapshot)) == 35
+    assert any("!conflict" in line for line in snapshot)
+    assert sum(" x2 " in line for line in snapshot) == 2
 
 
 def test_work_ref_requires_qualified_workspace_and_contains_no_locator(tmp_path):
@@ -301,6 +349,392 @@ def test_false_zero_regression_preserves_31_unavailable_components(tmp_path):
     assert result["aggregate"]["unavailable_component_count"] == 31
     assert result["aggregate"]["false_zero_guard"] == "unknown-not-empty"
     assert result["aggregate"]["complete"] is False
+
+
+def test_global_projection_folds_only_root_proven_replicas(tmp_path):
+    config_home = tmp_path / "config"
+    left = _qualified_project(tmp_path, "replica-left")
+    right = _qualified_project(tmp_path, "replica-right")
+    for identity in (left, right):
+        observe_workspace_locator(
+            identity,
+            config_home=str(config_home),
+            env={"HOME": str(tmp_path)},
+        )
+    assignments = {
+        left.identity_root: [
+            {
+                "title": "Shared delivery",
+                "status": "active",
+                "work_ref": _ref(left, "kungfu:shared", ROOT_A, ROOT_D).as_dict(),
+            }
+        ],
+        right.identity_root: [
+            {
+                "title": "Shared delivery",
+                "status": "active",
+                "work_ref": _ref(right, "kungfu:shared", ROOT_A, ROOT_D).as_dict(),
+            }
+        ],
+    }
+
+    result = query_federation(
+        left,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+        loader=lambda identity: _component_fixture(identity, assignments),
+    )
+
+    rows = result["global_work"]["canonical_work"]
+    assert len(rows) == 1
+    assert rows[0]["equivalence"]["state"] == "proven-replica"
+    assert rows[0]["replica_count"] == 1
+    assert len(rows[0]["authority_roots"]) == 2
+    assert result["aggregate"]["canonical_work_count"] == 1
+    assert result["aggregate"]["work_observation_count"] == 2
+    assert result["aggregate"]["replica_count"] == 1
+
+
+def test_same_label_divergent_roots_remain_distinct_without_unsafe_collapse(tmp_path):
+    config_home = tmp_path / "config"
+    left = _qualified_project(tmp_path, "conflict-left")
+    right = _qualified_project(tmp_path, "conflict-right")
+    for identity in (left, right):
+        observe_workspace_locator(
+            identity,
+            config_home=str(config_home),
+            env={"HOME": str(tmp_path)},
+        )
+    assignments = {
+        left.identity_root: [
+            {
+                "title": "Same label",
+                "work_ref": _ref(left, "kungfu:same", ROOT_A, ROOT_D).as_dict(),
+            }
+        ],
+        right.identity_root: [
+            {
+                "title": "Same label",
+                "work_ref": _ref(right, "kungfu:same", ROOT_B, ROOT_D).as_dict(),
+            }
+        ],
+    }
+
+    result = query_federation(
+        left,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+        loader=lambda identity: _component_fixture(identity, assignments),
+    )
+
+    assert result["aggregate"]["canonical_work_count"] == 2
+    assert result["aggregate"]["conflict_count"] == 0
+    assert result["aggregate"]["label_collision_count"] == 1
+    assert not any(row["conflict"] for row in result["global_work"]["canonical_work"])
+    collision = result["global_work"]["label_collisions"][0]
+    assert collision["state"] == "authority-distinct"
+    assert len(collision["canonical_roots"]) == 2
+
+
+def test_same_authority_divergent_versions_are_a_strict_conflict(tmp_path):
+    identity = _qualified_project(tmp_path, "authority-conflict")
+    assignments = {
+        identity.identity_root: [
+            {
+                "title": "Version A",
+                "work_ref": _ref(identity, "kungfu:conflict", ROOT_A, ROOT_D).as_dict(),
+            },
+            {
+                "title": "Version B",
+                "work_ref": _ref(identity, "kungfu:conflict", ROOT_B, ROOT_D).as_dict(),
+            },
+        ]
+    }
+
+    result = query_federation(
+        identity,
+        scope="local",
+        config_home=str(tmp_path / "config"),
+        env={"HOME": str(tmp_path)},
+        loader=lambda current: _component_fixture(current, assignments),
+    )
+
+    assert result["aggregate"]["conflict_count"] == 1
+    assert result["aggregate"]["complete"] is False
+    assert result["global_work"]["canonical_work"][0]["conflict_reasons"] == [
+        "same-authority-divergent-version"
+    ]
+
+
+def test_ambiguous_legacy_dependency_has_distinct_fail_closed_reason(tmp_path):
+    source = _qualified_project(tmp_path, "ambiguous-source")
+    left = _qualified_project(tmp_path, "ambiguous-left")
+    right = _qualified_project(tmp_path, "ambiguous-right")
+    config_home = tmp_path / "config"
+    for identity in (source, left, right):
+        observe_workspace_locator(
+            identity,
+            config_home=str(config_home),
+            env={"HOME": str(tmp_path)},
+        )
+    assignments = {
+        source.identity_root: [
+            {
+                "title": "Source",
+                "work_ref": _ref(source, "kungfu:source", ROOT_C, ROOT_D).as_dict(),
+            }
+        ],
+        left.identity_root: [
+            {
+                "title": "Target A",
+                "work_ref": _ref(left, "kungfu:target", ROOT_A, ROOT_D).as_dict(),
+            }
+        ],
+        right.identity_root: [
+            {
+                "title": "Target B",
+                "work_ref": _ref(right, "kungfu:target", ROOT_B, ROOT_D).as_dict(),
+            }
+        ],
+    }
+
+    def loader(identity):
+        component = _component_fixture(identity, assignments)
+        if identity.identity_root == source.identity_root:
+            component["problems"] = [
+                {
+                    "code": "unresolved-assignment-dependency",
+                    "assignment_subject": "kungfu:source",
+                    "dependency_id": "target",
+                }
+            ]
+        return component
+
+    result = query_federation(
+        source,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+        loader=loader,
+    )
+
+    unresolved = result["global_work"]["reference_resolution"]["unresolved"]
+    assert unresolved[0]["code"] == "ambiguous-reference"
+    assert len(unresolved[0]["candidate_canonical_roots"]) == 2
+    assert result["aggregate"]["complete"] is False
+
+
+def test_stale_required_component_fails_strict_completeness(tmp_path):
+    identity = _qualified_project(tmp_path, "stale-required")
+
+    def loader(current):
+        component = _component_fixture(current, {})
+        component["stale"] = True
+        return component
+
+    result = query_federation(
+        identity,
+        scope="local",
+        config_home=str(tmp_path / "config"),
+        env={"HOME": str(tmp_path)},
+        loader=loader,
+    )
+
+    assert result["aggregate"]["stale_component_count"] == 1
+    assert result["aggregate"]["unknown_component_count"] == 1
+    assert result["aggregate"]["complete"] is False
+
+
+def test_legacy_dependencies_resolve_after_complete_identity_composition(tmp_path):
+    config_home = tmp_path / "config"
+    source = _qualified_project(tmp_path, "dependency-source")
+    target = _qualified_project(tmp_path, "dependency-target")
+    for identity in (target, source):
+        observe_workspace_locator(
+            identity,
+            config_home=str(config_home),
+            env={"HOME": str(tmp_path)},
+        )
+    assignments = {
+        source.identity_root: [
+            {
+                "title": "Source",
+                "work_ref": _ref(source, "kungfu:source", ROOT_A, ROOT_D).as_dict(),
+            }
+        ],
+        target.identity_root: [
+            {
+                "title": "Target",
+                "work_ref": _ref(target, "kungfu:target", ROOT_B, ROOT_D).as_dict(),
+            }
+        ],
+    }
+
+    def loader(identity):
+        component = _component_fixture(identity, assignments)
+        if identity.identity_root == source.identity_root:
+            component["problems"] = [
+                {
+                    "code": "unresolved-assignment-dependency",
+                    "assignment_subject": "kungfu:source",
+                    "dependency_id": "target",
+                }
+            ]
+        return component
+
+    result = query_federation(
+        source,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+        loader=loader,
+    )
+
+    resolution = result["global_work"]["reference_resolution"]
+    assert resolution["unresolved"] == []
+    assert resolution["resolved"][0]["dependency_subject"] == "kungfu:target"
+    assert result["aggregate"]["complete"] is True
+
+
+def test_retained_sealed_state_closes_deleted_worktree_dependency(tmp_path):
+    source = _qualified_project(tmp_path, "sealed-dependency-source")
+    target_root = "sha256:" + "e" * 64
+    state_root = "sha256:" + "f" * 64
+    assignments = {
+        source.identity_root: [
+            {
+                "title": "Source",
+                "work_ref": _ref(source, "kungfu:source", ROOT_A, ROOT_D).as_dict(),
+            }
+        ]
+    }
+
+    def loader(identity):
+        component = _component_fixture(identity, assignments)
+        component["problems"] = [
+            {
+                "code": "unresolved-assignment-dependency",
+                "assignment_subject": "kungfu:source",
+                "dependency_id": "deleted-target",
+            }
+        ]
+        component["retained_assignment_states"] = [
+            {
+                "schema": "kungfu.assignment-orchestration.sealed-work-coordinate/v1",
+                "assignment_subject": "kungfu:deleted-target",
+                "workspace_identity_root": target_root,
+                "state_root": state_root,
+                "query_proof_root": ROOT_C,
+                "phase": "continuation-decided",
+                "settled": True,
+                "storage_kind": "git-common-dir",
+            }
+        ]
+        return component
+
+    result = query_federation(
+        source,
+        scope="local",
+        config_home=str(tmp_path / "config"),
+        env={"HOME": str(tmp_path)},
+        loader=loader,
+    )
+
+    resolution = result["global_work"]["reference_resolution"]
+    assert resolution["unresolved"] == []
+    assert resolution["resolved"][0]["resolution"] == (
+        "retained-sealed-assignment-state"
+    )
+    assert resolution["resolved"][0]["work_ref"]["workspace_identity_root"] == (
+        target_root
+    )
+    assert result["aggregate"]["retained_assignment_state_count"] == 1
+
+
+def test_explicit_catalog_exclusion_is_retained_but_not_required(tmp_path):
+    config_home = tmp_path / "config"
+    active = _qualified_project(tmp_path, "active")
+    retired = _qualified_project(tmp_path, "retired")
+    for identity in (active, retired):
+        observe_workspace_locator(
+            identity,
+            config_home=str(config_home),
+            env={"HOME": str(tmp_path)},
+        )
+    retired_root = retired.identity_root
+    os.rename(retired.workspace_root, tmp_path / "retired-moved")
+    maintain_workspace_catalog(
+        [retired_root],
+        "retire",
+        "disposable fixture retired",
+        execute=True,
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+    )
+
+    clean = query_federation(
+        active,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+    )
+    detailed = query_federation(
+        active,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+        include_excluded=True,
+    )
+
+    assert clean["aggregate"]["complete"] is True
+    assert clean["aggregate"]["excluded_component_count"] == 1
+    assert clean["aggregate"]["tombstoned_component_count"] == 1
+    assert all(
+        row["workspace"]["identity_root"] != retired_root for row in clean["components"]
+    )
+    excluded = [
+        row for row in detailed["components"] if row["availability"] == "excluded"
+    ]
+    assert excluded[0]["workspace"]["identity_root"] == retired_root
+    assert detailed["proof"]["excluded_entries"][0]["identity_root"] == retired_root
+
+
+def test_catalog_churn_is_explicit_and_never_claims_complete(tmp_path):
+    config_home = tmp_path / "config"
+    current = _qualified_project(tmp_path, "catalog-current")
+    concurrent = _qualified_project(tmp_path, "catalog-concurrent")
+    observe_workspace_locator(
+        current,
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+    )
+    changed = False
+
+    def loader(identity):
+        nonlocal changed
+        if not changed:
+            changed = True
+            observe_workspace_locator(
+                concurrent,
+                config_home=str(config_home),
+                env={"HOME": str(tmp_path)},
+            )
+        return _component_fixture(identity, {})
+
+    result = query_federation(
+        current,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+        loader=loader,
+    )
+
+    assert result["proof"]["catalog_changed_during_query"] is True
+    assert result["proof"]["catalog_cut"] != result["proof"]["catalog_cut_after"]
+    assert result["aggregate"]["complete"] is False
+    assert result["aggregate"]["false_zero_guard"] == "unknown-not-empty"
 
 
 def test_query_verifier_rejects_replayed_or_tampered_component_envelope(tmp_path):
@@ -555,7 +989,16 @@ def test_related_query_resolves_catalog_workspace_from_typed_edge(tmp_path):
             "cut_root": ROOT_D,
             "query_proof_root": ROOT_C,
             "initiatives": [],
-            "assignments": [],
+            "assignments": [
+                {
+                    "title": "Left" if identity == left_identity else "Right",
+                    "work_ref": (
+                        _ref(left_identity, "kungfu:left", ROOT_A, ROOT_D)
+                        if identity == left_identity
+                        else _ref(right_identity, "kungfu:right", ROOT_B, ROOT_D)
+                    ).as_dict(),
+                }
+            ],
             "relations": (
                 [edge] if identity.identity_root == left_identity.identity_root else []
             ),

--- a/framework/workspace-federation/workspace-federation.contract.json
+++ b/framework/workspace-federation/workspace-federation.contract.json
@@ -161,13 +161,41 @@
         "unavailable"
       ],
       "knownAssignmentCountRequired": true,
+      "canonicalWorkCountRequired": true,
+      "workObservationCountRequired": true,
+      "replicaCountRequired": true,
+      "conflictCountRequired": true,
+      "excludedComponentCountRequired": true,
+      "staleComponentCountRequired": true,
+      "unresolvedReferenceCountRequired": true,
+      "proofStatusRequired": true,
+      "writesZeroRequired": true,
       "unknownComponentCountRequired": true,
       "residualErrorsRequired": true,
       "falseZeroMeansUnknown": true
     },
     "strictMode": {
       "nonzeroWhenIncomplete": true,
-      "nonzeroWhenProofInvalid": true
+      "nonzeroWhenProofInvalid": true,
+      "nonzeroWhenCatalogChanged": true,
+      "nonzeroWhenCanonicalIdentityAmbiguous": true,
+      "validExclusionsRemainInProof": true
+    },
+    "globalWorkProjection": {
+      "schema": "kungfu.workspace-federation.global-work/v1",
+      "defaultFilter": "active-and-attention",
+      "canonicalIdentity": "authority-qualified, or shared version root as an explicit replica witness",
+      "sameLabelDifferentRoot": "authority-distinct; ambiguous only to an unqualified reference",
+      "retainedSettledReference": "verified worktree-deletion-safe Assignment seal with owning workspace, state root, and query proof root",
+      "humanAndJsonShareProjection": true,
+      "rawComponentsRetained": true
+    },
+    "catalogCut": {
+      "schema": "kungfu.workspace.locator-catalog-cut/v1",
+      "epochRequired": true,
+      "beforeAfterRequired": true,
+      "atomicGlobalCut": false,
+      "changeResult": "stale-retry-fail-closed"
     },
     "dogfoodGate": {
       "schema": "kungfu.workspace-federation.dogfood-gate-receipt/v1",
@@ -198,10 +226,25 @@
     "separateFromBoundedRecents": true,
     "authority": false,
     "filesystemScan": false,
+    "lifecycleStates": [
+      "active",
+      "retired",
+      "test-only",
+      "quarantined"
+    ],
+    "defaultRequiredState": "active",
+    "excludedStatesRetained": true,
+    "maintenanceDryRunDefault": true,
+    "maintenanceReceiptSchema": "kungfu.workspace.catalog-lifecycle-receipt/v1",
+    "testProcessIsolation": "ephemeral config home unless explicitly overridden",
     "repairOperations": [
       "verify",
       "rebuild-from-bounded-recents-and-explicit-locators",
-      "rebind-exact-identity"
+      "rebind-exact-identity",
+      "retire-exact-entry",
+      "classify-test-only-exact-entry",
+      "quarantine-exact-entry",
+      "restore-exact-entry"
     ]
   },
   "completion": {

--- a/scripts/run-workspace-continuation-tests.mjs
+++ b/scripts/run-workspace-continuation-tests.mjs
@@ -28,6 +28,7 @@ run(process.execPath, [
 
 const pythonPath = [
   path.join(root, 'framework', 'core', 'src', 'python'),
+  path.join(root, 'framework', 'core', 'build', 'Release'),
   process.env.PYTHONPATH,
 ]
   .filter(Boolean)
@@ -47,6 +48,22 @@ run(
       'tests',
       'python',
       'test_workspace.py',
+    ),
+    path.join(
+      root,
+      'framework',
+      'core',
+      'tests',
+      'python',
+      'test_workspace_federation.py',
+    ),
+    path.join(
+      root,
+      'framework',
+      'core',
+      'tests',
+      'python',
+      'test_assignment_orchestration.py',
     ),
     '-q',
   ],


### PR DESCRIPTION
## Summary

Close the installed federated Work reader into a strict, clean user projection while preserving every workspace authority boundary and every degraded observation.

## Related issue

Atlas go: 2026-07-24-kungfu-global-work-view-strict-clean-closure

## Changes

- add explicit active, retired, test-only, and quarantined Catalog lifecycle with dry-run-first exact-entry maintenance receipts
- isolate pytest discovery from the persistent user Catalog unless an exact config home is explicitly supplied
- compose authority-qualified canonical Work identities, fold only proven replicas, and preserve label collisions and divergent conflicts
- resolve typed and legacy references against the complete federated identity index, including verified retained Assignment seals
- provide one-row-per-canonical-Work human output plus progressive component, replica, conflict, unresolved, and proof details
- fail strict reads on required component, proof, Catalog churn, identity, or reference defects while retaining policy-valid exclusions

## Verification

- ./shifu test:workspace-continuation (67 passed)
- ./shifu check:workspace-continuation
- Home and explicit workspace strict scope=all: complete=true, canonical_work_count=75 before child orchestration, writes=0, same canonical identity-root set
- persistent Catalog maintenance receipts retained for 5 test-only and 4 retired locators; no workspace authority was modified
- full staged pre-commit gate, including release rehearsal (92 passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3"],
  "summary": "Close the staged workspace federation reader with strict Catalog lifecycle, canonical Work identity, reference closure, and user projection semantics.",
  "verification": ["workspace continuation suite", "strict Home and project read parity", "staged repository gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Catalog maintenance is dry-run-first, exact-entry-bound, receipt-producing, and does not rewrite workspace authority. Installed Product promotion remains a separate post-merge Shifu step.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Contract and tests updated for behavior changes
