### PR TITLE
fix(ci): normalize artifact expiry precision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,6 +277,13 @@ jobs:
               );
             }
             const declared = declaredLinux[0];
+            const canonicalExpiry = (value, label) => {
+              const milliseconds = Date.parse(value || "");
+              if (!Number.isFinite(milliseconds)) {
+                throw new Error(`${label} is not a valid artifact expiry`);
+              }
+              return new Date(milliseconds).toISOString();
+            };
             if (
               !/^[1-9][0-9]*$/.test(declared.id || "") ||
               declared.name !== name ||
@@ -289,6 +296,10 @@ jobs:
                 "producer-owned Linux coordinate is incomplete or malformed",
               );
             }
+            const declaredExpiry = canonicalExpiry(
+              declared.expiresAt,
+              "producer-owned Linux coordinate expiry",
+            );
             const matches = artifacts.filter(
               (artifact) =>
                 String(artifact.id) === declared.id && !artifact.expired,
@@ -299,10 +310,14 @@ jobs:
               );
             }
             const observed = matches[0];
+            const observedExpiry = canonicalExpiry(
+              observed.expires_at,
+              "live Linux artifact expiry",
+            );
             if (
               observed.name !== declared.name ||
               observed.digest !== declared.digest ||
-              observed.expires_at !== declared.expiresAt
+              observedExpiry !== declaredExpiry
             ) {
               throw new Error(
                 "live Linux artifact drifted from the producer-owned coordinate",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -980,7 +980,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4efe6c3897c89c2bc15d5ceb338bdecc8bdf02e201466187f0ae32a02e174a5c",
+          "definitionDigest": "sha256:0fb00bc8eb417ddd3ff8ff7bc0c3a7bc4bb42cfe7e81e71d917fdc3b8ac80d49",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -997,7 +997,7 @@
               "index": 1,
               "label": "id:resolve",
               "authority": "qualification",
-              "definitionDigest": "sha256:785b5659197f9cf5e7b2edb115ac105f9f436da40fac7b69e70dd2be7b02a530"
+              "definitionDigest": "sha256:6929254306abf28805fd0930ea21895c8416c0ebbc6bef90d1675f0ce8d8f004"
             },
             {
               "index": 2,

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -12,6 +12,74 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW_PATH = path.join(ROOT, '.github', 'workflows', 'build.yml');
 const WORKFLOW_TEXT = fs.readFileSync(WORKFLOW_PATH, 'utf8');
 const WORKFLOW = parse(WORKFLOW_TEXT);
+const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+
+async function runResolver({ declaredExpiry, observedExpiry }) {
+  const resolver = WORKFLOW.jobs['resolve-auditable-demo-source'];
+  const script = resolver.steps.find(({ id }) => id === 'resolve').with.script;
+  const sourceSha = '1'.repeat(40);
+  const runId = '30182763118';
+  const artifactId = '8626649251';
+  const name = `kungfu-linux-x64-${sourceSha}`;
+  const digest = `sha256:${'2'.repeat(64)}`;
+  const url = `https://github.com/kungfu-systems/kungfu/actions/runs/${runId}/artifacts/${artifactId}`;
+  const outputs = new Map();
+  await new AsyncFunction(
+    'require',
+    'process',
+    'github',
+    'context',
+    'core',
+    script,
+  )(
+    (name) => {
+      assert.equal(name, 'fs');
+      return {
+        writeFileSync: () =>
+          assert.fail('applicable resolver wrote a diagnosis'),
+      };
+    },
+    {
+      env: {
+        SOURCE_SHA: sourceSha,
+        PLATFORMS_JSON: JSON.stringify([{ id: 'linux-x64' }]),
+        ARTIFACT_COORDINATES_JSON: JSON.stringify({
+          schema: 'buildchain.github-artifact-coordinate-set/v1',
+          repository: 'kungfu-systems/kungfu',
+          runId,
+          runAttempt: '1',
+          sourceSha,
+          artifacts: [
+            {
+              platformId: 'linux-x64',
+              id: artifactId,
+              name,
+              digest,
+              url,
+              expiresAt: declaredExpiry,
+            },
+          ],
+        }),
+        GITHUB_RUN_ATTEMPT: '1',
+      },
+    },
+    {
+      paginate: async () => [
+        {
+          id: Number(artifactId),
+          name,
+          digest,
+          expired: false,
+          expires_at: observedExpiry,
+        },
+      ],
+      rest: { actions: { listWorkflowRunArtifacts: () => undefined } },
+    },
+    { repo: { owner: 'kungfu-systems', repo: 'kungfu' }, runId },
+    { setOutput: (key, value) => outputs.set(key, value) },
+  );
+  return outputs;
+}
 
 test('every produced Linux artifact enters the required exact-output Gate', () => {
   const build = WORKFLOW.jobs.build;
@@ -50,6 +118,22 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
     '${{ needs.resolve-auditable-demo-source.outputs.artifact-digest }}',
   );
   assert.equal(gate.with['require-trusted-event'], true);
+});
+
+test('resolver accepts GitHub expiry precision normalization without weakening the coordinate', async () => {
+  const outputs = await runResolver({
+    declaredExpiry: '2026-08-09T01:47:51.000Z',
+    observedExpiry: '2026-08-09T01:47:51Z',
+  });
+  assert.equal(outputs.get('applicable'), 'true');
+  assert.equal(outputs.get('artifact-expires-at'), '2026-08-09T01:47:51.000Z');
+  await assert.rejects(
+    runResolver({
+      declaredExpiry: '2026-08-09T01:47:51.000Z',
+      observedExpiry: '2026-08-09T01:47:52Z',
+    }),
+    /live Linux artifact drifted from the producer-owned coordinate/u,
+  );
 });
 
 test('Gate runtime and renderer are immutable and Passport uses the same runtime', () => {


### PR DESCRIPTION
## Summary

Normalize producer and GitHub artifact expiry timestamps before equality comparison while preserving the exact producer-owned downstream coordinate.

## Root cause

Exact-source run 30182763118 produced matching artifact id, name, digest, URL, and expiry instant, but the producer coordinate used `.000Z` while the GitHub API returned `Z`. Raw string equality rejected that semantically identical RFC3339 timestamp.

## Changes

- parse both expiry representations and compare their canonical UTC instants
- keep id, name, digest, source, run, and URL matching unchanged
- preserve the producer-owned expiry representation in downstream outputs
- add executable regression coverage for precision normalization and a real one-second drift
- refresh the closed-world workflow authority digest

## Verification

- `./shifu test:auditable-demo` (17 passed)
- `./shifu check:staged` (passed)
- `node scripts/check-kungfu-gate-catalog.mjs` (passed)
- failed exact-source probe: https://github.com/kungfu-systems/kungfu/actions/runs/30182763118/job/89747271425

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Normalize two equivalent RFC3339 expiry representations at an existing exact artifact-coordinate boundary; no public behavior or authority model changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This preserves fail-closed coordinate binding and adds no publication, deployment, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed run evidence cited