### PR TITLE
chore(deps-dev): update setuptools and classify Core lock changes

### DIFF
--- a/framework/core/pyproject.toml
+++ b/framework/core/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
     "keyring~=25.5.0",
     "zstandard~=0.23.0",
     # was Pipfile [packages] seed
-    "setuptools>=78.1.1,<81.0.0",
+    "setuptools>=83.0.0,<84.0.0",
     "virtualenv>=20.36.1,<21.0.0",
     "wheel>=0.46.2,<0.47.0",
     "pip>=26.1,<27.0",
@@ -218,5 +218,5 @@ python-preference = "only-managed"
 # S1 阶段 B：脱 poetry-core，单一真相源收敛到 [project]/[tool.uv]。
 # wheel build 由 setuptools 后端 + src/python/setup.py（读 [project]）承担。
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=83.0.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/framework/core/uv.lock
+++ b/framework/core/uv.lock
@@ -679,7 +679,7 @@ dev = [
     { name = "scipy", specifier = "~=1.14.0" },
     { name = "scons", specifier = "~=4.8.0" },
     { name = "secretstorage", marker = "sys_platform == 'linux'", specifier = "==3.3.3" },
-    { name = "setuptools", specifier = ">=78.1.1,<81.0.0" },
+    { name = "setuptools", specifier = ">=83.0.0,<84.0.0" },
     { name = "shellingham" },
     { name = "statsmodels", specifier = "~=0.14.4" },
     { name = "tomli-w", specifier = "~=1.0.0" },
@@ -1368,11 +1368,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.10.2"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -77,6 +77,7 @@ const sdkQualificationPaths = [
   'framework/core/conanfile.py',
   'framework/core/package.json',
   'framework/core/pyproject.toml',
+  'framework/core/uv.lock',
   'framework/core/src/bindings/',
   'framework/core/src/libkungfu/include/',
   'framework/core/src/libkungfu/schemas/',
@@ -459,6 +460,10 @@ export function planFromChanged(
     // and this gate cannot read TOML sections, so a change expands globally and
     // re-validates every component rather than failing closed as unclassified.
     'framework/core/pyproject.toml',
+    // uv.lock is the exact resolution of the same native Python toolchain.
+    // A lock-only update can therefore change the compiler/build helpers even
+    // when pyproject.toml is unchanged and needs the same global qualification.
+    'framework/core/uv.lock',
     'framework/core/package.json',
     'framework/core/tests/',
     'scripts/run-core-affected-native.mjs',
@@ -1272,6 +1277,21 @@ function selfTest(authority, buildAuthority) {
         throw new Error(`${file} skipped SDK qualification`);
       }
     }
+  });
+  expect('Core uv lock changes expand native and SDK qualification', () => {
+    const plan = planFromChanged(
+      ['framework/core/uv.lock'],
+      authority,
+      buildAuthority,
+      'base',
+      'head',
+    );
+    if (plan.closureComponents.length !== authority.components.length)
+      throw new Error('Core uv lock native closure incomplete');
+    if (!plan.profile)
+      throw new Error('Core uv lock did not select a native profile');
+    if (!plan.sdkQualification.required)
+      throw new Error('Core uv lock skipped SDK qualification');
   });
   expect('partition set is deterministic, disjoint, and complete', () => {
     const partitions = [0, 1].map((index) =>


### PR DESCRIPTION
## Summary

- update the Core development toolchain from setuptools 80.10.2 to 83.0.0
- classify `framework/core/uv.lock` as a global native and SDK qualification input
- add a fail-closed self-test for lock-only dependency updates

Supersedes #1208.

## Verification

- `./shifu exec -- node scripts/run-core-affected-native.mjs --self-test`
- `./shifu exec -- node scripts/run-core-affected-native.mjs --changed-file framework/core/uv.lock --json`
- repository pre-commit staged gate
- `git diff --check`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Routine development dependency maintenance and CI impact classification; no architecture contract changes."
}
-->