### PR TITLE
feat(gui): make agent qualification handoffs visual

### DIFF
--- a/framework/gui/src/qualification-lab.test.ts
+++ b/framework/gui/src/qualification-lab.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import type { QualificationLabReport } from '@kungfu-tech/api/capability';
+import {
+  QUALIFICATION_MODES,
+  qualificationBehaviorFindings,
+  qualificationModeNeeds,
+  qualificationSessionStories,
+} from './renderer/src/qualification-lab';
+
+const qualifiedReport = {
+  status: 'qualified',
+  events: [
+    { step: 'session-1', status: 'ended-partial' },
+    { step: 'session-2', status: 'ended-complete' },
+  ],
+  assessment: {
+    oracleChecks: [
+      {
+        id: 'second-attempt-recognized-partial-state',
+        passed: true,
+      },
+    ],
+    residualRisks: [],
+  },
+} as unknown as QualificationLabReport;
+
+test('the Lab exposes one explicit selector for all three experiment modes', () => {
+  assert.deepEqual(
+    QUALIFICATION_MODES.map(({ id }) => id),
+    ['offline-demo', 'same-agent', 'cross-agent'],
+  );
+  assert.deepEqual(qualificationModeNeeds('offline-demo'), {
+    source: false,
+    target: false,
+  });
+  assert.deepEqual(qualificationModeNeeds('same-agent'), {
+    source: true,
+    target: false,
+  });
+  assert.deepEqual(qualificationModeNeeds('cross-agent'), {
+    source: true,
+    target: true,
+  });
+});
+
+test('the two session stories distinguish bounded progress from continuation', () => {
+  const [first, second] = qualificationSessionStories(
+    'cross-agent',
+    false,
+    qualifiedReport,
+  );
+
+  assert.equal(first.title, 'Session 1');
+  assert.equal(first.subtitle, 'Source local agent');
+  assert.equal(first.milestones[0]?.status, 'correct');
+  assert.match(first.milestones[0]?.title ?? '', /partial result/);
+
+  assert.equal(second.title, 'Session 2');
+  assert.equal(second.subtitle, 'Target local agent');
+  assert.equal(second.milestones[0]?.status, 'correct');
+  assert.match(second.milestones[1]?.title ?? '', /recorded state/);
+});
+
+test('an in-flight atomic report never fabricates Session 2 progress', () => {
+  const [first, second] = qualificationSessionStories('same-agent', true, null);
+
+  assert.equal(first.milestones[0]?.status, 'running');
+  assert.equal(second.milestones[0]?.status, 'waiting');
+  assert.match(
+    second.milestones[0]?.detail ?? '',
+    /waits rather than guessing/,
+  );
+});
+
+test('canonical oracle failures and residuals stay visually distinct', () => {
+  const report = {
+    ...qualifiedReport,
+    status: 'qualified-with-residuals',
+    assessment: {
+      oracleChecks: [
+        {
+          id: 'second-attempt-recognized-partial-state',
+          passed: false,
+        },
+      ],
+      residualRisks: [
+        'Provider confinement remains to be independently proven.',
+      ],
+    },
+  } as QualificationLabReport;
+  const findings = qualificationBehaviorFindings(report);
+
+  assert.deepEqual(
+    findings.map(({ status }) => status),
+    ['undesirable', 'warning'],
+  );
+});
+
+test('the shell keeps navigation outside the Lab content branch', () => {
+  const source = readFileSync(
+    new URL('./renderer/src/main.tsx', import.meta.url),
+    'utf8',
+  );
+  const body = source.slice(
+    source.indexOf('<div style={chromeBodyStyle}>'),
+    source.indexOf('{notificationToasts}'),
+  );
+
+  assert.ok(body.indexOf('<nav') >= 0);
+  assert.ok(body.indexOf('{labOpen ?') >= 0);
+  assert.ok(body.indexOf('<nav') < body.indexOf('{labOpen ?'));
+});
+
+test('the visual contract is accessible and remains a responsive two-column comparison', () => {
+  const source = readFileSync(
+    new URL('./renderer/src/qualification-lab.tsx', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(source, /aria-label="Test mode"/);
+  assert.match(source, /aria-label="Session 1 agent"/);
+  assert.match(source, /aria-label="Session 2 agent"/);
+  assert.match(source, /<output[\s\S]*aria-label=\{meta\.label\}/);
+  assert.match(source, /repeat\(auto-fit, minmax\(min\(100%, 360px\), 1fr\)\)/);
+});

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -1871,80 +1871,76 @@ function App() {
         onWindowControl={controlWindow}
       />
       <div style={chromeBodyStyle}>
-        {labOpen ? (
-          <QualificationLabPanel
-            lab={qualificationLab}
-            startup={startup}
-            onOpenWork={
-              startup.route === 'work-graph'
-                ? () => setLabOpen(false)
-                : undefined
-            }
-          />
-        ) : runtime.ok ? (
-          <div
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            flex: 1,
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <nav
+            aria-label="Views"
             style={{
-              display: 'flex',
-              gap: 12,
-              flex: 1,
+              width: sidebarCollapsed ? 44 : 150,
+              flexShrink: 0,
               minHeight: 0,
-              overflow: 'hidden',
+              overflow: 'auto',
+              overflowX: 'hidden',
+              transition: 'width 120ms ease',
             }}
           >
-            <nav
-              aria-label="Views"
+            <button
+              type="button"
+              aria-label={
+                sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'
+              }
+              title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+              onClick={toggleSidebar}
               style={{
-                width: sidebarCollapsed ? 44 : 150,
-                flexShrink: 0,
-                minHeight: 0,
-                overflow: 'auto',
-                overflowX: 'hidden',
-                transition: 'width 120ms ease',
+                ...mono,
+                width: '100%',
+                height: 32,
+                marginBottom: 8,
+                border: '1px solid #3c3c3c',
+                borderRadius: 5,
+                cursor: 'pointer',
+                background: '#252526',
+                color: '#cccccc',
+                fontSize: 14,
               }}
             >
-              <button
-                type="button"
-                aria-label={
-                  sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'
-                }
-                title={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-                onClick={toggleSidebar}
+              {sidebarCollapsed ? '›' : '‹'}
+            </button>
+            {labButton}
+            {primaryNav.map(navButton)}
+            {loaded.failures.length > 0 && (
+              <div
+                title={`${loaded.failures.length} kfx failed to load`}
                 style={{
                   ...mono,
-                  width: '100%',
-                  height: 32,
-                  marginBottom: 8,
-                  border: '1px solid #3c3c3c',
-                  borderRadius: 5,
-                  cursor: 'pointer',
-                  background: '#252526',
-                  color: '#cccccc',
-                  fontSize: 14,
+                  color: '#f48771',
+                  marginTop: 12,
+                  fontSize: 10,
+                  textAlign: sidebarCollapsed ? 'center' : 'left',
                 }}
               >
-                {sidebarCollapsed ? '›' : '‹'}
-              </button>
-              {labButton}
-              {primaryNav.map(navButton)}
-              {loaded.failures.length > 0 && (
-                <div
-                  title={`${loaded.failures.length} kfx failed to load`}
-                  style={{
-                    ...mono,
-                    color: '#f48771',
-                    marginTop: 12,
-                    fontSize: 10,
-                    textAlign: sidebarCollapsed ? 'center' : 'left',
-                  }}
-                >
-                  {sidebarCollapsed
-                    ? '!'
-                    : `${loaded.failures.length} kfx failed to load`}
-                </div>
-              )}
-            </nav>
-            <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-              {activeKfx && activeKfx.tier === 'sandboxed-ipc' ? (
+                {sidebarCollapsed
+                  ? '!'
+                  : `${loaded.failures.length} kfx failed to load`}
+              </div>
+            )}
+          </nav>
+          <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+            {labOpen ? (
+              <QualificationLabPanel
+                lab={qualificationLab}
+                startup={startup}
+                onOpenWork={() => setLabOpen(false)}
+              />
+            ) : runtime.ok ? (
+              activeKfx && activeKfx.tier === 'sandboxed-ipc' ? (
                 // isolated third-party view: embedded, not mounted here
                 <KfxErrorBoundary kfxId={activeKfx.id}>
                   <SandboxSlot
@@ -1974,28 +1970,28 @@ function App() {
                     </div>
                   ))}
                 </section>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div
-            style={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            {window.process.env.KF_WORKSPACE_STATE === 'uninitialized' ||
-            window.process.env.KF_WORKSPACE_STATE === 'shadow-only' ||
-            window.process.env.KF_WORKSPACE_STATE === 'evidence-degraded' ||
-            window.process.env.KF_WORKSPACE_STATE === 'unavailable' ? (
-              <WorkspacePanel />
+              )
             ) : (
-              <RuntimeFailurePanel message={runtime.message} />
+              <div
+                style={{
+                  height: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                {window.process.env.KF_WORKSPACE_STATE === 'uninitialized' ||
+                window.process.env.KF_WORKSPACE_STATE === 'shadow-only' ||
+                window.process.env.KF_WORKSPACE_STATE === 'evidence-degraded' ||
+                window.process.env.KF_WORKSPACE_STATE === 'unavailable' ? (
+                  <WorkspacePanel />
+                ) : (
+                  <RuntimeFailurePanel message={runtime.message} />
+                )}
+              </div>
             )}
           </div>
-        )}
+        </div>
       </div>
       {notificationToasts}
       {workspaceOverlay}

--- a/framework/gui/src/renderer/src/qualification-lab.tsx
+++ b/framework/gui/src/renderer/src/qualification-lab.tsx
@@ -10,8 +10,480 @@ import type {
 import { mono, panelStyle } from '@kungfu-tech/kfx';
 import React from 'react';
 
+export type QualificationMode = 'offline-demo' | 'same-agent' | 'cross-agent';
+
+type VisualStatus =
+  | 'ready'
+  | 'waiting'
+  | 'running'
+  | 'correct'
+  | 'warning'
+  | 'undesirable';
+
+type Milestone = {
+  status: VisualStatus;
+  title: string;
+  detail: string;
+};
+
+type SessionStory = {
+  title: string;
+  subtitle: string;
+  milestones: Milestone[];
+};
+
+type BehaviorFinding = {
+  status: 'correct' | 'warning' | 'undesirable';
+  title: string;
+  detail: string;
+};
+
+export const QUALIFICATION_MODES: Array<{
+  id: QualificationMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: 'offline-demo',
+    label: 'Offline demo',
+    description:
+      'Start here. A bundled deterministic agent proves the continuity mechanism without accounts or configuration.',
+  },
+  {
+    id: 'same-agent',
+    label: 'Same-agent continuity',
+    description:
+      'Run one selected local agent in two fresh processes and check whether the second process continues the first.',
+  },
+  {
+    id: 'cross-agent',
+    label: 'Cross-agent handoff',
+    description:
+      'Let one local agent begin the task and a different local agent continue from the same governed evidence.',
+  },
+];
+
+const STATUS_META: Record<
+  VisualStatus,
+  { icon: string; label: string; color: string; background: string }
+> = {
+  ready: {
+    icon: '◆',
+    label: 'Ready',
+    color: '#9cdcfe',
+    background: '#102c3c',
+  },
+  waiting: {
+    icon: '○',
+    label: 'Waiting',
+    color: '#cccccc',
+    background: '#292929',
+  },
+  running: {
+    icon: '↻',
+    label: 'Running',
+    color: '#dcdcaa',
+    background: '#3b3215',
+  },
+  correct: {
+    icon: '✓',
+    label: 'Correct',
+    color: '#4ec9b0',
+    background: '#12352f',
+  },
+  warning: {
+    icon: '!',
+    label: 'Warning',
+    color: '#d7ba7d',
+    background: '#3b3018',
+  },
+  undesirable: {
+    icon: '×',
+    label: 'Undesirable',
+    color: '#f48771',
+    background: '#421f1b',
+  },
+};
+
+const CHECK_COPY: Record<string, { title: string; detail: string }> = {
+  'two-distinct-fresh-processes': {
+    title: 'The two sessions were genuinely fresh',
+    detail:
+      'Kungfu observed two different process identities instead of reusing one hidden session.',
+  },
+  'second-attempt-no-transcript-or-explanation': {
+    title: 'No transcript or human re-explanation was injected',
+    detail:
+      'Session 2 had to recover the work from governed state, not from copied conversation context.',
+  },
+  'second-attempt-recognized-partial-state': {
+    title: 'Session 2 recognized the partial result',
+    detail:
+      'The continuation found the exact state left by Session 1 before deciding what to do next.',
+  },
+  'fixture-completed': {
+    title: 'The task reached the expected final state',
+    detail:
+      'The deterministic oracle found both the first claim and the continuation result.',
+  },
+  'both-processes-exited-cleanly': {
+    title: 'Both agent processes exited cleanly',
+    detail:
+      'Process completion was observed for both sessions without treating exit alone as task proof.',
+  },
+  'fresh-session-completed-exact-state': {
+    title: 'The fresh session completed the exact governed task',
+    detail:
+      'The final state retained the same Work identity and the expected ordered steps.',
+  },
+};
+
 function shortRoot(value: string): string {
   return value.length > 28 ? `${value.slice(0, 16)}…${value.slice(-8)}` : value;
+}
+
+function eventStatus(
+  report: QualificationLabReport | null,
+  session: 1 | 2,
+): VisualStatus {
+  if (!report) return 'waiting';
+  const event = report.events.find((row) => row.step === `session-${session}`);
+  const status = event?.status ?? '';
+  if (status === 'failed' || report.status === 'failed') return 'undesirable';
+  if (
+    (session === 1 &&
+      ['ended-partial', 'partial', 'partial-first-attempt'].includes(status)) ||
+    (session === 2 &&
+      ['ended-complete', 'complete', 'continuation-completed'].includes(status))
+  ) {
+    return 'correct';
+  }
+  return 'warning';
+}
+
+export function qualificationModeNeeds(mode: QualificationMode): {
+  source: boolean;
+  target: boolean;
+} {
+  return {
+    source: mode !== 'offline-demo',
+    target: mode === 'cross-agent',
+  };
+}
+
+export function qualificationSessionStories(
+  mode: QualificationMode,
+  running: boolean,
+  report: QualificationLabReport | null,
+): [SessionStory, SessionStory] {
+  const firstStatus = running
+    ? 'running'
+    : report
+      ? eventStatus(report, 1)
+      : 'ready';
+  const secondStatus = running
+    ? 'waiting'
+    : report
+      ? eventStatus(report, 2)
+      : 'waiting';
+  const firstAgent =
+    mode === 'offline-demo'
+      ? 'Bundled Demo Agent'
+      : mode === 'same-agent'
+        ? 'Selected local agent'
+        : 'Source local agent';
+  const secondAgent =
+    mode === 'offline-demo'
+      ? 'Fresh Demo Agent process'
+      : mode === 'same-agent'
+        ? 'Same agent, fresh process'
+        : 'Target local agent';
+
+  return [
+    {
+      title: 'Session 1',
+      subtitle: firstAgent,
+      milestones: [
+        {
+          status: firstStatus,
+          title: report
+            ? 'Created a bounded partial result'
+            : running
+              ? 'Canonical two-session action is running'
+              : 'Will receive the governed test task',
+          detail: report
+            ? 'The first process stopped after leaving evidence that a fresh session can inspect.'
+            : running
+              ? 'Kungfu is waiting for Core evidence before declaring what this session actually did.'
+              : 'It should claim the work, make bounded progress, record evidence, and end before completion.',
+        },
+        {
+          status: report ? firstStatus : 'waiting',
+          title: 'Ends without completing the whole task',
+          detail:
+            'This creates a real continuity question for Session 2 instead of two unrelated successful runs.',
+        },
+      ],
+    },
+    {
+      title: 'Session 2',
+      subtitle: secondAgent,
+      milestones: [
+        {
+          status: secondStatus,
+          title: report
+            ? 'Started without the prior transcript'
+            : running
+              ? 'Will start after Session 1 leaves evidence'
+              : 'Will start as a genuinely fresh process',
+          detail: report
+            ? 'The second process had to identify the task and prior state from Kungfu evidence.'
+            : running
+              ? 'Core returns one canonical report for the complete sequence, so the UI waits rather than guessing whether the handoff has occurred.'
+              : 'No copied chat and no human re-explanation should be available.',
+        },
+        {
+          status: report ? secondStatus : 'waiting',
+          title: report
+            ? 'Continued from the recorded state'
+            : 'Must continue instead of restart',
+          detail:
+            'Correct behavior is to recognize what Session 1 already did, perform only the remaining work, and preserve the same task identity.',
+        },
+      ],
+    },
+  ];
+}
+
+export function qualificationBehaviorFindings(
+  report: QualificationLabReport | null,
+): BehaviorFinding[] {
+  if (!report) {
+    return [
+      {
+        status: 'correct',
+        title: 'What good behavior looks like',
+        detail:
+          'Session 2 identifies the same task, uses the partial result, and continues without asking you to restate everything.',
+      },
+      {
+        status: 'undesirable',
+        title: 'What bad behavior looks like',
+        detail:
+          'The second session repeats finished work, loses task identity, relies on hidden context, or touches a real project.',
+      },
+      {
+        status: 'warning',
+        title: 'What remains a warning',
+        detail:
+          'Incomplete evidence, an unavailable agent, ambiguous state, or a provider confinement residual stays visible instead of becoming a pass.',
+      },
+    ];
+  }
+  const assessment = report.assessment as {
+    oracleChecks?: Array<{ id: string; passed: boolean }>;
+    residualRisks?: string[];
+  };
+  const checks = (assessment.oracleChecks ?? []).map((check) => {
+    const copy = CHECK_COPY[check.id] ?? {
+      title: check.id,
+      detail: 'This canonical oracle check is included in the report.',
+    };
+    return {
+      status: check.passed ? ('correct' as const) : ('undesirable' as const),
+      ...copy,
+    };
+  });
+  const residuals = (assessment.residualRisks ?? []).map((detail) => ({
+    status: 'warning' as const,
+    title: 'Qualified with a visible residual',
+    detail,
+  }));
+  return [...checks, ...residuals];
+}
+
+function StatusBadge({ status }: { status: VisualStatus }) {
+  const meta = STATUS_META[status];
+  return (
+    <output
+      aria-label={meta.label}
+      style={{
+        ...mono,
+        display: 'inline-flex',
+        gap: 5,
+        alignItems: 'center',
+        padding: '3px 7px',
+        borderRadius: 999,
+        color: meta.color,
+        background: meta.background,
+        fontSize: 11,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span aria-hidden="true">{meta.icon}</span>
+      {meta.label}
+    </output>
+  );
+}
+
+function SessionColumn({ story }: { story: SessionStory }) {
+  return (
+    <article
+      style={{
+        ...panelStyle,
+        minWidth: 0,
+        padding: 18,
+        background: '#181818',
+        border: '1px solid #3c3c3c',
+      }}
+    >
+      <div style={{ ...mono, color: '#9cdcfe', fontSize: 12 }}>
+        {story.title.toUpperCase()}
+      </div>
+      <h2 style={{ margin: '6px 0 16px', fontSize: 19 }}>{story.subtitle}</h2>
+      <div style={{ display: 'grid', gap: 14 }}>
+        {story.milestones.map((milestone) => (
+          <div
+            key={milestone.title}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'auto minmax(0, 1fr)',
+              alignItems: 'start',
+              gap: 10,
+            }}
+          >
+            <StatusBadge status={milestone.status} />
+            <div>
+              <strong>{milestone.title}</strong>
+              <div
+                style={{
+                  marginTop: 4,
+                  color: '#a9a9a9',
+                  lineHeight: 1.45,
+                }}
+              >
+                {milestone.detail}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function HandoffBridge({
+  report,
+}: {
+  report: QualificationLabReport | null;
+}) {
+  const proven = report && report.status !== 'failed';
+  return (
+    <section
+      aria-label="Kungfu handoff bridge"
+      style={{
+        margin: '12px 0',
+        padding: '12px 16px',
+        border: `1px solid ${proven ? '#287f70' : '#3c3c3c'}`,
+        borderRadius: 8,
+        background: proven ? '#102c28' : '#202020',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
+          textAlign: 'center',
+        }}
+      >
+        <strong>Session 1</strong>
+        <span aria-hidden="true">──▶</span>
+        <strong style={{ color: '#4ec9b0' }}>
+          {proven
+            ? 'Kungfu evidence proved the handoff'
+            : 'Kungfu handoff evidence'}
+        </strong>
+        <span aria-hidden="true">──▶</span>
+        <strong>Session 2</strong>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+          gap: 8,
+          marginTop: 10,
+          color: '#b8b8b8',
+          fontSize: 12,
+        }}
+      >
+        <span>Retained: task identity and Work reference</span>
+        <span>Retained: partial state, evidence, and next action</span>
+        <span>Excluded: prior transcript and credentials</span>
+      </div>
+    </section>
+  );
+}
+
+function ResultPanel({ report }: { report: QualificationLabReport }) {
+  const passed = report.status !== 'failed';
+  const findings = qualificationBehaviorFindings(report);
+  return (
+    <section
+      aria-label="Qualification result"
+      style={{
+        ...panelStyle,
+        marginTop: 18,
+        padding: 18,
+        border: `1px solid ${passed ? '#287f70' : '#a14a3a'}`,
+        background: passed ? '#102a26' : '#351b18',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <StatusBadge status={passed ? 'correct' : 'undesirable'} />
+        <h2 style={{ margin: 0 }}>
+          {passed
+            ? 'Continuity proved: the session changed, but the work did not disappear.'
+            : 'Continuity was not proved.'}
+        </h2>
+      </div>
+      <p style={{ margin: '10px 0 0', fontSize: 16, lineHeight: 1.5 }}>
+        {passed
+          ? 'Kungfu made the handoff evidenced rather than guessed: Session 2 used the same governed work identity and state to continue.'
+          : 'The report found at least one behavior that breaks trustworthy continuation. Review the evidence below before relying on this agent path.'}
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          gap: 10,
+          marginTop: 16,
+        }}
+      >
+        {findings.map((finding) => (
+          <div
+            key={`${finding.status}-${finding.title}`}
+            style={{
+              padding: 12,
+              borderRadius: 6,
+              background: '#181818',
+              border: '1px solid #3c3c3c',
+            }}
+          >
+            <StatusBadge status={finding.status} />
+            <strong style={{ display: 'block', marginTop: 8 }}>
+              {finding.title}
+            </strong>
+            <div style={{ marginTop: 4, color: '#a9a9a9', lineHeight: 1.45 }}>
+              {finding.detail}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }
 
 export function QualificationLabPanel({
@@ -23,6 +495,7 @@ export function QualificationLabPanel({
   startup: QualificationLabStartupRoute;
   onOpenWork?: () => void;
 }) {
+  const [mode, setMode] = React.useState<QualificationMode>('offline-demo');
   const [agents, setAgents] = React.useState<AgentRuntimeCatalog | null>(null);
   const [selectedAgent, setSelectedAgent] = React.useState('');
   const [targetAgent, setTargetAgent] = React.useState('');
@@ -65,10 +538,25 @@ export function QualificationLabPanel({
     void discover();
   }, [discover]);
 
-  const runDemo = async () => {
-    setBusy('demo');
+  const resetRun = (nextMode: QualificationMode) => {
+    setMode(nextMode);
+    setAgentPlan(null);
+    setTargetPlan(null);
+    setReport(null);
+    setError('');
+  };
+
+  const prepareAgent = async () => {
+    if (!selectedAgent) return;
+    setBusy('prepare');
     try {
-      setReport(await lab.runDemo());
+      const target = mode === 'cross-agent' ? targetAgent : selectedAgent;
+      const [sourcePlan, continuationPlan] = await Promise.all([
+        lab.planAgent(selectedAgent),
+        lab.planAgent(target),
+      ]);
+      setAgentPlan(sourcePlan);
+      setTargetPlan(continuationPlan);
       setError('');
     } catch (reason) {
       setError((reason as Error).message);
@@ -77,40 +565,17 @@ export function QualificationLabPanel({
     }
   };
 
-  const previewAgent = async () => {
-    if (!selectedAgent) return;
-    setBusy('agent');
+  const run = async () => {
+    setBusy('run');
+    setReport(null);
     try {
-      const [source, target] = await Promise.all([
-        lab.planAgent(selectedAgent),
-        lab.planAgent(targetAgent || selectedAgent),
-      ]);
-      setAgentPlan(source);
-      setTargetPlan(target);
-      setError('');
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setBusy('');
-    }
-  };
-  const runAgent = async () => {
-    if (!selectedAgent) return;
-    setBusy('agent-run');
-    try {
-      setReport(await lab.runAgent(selectedAgent));
-      setError('');
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setBusy('');
-    }
-  };
-  const runMigration = async () => {
-    if (!selectedAgent || !targetAgent) return;
-    setBusy('agent-run');
-    try {
-      setReport(await lab.runMigration(selectedAgent, targetAgent));
+      const nextReport =
+        mode === 'offline-demo'
+          ? await lab.runDemo()
+          : mode === 'cross-agent'
+            ? await lab.runMigration(selectedAgent, targetAgent)
+            : await lab.runAgent(selectedAgent);
+      setReport(nextReport);
       setError('');
     } catch (reason) {
       setError((reason as Error).message);
@@ -127,6 +592,27 @@ export function QualificationLabPanel({
       ].map((profile) => [profile.id, profile]),
     ).values(),
   );
+  const needs = qualificationModeNeeds(mode);
+  const running = busy === 'run';
+  const prepared =
+    mode === 'offline-demo' ||
+    (Boolean(agentPlan) && (mode !== 'cross-agent' || Boolean(targetPlan)));
+  const canRun =
+    prepared &&
+    !busy &&
+    (!needs.source || Boolean(selectedAgent)) &&
+    (!needs.target || (Boolean(targetAgent) && selectedAgent !== targetAgent));
+  const [sessionOne, sessionTwo] = qualificationSessionStories(
+    mode,
+    running,
+    report,
+  );
+  const selectedMode = QUALIFICATION_MODES.find((row) => row.id === mode) ?? {
+    id: mode,
+    label: 'Unknown test mode',
+    description: 'Choose a supported qualification mode.',
+  };
+
   return (
     <section
       style={{
@@ -134,17 +620,47 @@ export function QualificationLabPanel({
         height: '100%',
         overflow: 'auto',
         boxSizing: 'border-box',
+        padding: 20,
       }}
     >
-      <div style={{ ...mono, color: '#9cdcfe' }}>AGENT QUALIFICATION LAB</div>
-      <h1 style={{ margin: '8px 0' }}>Prove continuity before configuration</h1>
-      <p style={{ maxWidth: 820 }}>
-        This Quickstart runs a real isolated two-session fixture offline. The
-        bundled Demo Agent proves deterministic state recognition and
-        continuation—not model intelligence, security, production fitness, or
-        provider ranking.
-      </p>
-      <div style={{ ...mono, color: '#858585' }}>
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 20,
+          flexWrap: 'wrap',
+        }}
+      >
+        <div>
+          <div style={{ ...mono, color: '#9cdcfe' }}>
+            AGENT QUALIFICATION LAB
+          </div>
+          <h1 style={{ margin: '7px 0' }}>
+            Can a fresh agent session continue the same work?
+          </h1>
+          <p style={{ maxWidth: 820, margin: 0, lineHeight: 1.55 }}>
+            This Lab runs one bounded task across two independent sessions.
+            Session 1 begins and leaves evidence. Session 2 gets no prior chat
+            and must discover what happened, then continue from the correct
+            point.
+          </p>
+        </div>
+        {onOpenWork ? (
+          <button type="button" onClick={onOpenWork}>
+            Back to Work
+          </button>
+        ) : null}
+      </header>
+
+      <div
+        style={{
+          ...mono,
+          color: '#858585',
+          marginTop: 10,
+          fontSize: 11,
+        }}
+      >
         startup {startup.state} · {startup.reasonCode} · no real workspace write
       </div>
       {startup.route === 'diagnostic' ? (
@@ -152,122 +668,226 @@ export function QualificationLabPanel({
           {startup.message}
         </div>
       ) : null}
-      <div style={{ display: 'flex', gap: 8, marginTop: 18 }}>
-        <button type="button" disabled={Boolean(busy)} onClick={runDemo}>
-          {busy === 'demo' ? 'Running two fresh sessions…' : 'Run offline demo'}
-        </button>
-        {onOpenWork ? (
-          <button type="button" onClick={onOpenWork}>
-            Return to Work graph
-          </button>
-        ) : null}
-      </div>
-      {report ? (
-        <article style={{ ...panelStyle, marginTop: 16 }}>
-          <strong
-            style={{
-              color: report.status === 'failed' ? '#f48771' : '#4ec9b0',
-            }}
-          >
-            {report.status}
-          </strong>
-          <div style={mono}>report {shortRoot(report.reportRoot)}</div>
-          <div style={mono}>plan {shortRoot(report.planRoot)}</div>
-          <div style={mono}>
-            attempts {report.sessionAttempts.length} · fresh process · no prior
-            transcript
+
+      <section
+        aria-label="Test configuration"
+        style={{
+          ...panelStyle,
+          marginTop: 18,
+          padding: 16,
+          background: '#202020',
+        }}
+      >
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+            gap: 12,
+            alignItems: 'end',
+          }}
+        >
+          <label>
+            <strong style={{ display: 'block', marginBottom: 6 }}>
+              Test mode
+            </strong>
+            <select
+              aria-label="Test mode"
+              value={mode}
+              disabled={Boolean(busy)}
+              onChange={(event) =>
+                resetRun(event.target.value as QualificationMode)
+              }
+              style={{ width: '100%', minHeight: 34 }}
+            >
+              {QUALIFICATION_MODES.map((row) => (
+                <option key={row.id} value={row.id}>
+                  {row.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {needs.source ? (
+            <label>
+              <strong style={{ display: 'block', marginBottom: 6 }}>
+                Session 1 agent
+              </strong>
+              <select
+                aria-label="Session 1 agent"
+                value={selectedAgent}
+                disabled={Boolean(busy)}
+                onChange={(event) => {
+                  setSelectedAgent(event.target.value);
+                  setAgentPlan(null);
+                  setTargetPlan(null);
+                  setReport(null);
+                }}
+                style={{ width: '100%', minHeight: 34 }}
+              >
+                <option value="">No local agent discovered</option>
+                {options.map((profile) => (
+                  <option key={profile.id} value={profile.id}>
+                    {profile.label} · {profile.launch.executable}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          {needs.target ? (
+            <label>
+              <strong style={{ display: 'block', marginBottom: 6 }}>
+                Session 2 agent
+              </strong>
+              <select
+                aria-label="Session 2 agent"
+                value={targetAgent}
+                disabled={Boolean(busy)}
+                onChange={(event) => {
+                  setTargetAgent(event.target.value);
+                  setTargetPlan(null);
+                  setReport(null);
+                }}
+                style={{ width: '100%', minHeight: 34 }}
+              >
+                <option value="">No continuation agent discovered</option>
+                {options.map((profile) => (
+                  <option key={profile.id} value={profile.id}>
+                    {profile.label} · {profile.launch.executable}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {needs.source ? (
+              <button
+                type="button"
+                disabled={
+                  !selectedAgent ||
+                  (needs.target &&
+                    (!targetAgent || selectedAgent === targetAgent)) ||
+                  Boolean(busy)
+                }
+                onClick={prepareAgent}
+              >
+                {busy === 'prepare' ? 'Preparing…' : '1 · Prepare exact test'}
+              </button>
+            ) : null}
+            <button type="button" disabled={!canRun} onClick={run}>
+              {running
+                ? 'Running canonical test…'
+                : needs.source
+                  ? '2 · Start test'
+                  : 'Start offline demo'}
+            </button>
+            <button type="button" disabled={Boolean(busy)} onClick={discover}>
+              Refresh agents
+            </button>
           </div>
-          <div style={{ ...mono, color: '#858585', marginTop: 6 }}>
-            {report.meaning}
-          </div>
-        </article>
-      ) : null}
-      <h2 style={{ marginTop: 24 }}>Qualify your local agent</h2>
-      <p>
-        Kungfu discovers launch coordinates and bounded version output only. It
-        does not read or copy provider credentials, prompts, chats, or sessions.
-      </p>
-      <div style={{ display: 'flex', gap: 8 }}>
-        <select
-          value={selectedAgent}
-          onChange={(event) => setSelectedAgent(event.target.value)}
-          style={{ minWidth: 320 }}
+        </div>
+        <p style={{ margin: '12px 0 0', color: '#b8b8b8' }}>
+          <strong>{selectedMode.label}:</strong> {selectedMode.description}
+        </p>
+      </section>
+
+      <section aria-label="Two-session experiment" style={{ marginTop: 18 }}>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns:
+              'repeat(auto-fit, minmax(min(100%, 360px), 1fr))',
+            gap: 12,
+          }}
         >
-          <option value="">No local agent discovered</option>
-          {options.map((profile) => (
-            <option key={profile.id} value={profile.id}>
-              {profile.label} · {profile.launch.executable}
-            </option>
+          <SessionColumn story={sessionOne} />
+          <SessionColumn story={sessionTwo} />
+        </div>
+        <HandoffBridge report={report} />
+      </section>
+
+      {!report ? (
+        <section
+          aria-label="Behavior guide"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+            gap: 10,
+            marginTop: 16,
+          }}
+        >
+          {qualificationBehaviorFindings(null).map((finding) => (
+            <div
+              key={finding.status}
+              style={{
+                ...panelStyle,
+                padding: 12,
+                background: '#181818',
+                border: '1px solid #3c3c3c',
+              }}
+            >
+              <StatusBadge status={finding.status} />
+              <strong style={{ display: 'block', marginTop: 8 }}>
+                {finding.title}
+              </strong>
+              <div style={{ marginTop: 4, color: '#a9a9a9', lineHeight: 1.45 }}>
+                {finding.detail}
+              </div>
+            </div>
           ))}
-        </select>
-        <select
-          aria-label="Continuation agent"
-          value={targetAgent}
-          onChange={(event) => setTargetAgent(event.target.value)}
-          style={{ minWidth: 320 }}
-        >
-          <option value="">No continuation agent discovered</option>
-          {options.map((profile) => (
-            <option key={profile.id} value={profile.id}>
-              then {profile.label} · {profile.launch.executable}
-            </option>
-          ))}
-        </select>
-        <button
-          type="button"
-          disabled={!selectedAgent || Boolean(busy)}
-          onClick={previewAgent}
-        >
-          Preview exact qualification
-        </button>
-        <button
-          type="button"
-          disabled={!agentPlan || Boolean(busy)}
-          onClick={runAgent}
-          title="Runs the selected provider twice in a discardable directory"
-        >
-          {busy === 'agent-run'
-            ? 'Running selected agent…'
-            : 'Run self-continuity'}
-        </button>
-        <button
-          type="button"
-          disabled={
-            !agentPlan ||
-            !targetPlan ||
-            selectedAgent === targetAgent ||
-            Boolean(busy)
-          }
-          onClick={runMigration}
-          title="Runs the first session with the source and continuation with the target"
-        >
-          Run cross-provider handoff
-        </button>
-        <button type="button" disabled={Boolean(busy)} onClick={discover}>
-          Refresh
-        </button>
-      </div>
-      {agentPlan ? (
+        </section>
+      ) : (
+        <ResultPanel report={report} />
+      )}
+
+      <section
+        style={{
+          marginTop: 18,
+          padding: 14,
+          borderLeft: '3px solid #4ec9b0',
+          background: '#182522',
+        }}
+      >
+        <strong>What Kungfu changes</strong>
+        <div style={{ marginTop: 5, lineHeight: 1.5 }}>
+          Kungfu does not answer the task for the agent. It makes work
+          continuable, handoff-ready, and provable across sessions, agents, and
+          time.
+        </div>
+      </section>
+
+      <details style={{ marginTop: 16 }}>
+        <summary style={{ cursor: 'pointer' }}>Technical details</summary>
         <pre
           style={{
             ...mono,
             whiteSpace: 'pre-wrap',
             padding: 12,
             background: '#111',
+            overflow: 'auto',
           }}
         >
-          {JSON.stringify(agentPlan.commandPreview)}
-          {'\n'}identity {agentPlan.identityRoot}
-          {'\n'}plan {agentPlan.planRoot}
-          {'\n'}continuation {JSON.stringify(targetPlan?.commandPreview)}
-          {'\n'}continuation identity {targetPlan?.identityRoot}
-          {'\n'}credential contents read: no
-          {'\n'}Running uses the provider's existing authentication only after
-          this explicit action.
+          {agentPlan
+            ? `source command ${JSON.stringify(agentPlan.commandPreview)}
+source identity ${agentPlan.identityRoot}
+source plan ${agentPlan.planRoot}
+continuation command ${JSON.stringify(targetPlan?.commandPreview)}
+continuation identity ${targetPlan?.identityRoot}
+credential contents read: no`
+            : 'No local-agent plan prepared.'}
+          {report
+            ? `
+report ${shortRoot(report.reportRoot)}
+plan ${shortRoot(report.planRoot)}
+identity ${shortRoot(report.identityRoot)}
+attempts ${report.sessionAttempts.length}
+meaning ${report.meaning}
+evidence ${report.evidenceDirectory}`
+            : ''}
         </pre>
-      ) : null}
+      </details>
       {error ? (
-        <div style={{ ...mono, color: '#f48771', marginTop: 12 }}>{error}</div>
+        <div role="alert" style={{ ...mono, color: '#f48771', marginTop: 12 }}>
+          {error}
+        </div>
       ) : null}
     </section>
   );

--- a/scripts/run-kfx-profile-suite-tests.mjs
+++ b/scripts/run-kfx-profile-suite-tests.mjs
@@ -38,6 +38,15 @@ run('GUI Profile navigation projection', 'pnpm', [
   path.join(root, 'framework/gui/src/navigation.test.ts'),
 ]);
 
+run('GUI Agent Qualification Lab visual contract', 'pnpm', [
+  '--filter',
+  '@kungfu-tech/tui',
+  'exec',
+  'tsx',
+  '--test',
+  path.join(root, 'framework/gui/src/qualification-lab.test.ts'),
+]);
+
 run('GUI KFX shared-module contract', 'pnpm', [
   '--filter',
   '@kungfu-tech/tui',


### PR DESCRIPTION
## Summary

Turn Agent Qualification Lab into a legible two-session experiment for a first-time Kungfu user. The shell navigation now remains available while the Lab is open, the three qualification scales share one mode selector, and the two fresh sessions are compared side by side with explicit good, bad, warning, handoff, and value states.

## Related issue

Native Assignment `2026-07-26-kungfu-agent-qualification-visual-experiment`.

## Changes

- Keep the primary shell sidebar mounted while Agent Qualification Lab is open, including a direct Back to Work action.
- Replace separate run paths with one Test mode selector for offline demo, same-agent continuity, and cross-agent handoff.
- Present Session 1 and Session 2 in responsive comparison columns with a visible Kungfu evidence bridge.
- Explain the experiment, correct continuation, undesirable restart/context behavior, residual warnings, and the final Kungfu value in product language.
- Preserve canonical Core authority: while the atomic action is running, the UI waits for evidence instead of fabricating Session 2 progress.
- Add focused visual-contract and navigation regression tests to the Profile Suite.

## Verification

- `./shifu check:source` in a clean review worktree: passed; 636 Node tests passed, 10 environment-gated skips, 0 failures, plus Python, type, format, and source gates.
- `./shifu test:kfx-profile-suite`: passed, including 6 new Lab visual-contract tests and 11 Python contract fixtures.
- `./shifu build:app`: production Electron renderer/main/preload build passed.
- Staged repository gate and DCO hook passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "GUI presentation and navigation refinement over the existing canonical Agent Qualification Lab authority; no runtime semantics, schema, architecture contract, or release policy changes."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Focused tests and production GUI build passed
- [x] Documentation impact is contained in self-explanatory product UI copy
