### PR TITLE
ci(alpha): rerun builds on source updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - alpha/v*/v*
       - release/v*/v*

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -724,7 +724,7 @@
     {
       "path": ".github/workflows/build.yml",
       "authority": "product-publication",
-      "definitionDigest": "sha256:0dada25e0a9f9a118c3c0aba1850d6728663c003749b0473145e340987dd94a2",
+      "definitionDigest": "sha256:aadbb97771ffd89eaec3f3ed67ef3925e1730472a5a722c1a8b956c8ee71b6c1",
       "jobs": [
         {
           "id": "auditable-demo",

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -14,6 +14,15 @@ const WORKFLOW_TEXT = fs.readFileSync(WORKFLOW_PATH, 'utf8');
 const WORKFLOW = parse(WORKFLOW_TEXT);
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 
+test('Alpha and release builds rerun when candidate source is synchronized', () => {
+  assert.deepEqual(WORKFLOW.on.pull_request.types, [
+    'opened',
+    'synchronize',
+    'reopened',
+    'ready_for_review',
+  ]);
+});
+
 async function runResolver({ declaredExpiry, observedExpiry }) {
   const resolver = WORKFLOW.jobs['resolve-auditable-demo-source'];
   const script = resolver.steps.find(({ id }) => id === 'resolve').with.script;


### PR DESCRIPTION
## Summary

Rerun the protected Alpha and release Build workflow whenever a pull request head is synchronized. This closes the stale-source gap that left Alpha PR #1448 building an older generated runtime stub while preserving the existing exact-source preflight, per-promotion concurrency cancellation, and full cross-platform Buildchain qualification.

The active dev merge-queue ruleset was also updated separately from `max_entries_to_build=1` to `2`; all required checks, ALLGREEN grouping, REBASE, review policy, and one-at-a-time merge semantics remain unchanged.

## Related issue

Relates to #1448.

## Changes

- Add `synchronize` to the Alpha/release Build pull-request events.
- Add a structural workflow regression test for the complete event set.
- Refresh the generated workflow-authority digest.

## Verification

- `./shifu build:core` (clean tracked source after generated binding output)
- `actionlint .github/workflows/build.yml`
- `node --test scripts/auditable-demo-workflow.test.mjs`
- `./shifu test:alpha-promotion-preflight`
- `./shifu check:source`
- Local pre-commit gate suite
- GitHub ruleset `19057118` read-back after the concurrency update

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This changes pull-request event orchestration and its generated workflow digest without changing a runtime, schema, architecture, or release-policy contract."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: the Build workflow owns Alpha/release qualification evidence. The change only adds a missing head-update event; the exact-source preflight, current-head checkout, concurrency cancellation, pinned Buildchain runtime, and cross-platform gates are unchanged and covered by the workflow contract tests and source acceptance.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
