### PR TITLE
fix(qualification): stabilize macOS process sampling

### DIFF
--- a/tests/qualification/layers/process-metrics.mjs
+++ b/tests/qualification/layers/process-metrics.mjs
@@ -26,7 +26,9 @@ function sampleResidentBytes(pid) {
 }
 
 export function qualificationHoldMs(platform = process.platform) {
-  return platform === 'win32' || platform === 'linux' ? 1000 : 100;
+  return platform === 'win32' || platform === 'linux' || platform === 'darwin'
+    ? 1000
+    : 100;
 }
 
 export function runMeasured(command, args, options = {}) {

--- a/tests/qualification/layers/process-metrics.test.mjs
+++ b/tests/qualification/layers/process-metrics.test.mjs
@@ -7,10 +7,11 @@ import path from 'node:path';
 import test from 'node:test';
 import { qualificationHoldMs, runMeasured } from './process-metrics.mjs';
 
-test('keeps Windows qualification processes observable to tasklist', () => {
+test('keeps qualification processes observable to platform samplers', () => {
   assert.equal(qualificationHoldMs('win32'), 1000);
   assert.equal(qualificationHoldMs('linux'), 1000);
-  assert.equal(qualificationHoldMs('darwin'), 100);
+  assert.equal(qualificationHoldMs('darwin'), 1000);
+  assert.equal(qualificationHoldMs('freebsd'), 100);
 });
 
 test('records peak resident memory for a short-lived cross-platform process', async () => {


### PR DESCRIPTION
## Summary

Keep macOS SDK qualification fixtures observable long enough for the cross-platform resident-memory sampler to record a real RSS value under loaded native runners.

## Root cause

Exact-source Build run 30192925949 completed install, product build, clean installed CLI/Agent Hub smoke, verify, live-Peer continuity, runtime activation, upgrade, and zero-burden desktop qualification. The final `layers.sdk` gate failed because the Rust `kungfu-sdk-call` fixture exited inside the 100 ms macOS hold before `ps` returned its first RSS sample. Linux and Windows already use a 1000 ms hold.

## Changes

- use the existing 1000 ms observation hold on macOS as well as Linux and Windows
- keep the 100 ms fallback for unknown platforms
- bind the platform policy in the process-metrics unit test

## Verification

- `node --test tests/qualification/layers/process-metrics.test.mjs` (2 passed, 1 Windows-only skipped)
- full pre-commit repository gate passed, including source, invariant, docs, and release contract checks

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair a timing race in an existing qualification measurement fixture; no product, package, authority, or ADR projection changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only the observation window of a qualification fixture. It adds no publication, deployment, credential, package write, or token authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed Build evidence cited
