### PR TITLE
fix(product): stabilize installed profile closure

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -208,24 +208,22 @@ function documentationAtlasSource(repository = path.resolve(CORE, '..', '..')) {
 
 /**
  * Keep generated interpreter caches out of installed first-party Profiles.
- * Workspace dependencies remain part of each suite and are materialized
- * instead of retained as symlinks.
+ * Workspace node_modules are transient build-tree state. Declared Suite
+ * members are materialized separately into a stable package closure.
  *
  * @param {string} src
  * @returns {boolean}
  */
 function firstPartyProfileFilter(src) {
   const segments = path.resolve(src).split(path.sep);
-  const dependencyDepth = segments.filter(
-    (segment) => segment === 'node_modules',
-  ).length;
-  return !segments.includes('__pycache__') && dependencyDepth <= 1;
+  return (
+    !segments.includes('__pycache__') && !segments.includes('node_modules')
+  );
 }
 
 /**
- * pnpm represents workspace dependencies as absolute links. Dereference them
- * into the product image so suite member resolution stays complete without a
- * dependency on the build worktree.
+ * Copy the authored Suite, then close every declared member independently of
+ * pnpm's build-worktree layout.
  *
  * @param {string} source
  * @param {string} destination
@@ -255,6 +253,8 @@ function materializeFirstPartyProfileMembers(source, destination) {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
   const members = manifest.kungfuConfig?.suite?.members;
   if (!Array.isArray(members)) return;
+  const memberDestination = path.join(destination, 'members');
+  fs.mkdirSync(memberDestination, { recursive: true });
 
   /** @param {string} directory */
   const packageKey = (directory) => {
@@ -303,7 +303,7 @@ function materializeFirstPartyProfileMembers(source, destination) {
         `[freeze] first-party Profile member ${member} resolved ${candidates.length} times`,
       );
     }
-    fs.cpSync(candidates[0], path.join(destination, member), {
+    fs.cpSync(candidates[0], path.join(memberDestination, member), {
       recursive: true,
       dereference: true,
       filter: firstPartyProfileFilter,

--- a/scripts/documentation-product-pack.test.mjs
+++ b/scripts/documentation-product-pack.test.mjs
@@ -91,35 +91,46 @@ test('freeze assembly stages the selected verified Atlas into the product', () =
   assert.match(source, /agent', 'documentation'/);
 });
 
-test('freeze materializes Mission Control dependency links', (t) => {
+test('freeze replaces transient workspace links with stable Suite members', (t) => {
   const temporary = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-mission-profile-'),
   );
   t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
-  const source = path.join(temporary, 'source');
-  const member = path.join(temporary, 'member');
+  const extensions = path.join(temporary, 'extensions');
+  const source = path.join(extensions, 'source');
+  const member = path.join(extensions, 'member');
   const destination = path.join(temporary, 'installed');
   fs.mkdirSync(path.join(source, 'node_modules', '@kungfu-tech'), {
     recursive: true,
   });
   fs.mkdirSync(member);
-  fs.writeFileSync(path.join(member, 'package.json'), '{}\n');
+  fs.writeFileSync(
+    path.join(source, 'package.json'),
+    `${JSON.stringify({
+      kungfuConfig: {
+        key: 'suite',
+        suite: { members: ['member'] },
+      },
+    })}\n`,
+  );
+  fs.writeFileSync(
+    path.join(member, 'package.json'),
+    `${JSON.stringify({ kungfuConfig: { key: 'member' } })}\n`,
+  );
   fs.symlinkSync(
     member,
     path.join(source, 'node_modules', '@kungfu-tech', 'member'),
     process.platform === 'win32' ? 'junction' : 'dir',
   );
   copyMissionControlProfile(source, destination);
-  const installedMember = path.join(
-    destination,
-    'node_modules',
-    '@kungfu-tech',
-    'member',
-  );
+  assert.equal(fs.existsSync(path.join(destination, 'node_modules')), false);
+  const installedMember = path.join(destination, 'members', 'member');
   assert.equal(fs.lstatSync(installedMember).isSymbolicLink(), false);
   assert.equal(
-    fs.readFileSync(path.join(installedMember, 'package.json'), 'utf8'),
-    '{}\n',
+    JSON.parse(
+      fs.readFileSync(path.join(installedMember, 'package.json'), 'utf8'),
+    ).kungfuConfig.key,
+    'member',
   );
   assert.equal(
     missionControlProfileFilter(
@@ -132,7 +143,7 @@ test('freeze materializes Mission Control dependency links', (t) => {
         'kfx-view-work-dashboard',
       ),
     ),
-    true,
+    false,
   );
   assert.equal(
     missionControlProfileFilter(
@@ -212,7 +223,7 @@ test('freeze closes a first-party Profile when pnpm dependencies are hoisted', (
   assert.equal(
     JSON.parse(
       fs.readFileSync(
-        path.join(destination, 'hoisted-member', 'package.json'),
+        path.join(destination, 'members', 'hoisted-member', 'package.json'),
         'utf8',
       ),
     ).kungfuConfig.key,


### PR DESCRIPTION
## Summary

Ensure installed first-party Profile Suites never depend on transient pnpm `node_modules` links. Materialize declared external members under the stable `members/` closure so the installed Assignment smoke observes the same package set after archive packaging.

## Related evidence

- Native dogfood Issue `issue-installed-mission-control-suite-closure`.
- Exact source build run 30116119822 reproduced the failure after build lifecycle, proving the transient-link branch was still incomplete.

## Changes

- Exclude `node_modules` from installed first-party Profile copies.
- Materialize missing declared members under `members/<key>` from the sibling first-party extension authority.
- Add a regression where a Suite-local workspace symlink exists during freeze but must not survive in the installed closure.

## Verification

- `node --test scripts/documentation-product-pack.test.mjs`
- `./shifu check:source`
- full staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix makes the already-declared installed Profile Suite closure independent of transient package-manager layout without changing architecture semantics."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to deterministic installed package closure and its regression. No publication is performed by this PR.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed