### PR TITLE
fix(ci): keep dev patrol on active Buildchain runtime

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -36,7 +36,12 @@ jobs:
       id-token: write
     uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5 # v2.13.0
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '' }}
+      # The reusable workflow commit is immutable, but its historical source
+      # SHA may no longer belong to the retained self-hosted Git bundle after
+      # the v2 release line diverges. Resolve the official stable runtime for
+      # standing patrols; trusted manual runs may still supply an exact SHA or
+      # train ref through the workflow_dispatch input.
+      buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}
       gate-profile: dev-patrol
       runner-preset: kungfu-v4-self-hosted
       artifact-name: kungfu-dev-patrol-gates

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1324,7 +1324,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:c07d917791b1220526427325815b6675aa0e54cccf77c16c8bca98a210127265",
+          "definitionDigest": "sha256:fce32b571c74e419ac2402b42ca04c8d28ab9e644c4586c2b83badf46bcdf32b",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -323,6 +323,7 @@
       "invocation": {
         "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5",
         "with": {
+          "buildchain-ref": "${{ inputs.buildchain-ref || 'v2' }}",
           "gate-profile": "dev-patrol",
           "runner-preset": "kungfu-v4-self-hosted",
           "gate-command-json": "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}"

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -986,6 +986,28 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
       ),
     ),
   );
+
+  const profileRuntimeRoot = fixture();
+  const profileRuntimeWorkflow = path.join(
+    profileRuntimeRoot,
+    '.github/workflows/dev-verify-patrol.yml',
+  );
+  fs.writeFileSync(
+    profileRuntimeWorkflow,
+    fs
+      .readFileSync(profileRuntimeWorkflow, 'utf8')
+      .replace(
+        "buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}",
+        "buildchain-ref: ${{ inputs.buildchain-ref || '' }}",
+      ),
+  );
+  assert.ok(
+    checkKungfuGateCatalog(profileRuntimeRoot).issues.some((issue) =>
+      issue.includes(
+        '[workflow-profile] dev-heavy-patrol: invocation drift at with.buildchain-ref',
+      ),
+    ),
+  );
 });
 
 test('schema v2 rejects missing invocation contracts and legacy snippets', () => {


### PR DESCRIPTION
## Summary

- resolve the official stable `v2` Buildchain runtime for standing dev patrols
- preserve trusted manual train and exact-SHA overrides
- bind the runtime selection in the closed-world workflow authority

The immutable reusable-workflow commit remains pinned. Only its runtime selection changes, preventing a diverged historical source SHA from being redirected to a retained self-hosted Git bundle that no longer contains that object.

## Verification

- `./shifu exec -- node --test scripts/check-kungfu-gate-catalog.test.mjs`
- `./shifu check:gate-catalog`
- `./shifu check:source`
- pre-commit repository gates

Closes #1061

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "CI runtime routing repair; no architecture contract changes."
}
-->