### PR TITLE
fix(ci): pin auditable demo to Buildchain alpha.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939 # v2.14.19-alpha.2 protected artifact-coordinate output
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787 # v2.14.19-alpha.5 protected artifact-coordinate output
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
@@ -349,7 +349,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939 # v2.14.19-alpha.2 protected version state
+    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787 # v2.14.19-alpha.5 protected version state
     with:
       source-ref: ${{ needs.build.outputs.publish-source-sha }}
       source-artifact-name: ${{ needs.resolve-auditable-demo-source.outputs.artifact-name }}
@@ -472,7 +472,7 @@ jobs:
           MEDIA_ARTIFACT_URL: ${{ needs.auditable-demo.outputs.media-artifact-url }}
           MEDIA_ARTIFACT_EXPIRES_AT: ${{ steps.artifact-expiry.outputs.media-artifact-expires-at }}
           MEDIA_ROOT: ${{ needs.auditable-demo.outputs.media-root }}
-          BUILDCHAIN_SHA: 2f6259760cb6831ad129065d3bb6ccc3a5869939
+          BUILDCHAIN_SHA: 9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787
           RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:cb5e1dec368d21c7d4e8baded99ac75f12f7eff0d19505751888cf974086efa6
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -52,10 +52,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939 # v2.14.19-alpha.2 protected workflow shell
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787 # v2.14.19-alpha.5 protected workflow shell
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 2f6259760cb6831ad129065d3bb6ccc3a5869939
+      buildchain-ref: 9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -731,7 +731,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:954f36880ddb946320c63316978008c58a58eecb2634f79d408ddc113c7ffe78",
+          "definitionDigest": "sha256:5cbbafad3844f86aaabd3cea39e43ed47267f74f62dacc80608edfd43e06b8d4",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -740,7 +740,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939"
+            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787"
           ],
           "steps": []
         },
@@ -749,7 +749,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:44408bcc7fcfc0f7b2016e4f5ff9fe33a0ddd76f06eaa3c96b9784425fad95b4",
+          "definitionDigest": "sha256:ed3ab669a2d3863f72bac22e3078e9b96da872616e95fd667333d21558cfd197",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -779,7 +779,7 @@
               "index": 3,
               "label": "name:Write exact auditable demo Release Passport",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:5e5462cf0b3f10d06edcda361620b16d33bfad5525647c9a6e18c6b9f6aca8de"
+              "definitionDigest": "sha256:9e4993ec621ee90f46625b6c6d2f1da6bfce50e080e6b800e07899f584285069"
             },
             {
               "index": 4,
@@ -794,7 +794,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:c51697c583d925a12a3d1c63bc7529899d333c3e34ce9930459b32913d1bea2a",
+          "definitionDigest": "sha256:100ae0a8bad11519fd5387ef218be5a0a2fef3fcc76fee986d479615faf30982",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -807,7 +807,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787"
           ],
           "steps": []
         },
@@ -2005,7 +2005,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:a0addd4ee61a4094ec4dd19358ee781d550a38689e0f8061b767db4dfe6bdfeb",
+          "definitionDigest": "sha256:72d98f37d727ba52f7976c96e0a01a80874d8e455abf17cbbee0c712ccdba4c9",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -2020,7 +2020,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -439,7 +439,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -521,14 +521,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "2f6259760cb6831ad129065d3bb6ccc3a5869939",
+          "buildchain-ref": "9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "2f6259760cb6831ad129065d3bb6ccc3a5869939",
+    "workflow_shell_sha": "9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787",
     "alpha": {
       "workflow_ref": "v2-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -102,7 +102,7 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
   );
   assert.equal(
     build.uses,
-    'kungfu-systems/buildchain/.github/workflows/.build.yml@2f6259760cb6831ad129065d3bb6ccc3a5869939',
+    'kungfu-systems/buildchain/.github/workflows/.build.yml@9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787',
     'the build runtime must be the protected Buildchain release that owns artifact-coordinates-json',
   );
   assert.match(


### PR DESCRIPTION
## Summary

Pin every Kungfu auditable-demo and release-promotion Buildchain boundary to protected `v2.14.19-alpha.5` commit `9531e4fa2849a48d4f45e7c6dc2516e2a9ddb787`.

## Root cause

Exact-source run 30185774420 reached the required checked-in consumer adapter but exposed a Buildchain runtime variable binding defect. Buildchain PRs #1875, #1876, and #1877 fixed, promoted, and released the regression-tested correction as `v2.14.19-alpha.5`.

## Changes

- pin build, auditable-demo Gate, and release promotion reusable workflows to the protected alpha.5 commit
- bind the Release Passport to the same exact Buildchain commit
- refresh structured workflow bindings, release rehearsal contract, and closed-world workflow authority evidence
- update the executable workflow contract assertion

## Verification

- `./shifu test:auditable-demo` (17 passed)
- `./shifu check:staged` (passed)
- pre-commit staged gate (passed)
- failed exact-source diagnostic: https://github.com/kungfu-systems/kungfu/actions/runs/30185774420
- fixed Buildchain release: https://github.com/kungfu-systems/buildchain/releases/tag/v2.14.19-alpha.5

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Advance an existing immutable Buildchain workflow boundary to its regression-tested protected patch release; no product behavior or authority model changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This preserves fail-closed exact-source and exact-output evidence binding and adds no publication, deployment, secret, or identity-token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed run and protected fix release cited
