### PR TITLE
docs(readme): map the open Kungfu system

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,21 @@ qualification evidence.
 - Issues and questions: [GitHub issue forms](https://github.com/kungfu-systems/kungfu/issues/new/choose)
 - Security reports: [SECURITY.md](SECURITY.md)
 - License: [Apache License 2.0](LICENSE)
+
+## Open system repositories
+
+Kungfu's protocol, release infrastructure, build environments, and public
+sites are developed in the open:
+
+- [Buildchain](https://github.com/kungfu-systems/buildchain) — auditable build
+  and release infrastructure with verifiable Release Passports.
+- [KFD](https://github.com/kungfu-systems/kfd) — the open engineering standard
+  for reliable action and continuity under uncertainty.
+- [Build Images](https://github.com/kungfu-systems/build-images) — source for
+  the reproducible environments used to build Kungfu system artifacts.
+- [kungfu.tech source](https://github.com/kungfu-systems/site-kungfu-tech) —
+  source for the public product site.
+- [libkungfu.dev source](https://github.com/kungfu-systems/site-libkungfu-dev) —
+  source for the developer and agent surface.
+- [All public repositories](https://github.com/kungfu-systems) — the complete
+  organization-level source map.


### PR DESCRIPTION
## Summary

Make the root README an explicit source map for Kungfu as an open system, so readers arriving through the product repository can discover the protocol, release infrastructure, build environments, public sites, and the complete organization.

## Changes

- Link Buildchain, KFD, Build Images, and both public site repositories.
- Link the complete kungfu-systems organization repository list.

## Verification

- `./shifu docs:check`
- `./shifu docs:prose:required`
- `./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This documentation-only source map does not alter an architecture or release contract"
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed