### PR TITLE
fix(release): disambiguate Windows catalog assertion

### DIFF
--- a/framework/core/src/libkungfu/tests/action_runtime_tests.cpp
+++ b/framework/core/src/libkungfu/tests/action_runtime_tests.cpp
@@ -138,7 +138,8 @@ void check_primitive_catalog_contract() {
   const auto catalog = action::run_action_runtime_operation("/runtime", json{{"action", "primitive_catalog"}});
   require(catalog.at("schema") == "kungfu.primitive-catalog/v1", "primitive catalog schema");
   require(catalog.at("primitives").size() == 9, "primitive catalog inventory count");
-  require(catalog.at("catalogRoot") == kungfu::sdk::generated::primitive_catalog_v1::CATALOG_ROOT,
+  require(catalog.at("catalogRoot").get<std::string>() ==
+              std::string(kungfu::sdk::generated::primitive_catalog_v1::CATALOG_ROOT),
           "runtime and generated primitive catalog Roots must agree");
   require(catalog.at("facetRoots").size() == 6, "primitive catalog facet count");
 }

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -563,6 +563,7 @@ export function planFromChanged(
     }
     const owner = componentOwner(authority, relative);
     direct.add(owner.id);
+    if (owner.id === 'core-native-qualification') forceFull = true;
     const rule = publicRule(authority, relative);
     const header = ['.h', '.hh', '.hpp', '.hxx'].includes(extension);
     if (rule) publicRules.add(rule.id);
@@ -1306,6 +1307,8 @@ function selfTest(authority, buildAuthority) {
       throw new Error('qualification owner missing');
     if (!plan.tests.includes('kungfu_native_kfx_contract_tests'))
       throw new Error('native KFX contract test missing');
+    if (plan.profile !== buildAuthority.default_profile)
+      throw new Error('native qualification did not select full profile');
   });
   expect('cross-language Core qualification expands globally', () => {
     const plan = planFromChanged(


### PR DESCRIPTION
## Summary

Restore the frozen Alpha publication build on Windows and make native qualification planning select the full CMake profile that owns its scheduled test targets.

## Related evidence

- Supersedes the test compile failure in Alpha Build run `30110562445`.
- Supersedes the merge-group planner failure in run `30113131223`, where the journal profile did not define the scheduled qualification targets.
- Production comparison was already fixed and merge-queue qualified in #1434.

## Changes

- compare the generated primitive catalog root through explicit `std::string` values in `action_runtime_tests.cpp`
- force the `full` native profile whenever `core-native-qualification` owns an affected path
- extend the planner self-test so qualification paths cannot regress to the default journal profile

## Verification

- `node scripts/run-core-affected-native.mjs --self-test`: 28/28 fixtures passed
- direct qualification-path reproduction: `profile=full`, seven qualification targets
- `node --test scripts/run-core-affected-native.test.mjs`: 3/3 passed
- `pnpm exec biome check --no-errors-on-unmatched scripts/run-core-affected-native.mjs`: passed
- staged repository gate: passed, including 92/92 documentation fixtures
- authoritative MSVC compile remains required in the protected merge-group and replacement Alpha Build

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This platform-compatibility and qualification-planning bugfix restores the declared native test targets without changing architecture, release authority, installer behavior, or public API."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No signing material is read or changed by this patch.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (planner invariant covered by self-test)