### PR TITLE
fix(agent-hub): isolate installed adapter variant

### DIFF
--- a/framework/core/src/python/kungfu/agent/agent_hub_qualification.py
+++ b/framework/core/src/python/kungfu/agent/agent_hub_qualification.py
@@ -124,6 +124,12 @@ def run_kfd_step(entry: Path, *commands: str) -> None:
 
 def _run_kfd(executable: Path, entry: Path, *commands: str) -> None:
     env = os.environ.copy()
+    # The embedded Node host may mark its own process as the node variant.  That
+    # marker must not cross the fresh installed-product boundary: the KFD runner
+    # launches this executable again as the Agent Hub adapter, and the trunk
+    # would otherwise interpret the first public argument ("agent") as a Node
+    # module path instead of routing it through the Python CLI.
+    env.pop("KUNGFU_AS_VARIANT", None)
     env["KUNGFU_INTERNAL_AGENT_HUB_KFD_STEP"] = json.dumps(
         {"entry": str(entry), "commands": list(commands)},
         separators=(",", ":"),

--- a/framework/core/tests/python/test_agent_hub_profile.py
+++ b/framework/core/tests/python/test_agent_hub_profile.py
@@ -213,6 +213,7 @@ def test_kfd_steps_reenter_the_installed_product_in_fresh_processes(
         return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     monkeypatch.setattr(agent_hub_qualification.subprocess, "run", run)
+    monkeypatch.setenv("KUNGFU_AS_VARIANT", "node")
     agent_hub_qualification._run_kfd(executable, entry, "test", "agent-hub")
     agent_hub_qualification._run_kfd(
         executable, entry, "verify", "agent-hub-report", "report.json"
@@ -231,4 +232,5 @@ def test_kfd_steps_reenter_the_installed_product_in_fresh_processes(
             "commands": ["verify", "agent-hub-report", "report.json"],
         },
     ]
+    assert all("KUNGFU_AS_VARIANT" not in call[1]["env"] for call in calls)
     assert all(call[1]["capture_output"] is True for call in calls)


### PR DESCRIPTION
## Summary

Keep the embedded Node-only variant marker inside the KFD execution process so the Agent Hub qualification can re-enter the exact installed Kungfu product as its adapter.

## Root cause

Auditable-demo build run 30175240748 reached the installed `kungfu agent hub qualify` smoke, then the KFD runner launched the packaged Kungfu front door while `KUNGFU_AS_VARIANT=node` was still inherited. The Rust trunk therefore treated the first public argument `agent` as a Node module path and failed with `Cannot find module .../agent`.

## Changes

- clear `KUNGFU_AS_VARIANT` at the fresh installed-product subprocess boundary
- preserve the internal KFD step envelope and all public Agent Hub arguments
- add a regression test that starts from a deliberately polluted parent environment

## Verification

- `PYTHONPATH=framework/core/src/python uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_agent_hub_profile.py` (8 passed)
- `./shifu node --test product/scripts/dist.test.mjs` (23 passed)
- full pre-commit repository gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair environment isolation at an existing installed-product qualification subprocess boundary; no contract, authority, or ADR projection changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only the environment inherited by a build-time installed-archive qualification subprocess. It adds no publication, deployment, package write, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed build evidence cited