### PR TITLE
fix(product): use canonical work CLI in installed smoke

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1860,7 +1860,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
       installRoot,
       home,
       args: [
-        'assignment',
+        'work',
         'capture',
         '--request',
         requestPath,
@@ -1870,7 +1870,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
       ],
       env: assignmentEnv,
     }),
-    'assignment capture',
+    'work capture',
   );
   const admitted = parseJsonOutput(
     run({
@@ -1878,7 +1878,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
       installRoot,
       home,
       args: [
-        'assignment',
+        'work',
         'admit',
         captured.requestPath,
         '--workspace',
@@ -1890,7 +1890,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
       ],
       env: assignmentEnv,
     }),
-    'assignment admit',
+    'work admit',
   );
   if (
     admitted.admitted !== true ||

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -233,6 +233,13 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
 
   assert.equal(fs.readFileSync(operatorCatalog, 'utf8'), operatorBytes);
   assert.equal(invocations.length, 2);
+  assert.deepEqual(
+    invocations.map(({ args }) => args.slice(0, 2)),
+    [
+      ['work', 'capture'],
+      ['work', 'admit'],
+    ],
+  );
   for (const invocation of invocations) {
     assert.equal(
       invocation.env.HOME,


### PR DESCRIPTION
## Summary

Repair the installed product admission smoke after the canonical CLI route moved from `kungfu assignment` to `kungfu work`.

## Root cause

The protected product build for auditable demo run 30174217514 passed the unchanged 100 MiB package ceiling at 103,388,024 compressed bytes, then failed because the installed archive smoke still invoked the retired `assignment` route. The native CLI has exposed the same authority under `work` since f83febb30f70f34f461085ec60bf6f53ac05007c.

## Changes

- invoke `work capture` and `work admit` in the installed archive smoke
- assert both exact canonical route prefixes in the unit test
- keep Workspace Catalog isolation and admission receipt checks unchanged

## Verification

- `./shifu node --test product/scripts/dist.test.mjs` (23 passed)
- targeted Biome check
- full pre-commit repository gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair a stale installed-product smoke invocation after the already-governed canonical CLI route moved from assignment to work; no contract or ADR projection changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only a build-time installed-archive qualification invocation. It adds no publication, deployment, package write, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed build evidence cited
