### PR TITLE
fix(gui): protect packaged Python resources

### DIFF
--- a/framework/gui/src/main/desktop-python-environment.ts
+++ b/framework/gui/src/main/desktop-python-environment.ts
@@ -1,0 +1,6 @@
+export function protectPackagedPythonEnvironment(
+  env: NodeJS.ProcessEnv,
+  isPackaged: boolean,
+) {
+  if (isPackaged) env.PYTHONDONTWRITEBYTECODE = '1';
+}

--- a/framework/gui/src/main/global-work-observer-host.test.ts
+++ b/framework/gui/src/main/global-work-observer-host.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import test from 'node:test';
 
+import { protectPackagedPythonEnvironment } from './desktop-python-environment.ts';
 import { createGlobalWorkObserverHost } from './global-work-observer-host.ts';
 
 function fakeChild() {
@@ -20,6 +21,20 @@ function fakeChild() {
   };
   return child;
 }
+
+test('packaged desktop disables Python bytecode writes before child launches', () => {
+  const packagedEnv = {
+    KUNGFU_TEST_ENV: 'kept',
+    PYTHONDONTWRITEBYTECODE: '0',
+  };
+  protectPackagedPythonEnvironment(packagedEnv, true);
+  assert.equal(packagedEnv.KUNGFU_TEST_ENV, 'kept');
+  assert.equal(packagedEnv.PYTHONDONTWRITEBYTECODE, '1');
+
+  const developmentEnv = { PYTHONDONTWRITEBYTECODE: '0' };
+  protectPackagedPythonEnvironment(developmentEnv, false);
+  assert.equal(developmentEnv.PYTHONDONTWRITEBYTECODE, '0');
+});
 
 test('main observer owns one durable child and pushes incremental snapshots', () => {
   const child = fakeChild();

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -61,6 +61,7 @@ import {
   bindElectronAgentSessionHost,
   createMainAgentSessionHost,
 } from './agent-session-host';
+import { protectPackagedPythonEnvironment } from './desktop-python-environment';
 import {
   type ProductionDesktopUpdateProvider,
   createProductionDesktopUpdateProvider,
@@ -105,6 +106,8 @@ import {
   listRecentDesktopWorkspaces,
   resolveLastDesktopWorkspace,
 } from './workspace-selection';
+
+protectPackagedPythonEnvironment(process.env, app.isPackaged);
 
 const qualificationMode = process.env.KF_QUALIFICATION_MODE === '1';
 


### PR DESCRIPTION
## Summary

Set Python bytecode suppression at the packaged desktop entry before any child process can touch signed bundle resources.

## Changes

- protect the packaged desktop environment before main-process startup work
- preserve development behavior while retaining the observer-level defense
- cover packaged override, existing environment preservation, and development behavior

## Verification

- targeted desktop test: 3/3 passed
- `./shifu check:source` passed
- startup-level experiment kept strict deep codesign valid after the live observer started

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Keep packaged desktop resources immutable across all Python child launches without changing Work authority or observer semantics"
}
-->