### PR TITLE
fix(sdk): use canonical engage subprocess path

### DIFF
--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -2733,7 +2733,7 @@ function pythonAotBuild(manifest) {
   // legacy pdm-pep517 backend again for every extension build.
   runOrFail(
     py,
-    ['-m', 'kungfu', 'engage', 'pdm', 'install', '--no-isolation'],
+    ['-m', 'kungfu', 'dev', 'engage', 'pdm', 'install', '--no-isolation'],
     { env },
   );
   // AOT-compile just this module: declared deps stay runtime imports, so we do
@@ -2743,6 +2743,7 @@ function pythonAotBuild(manifest) {
     [
       '-m',
       'kungfu',
+      'dev',
       'engage',
       'nuitka',
       '--module',

--- a/framework/core/src/python/kungfu/cli/bridging/nuitka/__init__.py
+++ b/framework/core/src/python/kungfu/cli/bridging/nuitka/__init__.py
@@ -32,6 +32,7 @@ def useEngagedCommands():
                     sys.executable,
                     "-m",
                     "kungfu",
+                    "dev",
                     "engage",
                     "nuitka-data-composer",
                     source_dir,
@@ -47,7 +48,7 @@ def useEngagedCommands():
             + os.pathsep
             + dirname(kungfu.__binding__.__file__)
         )
-        return [sys.executable, "-m", "kungfu", "engage", "scons"]
+        return [sys.executable, "-m", "kungfu", "dev", "engage", "scons"]
 
     DataComposerInterface.runDataComposer = runEngagedDataComposer
     SconsInterface._getSconsBinaryCall = getEngagedSconsBinaryCall

--- a/framework/core/tests/python/test_cli_surface_contract.py
+++ b/framework/core/tests/python/test_cli_surface_contract.py
@@ -3,6 +3,7 @@
 import copy
 import importlib.util
 import json
+import re
 from pathlib import Path
 
 import click
@@ -408,6 +409,29 @@ def test_every_removed_path_is_unknown_and_every_canonical_path_is_live(tmp_path
         assert result.exit_code == 2, (removed, result.output)
         assert "No such command" in result.output
         assert _click_path(kfc, canonical) is not None
+
+
+def test_internal_engage_subprocesses_use_the_only_canonical_path():
+    sources = {
+        "SDK Python-AOT builder": (REPO_ROOT / "developer/sdk/src/sdk.js").read_text(
+            encoding="utf-8"
+        ),
+        "Nuitka bridge": (
+            REPO_ROOT
+            / "framework/core/src/python/kungfu/cli/bridging/nuitka/__init__.py"
+        ).read_text(encoding="utf-8"),
+    }
+    removed_path = re.compile(
+        r'["\']-m["\']\s*,\s*["\']kungfu["\']\s*,\s*["\']engage["\']'
+    )
+    canonical_path = re.compile(
+        r'["\']-m["\']\s*,\s*["\']kungfu["\']\s*,\s*'
+        r'["\']dev["\']\s*,\s*["\']engage["\']'
+    )
+
+    for owner, source in sources.items():
+        assert removed_path.search(source) is None, owner
+        assert canonical_path.search(source) is not None, owner
 
 
 def test_python_wheel_does_not_publish_the_kfc_executable_alias():


### PR DESCRIPTION
## Summary

- route SDK Python-AOT PDM and Nuitka subprocesses through the sole canonical `kungfu dev engage` path
- route Nuitka data-composer and SCons re-entry through the same canonical path
- add a regression that rejects the removed top-level `kungfu engage` path in internal subprocess owners

This fixes the real product.verify-full failure exposed after the Dev Patrol checkout repair and is a follow-up to #1061.

## Testing

- `./shifu --filter @kungfu-tech/sdk build` (32/32)
- targeted CLI surface regression (1/1)
- `./shifu check:source` (646 Node tests, 40 Python tests, 116 upgrade tests, 69 desktop tests; Ruff, Biome, mypy passed)
- staged pre-commit gate passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Internal CLI subprocess routing repair; no architecture contract changes."
}
-->