### PR TITLE
fix(product): admit Windows runtime entrypoint

### DIFF
--- a/framework/core/src/python/kungfu/assignment_orchestration.py
+++ b/framework/core/src/python/kungfu/assignment_orchestration.py
@@ -97,6 +97,12 @@ def _same_or_descendant(path: Path, root: Path) -> bool:
     return False
 
 
+def _installed_runtime_entrypoint(binding_file: Path) -> str:
+    """Bind the manifest entrypoint to the packaged native runtime platform."""
+
+    return "kungfu.exe" if binding_file.suffix.lower() == ".pyd" else "kungfu"
+
+
 def binding_provenance(*, allow_foreign: bool = False) -> dict[str, Any]:
     """Fail closed unless pykungfu belongs to this source or installed product.
 
@@ -163,7 +169,8 @@ def binding_provenance(*, allow_foreign: bool = False) -> dict[str, Any]:
         and manifest.get("schema") == PRODUCT_MANIFEST_SCHEMA
         and _GIT_REVISION.fullmatch(manifest_revision)
         and manifest_revision == build_revision
-        and str(manifest.get("runtimeEntrypoint") or "") == "kungfu"
+        and str(manifest.get("runtimeEntrypoint") or "")
+        == _installed_runtime_entrypoint(binding_file)
         and str(manifest.get("runtimeArtifactDigest") or "").startswith(ROOT)
     )
     override = (

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -81,12 +81,16 @@ def test_source_root_recovers_checkout_from_assembled_binding(tmp_path):
     assert assignment_orchestration.source_root(binding) == checkout
 
 
-def test_binding_provenance_accepts_one_manifest_bound_installed_product(
-    tmp_path, monkeypatch
+@pytest.mark.parametrize(
+    ("binding_name", "runtime_entrypoint"),
+    (("pykungfu.so", "kungfu"), ("pykungfu.pyd", "kungfu.exe")),
+)
+def test_binding_provenance_accepts_platform_bound_installed_product(
+    tmp_path, monkeypatch, binding_name, runtime_entrypoint
 ):
     runtime = tmp_path / "installed" / "kungfu"
     runtime.mkdir(parents=True)
-    binding = runtime / "pykungfu.so"
+    binding = runtime / binding_name
     binding.touch()
     revision = "a" * 40
     build_info = {
@@ -99,7 +103,7 @@ def test_binding_provenance_accepts_one_manifest_bound_installed_product(
     manifest = {
         "schema": "kungfu.product-upgrade.manifest/v1",
         "sourceCommit": revision,
-        "runtimeEntrypoint": "kungfu",
+        "runtimeEntrypoint": runtime_entrypoint,
         "runtimeArtifactDigest": "sha256:" + "b" * 64,
     }
     manifest_path = tmp_path / "kungfu-release-manifest.json"
@@ -115,6 +119,46 @@ def test_binding_provenance_accepts_one_manifest_bound_installed_product(
     assert provenance["state"] == "installed-product"
     assert provenance["source_revision"] == revision
     assert provenance["override"] is False
+
+
+def test_binding_provenance_rejects_platform_mismatched_manifest_entrypoint(
+    tmp_path, monkeypatch
+):
+    runtime = tmp_path / "installed" / "kungfu"
+    runtime.mkdir(parents=True)
+    binding = runtime / "pykungfu.pyd"
+    binding.touch()
+    revision = "a" * 40
+    (runtime / "kungfubuildinfo.json").write_text(
+        json.dumps(
+            {
+                "version": "4.0.0-alpha.1",
+                "git": {"revision": revision, "pristine": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    manifest_path = tmp_path / "kungfu-release-manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema": "kungfu.product-upgrade.manifest/v1",
+                "sourceCommit": revision,
+                "runtimeEntrypoint": "kungfu",
+                "runtimeArtifactDigest": "sha256:" + "b" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kungfu, "_binding", SimpleNamespace(__file__=str(binding)))
+    monkeypatch.setenv("KUNGFU_INSTALL_SOURCE", "archive")
+    monkeypatch.setenv("KUNGFU_DIR", str(runtime))
+    monkeypatch.setenv("KUNGFU_UPGRADE_MANIFEST", str(manifest_path))
+
+    provenance = assignment_orchestration.binding_provenance()
+
+    assert provenance["ok"] is False
+    assert provenance["state"] == "degraded"
 
 
 def test_installed_runtime_accepts_a_filesystem_alias_root(monkeypatch):


### PR DESCRIPTION
## Summary

Accept the platform-declared `kungfu.exe` entrypoint when validating an installed Windows runtime, while preserving fail-closed platform identity.

## Related issue

Alpha Build run 30135544687 exposed the Windows installed Assignment admission failure.

## Changes

- derive the expected installed runtime entrypoint from the native binding platform
- require `.pyd` packages to declare `kungfu.exe` and Unix packages to declare `kungfu`
- cover both accepted platform pairs and reject a mismatched Windows manifest

## Verification

- `./shifu check:source`
- runtime upgrade control-plane tests: 116 passed
- changed Python format and lint
- Python type baseline: 191 source files
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix aligns installed Windows provenance validation with the existing platform-specific manifest contract without changing architecture authority."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change tightens installed-product provenance and is exercised by the complete build-free source acceptance gate; it does not publish a release.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; existing platform manifest contract is unchanged)