### PR TITLE
feat(workspace): bind lifecycle execution to dry-run receipt

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+        "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+        "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+        "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919",
+      "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+            "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+        "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -76,7 +76,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+        "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/mode-selection.md",
@@ -106,7 +106,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+        "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
       }
     ]
   },
@@ -126,7 +126,7 @@
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919",
+      "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     }
   ],

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "0e2c5d611503796631e51ffa01342fbdc9eb96c14f9eae4538faf59833730919"
+            "sha256": "d6cc874deefceed7eb039b58cad5c3e070eb0a1c89202359b3c5cf61681fd4bd"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },

--- a/docs/adr/KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3.md
+++ b/docs/adr/KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3
 decision_status: accepted
 implementation_status: staged
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1341, https://github.com/kungfu-systems/kungfu/pull/1423, https://github.com/kungfu-systems/kungfu/pull/1436]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1341, https://github.com/kungfu-systems/kungfu/pull/1423, https://github.com/kungfu-systems/kungfu/pull/1436, https://github.com/kungfu-systems/kungfu/pull/1452]
 qualification_refs: [framework/workspace-federation/workspace-federation.contract.json, framework/workspace-federation/qualification/2026-07-23-home-two-repositories.json, framework/core/tests/python/test_workspace.py, framework/core/tests/python/test_workspace_federation.py, framework/core/tests/python/test_assignment_orchestration.py, framework/core/tests/python/test_cli_surface_contract.py, product/scripts/cli-surface-qualification.mjs]
 review_state: self-reviewed
 sensitivity: public
@@ -103,8 +103,10 @@ Catalog membership has an explicit local lifecycle. Active entries are
 required by default; retired, test-only, and quarantined entries stay retained
 and counted but are excluded by declared policy. Lifecycle maintenance is
 exact-entry and dry-run-first, binds the observed Catalog cut, emits a durable
-before/after receipt, and never rewrites a workspace authority. A Catalog
-change during a query yields a marked retry result rather than a hybrid view.
+before/after receipt, and never rewrites a workspace authority. Execution may
+bind the transition timestamp and expected plan root from that dry run; a
+recomputed-plan mismatch fails before writes. A Catalog change during a query
+yields a marked retry result rather than a hybrid view.
 
 Global completion remains false until an independent continuation Decision
 accepts the result and the applicable Project Cut root plus settlement receipt

--- a/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
+++ b/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
@@ -1,7 +1,7 @@
 {
-  "catalogRoot": "sha256:7564f1412874de51eeaa1b943e356075e61ff9b270f130d76509858d82fe0283",
+  "catalogRoot": "sha256:a98e3427d381fd84b03a86ee85df89cadd25a2cad74364edbf41cd3b45f3c62c",
   "contractId": "kungfu-cli-surface",
-  "contractRoot": "sha256:f1ee2517096dcba641bdc2ffb11ef293cb551175b6b0e6da2e3eb75b880c7402",
+  "contractRoot": "sha256:72436540ea162e48f9c070834292812b83a0ae63c9ffcbc6680d72b2d01a6d98",
   "kfd3Linkage": [
     {
       "apiIds": [],
@@ -3001,11 +3001,11 @@
       "kfd3Registry": "strict-link",
       "packagedInventory": "required-agent-pack-entry"
     },
-    "expectedSurfaceRoot": "sha256:2134ec1a29c29d8b29baec2ee2594c4a746306034f1c1d15497a056c47eb078e",
+    "expectedSurfaceRoot": "sha256:8eaa230c09e9ff600dd71fac06a4485df522a547ebe1e066cf0a50d161ae3931",
     "regeneration": "./shifu fix:cli-catalog-parity",
     "validation": "./shifu check:cli-catalog-parity"
   },
-  "registryRoot": "sha256:da0040f545756118cb672d272785d6fda507ce061eb61188d88a5d56519a34c4",
+  "registryRoot": "sha256:e78698679b56e283addacdd373beb8122ca0fda5b0fcf2ede713064c1ae7059a",
   "schema": "kungfu.cli-surface-catalog/v1",
   "schemaRoot": "sha256:01576fab12d4792d542c9c8bf3dd10069f6049490162cce24a92a500e4948d04",
   "source": {
@@ -3018,7 +3018,7 @@
     "pathAuthority": "live-click-tree",
     "root": "kungfu"
   },
-  "surfaceRoot": "sha256:2134ec1a29c29d8b29baec2ee2594c4a746306034f1c1d15497a056c47eb078e",
+  "surfaceRoot": "sha256:8eaa230c09e9ff600dd71fac06a4485df522a547ebe1e066cf0a50d161ae3931",
   "surfaces": [
     {
       "alias_diagnostics": [],
@@ -35660,7 +35660,9 @@
       "approval_policy": {
         "caller_confirmation_required": false,
         "mode": "explicit-execute",
-        "preconditions": []
+        "preconditions": [
+          "expected_plan_root"
+        ]
       },
       "audience": [
         "human",
@@ -35724,6 +35726,28 @@
           "name": "execute",
           "required": false,
           "type": "boolean"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--transitioned-at"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "transitioned_at",
+          "required": false,
+          "type": "text"
+        },
+        {
+          "arity": 1,
+          "flags": [
+            "--expected-plan-root"
+          ],
+          "hidden": false,
+          "kind": "option",
+          "name": "expected_plan_root",
+          "required": false,
+          "type": "text"
         },
         {
           "arity": 1,

--- a/framework/core/src/python/kungfu/cli/commands/workspace.py
+++ b/framework/core/src/python/kungfu/cli/commands/workspace.py
@@ -379,14 +379,32 @@ def catalog_rebind(identity_root, path, as_json):
     is_flag=True,
     help="write the exact dry-run transition and durable receipt",
 )
+@click.option(
+    "--transitioned-at",
+    help="reuse the transition timestamp from an exact dry-run plan",
+)
+@click.option(
+    "--expected-plan-root",
+    help="execute only when the recomputed transition matches this dry-run root",
+)
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
-def catalog_maintain(entry_keys, action, reason, execute, as_json):
+def catalog_maintain(
+    entry_keys,
+    action,
+    reason,
+    execute,
+    transitioned_at,
+    expected_plan_root,
+    as_json,
+):
     try:
         payload = maintain_workspace_catalog(
             list(entry_keys),
             action,
             reason,
             execute=execute,
+            transitioned_at=transitioned_at,
+            expected_plan_root=expected_plan_root,
         )
     except (OSError, ValueError) as error:
         raise click.ClickException(str(error)) from error

--- a/framework/core/src/python/kungfu/cli/surface_contract.registry.json
+++ b/framework/core/src/python/kungfu/cli/surface_contract.registry.json
@@ -246,7 +246,7 @@
   "catalogProjection": {
     "artifact": "kungfu.agent/cli_surface.catalog.json",
     "authority": "runtime-fold",
-    "expectedSurfaceRoot": "sha256:2134ec1a29c29d8b29baec2ee2594c4a746306034f1c1d15497a056c47eb078e",
+    "expectedSurfaceRoot": "sha256:8eaa230c09e9ff600dd71fac06a4485df522a547ebe1e066cf0a50d161ae3931",
     "consumers": {
       "agentCapabilities": "embed-complete",
       "agentCommands": "strict-link",

--- a/framework/core/src/python/kungfu/workspace.py
+++ b/framework/core/src/python/kungfu/workspace.py
@@ -783,6 +783,8 @@ def maintain_workspace_catalog(
     reason: str,
     *,
     execute: bool = False,
+    transitioned_at: str | None = None,
+    expected_plan_root: str | None = None,
     config_home: str | None = None,
     env: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
@@ -798,6 +800,32 @@ def maintain_workspace_catalog(
         raise ValueError("unsupported Catalog lifecycle action")
     if not reason:
         raise ValueError("Catalog lifecycle maintenance requires a reason")
+    if transitioned_at is not None:
+        try:
+            parsed_transition = datetime.fromisoformat(
+                transitioned_at.replace("Z", "+00:00")
+            )
+        except ValueError as error:
+            raise ValueError(
+                "Catalog lifecycle transitioned_at must be an ISO-8601 timestamp"
+            ) from error
+        if parsed_transition.tzinfo is None:
+            raise ValueError(
+                "Catalog lifecycle transitioned_at must include a timezone"
+            )
+    if expected_plan_root is not None:
+        if not execute:
+            raise ValueError(
+                "expected Catalog lifecycle plan root requires execute=True"
+            )
+        if transitioned_at is None:
+            raise ValueError(
+                "expected Catalog lifecycle plan root requires transitioned_at"
+            )
+        if not _ROOT.fullmatch(expected_plan_root):
+            raise ValueError(
+                "expected Catalog lifecycle plan root must be a SHA-256 root"
+            )
     requested = set(entry_keys)
     if not requested:
         raise ValueError("Catalog lifecycle maintenance requires an entry key")
@@ -815,7 +843,7 @@ def maintain_workspace_catalog(
         "test-only": "test-only",
         "quarantine": "quarantined",
     }[action]  # type: ignore[assignment]
-    transitioned_at = _now()
+    transitioned_at = transitioned_at or _now()
     changes: list[dict[str, Any]] = []
     persisted_entries: list[dict[str, Any]] = []
     for row in catalog["entries"]:
@@ -868,6 +896,10 @@ def maintain_workspace_catalog(
     plan_root = _semantic_root(
         {key: value for key, value in plan.items() if key != "catalog_path"}
     )
+    if expected_plan_root is not None and plan_root != expected_plan_root:
+        raise ValueError(
+            "Catalog lifecycle plan does not match expected dry-run plan root"
+        )
     if not execute:
         return {
             **plan,

--- a/framework/core/tests/python/test_workspace.py
+++ b/framework/core/tests/python/test_workspace.py
@@ -217,17 +217,22 @@ def test_catalog_lifecycle_is_dry_run_reversible_and_retains_authority(tmp_path)
         ]
         == before["catalog_cut"]
     )
+    transitioned_at = plan["changes"][0]["after"]["lifecycle"]["transitioned_at"]
 
     applied = maintain_workspace_catalog(
         [entry_key],
         "retire",
         "fixture retired",
         execute=True,
+        transitioned_at=transitioned_at,
+        expected_plan_root=plan["plan_root"],
         config_home=str(config_home),
         env={"HOME": str(tmp_path)},
     )
     retired = load_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})
 
+    assert applied["plan_root"] == plan["plan_root"]
+    assert applied["receipt"]["plan_root"] == plan["plan_root"]
     assert applied["receipt"]["receipt_root"].startswith("sha256:")
     assert retired["entries"][0]["lifecycle"]["state"] == "retired"
     assert retired["entries"][0]["required"] is False
@@ -249,6 +254,48 @@ def test_catalog_lifecycle_is_dry_run_reversible_and_retains_authority(tmp_path)
         ][0]["lifecycle"]["state"]
         == "active"
     )
+
+
+def test_catalog_lifecycle_expected_plan_mismatch_is_write_free(tmp_path):
+    config_home = tmp_path / "config"
+    repo = tmp_path / "cataloged"
+    repo.mkdir()
+    candidate = inspect_workspace(str(repo), env={"HOME": str(tmp_path)})
+    assert candidate is not None
+    ensure_workspace_data_home(candidate, "catalog-plan-mismatch-fixture")
+    qualified = inspect_workspace(str(repo), env={"HOME": str(tmp_path)})
+    assert qualified is not None
+    select_workspace(
+        qualified, config_home=str(config_home), env={"HOME": str(tmp_path)}
+    )
+    before = load_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})
+    entry_key = before["entries"][0]["identity_root"]
+    plan = maintain_workspace_catalog(
+        [entry_key],
+        "retire",
+        "fixture retired",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="does not match expected dry-run plan root",
+    ):
+        maintain_workspace_catalog(
+            [entry_key],
+            "retire",
+            "fixture retired",
+            execute=True,
+            transitioned_at="2026-07-25T00:00:00Z",
+            expected_plan_root=plan["plan_root"],
+            config_home=str(config_home),
+            env={"HOME": str(tmp_path)},
+        )
+
+    after = load_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})
+    assert after["catalog_cut"] == before["catalog_cut"]
+    assert not (config_home / "workspaces" / "receipts").exists()
 
 
 def test_tracked_settled_shadow_is_readable_without_runtime_initialization(tmp_path):


### PR DESCRIPTION
## Summary

Bind Workspace Catalog lifecycle execution to the exact dry-run plan root so managed-worktree closeout can delete first and still apply only the preflighted entry.

## Changes

- accept an explicit transition timestamp and expected plan root at execution
- fail before writes when the recomputed lifecycle plan differs
- expose the binding through the generated CLI surface
- retain zero Workspace-authority writes

## Verification

- 15 focused workspace tests
- ./shifu check:cli-catalog-parity
- staged Python format/lint, KFD evidence, documentation, and invariant gates
- Project Cut merge-queue admission

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f8e99-9354-7ab6-a9ba-b166f83f25a3"],
  "summary": "Bind exact Catalog lifecycle execution to its write-free dry-run plan and receipt boundary",
  "verification": ["15 focused workspace tests", "CLI catalog parity", "KFD and staged repository gates", "Project Cut merge-queue admission"]
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed