### PR TITLE
fix(assignment): keep mission parents advisory

### DIFF
--- a/framework/core/src/python/kungfu/assignment_orchestration.py
+++ b/framework/core/src/python/kungfu/assignment_orchestration.py
@@ -440,7 +440,7 @@ def atlas_assignment_projection(
         isinstance(row, dict) for row in dependency_refs
     ):
         raise ValueError("workDefinition.dependency_refs must be an array of objects")
-    if parent_assignment_ref and work.get("mission_parent_goal"):
+    if parent_assignment_ref and work.get("parent_goal"):
         raise ValueError(
             "workDefinition cannot mix parent Assignment ref and local shorthand"
         )
@@ -457,9 +457,7 @@ def atlas_assignment_projection(
         "assignment_id": assignment,
         "title": str(work.get("title") or assignment),
         "objective": str(work.get("objective") or work.get("summary") or assignment),
-        "parent_assignment_id": str(
-            work.get("parent_goal") or work.get("mission_parent_goal") or ""
-        ),
+        "parent_assignment_id": str(work.get("parent_goal") or ""),
         "depends_on": [str(row) for row in dependencies],
         "initiative_ref": initiative_ref,
         "parent_assignment_ref": parent_assignment_ref,

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -203,6 +203,57 @@ def test_installed_capture_matches_source_contract_without_runtime(tmp_path):
     )
 
 
+def test_atlas_mission_parent_goal_stays_advisory_at_assignment_admission():
+    work_definition = {
+        "goal_id": "child-assignment",
+        "mission_id": "initiative-a",
+        "mission_parent_goal": "remote-parent-go-card",
+        "objective": "Admit without inventing a workspace-local parent",
+    }
+    captured = {
+        "request": {"workDefinition": work_definition},
+        "request_root": "sha256:" + "a" * 64,
+        "capture_receipt_roots": ["sha256:" + "b" * 64],
+    }
+
+    projected = assignment_orchestration.atlas_assignment_projection(captured)
+
+    assert projected["parent_assignment_id"] == ""
+    assert projected["parent_assignment_ref"] == {}
+    assert projected["work_definition"]["mission_parent_goal"] == (
+        "remote-parent-go-card"
+    )
+
+
+def test_atlas_mission_parent_goal_can_accompany_an_exact_parent_work_ref():
+    parent_ref = {
+        "schema": "kungfu.assignment-graph.work-ref/v1",
+        "workspace_identity_root": "sha256:" + "c" * 64,
+        "object_kind": "assignment",
+        "subject": "kungfu:parent-assignment",
+        "version_root": "sha256:" + "d" * 64,
+        "component_cut_root": "sha256:" + "e" * 64,
+    }
+    captured = {
+        "request": {
+            "workDefinition": {
+                "goal_id": "child-assignment",
+                "mission_id": "initiative-a",
+                "mission_parent_goal": "remote-parent-go-card",
+                "parent_assignment_ref": parent_ref,
+                "objective": "Use only the exact cross-workspace parent edge",
+            }
+        },
+        "request_root": "sha256:" + "f" * 64,
+        "capture_receipt_roots": ["sha256:" + "1" * 64],
+    }
+
+    projected = assignment_orchestration.atlas_assignment_projection(captured)
+
+    assert projected["parent_assignment_id"] == ""
+    assert projected["parent_assignment_ref"] == parent_ref
+
+
 def test_captured_request_admits_losslessly_and_drives_bounded_execution(tmp_path):
     request = {
         "schema": "kungfu.assignment-request/v1",


### PR DESCRIPTION
## Summary

Prevent Atlas mission hierarchy metadata from being projected as a workspace-local Assignment parent edge. Local parent shorthand remains explicit through parent_goal, while exact cross-workspace edges remain owned by parent_assignment_ref.

## Changes

- keep mission_parent_goal losslessly inside the admitted work definition without turning it into parent_assignment_id
- preserve the conflict guard for explicit parent_goal plus parent_assignment_ref
- qualify both advisory-only and advisory-plus-exact-WorkRef projections

## Verification

- assignment orchestration tests: 21 passed
- staged repository gate passed, including Python format/lint, Gate catalog, docs 99/99, and promotion rehearsal
- git diff --check

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Correct an Atlas adapter projection bug without changing Assignment graph authority or the accepted exact WorkRef architecture."}
-->

## Governance risk check

- [x] no credentials, publication, provider, or release mutation
- [x] no Assignment authority is copied across workspaces
- [x] exact parent WorkRefs remain authoritative

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added