### PR TITLE
fix(product): close installed profile suites

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
   credential-island-macos:
     name: Sign and notarize sealed macOS application
     needs: build
-    if: ${{ needs.build.result == 'success' }}
+    if: ${{ needs.build.result == 'success' && (!inputs.platforms-json || contains(inputs.platforms-json, 'macos-arm64')) }}
     runs-on: macos-15
     timeout-minutes: 90
     environment:

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -753,7 +753,7 @@
           "authority": "product-publication",
           "publication": "product",
           "receipt": "none",
-          "definitionDigest": "sha256:d4b3ff09b7e84fbdd02b867bdc8c1982fb80861b8f3279315b60c122c72d73f2",
+          "definitionDigest": "sha256:cf04e1dfd30b4ec8cbe0aea3637b6b2f0cc52b8b11bd20ca96f5166b3db2a5c6",
           "credentials": {
             "githubToken": "read",
             "oidc": false,

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -236,6 +236,86 @@ function copyFirstPartyProfile(source, destination) {
     dereference: true,
     filter: firstPartyProfileFilter,
   });
+  materializeFirstPartyProfileMembers(source, destination);
+}
+
+/**
+ * A hoisted pnpm install can satisfy a Suite dependency only from the
+ * repository root, leaving the Suite's own node_modules absent.  Installed
+ * Profiles cannot depend on that build-worktree layout, so copy every declared
+ * member that is not already inside the Suite from the sibling first-party
+ * extension set and verify the resulting closure.
+ *
+ * @param {string} source
+ * @param {string} destination
+ */
+function materializeFirstPartyProfileMembers(source, destination) {
+  const manifestPath = path.join(source, 'package.json');
+  if (!fs.existsSync(manifestPath)) return;
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const members = manifest.kungfuConfig?.suite?.members;
+  if (!Array.isArray(members)) return;
+
+  const packageKey = (directory) => {
+    const candidate = path.join(directory, 'package.json');
+    if (!fs.existsSync(candidate)) return '';
+    const value = JSON.parse(fs.readFileSync(candidate, 'utf8'));
+    return value.kungfuConfig?.key || '';
+  };
+  const installedCandidates = (member) => {
+    const roots = [destination, path.join(destination, 'members')];
+    const dependencies = path.join(destination, 'node_modules');
+    if (fs.existsSync(dependencies)) {
+      roots.push(dependencies);
+      for (const entry of fs.readdirSync(dependencies, {
+        withFileTypes: true,
+      })) {
+        if (entry.isDirectory() && entry.name.startsWith('@')) {
+          roots.push(path.join(dependencies, entry.name));
+        }
+      }
+    }
+    return roots.flatMap((root) => {
+      if (!fs.existsSync(root)) return [];
+      return [
+        root,
+        ...fs
+          .readdirSync(root, { withFileTypes: true })
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => path.join(root, entry.name)),
+      ].filter((directory) => packageKey(directory) === member);
+    });
+  };
+
+  for (const member of members) {
+    if (installedCandidates(member).length) continue;
+    const candidates = fs
+      .readdirSync(path.dirname(source), {
+        withFileTypes: true,
+      })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(path.dirname(source), entry.name))
+      .filter((directory) => packageKey(directory) === member);
+    if (candidates.length !== 1) {
+      throw new Error(
+        `[freeze] first-party Profile member ${member} resolved ${candidates.length} times`,
+      );
+    }
+    fs.cpSync(candidates[0], path.join(destination, member), {
+      recursive: true,
+      dereference: true,
+      filter: firstPartyProfileFilter,
+    });
+  }
+
+  for (const member of members) {
+    const candidates = installedCandidates(member);
+    if (candidates.length !== 1) {
+      throw new Error(
+        `[freeze] installed first-party Profile member ${member} resolved ${candidates.length} times`,
+      );
+    }
+  }
 }
 
 // Ship <binary>.pdb next to a native so Windows field crash reports can resolve

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -256,12 +256,14 @@ function materializeFirstPartyProfileMembers(source, destination) {
   const members = manifest.kungfuConfig?.suite?.members;
   if (!Array.isArray(members)) return;
 
+  /** @param {string} directory */
   const packageKey = (directory) => {
     const candidate = path.join(directory, 'package.json');
     if (!fs.existsSync(candidate)) return '';
     const value = JSON.parse(fs.readFileSync(candidate, 'utf8'));
     return value.kungfuConfig?.key || '';
   };
+  /** @param {string} member */
   const installedCandidates = (member) => {
     const roots = [destination, path.join(destination, 'members')];
     const dependencies = path.join(destination, 'node_modules');

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1800,6 +1800,105 @@ function runInstalledActionPrimitiveDiscovery({ installRoot, kungfuBin, env }) {
   }
 }
 
+function runInstalledKungfuAssignmentAdmissionSmoke({
+  installRoot,
+  kungfuBin,
+  env,
+}) {
+  const home = path.join(installRoot, '.assignment-admission-home');
+  const workspace = path.join(installRoot, 'assignment-admission-workspace');
+  const requestPath = path.join(
+    installRoot,
+    'assignment-admission-request.json',
+  );
+  const assignmentId = 'installed-product-admission-smoke';
+  const assignmentEnv = {
+    ...env,
+    KUNGFU_INSTALL_SOURCE: 'archive',
+    KUNGFU_DIR: installRoot,
+    KUNGFU_UPGRADE_MANIFEST: path.join(
+      installRoot,
+      'upgrade',
+      'kungfu-release-manifest.json',
+    ),
+  };
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.writeFileSync(
+    requestPath,
+    `${JSON.stringify(
+      {
+        schema: 'kungfu.assignment-request/v1',
+        source: {
+          kind: 'installed-product-qualification',
+          sourceId: assignmentId,
+        },
+        retention: {
+          policy: 'explicit-expiry-retain-bytes-v1',
+          expiresAt: null,
+        },
+        workDefinition: {
+          goal_id: assignmentId,
+          mission_id: 'installed-product-qualification',
+          title: 'Verify installed Assignment admission',
+          objective: 'Prove the packaged Mission Control Suite is closed.',
+          owner_agent: 'product-qualification',
+          responsibility: 'installed product regression',
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const captured = parseJsonOutput(
+    runInstalledKungfu({
+      kungfuBin,
+      installRoot,
+      home,
+      args: [
+        'assignment',
+        'capture',
+        '--request',
+        requestPath,
+        '--workspace',
+        workspace,
+        '--json',
+      ],
+      env: assignmentEnv,
+    }),
+    'assignment capture',
+  );
+  const admitted = parseJsonOutput(
+    runInstalledKungfu({
+      kungfuBin,
+      installRoot,
+      home,
+      args: [
+        'assignment',
+        'admit',
+        captured.requestPath,
+        '--workspace',
+        workspace,
+        '--actor',
+        'product-qualification',
+        '--actor-type',
+        'agent',
+      ],
+      env: assignmentEnv,
+    }),
+    'assignment admit',
+  );
+  if (
+    admitted.admitted !== true ||
+    admitted.status !== 'admitted' ||
+    admitted.next_actions?.[0]?.input?.assignment_id !== assignmentId ||
+    !admitted.assignment_receipt?.receipt?.episode_id
+  ) {
+    throw new Error(
+      'installed kungfu Assignment admission returned invalid evidence',
+    );
+  }
+}
+
 export function smokeCliProductArchive({ archivePath, archiveBase }) {
   return buildchainLogger.spanSync(
     'product.cli.smoke',
@@ -2025,6 +2124,11 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
           env: smokeEnv,
         });
         runInstalledActionPrimitiveDiscovery({
+          installRoot,
+          kungfuBin,
+          env: smokeEnv,
+        });
+        runInstalledKungfuAssignmentAdmissionSmoke({
           installRoot,
           kungfuBin,
           env: smokeEnv,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -96,6 +96,17 @@ test('automatic hosted preflight does not inherit a private Cargo mirror', () =>
   );
 });
 
+test('custom Linux-only builds do not start the macOS credential island', () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), '.github/workflows/build.yml'),
+    'utf8',
+  );
+  assert.match(
+    workflow,
+    /credential-island-macos:[\s\S]*if: \$\{\{ needs\.build\.result == 'success' && \(!inputs\.platforms-json \|\| contains\(inputs\.platforms-json, 'macos-arm64'\)\) \}\}/u,
+  );
+});
+
 test('workflow uses setup-node for platform receipts and clean Shifu argv for aggregation', () => {
   const workflow = fs.readFileSync(
     path.join(process.cwd(), '.github/workflows/alpha-promotion-preflight.yml'),

--- a/scripts/documentation-product-pack.test.mjs
+++ b/scripts/documentation-product-pack.test.mjs
@@ -177,6 +177,49 @@ test('freeze materializes Mission Control dependency links', (t) => {
   );
 });
 
+test('freeze closes a first-party Profile when pnpm dependencies are hoisted', (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-hoisted-profile-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+  const extensions = path.join(temporary, 'extensions');
+  const source = path.join(extensions, 'suite');
+  const nestedMember = path.join(source, 'nested-member');
+  const hoistedMember = path.join(extensions, 'hoisted-member');
+  const destination = path.join(temporary, 'installed', 'suite');
+  fs.mkdirSync(nestedMember, { recursive: true });
+  fs.mkdirSync(hoistedMember, { recursive: true });
+  fs.writeFileSync(
+    path.join(source, 'package.json'),
+    `${JSON.stringify({
+      kungfuConfig: {
+        key: 'suite',
+        suite: { members: ['nested-member', 'hoisted-member'] },
+      },
+    })}\n`,
+  );
+  fs.writeFileSync(
+    path.join(nestedMember, 'package.json'),
+    `${JSON.stringify({ kungfuConfig: { key: 'nested-member' } })}\n`,
+  );
+  fs.writeFileSync(
+    path.join(hoistedMember, 'package.json'),
+    `${JSON.stringify({ kungfuConfig: { key: 'hoisted-member' } })}\n`,
+  );
+
+  copyMissionControlProfile(source, destination);
+
+  assert.equal(
+    JSON.parse(
+      fs.readFileSync(
+        path.join(destination, 'hoisted-member', 'package.json'),
+        'utf8',
+      ),
+    ).kungfuConfig.key,
+    'hoisted-member',
+  );
+});
+
 test('freeze restores an ignored product Atlas body from a tracked gzip bundle without Git', (t) => {
   const repository = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-doc-history-'),


### PR DESCRIPTION
## Summary

Close the exact installed Mission Control and Dogfood Profile Suite member sets so Assignment admission behaves the same in a CLI archive as it does in a source checkout. Keep custom Linux-only qualification runs from starting an unrelated macOS signing job.

## Related issue

Native dogfood Issue `issue-installed-mission-control-suite-closure`.

## Changes

- Materialize every declared first-party Suite member from sibling extensions when pnpm hoisting leaves the Suite-local dependency path absent, then fail closed unless each member resolves exactly once.
- Add a hoisted-dependency regression and an exact installed-product Assignment capture/admission smoke to CLI archive qualification.
- Skip the caller-owned macOS credential island for custom matrices that do not contain `macos-arm64`, and refresh the closed-world workflow authority digest.

## Verification

- `node --test scripts/documentation-product-pack.test.mjs scripts/alpha-promotion-preflight.test.mjs`
- `./shifu test:cli-surface-qualification`
- `./shifu check`
- `./shifu check:source`
- Linux exact-archive counterfactual: after materializing the two declared `work-dashboard` members, installed `kungfu assignment admit` returned `kungfu.assignment-orchestration.admission/v1` with Initiative and Assignment Episode receipts.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores the already-declared installed Profile Suite and qualification contracts without changing their architecture semantics."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The package boundary is covered by exact installed-layout admission, CLI qualification, source acceptance, and closed-world workflow authority validation. No publication is performed by this PR.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed