### PR TITLE
fix(gui): keep global Work observer app-scoped

### DIFF
--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -137,6 +137,8 @@ function GlobalWorkView({
   const [status, setStatus] = React.useState('connecting live global Work…');
   const [error, setError] = React.useState('');
   const lastNotification = React.useRef({ key: '', at: 0 });
+  const shellRef = React.useRef(shell);
+  shellRef.current = shell;
   const ipc = React.useMemo(
     () =>
       (
@@ -174,7 +176,7 @@ function GlobalWorkView({
           now - lastNotification.current.at > 4000
         ) {
           lastNotification.current = { key, at: now };
-          shell.notify({
+          shellRef.current.notify({
             level: 'info',
             title: 'Work updated',
             message: event.changed_workspace_ids.slice(0, 3).join(' · '),
@@ -198,7 +200,7 @@ function GlobalWorkView({
       stopped = true;
       if (dispose) void dispose();
     };
-  }, [ipc, shell]);
+  }, [ipc]);
 
   const rows = snapshot?.global_work?.visible_work ?? [];
   const needle = search.trim().toLowerCase();

--- a/framework/core/src/python/kungfu/cli/commands/workspace.py
+++ b/framework/core/src/python/kungfu/cli/commands/workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import signal
 from functools import wraps
 
 import click
@@ -541,15 +542,25 @@ def work(
                 raise ValueError(
                     "--observe does not accept traversal, gate, or inclusion options"
                 )
+            stop_requested = False
+
+            def request_stop(_signum, _frame):
+                nonlocal stop_requested
+                stop_requested = True
+
+            previous_sigterm = signal.signal(signal.SIGTERM, request_stop)
             try:
                 for event in observe_federation(
                     current,
                     state_path=observer_state,
                     max_workers=max_workers,
+                    stop=lambda: stop_requested,
                 ):
                     click.echo(json.dumps(event, sort_keys=True))
             except KeyboardInterrupt:
                 pass
+            finally:
+                signal.signal(signal.SIGTERM, previous_sigterm)
             return
         payload = query_federation(
             current,

--- a/framework/gui/src/main/global-work-observer-host.test.ts
+++ b/framework/gui/src/main/global-work-observer-host.test.ts
@@ -24,12 +24,14 @@ function fakeChild() {
 test('main observer owns one durable child and pushes incremental snapshots', () => {
   const child = fakeChild();
   let seenArgs: string[] = [];
+  let spawnCount = 0;
   const received: unknown[] = [];
   const host = createGlobalWorkObserverHost({
     bin: '/kungfu',
     env: {},
     statePath: '/config/gui/global-work-observer.json',
     spawn: (_file, args) => {
+      spawnCount += 1;
       seenArgs = args;
       return child as never;
     },
@@ -79,6 +81,11 @@ test('main observer owns one durable child and pushes incremental snapshots', ()
   assert.equal(received.length, 1);
 
   host.unsubscribe('renderer-1');
+  assert.equal(child.killedWith, '');
+  host.subscribe('renderer-1', () => {});
+  assert.equal(spawnCount, 1);
+  host.unsubscribe('renderer-1');
+  host.dispose();
   assert.equal(child.killedWith, 'SIGTERM');
 });
 

--- a/framework/gui/src/main/global-work-observer-host.ts
+++ b/framework/gui/src/main/global-work-observer-host.ts
@@ -161,12 +161,6 @@ export function createGlobalWorkObserverHost(deps: GlobalWorkObserverHostDeps) {
     },
     unsubscribe(clientKey: string) {
       subscribers.delete(clientKey);
-      if (subscribers.size === 0) {
-        if (restartTimer) deps.cancelRestart(restartTimer);
-        restartTimer = null;
-        child?.kill('SIGTERM');
-        child = null;
-      }
     },
     dispose() {
       stopped = true;


### PR DESCRIPTION
## Summary

Keep the installed global Work observer truly app-scoped after live dogfood exposed renderer subscription churn and orphaned recovery workers.

## Changes

- retain the single main-process observer when the renderer view unsubscribes or remounts
- keep the latest shell notification target in a ref so renderer re-renders do not restart observation
- handle `SIGTERM` in the observer CLI and let an active ProcessPool close before exit
- prove unsubscribe/resubscribe reuses one child and app disposal performs the one shutdown

## Verification

- `./shifu test:work-authority`
- 39 workspace federation Python tests
- 3 main-process and renderer observer tests
- GUI production build
- KFD buildchain check
- live SIGTERM during an active recovery ProcessPool: exit 0, orphaned children 0

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix renderer subscription churn and graceful observer shutdown without changing the accepted Work authority or federation contracts"
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
