### PR TITLE
fix(product): accept installed runtime path aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ jobs:
       BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN }}
     with:
       buildchain-ref: ${{ inputs.buildchain-ref || '' }}
-      publish-source-ref: ${{ startsWith(github.head_ref, 'publish-gate/') && github.head_ref || '' }}
       runner-preset: ${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}
       platforms-json: ${{ inputs.platforms-json || '' }}
       fail-fast: ${{ github.event_name == 'pull_request' || !inputs.diagnostic-mode }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:c80c16b51e3f1fa971bdce2db021a85b1e54cc2d03dd1c71c99937f3ab61aa78",
+          "definitionDigest": "sha256:596c770d0706ffd3724ee1c69cd6f4f7a2a0885f8ee59e6cdbefeedba343d06e",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/framework/core/src/python/kungfu/assignment_orchestration.py
+++ b/framework/core/src/python/kungfu/assignment_orchestration.py
@@ -83,6 +83,20 @@ def source_root(*starts: str | Path) -> Path:
     return Path(__file__).resolve().parents[5]
 
 
+def _same_or_descendant(path: Path, root: Path) -> bool:
+    """Accept filesystem aliases without weakening the runtime-root boundary."""
+
+    if path == root or root in path.parents:
+        return True
+    for candidate in (path, *path.parents):
+        try:
+            if candidate.samefile(root):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def binding_provenance(*, allow_foreign: bool = False) -> dict[str, Any]:
     """Fail closed unless pykungfu belongs to this source or installed product.
 
@@ -145,7 +159,7 @@ def binding_provenance(*, allow_foreign: bool = False) -> dict[str, Any]:
         compiled
         and install_source in {"archive", "desktop-companion"}
         and runtime_root is not None
-        and (binding_file == runtime_root or runtime_root in binding_file.parents)
+        and _same_or_descendant(binding_file, runtime_root)
         and manifest.get("schema") == PRODUCT_MANIFEST_SCHEMA
         and _GIT_REVISION.fullmatch(manifest_revision)
         and manifest_revision == build_revision

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -117,6 +117,18 @@ def test_binding_provenance_accepts_one_manifest_bound_installed_product(
     assert provenance["override"] is False
 
 
+def test_installed_runtime_accepts_a_filesystem_alias_root(monkeypatch):
+    binding = Path("/canonical/runtime/pykungfu.pyd")
+    runtime_alias = Path("/short/runtime")
+
+    def samefile(candidate, other):
+        return candidate == binding.parent and other == runtime_alias
+
+    monkeypatch.setattr(Path, "samefile", samefile)
+
+    assert assignment_orchestration._same_or_descendant(binding, runtime_alias)
+
+
 def test_installed_capture_matches_source_contract_without_runtime(tmp_path):
     request = {
         "schema": "kungfu.assignment-request/v1",

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -54,6 +54,11 @@ function requirePattern(source, pattern, findings, message) {
   if (!pattern.test(source)) findings.push(finding(message));
 }
 
+/** @param {string} source @param {RegExp} pattern @param {any[]} findings @param {string} message */
+function forbidPattern(source, pattern, findings, message) {
+  if (pattern.test(source)) findings.push(finding(message));
+}
+
 /** @param {string} root @param {any} contract @param {Record<string, string>} [overrides] */
 export function validateWorkflowSources(root, contract, overrides = {}) {
   /** @type {any[]} */
@@ -84,11 +89,11 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
     findings,
     'manual validation must retain the Buildchain ref pass-through',
   );
-  requirePattern(
+  forbidPattern(
     build,
-    /publish-source-ref: \$\{\{ startsWith\(github\.head_ref, 'publish-gate\/'\) && github\.head_ref \|\| '' \}\}/,
+    /^\s+publish-source-ref:/m,
     findings,
-    'promotion builds must lock Buildchain to the exact publish-gate head',
+    'PR-stage release-candidate builds must leave publish-source locking to post-merge promotion',
   );
   requirePattern(
     build,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -62,6 +62,26 @@ test('promotion workflow drift is rejected before Buildchain promotion', () => {
   );
 });
 
+test('PR-stage builds reject a premature publish-source lock', () => {
+  const buildPath = CONTRACT.workflows.build;
+  const original = fs.readFileSync(path.join(ROOT, buildPath), 'utf8');
+  const drifted = original.replace(
+    "      buildchain-ref: ${{ inputs.buildchain-ref || '' }}",
+    [
+      "      buildchain-ref: ${{ inputs.buildchain-ref || '' }}",
+      "      publish-source-ref: ${{ github.head_ref || '' }}",
+    ].join('\n'),
+  );
+  assert.notEqual(drifted, original);
+  const result = validateWorkflowSources(ROOT, CONTRACT, { build: drifted });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.findings.some((entry) =>
+      entry.message.includes('leave publish-source locking to post-merge'),
+    ),
+  );
+});
+
 test('release qualification rejects ADR admission before Episode evidence', () => {
   const qualification = fs.readFileSync(
     path.join(ROOT, 'scripts/run-release-qualification.mjs'),


### PR DESCRIPTION
## Summary

Accept filesystem-equivalent installed runtime roots so Windows long paths and 8.3 short-path aliases cannot falsely downgrade a manifest-bound Kungfu installation to foreign provenance.

## Changes

- Preserve the lexical installed-runtime boundary and add a `Path.samefile()` fallback for filesystem aliases.
- Add a focused regression for an installed binding reached through an alias root.
- Remove the premature PR-stage `publish-source-ref`; post-merge promotion remains responsible for source locking.
- Weld the PR-stage source-lock boundary into the release-promotion rehearsal and refresh workflow authority.

## Failure evidence

- Alpha Build run `30128140371` resolved the same pull-merge tree under two Windows path spellings, then failed Assignment admission because the binding path and runtime root were lexically different.
- Diagnostic run `30131920234` confirmed that a PR-stage publish source lock incorrectly targeted the post-merge channel branch before the release candidate was merged.

## Verification

- `./shifu check:source`
- `node --test scripts/release-promotion-rehearsal.test.mjs` (10 passed)
- `PYTHONPATH=framework/core/src/python:framework/core/build/Release uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_assignment_orchestration.py` (17 passed)
- full staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the installed provenance boundary while recognizing filesystem-equivalent paths; it does not change accepted product architecture."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change narrows release admission to filesystem identity and performs no publication itself.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
