### PR TITLE
fix(release): lock promotion builds to source gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
       BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN }}
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
+      publish-source-ref: ${{ startsWith(github.head_ref, 'publish-gate/') && github.head_ref || '' }}
       runner-preset: ${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}
       platforms-json: ${{ inputs.platforms-json || '' }}
       fail-fast: ${{ github.event_name == 'pull_request' || !inputs.diagnostic-mode }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:596c770d0706ffd3724ee1c69cd6f4f7a2a0885f8ee59e6cdbefeedba343d06e",
+          "definitionDigest": "sha256:c80c16b51e3f1fa971bdce2db021a85b1e54cc2d03dd1c71c99937f3ab61aa78",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -86,6 +86,12 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     build,
+    /publish-source-ref: \$\{\{ startsWith\(github\.head_ref, 'publish-gate\/'\) && github\.head_ref \|\| '' \}\}/,
+    findings,
+    'promotion builds must lock Buildchain to the exact publish-gate head',
+  );
+  requirePattern(
+    build,
     /uses: \.\/\.github\/actions\/require-alpha-preflight/,
     findings,
     'release-candidate build must admit the exact-source Alpha preflight receipt',


### PR DESCRIPTION
## Summary

Lock Alpha and release promotion builds to the exact `publish-gate/*` source branch instead of allowing Buildchain to fall back to the synthetic pull-request merge commit.

## Changes

- Pass the promotion PR head as Buildchain `publish-source-ref` only when it is a governed `publish-gate/*` branch.
- Weld that source-lock requirement into the release-promotion rehearsal.
- Refresh the closed-world workflow authority digest.

## Verification

- `./shifu check:source`
- focused release-promotion and source-acceptance tests
- full staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This release-control fix closes exact source provenance without changing product architecture or accepted ADR delivery."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change narrows release provenance and performs no publication itself.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
