### PR TITLE
fix(release): bound GitHub source fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,6 +135,11 @@ jobs:
       checkout-cache-reference-repository-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
+      # Alpha/release PRs intentionally qualify GitHub's synthetic merge tree
+      # rather than locking the head ref early. The merge ref is absent from
+      # the LAN mirror and this repository can exceed Buildchain's 600-second
+      # fallback default, so retain a bounded 20-minute GitHub fetch window.
+      checkout-cache-github-timeout-seconds: 1200
       # Custom qualification matrices can mix hosted and self-hosted runners.
       # Do not project the private-LAN runner profile onto hosted legs; use the
       # checked-in explicit-off profile so cache provenance remains auditable.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:596c770d0706ffd3724ee1c69cd6f4f7a2a0885f8ee59e6cdbefeedba343d06e",
+          "definitionDigest": "sha256:6f288f8ce3449bd2547cd68cd03ee02a2ff05eb04281ba0efae6dae761e15a10",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -114,6 +114,12 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
     'required promotion builds must fail fast while explicit diagnostics retain all platforms',
   );
   requirePattern(
+    build,
+    /checkout-cache-github-timeout-seconds:\s+1200/,
+    findings,
+    'release-candidate source checkout must retain the bounded large-repository GitHub fallback window',
+  );
+  requirePattern(
     `${build}\n${qualification}`,
     /episode:qualify:release[\s\S]*adr:release:gate[\s\S]*adr-release-admissibility\.json/,
     findings,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -82,6 +82,23 @@ test('PR-stage builds reject a premature publish-source lock', () => {
   );
 });
 
+test('release builds retain the bounded large-repository GitHub fallback window', () => {
+  const buildPath = CONTRACT.workflows.build;
+  const original = fs.readFileSync(path.join(ROOT, buildPath), 'utf8');
+  const drifted = original.replace(
+    '      checkout-cache-github-timeout-seconds: 1200',
+    '      checkout-cache-github-timeout-seconds: 600',
+  );
+  assert.notEqual(drifted, original);
+  const result = validateWorkflowSources(ROOT, CONTRACT, { build: drifted });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.findings.some((entry) =>
+      entry.message.includes('bounded large-repository GitHub fallback window'),
+    ),
+  );
+});
+
 test('release qualification rejects ADR admission before Episode evidence', () => {
   const qualification = fs.readFileSync(
     path.join(ROOT, 'scripts/run-release-qualification.mjs'),


### PR DESCRIPTION
## Summary

Retain a bounded 20-minute GitHub fallback for protected Alpha and release candidate source checkout when the synthetic merge ref is absent from the LAN mirror.

## Related evidence

Alpha Build run 30138755620 attempt 1 timed out after the default 600-second GitHub fetch and left a stale shallow lock. Attempt 2 passed source checkout on all three platforms, confirming the issue was the bounded fallback window rather than candidate identity.

## Changes

- set the release-candidate GitHub checkout fallback to 1200 seconds
- keep PR-stage qualification on the GitHub synthetic merge tree
- weld the timeout into the promotion rehearsal and workflow authority digest
- reject a regression back to 600 seconds

## Verification

- `./shifu check:source`
- source contract tests: 600 passed, 10 skipped
- Assignment tests: 42 passed
- runtime upgrade tests: 116 passed
- desktop update tests: 69 passed
- staged pre-commit gate: 99 documentation fixtures passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This reliability fix preserves the existing protected release-candidate source identity and only widens the bounded GitHub transport window after an observed timeout."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects source acquisition timing only. It does not weaken exact-SHA verification, event trust, merge-tree qualification, signing, or publication authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workflow authority projection refreshed