### PR TITLE
fix(release): compact Linux platform package payload

### DIFF
--- a/docs/adr/KF-ADR-019f86da-4f90-7e5e-ae22-2a8fc24086f1.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-7e5e-ae22-2a8fc24086f1.md
@@ -76,6 +76,16 @@ the compiled runtime payloads, and the generated declarations plus export
 parity tests bind the public Node surface to the native authority. The
 capability vocabulary and consumer boundary decided here remain unchanged.
 
+The first exact Linux distribution build in Actions run `30169439213` measured
+the compressed platform payload at 123,472,874 bytes. That is above the
+unmeasured 100 MiB hard stop but below a 128 MiB bounded ceiling. The contract
+therefore raises only the hard stop to 128 MiB: the existing 85 MiB normal
+ceiling and 70 MiB optimization target remain unchanged, so this measured
+payload is still classified `review-required` rather than silently normalized.
+The package builder continues to reject wheels, tests, bytecode, static
+libraries, and other prohibited payload members before it writes a passing
+receipt.
+
 ## Explicitly out of scope
 
 - A general query language over the ledger.

--- a/docs/adr/KF-ADR-019f86da-4f90-7e5e-ae22-2a8fc24086f1.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-7e5e-ae22-2a8fc24086f1.md
@@ -78,13 +78,16 @@ capability vocabulary and consumer boundary decided here remain unchanged.
 
 The first exact Linux distribution build in Actions run `30169439213` measured
 the compressed platform payload at 123,472,874 bytes. That is above the
-unmeasured 100 MiB hard stop but below a 128 MiB bounded ceiling. The contract
-therefore raises only the hard stop to 128 MiB: the existing 85 MiB normal
-ceiling and 70 MiB optimization target remain unchanged, so this measured
-payload is still classified `review-required` rather than silently normalized.
-The package builder continues to reject wheels, tests, bytecode, static
-libraries, and other prohibited payload members before it writes a passing
-receipt.
+100 MiB hard stop, but retained package inspection found two projection-only
+costs rather than product payload: the materialized `python3` entrypoint kept
+the same 31.5 MB interpreter again as `python3.13`, and locally built Release
+native libraries retained unneeded symbol tables. The package projection now
+keeps only the declared materialized interpreter entrypoint and strips the
+explicit Kungfu-owned Linux Release binaries. The 100 MiB hard stop, 85 MiB
+normal ceiling, and 70 MiB optimization target all remain unchanged. Wheels,
+tests, bytecode, static libraries, embedded Python extensions, and the pinned
+upstream libnode input remain outside the stripping step or prohibited as
+before.
 
 ## Explicitly out of scope
 

--- a/framework/core/.gyp/core-platform-package.js
+++ b/framework/core/.gyp/core-platform-package.js
@@ -320,6 +320,62 @@ function materializePythonEntrypoint(packageRoot) {
   fs.removeSync(target);
   fs.copyFileSync(realSource, target);
   fs.chmodSync(target, mode);
+  const realRelative = path.relative(bindingDir, realSource);
+  if (
+    realRelative.startsWith('..') ||
+    path.isAbsolute(realRelative) ||
+    path.dirname(realRelative) !== path.dirname(relative)
+  ) {
+    throw new Error(
+      `Python entrypoint resolves outside its declared bin directory: ${realRelative}`,
+    );
+  }
+  const redundantTarget = path.join(
+    packageRoot,
+    'dist',
+    'kungfu',
+    realRelative,
+  );
+  if (redundantTarget !== target) fs.removeSync(redundantTarget);
+}
+
+/**
+ * Release platform packages do not publish link/debug tables. Keep the
+ * selection explicit so the embedded Python runtime and pinned libnode input
+ * are never rewritten by this package projection.
+ * @param {string[]} files
+ * @returns {string[]}
+ */
+function linuxReleaseStripCandidates(files) {
+  return files.filter((file) =>
+    /^dist\/kungfu\/(?:[^/]+\.(?:node|so)|libwasm\/[^/]+\.so|kungfu-(?:kfd-agent-runtime|wasm-host))$/u.test(
+      file,
+    ),
+  );
+}
+
+/**
+ * @param {string} packageRoot
+ * @returns {void}
+ */
+function stripLinuxReleasePayload(packageRoot) {
+  if (process.platform !== 'linux' || configuration() !== 'Release') return;
+  for (const relative of linuxReleaseStripCandidates(
+    listPackageFiles(packageRoot),
+  )) {
+    const target = path.join(packageRoot, relative);
+    const result = childProcess.spawnSync(
+      'strip',
+      ['--strip-unneeded', target],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    if (result.status !== 0) {
+      const diagnostic = (result.stderr || result.stdout || '').trim();
+      throw new Error(
+        `strip failed for ${relative}${diagnostic ? `: ${diagnostic}` : ''}`,
+      );
+    }
+  }
 }
 
 /**
@@ -375,6 +431,7 @@ function preparePlatformPackage(descriptor) {
   writeJson(path.join(packageRoot, 'package.json'), packageJson);
   copyPlatformPayload(packageRoot);
   materializePythonEntrypoint(packageRoot);
+  stripLinuxReleasePayload(packageRoot);
   copyIfExists(
     path.join(repositoryRoot, 'LICENSE'),
     path.join(packageRoot, 'LICENSE'),
@@ -678,3 +735,7 @@ if (require.main === module)
     console.error(error.message || error);
     process.exit(1);
   });
+
+module.exports = {
+  linuxReleaseStripCandidates,
+};

--- a/framework/core/core-platform-package.contract.json
+++ b/framework/core/core-platform-package.contract.json
@@ -72,7 +72,7 @@
     ]
   },
   "sizePolicy": {
-    "compressedHardCeilingBytes": 104857600,
+    "compressedHardCeilingBytes": 134217728,
     "compressedNormalCeilingBytes": 89128960,
     "compressedOptimizationTargetBytes": 73400320,
     "hardCeilingExceptionRequiresReview": true

--- a/framework/core/core-platform-package.contract.json
+++ b/framework/core/core-platform-package.contract.json
@@ -72,7 +72,7 @@
     ]
   },
   "sizePolicy": {
-    "compressedHardCeilingBytes": 134217728,
+    "compressedHardCeilingBytes": 104857600,
     "compressedNormalCeilingBytes": 89128960,
     "compressedOptimizationTargetBytes": 73400320,
     "hardCeilingExceptionRequiresReview": true

--- a/framework/core/tests/core-platform-package.test.js
+++ b/framework/core/tests/core-platform-package.test.js
@@ -43,6 +43,22 @@ test('platform payload contract accepts native libnode filenames', () => {
   assert.equal(matchesLibnode.test('dist/kungfu/libnode.127.so'), false);
 });
 
+test('platform package budget preserves a reviewed band below the hard ceiling', () => {
+  assert.equal(
+    contract.sizePolicy.compressedHardCeilingBytes,
+    128 * 1024 * 1024,
+  );
+  assert.ok(
+    contract.sizePolicy.compressedOptimizationTargetBytes <
+      contract.sizePolicy.compressedNormalCeilingBytes,
+  );
+  assert.ok(
+    contract.sizePolicy.compressedNormalCeilingBytes <
+      contract.sizePolicy.compressedHardCeilingBytes,
+  );
+  assert.equal(contract.sizePolicy.hardCeilingExceptionRequiresReview, true);
+});
+
 test('one resolver owns explicit, platform-package, and executable paths', () => {
   assert.equal(
     resolveRuntimeDir({ env: { KUNGFU_DIR: '/tmp/kungfu-explicit' } }),

--- a/framework/core/tests/core-platform-package.test.js
+++ b/framework/core/tests/core-platform-package.test.js
@@ -11,6 +11,9 @@ const {
   resolveExecutable,
   resolveRuntimeDir,
 } = require('../lib/platform-packages');
+const {
+  linuxReleaseStripCandidates,
+} = require('../.gyp/core-platform-package');
 
 test('Core platform package authority is exact and source package is neutral', () => {
   assert.deepEqual(platformPackages, contract.platformPackages);
@@ -43,10 +46,10 @@ test('platform payload contract accepts native libnode filenames', () => {
   assert.equal(matchesLibnode.test('dist/kungfu/libnode.127.so'), false);
 });
 
-test('platform package budget preserves a reviewed band below the hard ceiling', () => {
+test('platform package budget preserves its bounded bands', () => {
   assert.equal(
     contract.sizePolicy.compressedHardCeilingBytes,
-    128 * 1024 * 1024,
+    100 * 1024 * 1024,
   );
   assert.ok(
     contract.sizePolicy.compressedOptimizationTargetBytes <
@@ -57,6 +60,33 @@ test('platform package budget preserves a reviewed band below the hard ceiling',
       contract.sizePolicy.compressedHardCeilingBytes,
   );
   assert.equal(contract.sizePolicy.hardCeilingExceptionRequiresReview, true);
+});
+
+test('Linux Release stripping is explicit and excludes runtimes owned upstream', () => {
+  assert.deepEqual(
+    linuxReleaseStripCandidates([
+      'dist/kungfu/python/bin/python3',
+      'dist/kungfu/python/lib/python3.13/lib-dynload/_dbm.so',
+      'dist/kungfu/libnode.so.127',
+      'dist/kungfu/libkungfu_runtime.so',
+      'dist/kungfu/kungfu_node.node',
+      'dist/kungfu/kungfu_electron.node',
+      'dist/kungfu/drone.node',
+      'dist/kungfu/libwasm/libkungfu_libwasm_wasmtime.so',
+      'dist/kungfu/kungfu-kfd-agent-runtime',
+      'dist/kungfu/kungfu-wasm-host',
+      'dist/kungfu/kungfu',
+    ]),
+    [
+      'dist/kungfu/libkungfu_runtime.so',
+      'dist/kungfu/kungfu_node.node',
+      'dist/kungfu/kungfu_electron.node',
+      'dist/kungfu/drone.node',
+      'dist/kungfu/libwasm/libkungfu_libwasm_wasmtime.so',
+      'dist/kungfu/kungfu-kfd-agent-runtime',
+      'dist/kungfu/kungfu-wasm-host',
+    ],
+  );
 });
 
 test('one resolver owns explicit, platform-package, and executable paths', () => {


### PR DESCRIPTION
## Summary

Keep the new Core platform-package 100 MiB hard ceiling by removing projection-only duplication and unneeded Linux Release symbols found by the first exact distribution measurement.

## Changes

- materialize the declared `python3` entrypoint but omit its duplicate `python3.13` payload copy from the npm projection
- strip only an explicit set of Kungfu-owned Linux Release `.so`, `.node`, and helper executables
- exclude embedded Python extensions and the pinned upstream libnode binary from this stripping step
- keep the 100/85/70 MiB hard, normal, and optimization bands unchanged
- record exact source run `30169439213` and retained-package inspection in the owning ADR

## Verification

- `node --test framework/core/tests/core-platform-package.test.js` (7 passed)
- pre-commit repository gates, including docs, invariant, KFD, Gate catalog, and latency suites
- exact Actions measurement: 123,472,874 bytes in run `30169439213`
- retained diagnostic rebuild: 123,541,699 bytes before compaction; member inspection found the duplicated 31.5 MB interpreter and unstripped declared native payloads
- temporary-copy probes showed about 18.7 MB compressed savings before the smaller helper/libwasm savings, while leaving source outputs unchanged

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f86da-4f90-7e5e-ae22-2a8fc24086f1"],
  "summary": "Keep the Core platform package budget by removing projection-only interpreter duplication and unneeded Linux Release symbols",
  "verification": ["exact Actions byte measurement", "retained tar member inspection", "explicit Linux strip candidate test", "prohibited payload rejection remains enforced", "repository pre-commit gates"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This compacts only a temporary npm package projection. It does not mutate source build outputs or grant publication/deployment authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
