### PR TITLE
fix(ci): keep manual artifacts on GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
       verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip
       release-candidate: true
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
-      artifact-transfer-mode: s3-to-github-artifacts
+      artifact-transfer-mode: ${{ github.event_name == 'workflow_dispatch' && 'github-artifacts' || 's3-to-github-artifacts' }}
       artifact-retention-days: 14
       checkout-cache-mode: auto
       checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -794,7 +794,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:9775aa49925f618a2cf57e4654f8771510dd307e37606917c7bb2b5efca8213a",
+          "definitionDigest": "sha256:c51697c583d925a12a3d1c63bc7529899d333c3e34ce9930459b32913d1bea2a",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -459,7 +459,7 @@
           "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip",
           "release-candidate": true,
           "publish-channel": "${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
-          "artifact-transfer-mode": "s3-to-github-artifacts",
+          "artifact-transfer-mode": "${{ github.event_name == 'workflow_dispatch' && 'github-artifacts' || 's3-to-github-artifacts' }}",
           "shifu-cache-profile-ref": "${{ inputs.platforms-json && 'docs/shifu/qualification-portable-off.cache-profile.json' || vars.SHIFU_CACHE_PROFILE_REF }}",
           "buildchain-contract-lock-path": ".buildchain/contract-lock.json",
           "buildchain-contract-compatibility-policy": "major-compatible"

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -17,7 +17,11 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
   const build = WORKFLOW.jobs.build;
   const resolver = WORKFLOW.jobs['resolve-auditable-demo-source'];
   const gate = WORKFLOW.jobs['auditable-demo'];
-  assert.equal(build.with['artifact-transfer-mode'], 's3-to-github-artifacts');
+  assert.equal(
+    build.with['artifact-transfer-mode'],
+    "${{ github.event_name == 'workflow_dispatch' && 'github-artifacts' || 's3-to-github-artifacts' }}",
+    'manual evidence runs must not enter the AWS relay while protected promotion retains its existing transfer path',
+  );
   assert.equal(
     resolver.env,
     undefined,


### PR DESCRIPTION
## Summary

Keep trusted manual evidence builds on direct GitHub Actions Artifact transfer while preserving the existing S3 transit mode for protected Alpha and Release pull-request promotion.

## Safety trigger

Manual auditable-demo run 30181124335 reached `Upload payload to S3 artifact relay`. This task has no separate AWS/NAS relay authority, so the run was cancelled before a relay manifest or GitHub payload artifact was emitted. A manual diagnostic/render run does not need the protected promotion transit path.

## Changes

- select `github-artifacts` for every `workflow_dispatch` build
- retain `s3-to-github-artifacts` for pull-request promotion events
- bind the exact expression into the governed workflow controller contract
- refresh the generated workflow authority digest
- add an explicit regression assertion for the manual safety boundary

## Verification

- `node --test scripts/auditable-demo-workflow.test.mjs` (4 passed)
- `node scripts/kungfu-workflow-authority.mjs --check`
- `node scripts/check-kungfu-gate-catalog.mjs`
- actual pre-commit staged repository gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Route manual evidence artifacts through the already supported direct GitHub transfer mode while preserving the governed protected-promotion path; no public product or authority model changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This narrows manual-run side effects. It adds no publication, deployment, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact cancelled run evidence cited