### PR TITLE
fix(workspace): keep repeated catalog observations stable

### DIFF
--- a/framework/core/src/python/kungfu/workspace.py
+++ b/framework/core/src/python/kungfu/workspace.py
@@ -613,16 +613,53 @@ def observe_workspace_locator(
     if existing is not None:
         entry["lifecycle"] = _catalog_lifecycle(existing)
         entry["provenance"] = _catalog_provenance(existing)
-    entries = [
-        row
-        for row in catalog["entries"]
-        if _catalog_entry_key(row) != _catalog_entry_key(entry)
-        and not (
+        unchanged_entry = {
+            **entry,
+            "observed_at": existing.get("observed_at"),
+        }
+        conflicting_locator = any(
+            _catalog_entry_key(row) != _catalog_entry_key(entry)
+            and identity.identity_state == "qualified"
+            and row.get("locator_key") == entry["locator_key"]
+            for row in catalog["entries"]
+        )
+        if (
+            _persisted_catalog_entry(existing) == unchanged_entry
+            and not conflicting_locator
+        ):
+            # The Catalog is a locator set, not a recency log. Re-observing the
+            # same locator must not invalidate a live federation query cut.
+            payload = {
+                "schema": CATALOG_SCHEMA,
+                "entries": [
+                    _persisted_catalog_entry(row) for row in catalog["entries"]
+                ],
+                "epoch": int(catalog.get("epoch") or 0),
+            }
+            if "updated_at" in catalog:
+                payload["updated_at"] = catalog["updated_at"]
+            return {
+                **payload,
+                "catalog_path": catalog["catalog_path"],
+                "catalog_cut": catalog["catalog_cut"],
+                "observed": _persisted_catalog_entry(existing),
+                "changed": False,
+            }
+    entries: list[dict[str, Any]] = []
+    replaced = False
+    for row in catalog["entries"]:
+        if _catalog_entry_key(row) == _catalog_entry_key(entry):
+            entries.append(entry)
+            replaced = True
+            continue
+        if (
             identity.identity_state == "qualified"
             and row.get("locator_key") == entry["locator_key"]
-        )
-    ]
-    entries.insert(0, entry)
+        ):
+            continue
+        entries.append(_persisted_catalog_entry(row))
+    if not replaced:
+        entries.insert(0, entry)
     payload = {
         "schema": CATALOG_SCHEMA,
         "entries": entries,
@@ -636,6 +673,7 @@ def observe_workspace_locator(
         "catalog_path": path,
         "catalog_cut": _catalog_cut(payload),
         "observed": entry,
+        "changed": True,
     }
 
 

--- a/framework/core/tests/python/test_workspace.py
+++ b/framework/core/tests/python/test_workspace.py
@@ -15,6 +15,7 @@ from kungfu.workspace import (
     load_workspace_catalog,
     load_workspace_registry,
     maintain_workspace_catalog,
+    observe_workspace_locator,
     prepare_workspace_write,
     rebuild_workspace_catalog,
     rebind_workspace_locator,
@@ -105,9 +106,58 @@ def test_ensure_creates_minimum_layout_and_receipt_without_git_effects(tmp_path)
     assert qualified is not None
     assert qualified.identity_state == "qualified"
     assert qualified.identity_root == receipt["workspace_identity_root"]
+    catalog_before = load_workspace_catalog(qualified.config_home)
     repeated = ensure_workspace_data_home(qualified, "create-go")
+    catalog_after = load_workspace_catalog(qualified.config_home)
     assert repeated["initialized"] is False
     assert repeated["created_paths"] == []
+    assert catalog_after["epoch"] == catalog_before["epoch"]
+    assert catalog_after["catalog_cut"] == catalog_before["catalog_cut"]
+
+
+def test_repeated_locator_observation_is_catalog_idempotent(tmp_path):
+    config_home = tmp_path / "config"
+    env = {"HOME": str(tmp_path)}
+    identities = []
+    for name in ("left", "right"):
+        repo = tmp_path / name
+        repo.mkdir()
+        candidate = inspect_workspace(str(repo), env=env)
+        assert candidate is not None
+        ensure_workspace_data_home(candidate, f"create-{name}")
+        qualified = inspect_workspace(str(repo), env=env)
+        assert qualified is not None
+        identities.append(qualified)
+
+    observe_workspace_locator(
+        identities[0],
+        config_home=str(config_home),
+        env=env,
+    )
+    observe_workspace_locator(
+        identities[1],
+        config_home=str(config_home),
+        env=env,
+    )
+    before = load_workspace_catalog(str(config_home), env=env)
+    catalog_path = config_home / "workspaces" / "catalog.json"
+    bytes_before = catalog_path.read_bytes()
+
+    repeated = observe_workspace_locator(
+        identities[0],
+        config_home=str(config_home),
+        env=env,
+    )
+    after = load_workspace_catalog(str(config_home), env=env)
+
+    assert repeated["changed"] is False
+    assert repeated["observed"]["identity_root"] == identities[0].identity_root
+    assert after["epoch"] == before["epoch"]
+    assert after["catalog_cut"] == before["catalog_cut"]
+    assert catalog_path.read_bytes() == bytes_before
+    assert [row["identity_root"] for row in after["entries"]] == [
+        row["identity_root"] for row in before["entries"]
+    ]
 
 
 def test_project_identity_survives_locator_move_and_rebind(tmp_path):


### PR DESCRIPTION
## Summary

Keep the app-scoped global Work observer incremental across separate semantic writes by making repeated observation of an unchanged Workspace locator write-free.

## Changes

- preserve the existing Catalog entry, epoch, bytes, and cut when a qualified locator is semantically unchanged
- continue updating the Catalog when identity, locator, availability, or candidate replacement actually changes
- avoid persisting read-only Catalog projection fields during real updates
- prove repeated observation does not reorder entries or mutate Catalog bytes

## Verification

- ./shifu check:source
- ./shifu test:workspace-continuation with the exact 700b1214a5 native artifact: Node 8/8, Python 76/76
- staged commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix repeated locator observation churn without changing Workspace identity, Catalog lifecycle, or global Work federation semantics"
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
