### PR TITLE
fix(gui): keep installed bundle immutable

### DIFF
--- a/framework/gui/src/main/global-work-observer-host.test.ts
+++ b/framework/gui/src/main/global-work-observer-host.test.ts
@@ -24,15 +24,20 @@ function fakeChild() {
 test('main observer owns one durable child and pushes incremental snapshots', () => {
   const child = fakeChild();
   let seenArgs: string[] = [];
+  let seenEnv: NodeJS.ProcessEnv = {};
   let spawnCount = 0;
   const received: unknown[] = [];
   const host = createGlobalWorkObserverHost({
     bin: '/kungfu',
-    env: {},
+    env: {
+      KUNGFU_TEST_ENV: 'kept',
+      PYTHONDONTWRITEBYTECODE: '0',
+    },
     statePath: '/config/gui/global-work-observer.json',
-    spawn: (_file, args) => {
+    spawn: (_file, args, options) => {
       spawnCount += 1;
       seenArgs = args;
+      seenEnv = options.env;
       return child as never;
     },
     restart: () => ({}) as NodeJS.Timeout,
@@ -52,6 +57,8 @@ test('main observer owns one durable child and pushes incremental snapshots', ()
     '/config/gui/global-work-observer.json',
     '--json',
   ]);
+  assert.equal(seenEnv.KUNGFU_TEST_ENV, 'kept');
+  assert.equal(seenEnv.PYTHONDONTWRITEBYTECODE, '1');
   child.stdout.emit(
     'data',
     `${JSON.stringify({

--- a/framework/gui/src/main/global-work-observer-host.ts
+++ b/framework/gui/src/main/global-work-observer-host.ts
@@ -104,7 +104,10 @@ export function createGlobalWorkObserverHost(deps: GlobalWorkObserverHostDeps) {
         deps.statePath,
         '--json',
       ],
-      { env: deps.env, stdio: ['ignore', 'pipe', 'pipe'] },
+      {
+        env: { ...deps.env, PYTHONDONTWRITEBYTECODE: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
     );
     child = launched;
     launched.stdout.on('data', (chunk: Buffer | string) => {


### PR DESCRIPTION
## Summary

Keep the installed Developer ID-signed app bundle immutable while its global Work observer runs.

## Changes

- force the observer child process to disable Python bytecode writes
- preserve all inherited observer environment values
- prove a conflicting caller value is overridden and unrelated values survive

## Verification

- framework/gui/node_modules/.bin/tsx --test framework/gui/src/main/global-work-observer-host.test.ts (2/2)
- ./shifu check:source
- staged commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Prevent runtime cache files from mutating the signed desktop bundle without changing Work observer semantics"
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed