### PR TITLE
fix(cli): admit qualified catalog diagnostics

### DIFF
--- a/framework/core/src/python/kungfu/cli/help_projection.py
+++ b/framework/core/src/python/kungfu/cli/help_projection.py
@@ -51,8 +51,11 @@ def build(
         from kungfu.agent import resources as agent_resources
 
         contract = agent_resources.cli_surface_catalog()
-    diagnostics = contract.get("diagnostics", {})
-    if not diagnostics.get("ok"):
+    diagnostics = contract.get("diagnostics")
+    if diagnostics is None:
+        if contract.get("schema") != "kungfu.cli-surface-catalog/v1":
+            raise ProjectionError("surface contract diagnostics are missing")
+    elif not diagnostics.get("ok"):
         codes = ", ".join(
             sorted(
                 {row.get("code", "unknown") for row in diagnostics.get("errors", [])}

--- a/framework/core/tests/python/test_cli_progressive_help.py
+++ b/framework/core/tests/python/test_cli_progressive_help.py
@@ -116,6 +116,8 @@ def test_projection_is_contract_bound_and_json_is_stable():
 
 def test_default_projection_uses_the_governed_agent_catalog(monkeypatch):
     catalog = _contract()
+    catalog["schema"] = "kungfu.cli-surface-catalog/v1"
+    del catalog["diagnostics"]
 
     from kungfu.agent import resources as agent_resources
 
@@ -124,6 +126,17 @@ def test_default_projection_uses_the_governed_agent_catalog(monkeypatch):
 
     assert projection["contractRoot"] == catalog["contractRoot"]
     assert projection["registryRoot"] == catalog["registryRoot"]
+
+
+def test_non_catalog_contract_cannot_omit_fold_diagnostics():
+    contract = _contract()
+    del contract["diagnostics"]
+
+    with pytest.raises(
+        help_projection.ProjectionError,
+        match="surface contract diagnostics are missing",
+    ):
+        help_projection.build(sample, metadata_registry=_registry(), contract=contract)
 
 
 def test_default_help_expands_public_objects_and_collapses_advanced_sections():


### PR DESCRIPTION
## Summary

Allow progressive help to consume the source-accepted governed CLI catalog, whose stable projection intentionally omits transient fold diagnostics, while keeping every non-catalog contract fail-closed.

## Root cause

Auditable-demo build run 30178806617 reached assembled help-manifest generation and failed with `surface contract diagnostics failed`. PR #1503 correctly selected the governed catalog as the shared Human/Agent projection, but the builder still treated the catalog schema as an unqualified live fold because the stable catalog has no `diagnostics` field.

## Changes

- accept missing transient diagnostics only for exact schema `kungfu.cli-surface-catalog/v1`
- preserve explicit diagnostic failure behavior
- reject every non-catalog contract that omits diagnostics
- update the governed-catalog regression to match the actual packaged catalog shape

## Verification

- `PYTHONPATH=framework/core/src/python uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_cli_progressive_help.py` (5 passed, 2 native-only skipped)
- `node --test product/scripts/cli-surface-qualification.test.mjs` (4 passed)
- `node scripts/check-cli-catalog-parity.mjs`
- `uv run --project framework/core --frozen ruff format --check framework/core/src/python/kungfu/cli/help_projection.py framework/core/tests/python/test_cli_progressive_help.py`
- actual pre-commit staged repository gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Complete the existing Human and Agent catalog parity repair by recognizing the already qualified stable catalog schema; no public CLI or authority contract changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This narrows one existing offline build-time schema distinction. It adds no publication, deployment, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed build evidence cited