### PR TITLE
fix(site): support immutable git pickup

### DIFF
--- a/framework/site/README.md
+++ b/framework/site/README.md
@@ -54,3 +54,15 @@ Run through Shifu from the repository root:
 ./shifu --filter @kungfu-tech/site verify
 ./shifu --filter @kungfu-tech/site test
 ```
+
+Until an npm release is required, a consumer may pin the package directly to an
+immutable Kungfu commit and this monorepo subdirectory:
+
+```text
+github:kungfu-systems/kungfu#<40-character-commit>&path:/framework/site
+```
+
+The `prepare` lifecycle generates and verifies `dist/site` inside pnpm's
+Git-hosted package build, so the consumer receives the same exported artifact
+shape as `pack`. The commit must be an exact SHA; a branch or tag is not an
+acceptable authority coordinate.

--- a/framework/site/package.json
+++ b/framework/site/package.json
@@ -34,6 +34,7 @@
     "build": "node scripts/generate.mjs",
     "verify": "node scripts/verify.mjs",
     "test": "node --test index.test.js",
+    "prepare": "node scripts/generate.mjs && node scripts/verify.mjs",
     "prepublishOnly": "node scripts/generate.mjs && node scripts/verify.mjs && node --test index.test.js",
     "clean": "rimraf dist"
   },


### PR DESCRIPTION
## Summary

- generate and verify `dist/site` during Git-hosted package preparation
- document exact commit plus monorepo `path:` pickup syntax
- keep branch/tag coordinates rejected as mutable authority

## Validation

- `./shifu --filter @kungfu-tech/site build`
- `./shifu --filter @kungfu-tech/site verify`
- `./shifu --filter @kungfu-tech/site test`
- staged Kungfu pre-commit gate

## Boundary

This changes package transport only. It does not change product facts, maturity claims, ABI/runtime semantics, or publication status.