### PR TITLE
fix(demo): bound long-output projection cues

### DIFF
--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -432,7 +432,11 @@ def build_projection(lines: list[str], exit_code: int) -> dict[str, Any]:
     stdout_lines = list(range(stdout_start, stdout_end + 1))
     if not stdout_lines:
         fail("installed kungfu agent brief produced no stdout")
-    midpoint = min(len(stdout_lines), max(1, len(stdout_lines) // 2))
+    first_stdout_lines = stdout_lines[:80]
+    remaining_stdout_lines = stdout_lines[80:]
+    continued_stdout_lines = (
+        remaining_stdout_lines[-80:] if remaining_stdout_lines else stdout_lines[-1:]
+    )
     return {
         "schema": "build-images.demo-projection/v1",
         "evidenceClass": "exact-installed-artifact-agent-brief/v1",
@@ -452,14 +456,17 @@ def build_projection(lines: list[str], exit_code: int) -> dict[str, Any]:
             {
                 "startMs": 4000,
                 "endMs": 10000,
-                "transcriptLines": stdout_lines[:midpoint],
+                "transcriptLines": first_stdout_lines,
                 "annotation": "Literal installed-product stdout.",
             },
             {
                 "startMs": 10000,
                 "endMs": 15000,
-                "transcriptLines": stdout_lines[midpoint:] or stdout_lines[-1:],
-                "annotation": "Literal installed-product stdout continued.",
+                "transcriptLines": continued_stdout_lines,
+                "annotation": (
+                    "Literal installed-product stdout continued; when output "
+                    "exceeds the cue budget this selects its exact tail."
+                ),
             },
             {
                 "startMs": 15000,

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -26,7 +26,10 @@ function report(source, schema, extra = {}) {
   };
 }
 
-function fixture(root, { source = SOURCE_SHA, unsafeArchive = false } = {}) {
+function fixture(
+  root,
+  { source = SOURCE_SHA, unsafeArchive = false, stdoutLineCount = 0 } = {},
+) {
   const artifact = path.join(root, 'artifact', 'product', 'release');
   const qualification = path.join(artifact, 'qualification');
   json(path.join(qualification, 'layer-qualification-summary.json'), {
@@ -72,10 +75,19 @@ function fixture(root, { source = SOURCE_SHA, unsafeArchive = false } = {}) {
   fs.mkdirSync(path.join(productRoot, 'runtime'), { recursive: true });
   fs.mkdirSync(path.join(productRoot, 'upgrade'), { recursive: true });
   const launcher = path.join(productRoot, 'kungfu');
-  fs.writeFileSync(
-    launcher,
-    '#!/bin/sh\nprintf "Kungfu agent brief fixture\\nFacts before trust.\\n"\n',
-  );
+  const launcherBody =
+    stdoutLineCount > 0
+      ? [
+          '#!/bin/sh',
+          'index=1',
+          `while [ "$index" -le ${stdoutLineCount} ]; do`,
+          '  printf "brief-line-%03d\\n" "$index"',
+          '  index=$((index + 1))',
+          'done',
+          '',
+        ].join('\n')
+      : '#!/bin/sh\nprintf "Kungfu agent brief fixture\\nFacts before trust.\\n"\n';
+  fs.writeFileSync(launcher, launcherBody);
   fs.chmodSync(launcher, 0o755);
   json(path.join(productRoot, 'product.json'), {
     schema: 'kungfu.product.cli/v1',
@@ -217,6 +229,31 @@ test('adapter rejects symlink members before extraction', () => {
     const { result } = run(root, { unsafeArchive: true });
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /unsupported CLI archive member type/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('adapter bounds each visual cue while retaining a complete long transcript', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'auditable-demo-adapter-'),
+  );
+  try {
+    const { result, output } = run(root, { stdoutLineCount: 181 });
+    assert.equal(result.status, 0, result.stderr);
+    const transcript = fs.readFileSync(
+      path.join(output, 'complete-transcript.txt'),
+      'utf8',
+    );
+    assert.match(transcript, /brief-line-001/u);
+    assert.match(transcript, /brief-line-181/u);
+    const projection = JSON.parse(
+      fs.readFileSync(path.join(output, 'public-projection.json'), 'utf8'),
+    );
+    assert.equal(projection.cues[1].transcriptLines.length, 80);
+    assert.equal(projection.cues[2].transcriptLines.length, 80);
+    assert.equal(projection.cues[1].transcriptLines[0], 13);
+    assert.equal(projection.cues[2].transcriptLines.at(-1), 193);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Keep every auditable-demo visual cue within Buildchain’s 1–80 transcript-line contract while retaining the complete installed-product transcript.

## Root cause

Exact-source run 30189805076 installed and executed the real Linux artifact successfully, then failed closed because `kungfu agent brief` emitted more than 160 lines and the adapter split stdout into two oversized cues.

## Changes

- cap each stdout visual cue at 80 exact transcript references
- preserve the complete stdout in `complete-transcript.txt`
- use the exact output tail for the continuation cue when the output exceeds the visual budget
- add a 181-line installed-launcher regression fixture

## Verification

- `./shifu test:auditable-demo` (19 passed)
- `./shifu check:staged` (passed)
- pre-commit staged gate, Ruff, Biome, invariant and docs suites (passed)
- failed exact-source diagnostic: https://github.com/kungfu-systems/kungfu/actions/runs/30189805076

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct an existing checked adapter to satisfy the already-governed Buildchain cue-size contract for real long stdout; no authority or product behavior changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The correction remains fail-closed and grants no publication, deployment, secret, or identity-token authority.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Exact failed run and regression fixture are cited