### PR TITLE
fix(cli): bind help to governed catalog

### DIFF
--- a/framework/core/src/python/kungfu/cli/help_projection.py
+++ b/framework/core/src/python/kungfu/cli/help_projection.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Stable progressive-help projection derived from the CLI surface contract."""
+"""Stable progressive-help projection derived from the governed CLI catalog."""
 
 from __future__ import annotations
 
@@ -48,11 +48,9 @@ def build(
         raise ProjectionError("helpProjection.sections contains duplicate ids")
 
     if contract is None:
-        from kungfu.cli import surface_contract
+        from kungfu.agent import resources as agent_resources
 
-        contract = surface_contract.fold(
-            root_command, metadata_registry=metadata_registry
-        )
+        contract = agent_resources.cli_surface_catalog()
     diagnostics = contract.get("diagnostics", {})
     if not diagnostics.get("ok"):
         codes = ", ".join(

--- a/framework/core/tests/python/test_cli_progressive_help.py
+++ b/framework/core/tests/python/test_cli_progressive_help.py
@@ -114,6 +114,18 @@ def test_projection_is_contract_bound_and_json_is_stable():
     )
 
 
+def test_default_projection_uses_the_governed_agent_catalog(monkeypatch):
+    catalog = _contract()
+
+    from kungfu.agent import resources as agent_resources
+
+    monkeypatch.setattr(agent_resources, "cli_surface_catalog", lambda: catalog)
+    projection = help_projection.build(sample, metadata_registry=_registry())
+
+    assert projection["contractRoot"] == catalog["contractRoot"]
+    assert projection["registryRoot"] == catalog["registryRoot"]
+
+
 def test_default_help_expands_public_objects_and_collapses_advanced_sections():
     projection = help_projection.build(
         sample, metadata_registry=_registry(), contract=_contract()


### PR DESCRIPTION
## Summary

Bind installed human help to the same governed, content-addressed CLI catalog exposed through Agent capabilities, closing the product-only root drift that blocked the auditable-demo build.

## Root cause

Auditable-demo build run 30177108755 assembled the exact CLI archive, then failed the installed product qualification with `human help roots do not match the Agent catalog`. Human help refolded the live Click tree inside the installed archive while Agent capabilities consumed the source-accepted governed catalog, leaving two runtime projections for the same roots.

## Changes

- make progressive help consume the governed Agent CLI catalog by default
- preserve explicit contract injection for isolated projection tests
- add a regression proving default human help binds the catalog contract and registry roots
- keep the installed qualification fail-closed; no check is relaxed or skipped

## Verification

- `PYTHONPATH=framework/core/src/python uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_cli_progressive_help.py` (4 passed, 2 native-only skipped)
- `node --test product/scripts/cli-surface-qualification.test.mjs` (4 passed)
- `node scripts/check-cli-catalog-parity.mjs`
- `uv run --project framework/core --frozen ruff format --check framework/core/src/python/kungfu/cli/help_projection.py framework/core/tests/python/test_cli_progressive_help.py`
- actual pre-commit staged repository gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair an existing installed-product parity invariant by selecting its already governed catalog as the single projection source; no public CLI or authority contract changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only the source used by an existing offline installed-product help projection. It adds no deployment, publication write, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed build evidence cited