### PR TITLE
fix(product): align installed SDK alias qualification

### DIFF
--- a/product/scripts/cli-surface-qualification.mjs
+++ b/product/scripts/cli-surface-qualification.mjs
@@ -227,18 +227,21 @@ export function qualifyCliSurface({
     const surfaces = observedCatalog.surfaces || [];
     const canonicalPaths = new Set(surfaces.map((row) => row.canonical_path));
     const sdkSurface = surfaces.find(
-      (row) => row.canonical_path === 'kungfu dev sdk',
+      (row) => row.canonical_path === 'kungfu sdk',
     );
-    assert(sdkSurface?.aliases?.includes('kungfu sdk'), 'SDK alias is missing');
     assert(
-      !canonicalPaths.has('kungfu sdk'),
+      sdkSurface?.aliases?.includes('kungfu dev sdk'),
+      'SDK alias is missing',
+    );
+    assert(
+      !canonicalPaths.has('kungfu dev sdk'),
       'legacy SDK path remained canonical',
     );
-    const legacySdk = run(['sdk', '--help'], 'kungfu sdk --help');
-    const canonicalSdk = run(['dev', 'sdk', '--help'], 'kungfu dev sdk --help');
+    const legacySdk = run(['dev', 'sdk', '--help'], 'kungfu dev sdk --help');
+    const canonicalSdk = run(['sdk', '--help'], 'kungfu sdk --help');
     assert(
       !legacySdk.stdout.includes('compatibility alias') &&
-        legacySdk.stderr.includes('use `kungfu dev sdk`'),
+        legacySdk.stderr.includes('use `kungfu sdk`'),
       'legacy SDK warning did not stay on stderr',
     );
     assert(

--- a/product/scripts/cli-surface-qualification.test.mjs
+++ b/product/scripts/cli-surface-qualification.test.mjs
@@ -20,8 +20,8 @@ function catalog(changes = {}) {
     ...roots,
     surfaces: [
       {
-        canonical_path: 'kungfu dev sdk',
-        aliases: ['kungfu sdk'],
+        canonical_path: 'kungfu sdk',
+        aliases: ['kungfu dev sdk'],
         owner: 'core',
         availability: { state: 'available' },
       },
@@ -77,8 +77,8 @@ function runner(observed = catalog()) {
           status: 0,
           stdout: 'SDK help\n',
           stderr: joined.includes(' dev sdk ')
-            ? ''
-            : 'warning: `kungfu sdk` is a compatibility alias; use `kungfu dev sdk`\n',
+            ? 'warning: `kungfu dev sdk` is a compatibility alias; use `kungfu sdk`\n'
+            : '',
         };
       }
       return {


### PR DESCRIPTION
## Summary

Align the installed-product qualification with the current CLI authority: `kungfu sdk` is canonical and `kungfu dev sdk` is the compatibility alias.

## Related issue

The Alpha package Build failed after successful packaging because the installed CLI qualifier still enforced the retired alias direction.

## Changes

- Require `kungfu sdk` as the canonical catalog path.
- Exercise `kungfu dev sdk` as the warning-bearing compatibility alias.
- Update the qualification fixture to preserve the same authority direction.

## Verification

- `./shifu test:cli-surface-qualification` (29 tests passed)
- focused release-promotion rehearsal fixture passed after one transient full-suite timing failure
- staged pre-commit gate passed
- Biome check and `git diff --check` passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix updates installed-product qualification to the already-established canonical SDK command and compatibility alias without changing architecture semantics."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes only the installed-product release qualification assertion and its fixture; it performs no publication.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed