### PR TITLE
fix(ci): make dev patrol cache non-semantic

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -34,14 +34,15 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5 # v2.13.0
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824
     with:
-      # The reusable workflow commit is immutable, but its historical source
-      # SHA may no longer belong to the retained self-hosted Git bundle after
-      # the v2 release line diverges. Resolve the official stable runtime for
-      # standing patrols; trusted manual runs may still supply an exact SHA or
-      # train ref through the workflow_dispatch input.
+      # Resolve the official stable runtime for standing patrols; trusted
+      # manual runs may still supply an exact SHA or train ref. Checkout cache
+      # hits are optional: every source/runtime checkout verifies the locked
+      # SHA and falls back to GitHub when a retained bundle is stale.
       buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}
+      checkout-cache-mode: auto
+      checkout-cache-fallback: github
       gate-profile: dev-patrol
       runner-preset: kungfu-v4-self-hosted
       artifact-name: kungfu-dev-patrol-gates

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1324,7 +1324,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:fce32b571c74e419ac2402b42ca04c8d28ab9e644c4586c2b83badf46bcdf32b",
+          "definitionDigest": "sha256:e381e8979a2ced342f7d0c964cd7d31ede302c0b59c1190aeb65623d9a55fc1c",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1333,7 +1333,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5"
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824"
           ],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -321,9 +321,11 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824",
         "with": {
           "buildchain-ref": "${{ inputs.buildchain-ref || 'v2' }}",
+          "checkout-cache-fallback": "github",
+          "checkout-cache-mode": "auto",
           "gate-profile": "dev-patrol",
           "runner-preset": "kungfu-v4-self-hosted",
           "gate-command-json": "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}"

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -953,7 +953,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@ec48c0b311212c5f3a591e0284da6e85a9fdded5',
+        '.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824',
         '.gate-profile.yml@v2-alpha',
       ),
   );


### PR DESCRIPTION
## Summary

- pin Dev Verify Patrol to the locked-checkout Gate Profile runtime
- use checkout cache in `auto` mode with mandatory GitHub fallback
- refresh the closed-world Gate binding and workflow authority evidence

## Validation

- `./shifu exec -- node --test scripts/check-kungfu-gate-catalog.test.mjs` (23/23)
- `./shifu check:gate-catalog`
- `./shifu check:source` (646 Node tests, 40 Python tests, 116 upgrade tests, 69 desktop tests)
- staged pre-commit gate

Depends on kungfu-systems/buildchain#1878. Closes #1061.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "CI checkout reliability repair; no architecture contract changes."
}
-->