### PR TITLE
fix(product): isolate assignment admission smoke home

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1800,12 +1800,14 @@ function runInstalledActionPrimitiveDiscovery({ installRoot, kungfuBin, env }) {
   }
 }
 
-function runInstalledKungfuAssignmentAdmissionSmoke({
+export function runInstalledKungfuAssignmentAdmissionSmoke({
   installRoot,
   kungfuBin,
   env,
+  run = runInstalledKungfu,
 }) {
   const home = path.join(installRoot, '.assignment-admission-home');
+  const userHome = path.join(installRoot, '.assignment-admission-user-home');
   const workspace = path.join(installRoot, 'assignment-admission-workspace');
   const requestPath = path.join(
     installRoot,
@@ -1814,6 +1816,8 @@ function runInstalledKungfuAssignmentAdmissionSmoke({
   const assignmentId = 'installed-product-admission-smoke';
   const assignmentEnv = {
     ...env,
+    HOME: userHome,
+    USERPROFILE: userHome,
     KUNGFU_INSTALL_SOURCE: 'archive',
     KUNGFU_DIR: installRoot,
     KUNGFU_UPGRADE_MANIFEST: path.join(
@@ -1850,7 +1854,7 @@ function runInstalledKungfuAssignmentAdmissionSmoke({
     )}\n`,
   );
   const captured = parseJsonOutput(
-    runInstalledKungfu({
+    run({
       kungfuBin,
       installRoot,
       home,
@@ -1868,7 +1872,7 @@ function runInstalledKungfuAssignmentAdmissionSmoke({
     'assignment capture',
   );
   const admitted = parseJsonOutput(
-    runInstalledKungfu({
+    run({
       kungfuBin,
       installRoot,
       home,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -16,6 +16,7 @@ import {
   installedKungfuInvocation,
   kfxBundleExternalModules,
   requiresManagedEsbuildPlatform,
+  runInstalledKungfuAssignmentAdmissionSmoke,
   runInstalledKungfuCommand,
   stageXinfaContract,
   verifyProductObservabilityEvents,
@@ -166,6 +167,90 @@ test('installed CLI surface runner uses the Windows launcher invocation', () => 
       shell: false,
     },
   });
+});
+
+test('Assignment admission smoke isolates the operator Workspace Catalog', (t) => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-assignment-smoke-isolation-'),
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const installRoot = path.join(root, 'installed');
+  const operatorHome = path.join(root, 'operator-home');
+  const operatorCatalog = path.join(
+    operatorHome,
+    '.kungfu',
+    'workspaces',
+    'catalog.json',
+  );
+  const operatorBytes = '{"operator":"catalog-authority"}\n';
+  fs.mkdirSync(path.dirname(operatorCatalog), { recursive: true });
+  fs.mkdirSync(installRoot, { recursive: true });
+  fs.writeFileSync(operatorCatalog, operatorBytes);
+
+  const invocations = [];
+  runInstalledKungfuAssignmentAdmissionSmoke({
+    installRoot,
+    kungfuBin: path.join(installRoot, 'kungfu'),
+    env: {
+      ...process.env,
+      HOME: operatorHome,
+      USERPROFILE: operatorHome,
+    },
+    run(invocation) {
+      invocations.push(invocation);
+      const isolatedCatalog = path.join(
+        invocation.env.HOME,
+        '.kungfu',
+        'workspaces',
+        'catalog.json',
+      );
+      if (invocation.args.includes('capture')) {
+        fs.mkdirSync(path.dirname(isolatedCatalog), { recursive: true });
+        fs.writeFileSync(
+          isolatedCatalog,
+          `${JSON.stringify({
+            locator: path.join(installRoot, 'assignment-admission-workspace'),
+          })}\n`,
+        );
+        return `${JSON.stringify({
+          requestPath: path.join(installRoot, 'captured-request.json'),
+        })}\n`;
+      }
+      return `${JSON.stringify({
+        admitted: true,
+        status: 'admitted',
+        next_actions: [
+          {
+            input: {
+              assignment_id: 'installed-product-admission-smoke',
+            },
+          },
+        ],
+        assignment_receipt: { receipt: { episode_id: '1' } },
+      })}\n`;
+    },
+  });
+
+  assert.equal(fs.readFileSync(operatorCatalog, 'utf8'), operatorBytes);
+  assert.equal(invocations.length, 2);
+  for (const invocation of invocations) {
+    assert.equal(
+      invocation.env.HOME,
+      path.join(installRoot, '.assignment-admission-user-home'),
+    );
+    assert.equal(invocation.env.USERPROFILE, invocation.env.HOME);
+  }
+  const isolatedCatalog = path.join(
+    installRoot,
+    '.assignment-admission-user-home',
+    '.kungfu',
+    'workspaces',
+    'catalog.json',
+  );
+  assert.equal(
+    JSON.parse(fs.readFileSync(isolatedCatalog, 'utf8')).locator,
+    path.join(installRoot, 'assignment-admission-workspace'),
+  );
 });
 
 test('product observability ignores errors from sibling components', () => {

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -178,7 +178,7 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
   const operatorHome = path.join(root, 'operator-home');
   const operatorCatalog = path.join(
     operatorHome,
-    '.kungfu',
+    '.kungfu-config',
     'workspaces',
     'catalog.json',
   );
@@ -200,7 +200,7 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
       invocations.push(invocation);
       const isolatedCatalog = path.join(
         invocation.env.HOME,
-        '.kungfu',
+        '.kungfu-config',
         'workspaces',
         'catalog.json',
       );
@@ -243,7 +243,7 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
   const isolatedCatalog = path.join(
     installRoot,
     '.assignment-admission-user-home',
-    '.kungfu',
+    '.kungfu-config',
     'workspaces',
     'catalog.json',
   );


### PR DESCRIPTION
## Summary

Keep the installed Assignment admission smoke inside the product archive's isolated user home so it cannot register temporary workspaces in the operator Workspace Catalog.

## Changes

- bind both `HOME` and `USERPROFILE` to an install-root-local smoke home
- retain the existing isolated Kungfu runtime home and installed product invocation
- add a regression that preserves sentinel operator Catalog bytes while proving both capture and admit use the isolated home

## Verification

- `./shifu test:cli-surface-qualification` (30/30)
- `pnpm exec biome check product/scripts/dist.mjs product/scripts/dist.test.mjs`
- staged repository pre-commit gates
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct test-process environment isolation without changing Workspace authority or an architecture contract"
}
-->

## Governance risk check

- [x] No Workspace authority is scanned, excluded, settled, or rewritten
- [x] No secrets, credentials, release publication, or external API compatibility change
- [x] none of the above template governance boundaries

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added for the behavior change
