### PR TITLE
fix(product): ship executable Agent Hub qualification

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "bbb4a790bf6f812fb8619da0331c97617cd73a02f18a576d3aaa238b8f9767a2",
-    "digest": "sha256:6306e97ddc07ea6fb883103ee67c9e571def0ed7a5b9445a1506bab5bebab84f"
+    "sha256": "ecd8565e24c70f7ca0f356ce42cc939a86a71d34031160c85f3661428aac1fd4",
+    "digest": "sha256:aeda7a46cd1005b270d44112761eb4609522c401b3556ca76bd4f5d8e86349c1"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -22,13 +22,13 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.21",
+      "kfd": "1.0.0-alpha.47",
       "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:37a89553458ef0018f6c5591082e619d80d7fe6679c7527fa33762d3daafec46"
+    "digest": "sha256:cb91fe0ecd96eaaa3fd047be7cd48efb1c99f5c9b545331c72e2c73b3cd88428"
   },
-  "collaborationInterfaceDigest": "sha256:d2963952d9140766101ac42ceaeb65279a81675d0b316392858d07c5372794d8",
+  "collaborationInterfaceDigest": "sha256:5f4ca4adfb8281ea4b12fb0dba41d024a64c506f845a54f207f47a3adfdbcf15",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "aeaad1bfc057d382dd4ba36d24c25ee676507d45",
+    "sourceSha": "234ec973cbd06a883622332f7b1a90cb12862609",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:6306e97ddc07ea6fb883103ee67c9e571def0ed7a5b9445a1506bab5bebab84f"
+    "registryDigest": "sha256:aeda7a46cd1005b270d44112761eb4609522c401b3556ca76bd4f5d8e86349c1"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "bbb4a790bf6f812fb8619da0331c97617cd73a02f18a576d3aaa238b8f9767a2",
-    "digest": "sha256:6306e97ddc07ea6fb883103ee67c9e571def0ed7a5b9445a1506bab5bebab84f"
+    "sha256": "ecd8565e24c70f7ca0f356ce42cc939a86a71d34031160c85f3661428aac1fd4",
+    "digest": "sha256:aeda7a46cd1005b270d44112761eb4609522c401b3556ca76bd4f5d8e86349c1"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -25,16 +25,16 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.21",
+      "kfd": "1.0.0-alpha.47",
       "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:37a89553458ef0018f6c5591082e619d80d7fe6679c7527fa33762d3daafec46"
+    "digest": "sha256:cb91fe0ecd96eaaa3fd047be7cd48efb1c99f5c9b545331c72e2c73b3cd88428"
   },
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:d2963952d9140766101ac42ceaeb65279a81675d0b316392858d07c5372794d8",
+  "collaborationInterfaceDigest": "sha256:5f4ca4adfb8281ea4b12fb0dba41d024a64c506f845a54f207f47a3adfdbcf15",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -53,11 +53,11 @@
         "buildchain"
       ],
       "packageVersions": {
-        "kfd": "1.0.0-alpha.21",
+        "kfd": "1.0.0-alpha.47",
         "libnode": "22.22.3-kf.4",
         "buildchain": "2.11.14-alpha.0"
       },
-      "digest": "sha256:37a89553458ef0018f6c5591082e619d80d7fe6679c7527fa33762d3daafec46"
+      "digest": "sha256:cb91fe0ecd96eaaa3fd047be7cd48efb1c99f5c9b545331c72e2c73b3cd88428"
     },
     "surfaces": [
       {

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -61,11 +61,11 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.21",
+      "kfd": "1.0.0-alpha.47",
       "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:37a89553458ef0018f6c5591082e619d80d7fe6679c7527fa33762d3daafec46"
+    "digest": "sha256:cb91fe0ecd96eaaa3fd047be7cd48efb1c99f5c9b545331c72e2c73b3cd88428"
   },
   "surfaces": [
     {

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -61,11 +61,11 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.21",
+      "kfd": "1.0.0-alpha.47",
       "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     },
-    "digest": "sha256:37a89553458ef0018f6c5591082e619d80d7fe6679c7527fa33762d3daafec46"
+    "digest": "sha256:cb91fe0ecd96eaaa3fd047be7cd48efb1c99f5c9b545331c72e2c73b3cd88428"
   },
   "surfaces": [
     {

--- a/developer/sdk/kfd/upstream-aggregate.json
+++ b/developer/sdk/kfd/upstream-aggregate.json
@@ -19,7 +19,7 @@
       "role": "standard-and-schema-provider",
       "package": {
         "name": "@kungfu-tech/kfd",
-        "version": "1.0.0-alpha.21"
+        "version": "1.0.0-alpha.47"
       },
       "repository": "kungfu-systems/kfd",
       "kfd": {
@@ -34,36 +34,36 @@
         "line": "v1.0",
         "channel": "alpha",
         "npmPackage": "@kungfu-tech/kfd",
-        "npmVersion": "1.0.0-alpha.21",
+        "npmVersion": "1.0.0-alpha.47",
         "source": {
           "repository": "kungfu-systems/kfd",
           "branch": "alpha/v1/v1.0"
         },
         "rationale": "KFD uses an anchored/manual Buildchain mode: the public package version is an explicit release fact, while the outer KFD line remains v1.0."
       },
-      "kfd3SurfaceCount": 18,
+      "kfd3SurfaceCount": 32,
       "assets": [
         {
           "path": "kfd.release.json",
-          "sha256": "sha256:bfb302c839b6cb45204d541b5af5b1c211568efb16fb3eebbb04dc65f7de83d2",
+          "sha256": "sha256:c4e0ca30c47b3cfca1b6d2d00c6277d62dd71423fd367e355f0f231c8a0b445d",
           "contract": "kfd-release-anchor"
         },
         {
           "path": "buildchain/kfd-1/contract-world.witness.json",
-          "sha256": "sha256:542fe5b730f2e4782655d096ec04a5dd82a88d4fc9e8701ee235eb111a06dab6"
+          "sha256": "sha256:fdd2d250fbac2246671f2444067234df5b6c519612196d1631c93e9da6de19b2"
         },
         {
           "path": "buildchain/kfd-2/public-release-trust.claim.json",
-          "sha256": "sha256:3780b47472762b5ce9575250da73ee800af71dd194a9b0a3f61a063569311237"
+          "sha256": "sha256:4886e6052a56ba0d8527cdb73443614a1b79f98a4fb3ab7f0a37f0c7bf0e5ece"
         },
         {
           "path": "buildchain/kfd-3/collaboration-interface.json",
-          "sha256": "sha256:fa41128be4ee57a4a40b76d4d7a063c01d7c2e5c53aec2b9c6db819c7a27b22b",
+          "sha256": "sha256:bf991c9f82094c37101b747b80ac9908bcfdd552f07875ab6ba6a27343a81f8c",
           "contract": "kfd-3-collaboration-interface"
         },
         {
           "path": "standards.json",
-          "sha256": "sha256:4ee9e5fc732eef1b43c75a146125496e0dbd859ef5a11d0c637c41e9091c677f",
+          "sha256": "sha256:65899780779a8e933f1f3a298bfdf2311104ccde84b773a0828ee4c23dd19d5b",
           "contract": "kfd-standards-metadata"
         }
       ]
@@ -177,7 +177,7 @@
       "status": "schema-only",
       "mode": "schema-only",
       "source": "@kungfu-tech/kfd/standards.json",
-      "schemaCount": 2,
+      "schemaCount": 3,
       "schemaCommand": "kungfu sdk kfd 4 schema --json",
       "residualRisk": [
         "Buildchain 2.10.8 exposes KFD-4 as schema-only; no release verification protocol is claimed."
@@ -192,7 +192,7 @@
       "buildchain"
     ],
     "packageVersions": {
-      "kfd": "1.0.0-alpha.21",
+      "kfd": "1.0.0-alpha.47",
       "libnode": "22.22.3-kf.4",
       "buildchain": "2.11.14-alpha.0"
     }

--- a/developer/sdk/package.json
+++ b/developer/sdk/package.json
@@ -29,7 +29,7 @@
     "@kungfu-tech/buildchain": "2.11.14-alpha.0",
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/gui": "workspace:*",
-    "@kungfu-tech/kfd": "1.0.0-alpha.21",
+    "@kungfu-tech/kfd": "1.0.0-alpha.47",
     "@kungfu-tech/kfx": "workspace:*",
     "@kungfu-tech/tui": "workspace:*",
     "ajv": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: workspace:*
         version: link:../../framework/gui
       '@kungfu-tech/kfd':
-        specifier: 1.0.0-alpha.21
-        version: 1.0.0-alpha.21
+        specifier: 1.0.0-alpha.47
+        version: 1.0.0-alpha.47
       '@kungfu-tech/kfx':
         specifier: workspace:*
         version: link:../../framework/kfx

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1171,6 +1171,11 @@ function writeCliManifest(stageRoot, archiveName, layout) {
           kfd3Registry: 'kfd/kfd-3-surfaces.json',
           kfdUpstreamAggregate: 'kfd/upstream-aggregate.json',
           kfdPackage: 'node_modules/@kungfu-tech/kfd/package.json',
+          kfdEntry: 'node_modules/@kungfu-tech/kfd/bin/kfd.mjs',
+          kfdAgentHubRunner:
+            'node_modules/@kungfu-tech/kfd/scripts/agent-hub-runner.mjs',
+          kfdAgentHubVerifier:
+            'node_modules/@kungfu-tech/kfd/scripts/agent-hub-report-verifier.mjs',
           kfdAgentRuntime: `runtime/${isWin ? 'kungfu-kfd-agent-runtime.exe' : 'kungfu-kfd-agent-runtime'}`,
           kfdAgentRuntimeManifest: 'runtime/kfd-agent-runtime.manifest.json',
           tui: 'tui/tui.mjs',
@@ -1522,6 +1527,84 @@ function runInstalledKungfuKfdSmoke({
   }
 }
 
+function runInstalledKungfuAgentHubSmoke({ installRoot, kungfuBin, env }) {
+  const qualificationDir = path.join(installRoot, 'agent-hub-qualification');
+  const runtimeHome = path.join(installRoot, '.agent-hub-runtime-home');
+  const userHome = path.join(installRoot, '.agent-hub-user-home');
+  const smokeEnv = {
+    ...env,
+    HOME: userHome,
+    USERPROFILE: userHome,
+  };
+  const qualification = parseJsonOutput(
+    runInstalledKungfu({
+      kungfuBin,
+      installRoot,
+      home: runtimeHome,
+      args: [
+        'agent',
+        'hub',
+        'qualify',
+        '--output-dir',
+        qualificationDir,
+        '--json',
+      ],
+      env: smokeEnv,
+    }),
+    'kungfu agent hub qualify',
+  );
+  if (
+    qualification.valid !== true ||
+    qualification.coverage?.passed !== 20 ||
+    qualification.coverage?.total !== 20 ||
+    qualification.isolation?.realHomeUnchanged !== true ||
+    typeof qualification.meaning !== 'string' ||
+    !qualification.meaning ||
+    !qualification.nonClaims?.includes('KFD certification') ||
+    !qualification.next?.verify?.includes('kungfu agent hub verify') ||
+    !/^sha256:[0-9a-f]{64}$/.test(qualification.evidence?.reportDigest || '')
+  ) {
+    throw new Error(
+      'installed kungfu Agent Hub qualification returned an incomplete verdict',
+    );
+  }
+  const verification = parseJsonOutput(
+    runInstalledKungfu({
+      kungfuBin,
+      installRoot,
+      home: runtimeHome,
+      args: [
+        'agent',
+        'hub',
+        'verify',
+        '--qualification-dir',
+        qualificationDir,
+        '--json',
+      ],
+      env: smokeEnv,
+    }),
+    'kungfu agent hub verify',
+  );
+  if (
+    verification.valid !== true ||
+    verification.coverage?.passed !== 20 ||
+    verification.coverage?.total !== 20 ||
+    verification.meaning !== qualification.meaning ||
+    JSON.stringify(verification.nonClaims) !==
+      JSON.stringify(qualification.nonClaims) ||
+    verification.checks?.some((check) => check.passed !== true)
+  ) {
+    throw new Error(
+      'installed kungfu Agent Hub verification did not preserve the qualification verdict',
+    );
+  }
+  if (fs.existsSync(userHome)) {
+    throw new Error(
+      'installed kungfu Agent Hub smoke modified its isolated user home',
+    );
+  }
+}
+
 function runInstalledKungfuActionSmoke({
   installRoot,
   kungfuBin,
@@ -1814,6 +1897,17 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
           manifest.entries,
           'kfdPackage',
         );
+        const kfdEntry = entryPath(installRoot, manifest.entries, 'kfdEntry');
+        const kfdAgentHubRunner = entryPath(
+          installRoot,
+          manifest.entries,
+          'kfdAgentHubRunner',
+        );
+        const kfdAgentHubVerifier = entryPath(
+          installRoot,
+          manifest.entries,
+          'kfdAgentHubVerifier',
+        );
         const kfdAgentRuntime = entryPath(
           installRoot,
           manifest.entries,
@@ -1869,6 +1963,9 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
         assertFile(kfd3Registry, 'installed KFD-3 registry');
         assertFile(kfdUpstreamAggregate, 'installed KFD upstream aggregate');
         assertFile(kfdPackage, 'installed KFD package metadata');
+        assertFile(kfdEntry, 'installed KFD executable');
+        assertFile(kfdAgentHubRunner, 'installed KFD Agent Hub runner');
+        assertFile(kfdAgentHubVerifier, 'installed KFD Agent Hub verifier');
         assertFile(kfdAgentRuntime, 'installed KFD Agent Runtime adapter');
         assertFile(
           kfdAgentRuntimeManifest,
@@ -1943,6 +2040,11 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
           kfd3Registry,
           kfdUpstreamAggregate,
           extensionsRoot,
+          env: smokeEnv,
+        });
+        runInstalledKungfuAgentHubSmoke({
+          installRoot,
+          kungfuBin,
           env: smokeEnv,
         });
         runInstalledCliSemanticSmoke({

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -27,10 +27,36 @@ import {
 
 const require = createRequire(import.meta.url);
 const workDashboardPackage = require('../../extensions/work-dashboard/package.json');
+const sdkPackage = require('../../developer/sdk/package.json');
+const agentHubKfdLock = require('../../tests/qualification/agent-hub-20/kfd-lock.json');
 const {
   esmEntrypointArgs,
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
+
+test('CLI authoring runtime resolves the exact Agent Hub KFD package', () => {
+  const packageJson = require.resolve('@kungfu-tech/kfd/package.json', {
+    paths: [path.resolve('developer/sdk')],
+  });
+  const kfdRoot = path.dirname(packageJson);
+  const installed = require(packageJson);
+  assert.equal(
+    sdkPackage.dependencies['@kungfu-tech/kfd'],
+    agentHubKfdLock.version,
+  );
+  assert.equal(installed.version, agentHubKfdLock.version);
+  for (const relative of [
+    'bin/kfd.mjs',
+    'scripts/agent-hub-runner.mjs',
+    'scripts/agent-hub-report-verifier.mjs',
+  ]) {
+    assert.equal(
+      fs.statSync(path.join(kfdRoot, relative)).isFile(),
+      true,
+      `missing installed KFD Agent Hub entry: ${relative}`,
+    );
+  }
+});
 
 test('CLI product archive name uses the Kungfu Episodes product prefix', () => {
   assert.equal(


### PR DESCRIPTION
## Summary

Fix the Kungfu CLI product archive so the already documented Agent Hub qualification is actually executable from the installed product. The archive now carries the exact KFD package locked by Hub 20 and fails packaging if `qualify` or offline `verify` cannot produce the bounded 20/20 verdict.

## Related issue

Follow-up to #1403.

## Changes

- align the SDK authoring/runtime dependency with `@kungfu-tech/kfd@1.0.0-alpha.47`
- require the installed KFD executable, Hub runner, and report verifier in the product manifest smoke
- execute `kungfu agent hub qualify --json` and `verify --json` from the extracted archive under an isolated HOME
- assert 20/20 coverage, human meaning, non-claims, rooted evidence, real-home isolation, and the next verification command
- bind the package version and executable files to the retained Hub 20 KFD lock
- refresh the generated KFD-3 product projections for the exact packaged dependency

## Verification

- `./shifu test:cli-surface-qualification` (29/29)
- `./shifu test:kfd-agent-hub-20` (5 Node tests and 8 Python tests)
- `./shifu kfd:buildchain:check` (155 KFD-3 surfaces)
- `./shifu dist:cli` (`CLI installed-layout smoke passed`)
- extracted product `kungfu agent hub qualify`: 20/20, human meaning and non-claims shown, real `~/.kungfu` metadata unchanged
- extracted product `kungfu agent hub verify`: 20/20 and all seven offline checks passed
- staged source, docs, ADR, lint, and Buildchain KFD hooks passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This packaging bugfix makes the already implemented and qualified Agent Hub surface executable in the CLI archive without changing its architecture contract or claim boundary."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The fix changes the exact KFD package carried by the Kungfu CLI archive and strengthens installed-product release evidence. It does not publish a Kungfu release or claim KFD certification, security assessment, production fitness, remote-network interoperability, external adoption, stable status, or unobserved platform support.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
