### PR TITLE
fix(agent-hub): scope embedded Node entry

### DIFF
--- a/crates/trunk/src/variant.rs
+++ b/crates/trunk/src/variant.rs
@@ -21,9 +21,12 @@
 // resolution), so it is not a mechanical "be python" the trunk can own.
 
 use std::env;
+use std::ffi::OsStr;
 
 /// The env the variant table reads to decide the process should *be* a variant.
 const ENV_VARIANT_KEY: &str = "KUNGFU_AS_VARIANT";
+/// Optional exact argv[1] that owns one internal Node-variant invocation.
+const ENV_VARIANT_ENTRY_KEY: &str = "KUNGFU_NODE_VARIANT_ENTRY";
 
 /// The standalone node-host library the product ships next to this binary; it
 /// exports the C entry `kungfu_node_run` (a thin wrapper over node::Start).
@@ -41,9 +44,28 @@ const NODE_HOST_LIB: &str = "kungfu_node_host.dll";
 /// the normal launch path, where the Python variant table still handles it.
 pub fn dispatch() -> Option<i32> {
     match env::var(ENV_VARIANT_KEY).ok().as_deref() {
-        Some("node") => run_node(),
+        Some("node")
+            if scoped_entry_matches(
+                env::var_os(ENV_VARIANT_ENTRY_KEY).as_deref(),
+                env::args_os().nth(1).as_deref(),
+            ) =>
+        {
+            run_node()
+        }
+        Some("node") => {
+            // A scoped Node host may launch the public Kungfu front door as a
+            // child adapter.  Do not let its private variant marker turn the
+            // child's first public argument into a Node module path.
+            env::remove_var(ENV_VARIANT_KEY);
+            env::remove_var(ENV_VARIANT_ENTRY_KEY);
+            None
+        }
         _ => None,
     }
+}
+
+fn scoped_entry_matches(expected: Option<&OsStr>, actual: Option<&OsStr>) -> bool {
+    expected.is_none() || expected == actual
 }
 
 /// The C entry the node-host exports: `int kungfu_node_run(int argc, char **argv)`.
@@ -176,14 +198,33 @@ mod tests {
     #[test]
     fn dispatch_falls_through_except_for_ownable_variants() {
         let prior = env::var(ENV_VARIANT_KEY).ok();
+        let prior_entry = env::var_os(ENV_VARIANT_ENTRY_KEY);
+
+        assert!(scoped_entry_matches(None, Some(OsStr::new("agent"))));
+        assert!(scoped_entry_matches(
+            Some(OsStr::new("/exact/runner.mjs")),
+            Some(OsStr::new("/exact/runner.mjs")),
+        ));
+        assert!(!scoped_entry_matches(
+            Some(OsStr::new("/exact/runner.mjs")),
+            Some(OsStr::new("agent")),
+        ));
 
         // No variant requested → fall through.
         env::remove_var(ENV_VARIANT_KEY);
+        env::remove_var(ENV_VARIANT_ENTRY_KEY);
         assert_eq!(dispatch(), None);
 
         // A variant the trunk does not own natively (python) → fall through.
         env::set_var(ENV_VARIANT_KEY, "python");
         assert_eq!(dispatch(), None);
+
+        // A scoped node request cannot leak into a child public CLI invocation.
+        env::set_var(ENV_VARIANT_KEY, "node");
+        env::set_var(ENV_VARIANT_ENTRY_KEY, "/not/the/test/entry.mjs");
+        assert_eq!(dispatch(), None);
+        assert_eq!(env::var_os(ENV_VARIANT_KEY), None);
+        assert_eq!(env::var_os(ENV_VARIANT_ENTRY_KEY), None);
 
         // node with no host library next to the test binary → the native path must
         // return None (delegating to the Python variant), never crash. This is the
@@ -194,6 +235,10 @@ mod tests {
         match prior {
             Some(v) => env::set_var(ENV_VARIANT_KEY, v),
             None => env::remove_var(ENV_VARIANT_KEY),
+        }
+        match prior_entry {
+            Some(v) => env::set_var(ENV_VARIANT_ENTRY_KEY, v),
+            None => env::remove_var(ENV_VARIANT_ENTRY_KEY),
         }
     }
 }

--- a/framework/core/src/python/kungfu/agent/agent_hub_qualification.py
+++ b/framework/core/src/python/kungfu/agent/agent_hub_qualification.py
@@ -133,6 +133,7 @@ def _run_kfd(executable: Path, entry: Path, *commands: str) -> None:
     env = os.environ.copy()
     env.pop("KUNGFU_INTERNAL_AGENT_HUB_KFD_STEP", None)
     env["KUNGFU_AS_VARIANT"] = "node"
+    env["KUNGFU_NODE_VARIANT_ENTRY"] = str(script)
     result = subprocess.run(
         [str(executable), str(script), *script_commands],
         check=False,

--- a/framework/core/tests/python/test_agent_hub_profile.py
+++ b/framework/core/tests/python/test_agent_hub_profile.py
@@ -230,6 +230,10 @@ def test_kfd_steps_reenter_the_python_free_node_variant_in_fresh_processes(
         [str(executable), str(verifier), "report.json"],
     ]
     assert all(call[1]["env"]["KUNGFU_AS_VARIANT"] == "node" for call in calls)
+    assert [call[1]["env"]["KUNGFU_NODE_VARIANT_ENTRY"] for call in calls] == [
+        str(runner),
+        str(verifier),
+    ]
     assert all(
         "KUNGFU_INTERNAL_AGENT_HUB_KFD_STEP" not in call[1]["env"] for call in calls
     )


### PR DESCRIPTION
## Summary

Bind the private embedded-Node variant to the exact KFD script entry so Agent Hub qualification can launch the installed Kungfu product as its public adapter without leaking Node routing into that child process.

## Root cause

Auditable-demo build run 30175240748 reached the installed `kungfu agent hub qualify` smoke. The qualification correctly launched the KFD runner through the Python-free `KUNGFU_AS_VARIANT=node` path, but that marker was inherited when the runner spawned the packaged Kungfu front door as `kungfu agent hub adapter`. The Rust trunk then treated the first public argument `agent` as a Node module path and failed with `Cannot find module .../agent`.

## Changes

- bind internal Node dispatch to the exact KFD runner or verifier argv entry
- preserve unscoped Node-variant behavior for existing callers
- clear the private marker when a scoped Node process starts a different child entry, restoring normal public CLI routing
- test exact-entry admission, mismatch rejection/cleanup, full Rust workspace behavior, and the Python qualification boundary

## Verification

- `PYTHONPATH=framework/core/src/python uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_agent_hub_profile.py` (8 passed)
- `./shifu node --test product/scripts/dist.test.mjs` (23 passed)
- `cargo test --manifest-path crates/trunk/Cargo.toml variant::tests::dispatch_falls_through_except_for_ownable_variants`
- full pre-commit repository gate, including `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair environment isolation at an existing installed-product qualification subprocess boundary; no contract, authority, or ADR projection changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only internal dispatch scope for a build-time installed-archive qualification subprocess. It adds no publication, deployment, package write, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed build evidence cited