### PR TITLE
fix(release): close cross-platform npm build gaps

### DIFF
--- a/framework/core/core-platform-package.contract.json
+++ b/framework/core/core-platform-package.contract.json
@@ -38,7 +38,7 @@
       "^dist/kungfu/kungfu(?:\\.exe)?$",
       "^dist/kungfu/kungfu_node\\.node$",
       "^dist/kungfu/(?:lib)?kungfu(?:_runtime)?\\.(?:dylib|so|dll)$",
-      "^dist/kungfu/libnode(?:\\.[0-9]+)?\\.(?:dylib|so)$|^dist/kungfu/libnode\\.dll$",
+      "^dist/kungfu/libnode(?:(?:\\.[0-9]+)?\\.dylib|\\.so(?:\\.[0-9]+)?|\\.dll)$",
       "^dist/kungfu/config/kungfu-runtime\\.contract\\.json$",
       "^dist/kungfu/python/kungfu-host\\.json$",
       "^dist/kungfu/python/(?:bin/python3|python\\.exe)$",

--- a/framework/core/src/python/kungfu/agent/agent_hub_qualification.py
+++ b/framework/core/src/python/kungfu/agent/agent_hub_qualification.py
@@ -105,7 +105,9 @@ def resolve_product_executable(override: str | Path | None = None) -> Path:
     return _regular(Path(sys.argv[0]), "Kungfu executable")
 
 
-def run_kfd_step(entry: Path, *commands: str) -> None:
+def _resolve_kfd_step(
+    entry: Path, commands: tuple[str, ...]
+) -> tuple[Path, tuple[str, ...]]:
     entry = Path(entry)
     package_root = entry.parent.parent
     if commands[:2] == ("test", "agent-hub"):
@@ -116,20 +118,23 @@ def run_kfd_step(entry: Path, *commands: str) -> None:
         script_commands = commands[2:]
     else:
         raise ValueError(f"unsupported bundled KFD Agent Hub command: {commands}")
-    _regular(script, "KFD Agent Hub script")
+    return _regular(script, "KFD Agent Hub script"), script_commands
+
+
+def run_kfd_step(entry: Path, *commands: str) -> None:
+    script, script_commands = _resolve_kfd_step(entry, commands)
     status = kungfu.__binding__.libnode.run(sys.argv[0], str(script), *script_commands)
     if isinstance(status, int) and status != 0:
         raise RuntimeError(f"bundled KFD command exited with status {status}")
 
 
 def _run_kfd(executable: Path, entry: Path, *commands: str) -> None:
+    script, script_commands = _resolve_kfd_step(entry, commands)
     env = os.environ.copy()
-    env["KUNGFU_INTERNAL_AGENT_HUB_KFD_STEP"] = json.dumps(
-        {"entry": str(entry), "commands": list(commands)},
-        separators=(",", ":"),
-    )
+    env.pop("KUNGFU_INTERNAL_AGENT_HUB_KFD_STEP", None)
+    env["KUNGFU_AS_VARIANT"] = "node"
     result = subprocess.run(
-        [str(executable), "agent"],
+        [str(executable), str(script), *script_commands],
         check=False,
         capture_output=True,
         env=env,

--- a/framework/core/tests/core-platform-package.test.js
+++ b/framework/core/tests/core-platform-package.test.js
@@ -31,6 +31,18 @@ test('Core platform package authority is exact and source package is neutral', (
   assert.equal(sourcePackage.optionalDependencies, undefined);
 });
 
+test('platform payload contract accepts native libnode filenames', () => {
+  const libnodePattern = contract.platformPayload.requiredPathPatterns.find(
+    (pattern) => pattern.includes('libnode'),
+  );
+  const matchesLibnode = new RegExp(libnodePattern, 'u');
+
+  assert.equal(matchesLibnode.test('dist/kungfu/libnode.127.dylib'), true);
+  assert.equal(matchesLibnode.test('dist/kungfu/libnode.so.127'), true);
+  assert.equal(matchesLibnode.test('dist/kungfu/libnode.dll'), true);
+  assert.equal(matchesLibnode.test('dist/kungfu/libnode.127.so'), false);
+});
+
 test('one resolver owns explicit, platform-package, and executable paths', () => {
   assert.equal(
     resolveRuntimeDir({ env: { KUNGFU_DIR: '/tmp/kungfu-explicit' } }),

--- a/framework/core/tests/python/test_agent_hub_profile.py
+++ b/framework/core/tests/python/test_agent_hub_profile.py
@@ -199,13 +199,21 @@ def test_product_executable_resolves_from_installed_manifest(tmp_path, monkeypat
     assert agent_hub_qualification.resolve_product_executable() == executable
 
 
-def test_kfd_steps_reenter_the_installed_product_in_fresh_processes(
+def test_kfd_steps_reenter_the_python_free_node_variant_in_fresh_processes(
     tmp_path, monkeypatch
 ):
     executable = tmp_path / "kungfu"
     executable.write_text("#!/bin/sh\n", encoding="utf-8")
-    entry = tmp_path / "kfd.mjs"
+    package_root = tmp_path / "kfd"
+    entry = package_root / "bin/kfd.mjs"
+    entry.parent.mkdir(parents=True)
     entry.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    scripts = package_root / "scripts"
+    scripts.mkdir()
+    runner = scripts / "agent-hub-runner.mjs"
+    verifier = scripts / "agent-hub-report-verifier.mjs"
+    runner.write_text("// runner\n", encoding="utf-8")
+    verifier.write_text("// verifier\n", encoding="utf-8")
     calls = []
 
     def run(argv, **kwargs):
@@ -218,17 +226,11 @@ def test_kfd_steps_reenter_the_installed_product_in_fresh_processes(
         executable, entry, "verify", "agent-hub-report", "report.json"
     )
     assert [call[0] for call in calls] == [
-        [str(executable), "agent"],
-        [str(executable), "agent"],
+        [str(executable), str(runner), "test", "agent-hub"],
+        [str(executable), str(verifier), "report.json"],
     ]
-    assert [
-        json.loads(call[1]["env"]["KUNGFU_INTERNAL_AGENT_HUB_KFD_STEP"])
-        for call in calls
-    ] == [
-        {"entry": str(entry), "commands": ["test", "agent-hub"]},
-        {
-            "entry": str(entry),
-            "commands": ["verify", "agent-hub-report", "report.json"],
-        },
-    ]
+    assert all(call[1]["env"]["KUNGFU_AS_VARIANT"] == "node" for call in calls)
+    assert all(
+        "KUNGFU_INTERNAL_AGENT_HUB_KFD_STEP" not in call[1]["env"] for call in calls
+    )
     assert all(call[1]["capture_output"] is True for call in calls)


### PR DESCRIPTION
## Summary

Close the remaining cross-platform failures exposed by exact-head Build run 30154618243 so the 28-package public npm publication set can proceed to a real dry-run rehearsal.

## Changes

- Accept the actual ELF libnode soname `libnode.so.127` while retaining the macOS and Windows native library contracts.
- Run installed Agent Hub qualification through the product Python-free Node variant, avoiding the Windows embedded-runtime `spawn EINVAL` boundary.
- Add regressions for both platform boundaries.
- Rebase the fix as one linear commit on the current protected base; the already-merged generated-authority prepack change supplies `@kungfu-tech/spec/dist/capabilities.json`.

## Verification

- `./shifu check:source`
- `pnpm --dir framework/core test:tooling` (25 pass, 2 native-only skips)
- `./shifu test:kfd-agent-hub-20` (5 Node tests and 8 Python tests)
- full pre-commit hook

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix closes platform-specific package assembly and installed-product execution defects within the already accepted npm distribution contract; it does not introduce a new architecture decision."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The release boundary remains rehearsal-only: the follow-up workflow will use `execute=false`, and no npm package is published by this PR.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
