### PR TITLE
fix(product): align installed SDK alias qualification

### DIFF
--- a/product/scripts/cli-surface-qualification.mjs
+++ b/product/scripts/cli-surface-qualification.mjs
@@ -227,23 +227,28 @@ export function qualifyCliSurface({
     const surfaces = observedCatalog.surfaces || [];
     const canonicalPaths = new Set(surfaces.map((row) => row.canonical_path));
     const sdkSurface = surfaces.find(
-      (row) => row.canonical_path === 'kungfu dev sdk',
+      (row) => row.canonical_path === 'kungfu sdk',
     );
-    assert(sdkSurface?.aliases?.includes('kungfu sdk'), 'SDK alias is missing');
     assert(
-      !canonicalPaths.has('kungfu sdk'),
-      'legacy SDK path remained canonical',
+      sdkSurface?.aliases?.includes('kungfu dev sdk'),
+      'SDK compatibility path is missing',
     );
-    const legacySdk = run(['sdk', '--help'], 'kungfu sdk --help');
-    const canonicalSdk = run(['dev', 'sdk', '--help'], 'kungfu dev sdk --help');
     assert(
-      !legacySdk.stdout.includes('compatibility alias') &&
-        legacySdk.stderr.includes('use `kungfu dev sdk`'),
-      'legacy SDK warning did not stay on stderr',
+      !canonicalPaths.has('kungfu dev sdk'),
+      'SDK compatibility path remained canonical',
+    );
+    const canonicalSdk = run(['sdk', '--help'], 'kungfu sdk --help');
+    const compatibilitySdk = run(
+      ['dev', 'sdk', '--help'],
+      'kungfu dev sdk --help',
     );
     assert(
       !canonicalSdk.stderr.includes('compatibility alias'),
       'canonical SDK path emitted a compatibility warning',
+    );
+    assert(
+      !compatibilitySdk.stderr.includes('compatibility alias'),
+      'corrected SDK compatibility path emitted a deprecation warning',
     );
 
     const linkage = observedCatalog.kfd3Linkage || [];
@@ -373,9 +378,9 @@ export function qualifyCliSurface({
           commandPackSchema: capabilities.commands?.schema,
         },
         canonicalAlias: {
-          canonical: 'kungfu dev sdk',
-          legacy: 'kungfu sdk',
-          warningChannel: 'stderr',
+          canonical: 'kungfu sdk',
+          compatibility: 'kungfu dev sdk',
+          warningChannel: null,
         },
         kfd3: { linkedApiCount: linkedIds.size },
         profileKfx: {

--- a/product/scripts/cli-surface-qualification.test.mjs
+++ b/product/scripts/cli-surface-qualification.test.mjs
@@ -20,8 +20,8 @@ function catalog(changes = {}) {
     ...roots,
     surfaces: [
       {
-        canonical_path: 'kungfu dev sdk',
-        aliases: ['kungfu sdk'],
+        canonical_path: 'kungfu sdk',
+        aliases: ['kungfu dev sdk'],
         owner: 'core',
         availability: { state: 'available' },
       },
@@ -76,9 +76,7 @@ function runner(observed = catalog()) {
         return {
           status: 0,
           stdout: 'SDK help\n',
-          stderr: joined.includes(' dev sdk ')
-            ? ''
-            : 'warning: `kungfu sdk` is a compatibility alias; use `kungfu dev sdk`\n',
+          stderr: '',
         };
       }
       return {


### PR DESCRIPTION
## Summary

Align the installed product CLI surface qualification with the current SDK alias authority: `kungfu sdk` is canonical and `kungfu dev sdk` is a non-deprecated compatibility path.

## Related evidence

- Exact Phase B source build run 30126438108 passed installed Assignment/Profile qualification, then failed with `[product] failed: SDK alias is missing`.
- The registry and generated Agent catalog already identify `kungfu sdk` as canonical; only the product qualifier and fixture retained the inverse assertion.

## Changes

- Qualify `kungfu sdk` as canonical and `kungfu dev sdk` as its compatibility path.
- Assert neither corrected canonical path nor compatibility path emits a deprecation warning.
- Update the installed qualification receipt projection and fixture.

## Verification

- `node --test product/scripts/cli-surface-qualification.test.mjs`
- `./shifu check:source`
- full staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix aligns an installed-product qualifier with the already-declared SDK alias authority without changing CLI architecture or behavior."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates installed product qualification only. It performs no publication.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed