### PR TITLE
fix(ci): restore proven dev patrol workflow

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -34,16 +34,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@9e904de2c85dbea7c799780ee166510b3336d812 # v3.0.0
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824
     with:
-      # The reusable workflow commit is immutable, but its historical source
-      # SHA may no longer belong to the retained self-hosted Git bundle after
-      # the v3 release line diverges. Resolve the official stable runtime for
-      # standing patrols; trusted manual runs may still supply an exact SHA or
-      # train ref through the workflow_dispatch input. Checkout cache hits are
-      # optional: every source/runtime checkout verifies the locked SHA and
-      # falls back to GitHub when a retained bundle is stale.
-      buildchain-ref: ${{ inputs.buildchain-ref || 'v3' }}
+      # Resolve the last workflow/runtime pair proven by an actual dev patrol.
+      # Trusted manual runs may still supply an exact SHA or train ref. Checkout
+      # cache hits are optional: every source/runtime checkout verifies the
+      # locked SHA and falls back to GitHub when a retained bundle is stale.
+      buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}
       checkout-cache-mode: auto
       checkout-cache-fallback: github
       gate-profile: dev-patrol

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1349,7 +1349,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:cd32345184499ca751e79400f7ca9b8d1c7d0f0cabd0ade2c395e8cffea46338",
+          "definitionDigest": "sha256:e381e8979a2ced342f7d0c964cd7d31ede302c0b59c1190aeb65623d9a55fc1c",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1358,7 +1358,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@9e904de2c85dbea7c799780ee166510b3336d812"
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824"
           ],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -321,9 +321,9 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@9e904de2c85dbea7c799780ee166510b3336d812",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824",
         "with": {
-          "buildchain-ref": "${{ inputs.buildchain-ref || 'v3' }}",
+          "buildchain-ref": "${{ inputs.buildchain-ref || 'v2' }}",
           "checkout-cache-fallback": "github",
           "checkout-cache-mode": "auto",
           "gate-profile": "dev-patrol",

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -953,7 +953,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@9e904de2c85dbea7c799780ee166510b3336d812',
+        '.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824',
         '.gate-profile.yml@v2-alpha',
       ),
   );
@@ -997,7 +997,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRuntimeWorkflow, 'utf8')
       .replace(
-        "buildchain-ref: ${{ inputs.buildchain-ref || 'v3' }}",
+        "buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}",
         "buildchain-ref: ${{ inputs.buildchain-ref || '' }}",
       ),
   );


### PR DESCRIPTION
## Summary

- restore the immutable Buildchain Gate workflow pin proven by #1517
- keep the standing Patrol runtime on the proven `v2` channel
- preserve the rest of the Buildchain v3 consumer migration
- refresh the governed workflow bindings and authority manifest

## Evidence

Latest-main workflow dispatches 30193291386 and 30193403981 fail at startup with zero jobs after the Patrol caller moved to Buildchain v3. The prior immutable workflow pin expands correctly and reaches the three-platform Gate matrix.

## Validation

- `node --test scripts/check-kungfu-gate-catalog.test.mjs` (23/23)
- `./shifu check:source`
- staged pre-commit gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "CI reusable-workflow startup repair; no architecture contract changes."
}
-->