### PR TITLE
fix(release): restore Windows Alpha build

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/action/action_runtime.cpp
+++ b/framework/core/src/libkungfu/src/runtime/action/action_runtime.cpp
@@ -148,7 +148,7 @@ nlohmann::json invoke_work_lifecycle(const nlohmann::json &request) {
 nlohmann::json primitive_catalog() {
   using namespace kungfu::sdk::generated::primitive_catalog_v1;
   auto catalog = nlohmann::json::parse(CATALOG_JSON.begin(), CATALOG_JSON.end());
-  if (catalog.at("catalogRoot") != CATALOG_ROOT) {
+  if (catalog.at("catalogRoot").get<std::string>() != std::string(CATALOG_ROOT)) {
     throw std::runtime_error("generated primitive catalog Root mismatch");
   }
   catalog["runtimeAuthority"] = "libkungfu/runtime/action";

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -49,6 +49,10 @@ test('current participant surfaces satisfy the contract', () => {
 });
 
 test('cold source Assignment failure remains machine-actionable', (t) => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX launcher contract');
+    return;
+  }
   const temp = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-shifu-assignment-'),
   );
@@ -83,6 +87,10 @@ test('cold source Assignment failure remains machine-actionable', (t) => {
 });
 
 test('partial Core assembly cannot masquerade as Assignment readiness', (t) => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX launcher contract');
+    return;
+  }
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-shifu-partial-'));
   t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
   const launcher = path.join(temp, 'shifu');


### PR DESCRIPTION
## Summary

Restore the frozen Alpha publication build on Windows without changing the release contract, frozen version, signing authority, or publication semantics.

## Related issue

Atlas Goal `2026-07-24-kungfu-cli-signed-bootstrap-installer`; follow-up to Alpha Build run `30101932608`.

## Changes

- compare the generated primitive catalog root through explicit `std::string` values so MSVC does not face ambiguous nlohmann JSON/string-view overloads
- skip two POSIX launcher execution tests on Windows while retaining the native `shifu.cmd` diagnosis contract test

## Verification

- `./shifu check:source`: passed (600 tests: 590 pass, 10 intentional skips; 41 Python source tests; 116 runtime-upgrade tests; 69 desktop-update tests)
- `node --test scripts/check-shifu-entry-contract.test.mjs`: 19/19 passed on macOS
- staged repository gate: passed
- C++ clang-format and changed JavaScript Biome checks: passed
- authoritative Windows compile remains required in the protected merge-group and replacement Alpha Build

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This platform-compatibility bugfix restores compilation and makes POSIX-only launcher tests platform-accurate without changing architecture, release authority, installer behavior, or public API."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No signing material is read or changed by this patch. The prior failed Alpha run passed its trust, exact-source, and material-anchoring gates before the Windows compiler failure.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no authored behavior change)
