### PR TITLE
fix(gui): stream qualification progress

### DIFF
--- a/framework/api/src/capability/qualification-lab.ts
+++ b/framework/api/src/capability/qualification-lab.ts
@@ -86,12 +86,18 @@ export type QualificationLab = {
   catalog: () => Promise<QualificationLabCatalog>;
   catalogSync: () => QualificationLabCatalog;
   discoverAgents: () => Promise<AgentRuntimeCatalog>;
-  runDemo: () => Promise<QualificationLabReport>;
+  runDemo: (
+    onEvent?: (event: QualificationLabEvent) => void,
+  ) => Promise<QualificationLabReport>;
   planAgent: (profileId: string) => Promise<QualificationLabAgentPlan>;
-  runAgent: (profileId: string) => Promise<QualificationLabReport>;
+  runAgent: (
+    profileId: string,
+    onEvent?: (event: QualificationLabEvent) => void,
+  ) => Promise<QualificationLabReport>;
   runMigration: (
     sourceProfileId: string,
     targetProfileId: string,
+    onEvent?: (event: QualificationLabEvent) => void,
   ) => Promise<QualificationLabReport>;
 };
 
@@ -113,10 +119,18 @@ export type QualificationLabExecFileSync = (
   options: ExecOptions,
 ) => string;
 
+export type QualificationLabExecFileEvents = (
+  file: string,
+  args: string[],
+  options: ExecOptions,
+  onLine: (line: string) => void,
+) => Promise<void>;
+
 export type OpenQualificationLabOptions = {
   runtimeDir: string;
   execFile: QualificationLabExecFile;
   execFileSync: QualificationLabExecFileSync;
+  execFileEvents?: QualificationLabExecFileEvents;
   env?: Record<string, string | undefined>;
   bin?: string;
 };
@@ -152,23 +166,62 @@ export function openQualificationLab(
         maxBuffer: 64 * 1024 * 1024,
       }),
     );
+  const runWithEvents = async (
+    command: string,
+    extra: string[],
+    onEvent?: (event: QualificationLabEvent) => void,
+  ): Promise<QualificationLabReport> => {
+    if (!onEvent) {
+      return run<QualificationLabReport>(command, extra);
+    }
+    if (!options.execFileEvents) {
+      const report = await run<QualificationLabReport>(command, extra);
+      report.events.forEach(onEvent);
+      return report;
+    }
+    let report: QualificationLabReport | null = null;
+    await options.execFileEvents(
+      bin,
+      args(command, [...extra, '--events-json']),
+      {
+        encoding: 'utf8',
+        env,
+        maxBuffer: 64 * 1024 * 1024,
+      },
+      (line) => {
+        const payload = parse<QualificationLabEvent | QualificationLabReport>(
+          line,
+        );
+        if (payload.schema === 'kungfu.qualification-lab.event/v1') {
+          onEvent(payload);
+        } else {
+          report = payload;
+        }
+      },
+    );
+    if (!report) {
+      throw new Error(
+        'qualification event stream ended without a canonical report',
+      );
+    }
+    return report;
+  };
   return {
     inspect: () => run<QualificationLabStartupRoute>('inspect'),
     inspectSync: () => runSync<QualificationLabStartupRoute>('inspect'),
     catalog: () => run<QualificationLabCatalog>('catalog'),
     catalogSync: () => runSync<QualificationLabCatalog>('catalog'),
     discoverAgents: () => run<AgentRuntimeCatalog>('agents'),
-    runDemo: () => run<QualificationLabReport>('demo'),
+    runDemo: (onEvent) => runWithEvents('demo', [], onEvent),
     planAgent: (profileId) =>
       run<QualificationLabAgentPlan>('agent-plan', [profileId]),
-    runAgent: (profileId) =>
-      run<QualificationLabReport>('agent-run', [profileId, '--execute']),
-    runMigration: (sourceProfileId, targetProfileId) =>
-      run<QualificationLabReport>('agent-run', [
-        sourceProfileId,
-        '--execute',
-        '--target-profile',
-        targetProfileId,
-      ]),
+    runAgent: (profileId, onEvent) =>
+      runWithEvents('agent-run', [profileId, '--execute'], onEvent),
+    runMigration: (sourceProfileId, targetProfileId, onEvent) =>
+      runWithEvents(
+        'agent-run',
+        [sourceProfileId, '--execute', '--target-profile', targetProfileId],
+        onEvent,
+      ),
   };
 }

--- a/framework/api/tests/qualification-lab.test.ts
+++ b/framework/api/tests/qualification-lab.test.ts
@@ -97,3 +97,39 @@ test('GUI and TUI adapter invokes only the canonical public CLI authority', asyn
     },
   ]);
 });
+
+test('the adapter streams safe milestones before returning the canonical report', async () => {
+  const received: string[] = [];
+  const event = {
+    schema: 'kungfu.qualification-lab.event/v1',
+    step: 'session-1-start',
+    status: 'running',
+    root: `sha256:${'a'.repeat(64)}`,
+  } as const;
+  const report = {
+    schema: 'kungfu.qualification-lab.report/v1',
+    status: 'qualified',
+    events: [event],
+  };
+  const lab = openQualificationLab({
+    runtimeDir: '/runtime',
+    bin: '/product/kungfu',
+    execFile: async () => JSON.stringify(report),
+    execFileSync: () => JSON.stringify(startup),
+    execFileEvents: async (_file, args, _options, onLine) => {
+      assert.deepEqual(args, [
+        'qualification-lab',
+        'demo',
+        '--events-json',
+        '--json',
+      ]);
+      onLine(JSON.stringify(event));
+      onLine(JSON.stringify(report));
+    },
+  });
+
+  const result = await lab.runDemo((value) => received.push(value.step));
+
+  assert.deepEqual(received, ['session-1-start']);
+  assert.equal(result.status, 'qualified');
+});

--- a/framework/core/.devtools/kungfu_cli.py
+++ b/framework/core/.devtools/kungfu_cli.py
@@ -2,6 +2,7 @@
 
 from env import __frozen__
 from kungfu import __main__ as origin
+from multiprocessing import freeze_support
 from pathlib import Path
 from os import environ
 
@@ -9,5 +10,11 @@ from os import environ
 environ["KUNGFU_DIR"] = Path("dist/kungfu").resolve().as_posix()
 
 
-if __frozen__:
-    origin.main()
+def main():
+    if __frozen__:
+        freeze_support()
+        origin.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/framework/core/src/python/kungfu/cli/commands/qualification_lab.py
+++ b/framework/core/src/python/kungfu/cli/commands/qualification_lab.py
@@ -16,6 +16,11 @@ def _json(value):
     click.echo(json.dumps(value, indent=2, sort_keys=True))
 
 
+def _event_json(value):
+    click.echo(json.dumps(value, sort_keys=True))
+    click.get_text_stream("stdout").flush()
+
+
 @kfc.group(
     name="qualification-lab",
     cls=PrioritizedCommandGroup,
@@ -99,13 +104,14 @@ def plan(as_json):
 @kfd3_api("kungfu.qualification-lab.demo")
 def demo(output, events_json, as_json):
     try:
-        payload = lab.run_demo(output)
+        payload = lab.run_demo(
+            output,
+            on_event=_event_json if events_json else None,
+        )
     except (OSError, RuntimeError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     if events_json:
-        for event in payload["events"]:
-            click.echo(json.dumps(event, sort_keys=True))
-        click.echo(json.dumps(payload, sort_keys=True))
+        _event_json(payload)
         return
     if as_json:
         _json(payload)
@@ -162,6 +168,11 @@ def agent_plan(ctx, profile_id, as_json):
     default=300,
     show_default=True,
 )
+@click.option(
+    "--events-json",
+    is_flag=True,
+    help="stream stable event boundaries followed by the final report",
+)
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @kfd3_api("kungfu.qualification-lab.agent-run")
 @kfc.pass_context()
@@ -172,6 +183,7 @@ def agent_run(
     target_profile,
     output,
     timeout_seconds,
+    events_json,
     as_json,
 ):
     if not execute:
@@ -187,9 +199,13 @@ def agent_run(
             runtime_home=ctx.home,
             output_dir=output,
             timeout_seconds=timeout_seconds,
+            on_event=_event_json if events_json else None,
         )
     except (OSError, RuntimeError, ValueError) as error:
         raise click.ClickException(str(error)) from error
+    if events_json:
+        _event_json(payload)
+        return
     if as_json:
         _json(payload)
         return

--- a/framework/core/src/python/kungfu/qualification_lab.py
+++ b/framework/core/src/python/kungfu/qualification_lab.py
@@ -17,6 +17,7 @@ import re
 import subprocess
 import tempfile
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any, Mapping
 
 import kungfu
@@ -61,12 +62,24 @@ DEMO_AGENT_IDENTITY = {
     "argv": ["bundled", "qualification-lab-demo"],
 }
 
+QualificationEventSink = Callable[[Mapping[str, Any]], None]
+
 
 def content_root(value: Any) -> str:
     encoded = json.dumps(
         value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
     ).encode("utf-8")
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _publish_event(
+    events: list[dict[str, Any]],
+    event: dict[str, Any],
+    on_event: QualificationEventSink | None,
+) -> None:
+    events.append(event)
+    if on_event is not None:
+        on_event(event)
 
 
 def _diagnostic(
@@ -377,7 +390,11 @@ def _semantic_attempt(attempt: Mapping[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in attempt.items() if key not in {"processId"}}
 
 
-def run_demo(output_dir: str | Path | None = None) -> dict[str, Any]:
+def run_demo(
+    output_dir: str | Path | None = None,
+    *,
+    on_event: QualificationEventSink | None = None,
+) -> dict[str, Any]:
     """Run the real two-process deterministic fixture in a discardable root."""
 
     plan = demo_plan()
@@ -388,7 +405,28 @@ def run_demo(output_dir: str | Path | None = None) -> dict[str, Any]:
         root.mkdir(parents=True, exist_ok=False)
     state_path = root / "fixture-state.json"
     process_ids: list[int] = []
+    events: list[dict[str, Any]] = []
+    _publish_event(
+        events,
+        {
+            "schema": "kungfu.qualification-lab.event/v1",
+            "step": "plan",
+            "status": "ready",
+            "root": plan["planRoot"],
+        },
+        on_event,
+    )
     for attempt_index in (1, 2):
+        _publish_event(
+            events,
+            {
+                "schema": "kungfu.qualification-lab.event/v1",
+                "step": f"session-{attempt_index}-start",
+                "status": "running",
+                "root": plan["planRoot"],
+            },
+            on_event,
+        )
         process = multiprocessing.get_context("spawn").Process(
             target=_demo_worker, args=(str(state_path), attempt_index)
         )
@@ -403,6 +441,18 @@ def run_demo(output_dir: str | Path | None = None) -> dict[str, Any]:
             raise RuntimeError(
                 f"demo session {attempt_index} exited {process.exitcode}"
             )
+        observed = json.loads(state_path.read_text(encoding="utf-8"))
+        observed_attempt = observed["attempts"][-1]
+        _publish_event(
+            events,
+            {
+                "schema": "kungfu.qualification-lab.event/v1",
+                "step": f"session-{attempt_index}",
+                "status": str(observed_attempt["status"]),
+                "root": content_root(_semantic_attempt(observed_attempt)),
+            },
+            on_event,
+        )
     state = json.loads(state_path.read_text(encoding="utf-8"))
     attempts = state.get("attempts", [])
     oracle_checks = [
@@ -449,32 +499,16 @@ def run_demo(output_dir: str | Path | None = None) -> dict[str, Any]:
         "fixtureRoot": content_root(semantic_state),
     }
     assessment["assessmentRoot"] = content_root(assessment)
-    events = [
-        {
-            "schema": "kungfu.qualification-lab.event/v1",
-            "step": "plan",
-            "status": "ready",
-            "root": plan["planRoot"],
-        },
-        {
-            "schema": "kungfu.qualification-lab.event/v1",
-            "step": "session-1",
-            "status": "ended-partial",
-            "root": content_root(_semantic_attempt(attempts[0])),
-        },
-        {
-            "schema": "kungfu.qualification-lab.event/v1",
-            "step": "session-2",
-            "status": "ended-complete",
-            "root": content_root(_semantic_attempt(attempts[1])),
-        },
+    _publish_event(
+        events,
         {
             "schema": "kungfu.qualification-lab.event/v1",
             "step": "assessment",
             "status": assessment["status"],
             "root": assessment["assessmentRoot"],
         },
-    ]
+        on_event,
+    )
     report_semantic = {
         "schema": DEMO_REPORT_SCHEMA,
         "status": assessment["status"],
@@ -638,6 +672,7 @@ def run_agent(
     runtime_home: str | None = None,
     output_dir: str | Path | None = None,
     timeout_seconds: int = 300,
+    on_event: QualificationEventSink | None = None,
 ) -> dict[str, Any]:
     """Qualify a selected local agent in two explicitly authorized fresh runs."""
 
@@ -700,7 +735,28 @@ def run_agent(
     }
     _atomic_json(state_path, initial_state)
     attempts: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    _publish_event(
+        events,
+        {
+            "schema": "kungfu.qualification-lab.event/v1",
+            "step": "plan",
+            "status": "ready",
+            "root": plan["planRoot"],
+        },
+        on_event,
+    )
     for attempt_index in (1, 2):
+        _publish_event(
+            events,
+            {
+                "schema": "kungfu.qualification-lab.event/v1",
+                "step": f"session-{attempt_index}-start",
+                "status": "running",
+                "root": plan["planRoot"],
+            },
+            on_event,
+        )
         prompt = _agent_prompt(state_path, attempt_index)
         command = _provider_command(profiles[attempt_index - 1], prompt)
         process_id, returncode, stdout, stderr = _run_agent_process(
@@ -718,28 +774,49 @@ def run_agent(
             "stderrRoot": content_root(stderr),
         }
         attempts.append(receipt)
+        stop_after_event = returncode != 0
         if returncode != 0:
-            break
-        try:
-            observed = json.loads(state_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeError, json.JSONDecodeError):
-            break
-        expected_status = "partial" if attempt_index == 1 else "complete"
-        expected_steps = (
-            ["claim-recorded"]
-            if attempt_index == 1
-            else ["claim-recorded", "continuation-completed"]
+            observed = None
+        else:
+            try:
+                observed = json.loads(state_path.read_text(encoding="utf-8"))
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                observed = None
+                stop_after_event = True
+        if observed is not None:
+            expected_status = "partial" if attempt_index == 1 else "complete"
+            expected_steps = (
+                ["claim-recorded"]
+                if attempt_index == 1
+                else ["claim-recorded", "continuation-completed"]
+            )
+            receipt["observedState"] = observed.get("status")
+            receipt["stateRoot"] = content_root(observed)
+            if (
+                observed.get("schema") != initial_state["schema"]
+                or observed.get("suite") != SUITE_ID
+                or observed.get("fixture") != FIXTURE_ID
+                or observed.get("workRef") != initial_state["workRef"]
+                or observed.get("status") != expected_status
+                or observed.get("steps") != expected_steps
+            ):
+                stop_after_event = True
+        event_status = (
+            str(receipt.get("observedState") or "complete")
+            if returncode == 0 and observed is not None
+            else "failed"
         )
-        receipt["observedState"] = observed.get("status")
-        receipt["stateRoot"] = content_root(observed)
-        if (
-            observed.get("schema") != initial_state["schema"]
-            or observed.get("suite") != SUITE_ID
-            or observed.get("fixture") != FIXTURE_ID
-            or observed.get("workRef") != initial_state["workRef"]
-            or observed.get("status") != expected_status
-            or observed.get("steps") != expected_steps
-        ):
+        _publish_event(
+            events,
+            {
+                "schema": "kungfu.qualification-lab.event/v1",
+                "step": f"session-{attempt_index}",
+                "status": event_status,
+                "root": content_root(receipt),
+            },
+            on_event,
+        )
+        if stop_after_event:
             break
     try:
         final_state = json.loads(state_path.read_text(encoding="utf-8"))
@@ -789,6 +866,16 @@ def run_agent(
         "fixtureRoot": content_root(final_state),
     }
     assessment["assessmentRoot"] = content_root(assessment)
+    _publish_event(
+        events,
+        {
+            "schema": "kungfu.qualification-lab.event/v1",
+            "step": "assessment",
+            "status": assessment["status"],
+            "root": assessment["assessmentRoot"],
+        },
+        on_event,
+    )
     report_semantic = {
         "schema": AGENT_REPORT_SCHEMA,
         "status": status,
@@ -800,19 +887,7 @@ def run_agent(
         "identity": plan["identity"],
         "identityRoot": plan["identityRoot"],
         "assessment": assessment,
-        "events": [
-            {
-                "schema": "kungfu.qualification-lab.event/v1",
-                "step": f"session-{index + 1}",
-                "status": (
-                    str(row.get("observedState") or "complete")
-                    if row.get("exitCode") == 0
-                    else "failed"
-                ),
-                "root": content_root(row),
-            }
-            for index, row in enumerate(attempts)
-        ],
+        "events": events,
         "meaning": "The selected identity recognized and continued exact governed state across two fresh local agent processes.",
         "runMode": ("cross-provider-migration" if migration else "self-continuity"),
         "nonClaims": SUITE_NON_CLAIMS,

--- a/framework/core/tests/python/test_qualification_lab.py
+++ b/framework/core/tests/python/test_qualification_lab.py
@@ -110,7 +110,8 @@ def test_unknown_or_incomplete_global_work_fails_closed_to_diagnostic(
 
 def test_demo_uses_distinct_fresh_processes_and_exact_oracle(tmp_path):
     output = tmp_path / "evidence"
-    report = qualification_lab.run_demo(output)
+    streamed_events = []
+    report = qualification_lab.run_demo(output, on_event=streamed_events.append)
     assert report["status"] == "qualified"
     assert report["writeOccurred"] is True
     assert report["identity"]["provider"] == "kungfu-demo-agent"
@@ -122,6 +123,15 @@ def test_demo_uses_distinct_fresh_processes_and_exact_oracle(tmp_path):
         for attempt in report["sessionAttempts"]
     )
     assert all(check["passed"] for check in report["assessment"]["oracleChecks"])
+    assert [event["step"] for event in streamed_events] == [
+        "plan",
+        "session-1-start",
+        "session-1",
+        "session-2-start",
+        "session-2",
+        "assessment",
+    ]
+    assert streamed_events == report["events"]
     retained = json.loads((output / "report.json").read_text(encoding="utf-8"))
     assert retained["reportRoot"] == report["reportRoot"]
 
@@ -223,13 +233,24 @@ path.write_text(json.dumps(state))
             "profileId": value["id"],
         },
     )
+    streamed_events = []
     report = qualification_lab.run_agent(
         "source",
         target_profile_id="target",
         output_dir=tmp_path / "evidence",
+        on_event=streamed_events.append,
     )
     assert report["status"] == "qualified"
     assert report["runMode"] == "cross-provider-migration"
     assert report["identity"]["source"]["profileId"] == "source"
     assert report["identity"]["target"]["profileId"] == "target"
     assert len({row["processId"] for row in report["sessionAttempts"]}) == 2
+    assert [event["step"] for event in streamed_events] == [
+        "plan",
+        "session-1-start",
+        "session-1",
+        "session-2-start",
+        "session-2",
+        "assessment",
+    ]
+    assert streamed_events == report["events"]

--- a/framework/gui/src/qualification-lab.test.ts
+++ b/framework/gui/src/qualification-lab.test.ts
@@ -6,8 +6,10 @@ import { test } from 'node:test';
 import type { QualificationLabReport } from '@kungfu-tech/api/capability';
 import {
   QUALIFICATION_MODES,
+  QUALIFICATION_PLAYBACK_TIMING,
   qualificationBehaviorFindings,
   qualificationModeNeeds,
+  qualificationPlaybackLine,
   qualificationSessionStories,
 } from './renderer/src/qualification-lab';
 
@@ -100,6 +102,23 @@ test('canonical oracle failures and residuals stay visually distinct', () => {
   );
 });
 
+test('safe runtime events map to incremental command-like output', () => {
+  const line = qualificationPlaybackLine({
+    schema: 'kungfu.qualification-lab.event/v1',
+    step: 'session-2-start',
+    status: 'running',
+    root: `sha256:${'a'.repeat(64)}`,
+  });
+
+  assert.equal(line.status, 'running');
+  assert.match(line.command, /launch session 2/);
+  assert.match(line.detail, /not interpreting raw terminal text/);
+  assert.ok(
+    QUALIFICATION_PLAYBACK_TIMING.eventDelayMs <
+      QUALIFICATION_PLAYBACK_TIMING.verdictDelayMs,
+  );
+});
+
 test('the shell keeps navigation outside the Lab content branch', () => {
   const source = readFileSync(
     new URL('./renderer/src/main.tsx', import.meta.url),
@@ -126,4 +145,9 @@ test('the visual contract is accessible and remains a responsive two-column comp
   assert.match(source, /aria-label="Session 2 agent"/);
   assert.match(source, /<output[\s\S]*aria-label=\{meta\.label\}/);
   assert.match(source, /repeat\(auto-fit, minmax\(min\(100%, 360px\), 1fr\)\)/);
+  assert.match(source, /SAFE EVENT STREAM/);
+  assert.match(source, /lab\.runDemo\(receiveEvent\)/);
+  assert.match(source, /lab\.runAgent\(selectedAgent, receiveEvent\)/);
+  assert.match(source, /kf-lab-verdict-focus/);
+  assert.match(source, /prefers-reduced-motion: reduce/);
 });

--- a/framework/gui/src/renderer/src/qualification-lab.tsx
+++ b/framework/gui/src/renderer/src/qualification-lab.tsx
@@ -4,6 +4,7 @@ import type {
   AgentRuntimeCatalog,
   QualificationLab,
   QualificationLabAgentPlan,
+  QualificationLabEvent,
   QualificationLabReport,
   QualificationLabStartupRoute,
 } from '@kungfu-tech/api/capability';
@@ -37,6 +38,18 @@ type BehaviorFinding = {
   title: string;
   detail: string;
 };
+
+type PlaybackLine = {
+  status: VisualStatus;
+  command: string;
+  detail: string;
+};
+
+export const QUALIFICATION_PLAYBACK_TIMING = {
+  eventDelayMs: 360,
+  verdictDelayMs: 520,
+  reducedMotionDelayMs: 24,
+} as const;
 
 export const QUALIFICATION_MODES: Array<{
   id: QualificationMode;
@@ -142,14 +155,21 @@ function shortRoot(value: string): string {
   return value.length > 28 ? `${value.slice(0, 16)}…${value.slice(-8)}` : value;
 }
 
+function waitForPlayback(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, milliseconds);
+  });
+}
+
 function eventStatus(
-  report: QualificationLabReport | null,
+  events: QualificationLabEvent[],
   session: 1 | 2,
 ): VisualStatus {
-  if (!report) return 'waiting';
-  const event = report.events.find((row) => row.step === `session-${session}`);
+  const event = [...events]
+    .reverse()
+    .find((row) => row.step === `session-${session}`);
   const status = event?.status ?? '';
-  if (status === 'failed' || report.status === 'failed') return 'undesirable';
+  if (status === 'failed') return 'undesirable';
   if (
     (session === 1 &&
       ['ended-partial', 'partial', 'partial-first-attempt'].includes(status)) ||
@@ -158,7 +178,52 @@ function eventStatus(
   ) {
     return 'correct';
   }
-  return 'warning';
+  return event ? 'warning' : 'waiting';
+}
+
+export function qualificationPlaybackLine(
+  event: QualificationLabEvent,
+): PlaybackLine {
+  if (event.step.endsWith('-start')) {
+    const session = event.step.includes('session-1')
+      ? 'Session 1'
+      : 'Session 2';
+    return {
+      status: 'running',
+      command: `$ launch ${session.toLowerCase()} as a fresh process`,
+      detail:
+        'The provider process is active. Kungfu is waiting for a governed state observation, not interpreting raw terminal text.',
+    };
+  }
+  if (event.step === 'session-1') {
+    return {
+      status: eventStatus([event], 1),
+      command: 'observe session-1 → partial state sealed',
+      detail: `A bounded result was recorded · ${shortRoot(event.root)}`,
+    };
+  }
+  if (event.step === 'session-2') {
+    return {
+      status: eventStatus([event], 2),
+      command: 'observe session-2 → continuation verified',
+      detail: `The fresh process continued the governed state · ${shortRoot(event.root)}`,
+    };
+  }
+  return {
+    status:
+      event.status === 'failed'
+        ? 'undesirable'
+        : event.step === 'assessment'
+          ? event.status === 'qualified-with-residuals'
+            ? 'warning'
+            : 'correct'
+          : 'ready',
+    command:
+      event.step === 'assessment'
+        ? 'assess canonical oracle checks'
+        : 'prepare bounded two-session plan',
+    detail: `${event.status} · ${shortRoot(event.root)}`,
+  };
 }
 
 export function qualificationModeNeeds(mode: QualificationMode): {
@@ -175,16 +240,21 @@ export function qualificationSessionStories(
   mode: QualificationMode,
   running: boolean,
   report: QualificationLabReport | null,
+  visibleEvents: QualificationLabEvent[] = [],
 ): [SessionStory, SessionStory] {
-  const firstStatus = running
-    ? 'running'
-    : report
-      ? eventStatus(report, 1)
+  const events = report?.events ?? visibleEvents;
+  const firstObserved = events.some((row) => row.step === 'session-1');
+  const secondObserved = events.some((row) => row.step === 'session-2');
+  const secondStarted = events.some((row) => row.step === 'session-2-start');
+  const firstStatus = firstObserved
+    ? eventStatus(events, 1)
+    : running
+      ? 'running'
       : 'ready';
-  const secondStatus = running
-    ? 'waiting'
-    : report
-      ? eventStatus(report, 2)
+  const secondStatus = secondObserved
+    ? eventStatus(events, 2)
+    : running && secondStarted
+      ? 'running'
       : 'waiting';
   const firstAgent =
     mode === 'offline-demo'
@@ -206,19 +276,19 @@ export function qualificationSessionStories(
       milestones: [
         {
           status: firstStatus,
-          title: report
+          title: firstObserved
             ? 'Created a bounded partial result'
             : running
               ? 'Canonical two-session action is running'
               : 'Will receive the governed test task',
-          detail: report
+          detail: firstObserved
             ? 'The first process stopped after leaving evidence that a fresh session can inspect.'
             : running
               ? 'Kungfu is waiting for Core evidence before declaring what this session actually did.'
               : 'It should claim the work, make bounded progress, record evidence, and end before completion.',
         },
         {
-          status: report ? firstStatus : 'waiting',
+          status: firstObserved ? firstStatus : 'waiting',
           title: 'Ends without completing the whole task',
           detail:
             'This creates a real continuity question for Session 2 instead of two unrelated successful runs.',
@@ -231,20 +301,20 @@ export function qualificationSessionStories(
       milestones: [
         {
           status: secondStatus,
-          title: report
+          title: secondObserved
             ? 'Started without the prior transcript'
             : running
               ? 'Will start after Session 1 leaves evidence'
               : 'Will start as a genuinely fresh process',
-          detail: report
+          detail: secondObserved
             ? 'The second process had to identify the task and prior state from Kungfu evidence.'
             : running
               ? 'Core returns one canonical report for the complete sequence, so the UI waits rather than guessing whether the handoff has occurred.'
               : 'No copied chat and no human re-explanation should be available.',
         },
         {
-          status: report ? secondStatus : 'waiting',
-          title: report
+          status: secondObserved ? secondStatus : 'waiting',
+          title: secondObserved
             ? 'Continued from the recorded state'
             : 'Must continue instead of restart',
           detail:
@@ -307,6 +377,7 @@ function StatusBadge({ status }: { status: VisualStatus }) {
   return (
     <output
       aria-label={meta.label}
+      className={status === 'running' ? 'kf-lab-running-badge' : undefined}
       style={{
         ...mono,
         display: 'inline-flex',
@@ -326,7 +397,20 @@ function StatusBadge({ status }: { status: VisualStatus }) {
   );
 }
 
-function SessionColumn({ story }: { story: SessionStory }) {
+function SessionColumn({
+  story,
+  session,
+  events,
+  running,
+}: {
+  story: SessionStory;
+  session: 1 | 2;
+  events: QualificationLabEvent[];
+  running: boolean;
+}) {
+  const sessionEvents = events.filter((event) =>
+    event.step.startsWith(`session-${session}`),
+  );
   return (
     <article
       style={{
@@ -341,6 +425,61 @@ function SessionColumn({ story }: { story: SessionStory }) {
         {story.title.toUpperCase()}
       </div>
       <h2 style={{ margin: '6px 0 16px', fontSize: 19 }}>{story.subtitle}</h2>
+      <div
+        aria-live="polite"
+        aria-label={`${story.title} live event stream`}
+        style={{
+          ...mono,
+          minHeight: 96,
+          marginBottom: 16,
+          padding: 12,
+          borderRadius: 6,
+          background: '#0f1112',
+          border: '1px solid #2f3638',
+          fontSize: 11,
+          lineHeight: 1.45,
+        }}
+      >
+        <div style={{ color: '#6fa8bd', marginBottom: 8 }}>
+          SAFE EVENT STREAM
+          {running && !sessionEvents.length ? (
+            <span className="kf-lab-live-dots"> · waiting</span>
+          ) : null}
+        </div>
+        {sessionEvents.length ? (
+          sessionEvents.map((event, index) => {
+            const line = qualificationPlaybackLine(event);
+            return (
+              <div
+                className="kf-lab-event-line"
+                key={`${event.step}-${event.status}-${index}`}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'auto minmax(0, 1fr)',
+                  gap: 8,
+                  marginTop: index ? 9 : 0,
+                }}
+              >
+                <span style={{ color: STATUS_META[line.status].color }}>
+                  {STATUS_META[line.status].icon}
+                </span>
+                <div>
+                  <div style={{ color: '#d7d7d7' }}>{line.command}</div>
+                  <div style={{ color: '#858585', marginTop: 2 }}>
+                    {line.detail}
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        ) : (
+          <div style={{ color: '#666' }}>
+            {running
+              ? 'No safe milestone has been observed yet.'
+              : 'Events will appear here one command boundary at a time.'}
+          </div>
+        )}
+      </div>
       <div style={{ display: 'grid', gap: 14 }}>
         {story.milestones.map((milestone) => (
           <div
@@ -374,19 +513,26 @@ function SessionColumn({ story }: { story: SessionStory }) {
 
 function HandoffBridge({
   report,
+  events,
+  running,
 }: {
   report: QualificationLabReport | null;
+  events: QualificationLabEvent[];
+  running: boolean;
 }) {
-  const proven = report && report.status !== 'failed';
+  const firstComplete = events.some((event) => event.step === 'session-1');
+  const secondComplete = events.some((event) => event.step === 'session-2');
+  const proven = Boolean(report && report.status !== 'failed');
+  const active = running && firstComplete && !secondComplete;
   return (
     <section
       aria-label="Kungfu handoff bridge"
       style={{
         margin: '12px 0',
         padding: '12px 16px',
-        border: `1px solid ${proven ? '#287f70' : '#3c3c3c'}`,
+        border: `1px solid ${proven ? '#287f70' : active ? '#9b7a31' : '#3c3c3c'}`,
         borderRadius: 8,
-        background: proven ? '#102c28' : '#202020',
+        background: proven ? '#102c28' : active ? '#332b18' : '#202020',
       }}
     >
       <div
@@ -401,10 +547,17 @@ function HandoffBridge({
       >
         <strong>Session 1</strong>
         <span aria-hidden="true">──▶</span>
-        <strong style={{ color: '#4ec9b0' }}>
+        <strong
+          className={active ? 'kf-lab-handoff-active' : undefined}
+          style={{ color: proven ? '#4ec9b0' : active ? '#d7ba7d' : '#b8b8b8' }}
+        >
           {proven
             ? 'Kungfu evidence proved the handoff'
-            : 'Kungfu handoff evidence'}
+            : active
+              ? 'Partial evidence sealed · starting the fresh continuation'
+              : secondComplete
+                ? 'Both session observations received · assessment pending'
+                : 'Kungfu handoff evidence'}
         </strong>
         <span aria-hidden="true">──▶</span>
         <strong>Session 2</strong>
@@ -427,12 +580,22 @@ function HandoffBridge({
   );
 }
 
-function ResultPanel({ report }: { report: QualificationLabReport }) {
+function ResultPanel({
+  report,
+  visibleFindingCount,
+  activeFindingIndex,
+}: {
+  report: QualificationLabReport;
+  visibleFindingCount: number;
+  activeFindingIndex: number;
+}) {
   const passed = report.status !== 'failed';
   const findings = qualificationBehaviorFindings(report);
   return (
     <section
       aria-label="Qualification result"
+      aria-live="polite"
+      className="kf-lab-result-enter"
       style={{
         ...panelStyle,
         marginTop: 18,
@@ -462,9 +625,12 @@ function ResultPanel({ report }: { report: QualificationLabReport }) {
           marginTop: 16,
         }}
       >
-        {findings.map((finding) => (
+        {findings.slice(0, visibleFindingCount).map((finding, index) => (
           <div
             key={`${finding.status}-${finding.title}`}
+            className={`kf-lab-verdict-card${
+              index === activeFindingIndex ? ' kf-lab-verdict-focus' : ''
+            }`}
             style={{
               padding: 12,
               borderRadius: 6,
@@ -506,8 +672,14 @@ export function QualificationLabPanel({
   const [report, setReport] = React.useState<QualificationLabReport | null>(
     null,
   );
+  const [visibleEvents, setVisibleEvents] = React.useState<
+    QualificationLabEvent[]
+  >([]);
+  const [visibleFindingCount, setVisibleFindingCount] = React.useState(0);
+  const [activeFindingIndex, setActiveFindingIndex] = React.useState(-1);
   const [busy, setBusy] = React.useState('');
   const [error, setError] = React.useState('');
+  const playbackRunRef = React.useRef(0);
 
   const discover = React.useCallback(async () => {
     setBusy('discover');
@@ -539,10 +711,14 @@ export function QualificationLabPanel({
   }, [discover]);
 
   const resetRun = (nextMode: QualificationMode) => {
+    playbackRunRef.current += 1;
     setMode(nextMode);
     setAgentPlan(null);
     setTargetPlan(null);
     setReport(null);
+    setVisibleEvents([]);
+    setVisibleFindingCount(0);
+    setActiveFindingIndex(-1);
     setError('');
   };
 
@@ -566,21 +742,59 @@ export function QualificationLabPanel({
   };
 
   const run = async () => {
+    const runId = playbackRunRef.current + 1;
+    playbackRunRef.current = runId;
     setBusy('run');
     setReport(null);
+    setVisibleEvents([]);
+    setVisibleFindingCount(0);
+    setActiveFindingIndex(-1);
+    const reducedMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const eventDelay = reducedMotion
+      ? QUALIFICATION_PLAYBACK_TIMING.reducedMotionDelayMs
+      : QUALIFICATION_PLAYBACK_TIMING.eventDelayMs;
+    const verdictDelay = reducedMotion
+      ? QUALIFICATION_PLAYBACK_TIMING.reducedMotionDelayMs
+      : QUALIFICATION_PLAYBACK_TIMING.verdictDelayMs;
+    let playbackQueue = Promise.resolve();
+    const receiveEvent = (event: QualificationLabEvent) => {
+      playbackQueue = playbackQueue.then(async () => {
+        await waitForPlayback(eventDelay);
+        if (playbackRunRef.current !== runId) return;
+        setVisibleEvents((current) => [...current, event]);
+      });
+    };
     try {
       const nextReport =
         mode === 'offline-demo'
-          ? await lab.runDemo()
+          ? await lab.runDemo(receiveEvent)
           : mode === 'cross-agent'
-            ? await lab.runMigration(selectedAgent, targetAgent)
-            : await lab.runAgent(selectedAgent);
+            ? await lab.runMigration(selectedAgent, targetAgent, receiveEvent)
+            : await lab.runAgent(selectedAgent, receiveEvent);
+      await playbackQueue;
+      if (playbackRunRef.current !== runId) return;
       setReport(nextReport);
+      const findings = qualificationBehaviorFindings(nextReport);
+      await waitForPlayback(verdictDelay);
+      for (let index = 0; index < findings.length; index += 1) {
+        if (playbackRunRef.current !== runId) return;
+        setVisibleFindingCount(index + 1);
+        setActiveFindingIndex(index);
+        await waitForPlayback(verdictDelay);
+      }
+      if (playbackRunRef.current !== runId) return;
+      setActiveFindingIndex(-1);
       setError('');
     } catch (reason) {
-      setError((reason as Error).message);
+      if (playbackRunRef.current === runId) {
+        setError((reason as Error).message);
+      }
     } finally {
-      setBusy('');
+      if (playbackRunRef.current === runId) {
+        setBusy('');
+      }
     }
   };
 
@@ -606,6 +820,7 @@ export function QualificationLabPanel({
     mode,
     running,
     report,
+    visibleEvents,
   );
   const selectedMode = QUALIFICATION_MODES.find((row) => row.id === mode) ?? {
     id: mode,
@@ -720,6 +935,9 @@ export function QualificationLabPanel({
                   setAgentPlan(null);
                   setTargetPlan(null);
                   setReport(null);
+                  setVisibleEvents([]);
+                  setVisibleFindingCount(0);
+                  setActiveFindingIndex(-1);
                 }}
                 style={{ width: '100%', minHeight: 34 }}
               >
@@ -745,6 +963,9 @@ export function QualificationLabPanel({
                   setTargetAgent(event.target.value);
                   setTargetPlan(null);
                   setReport(null);
+                  setVisibleEvents([]);
+                  setVisibleFindingCount(0);
+                  setActiveFindingIndex(-1);
                 }}
                 style={{ width: '100%', minHeight: 34 }}
               >
@@ -798,10 +1019,24 @@ export function QualificationLabPanel({
             gap: 12,
           }}
         >
-          <SessionColumn story={sessionOne} />
-          <SessionColumn story={sessionTwo} />
+          <SessionColumn
+            story={sessionOne}
+            session={1}
+            events={visibleEvents}
+            running={running}
+          />
+          <SessionColumn
+            story={sessionTwo}
+            session={2}
+            events={visibleEvents}
+            running={running}
+          />
         </div>
-        <HandoffBridge report={report} />
+        <HandoffBridge
+          report={report}
+          events={visibleEvents}
+          running={running}
+        />
       </section>
 
       {!report ? (
@@ -835,7 +1070,11 @@ export function QualificationLabPanel({
           ))}
         </section>
       ) : (
-        <ResultPanel report={report} />
+        <ResultPanel
+          report={report}
+          visibleFindingCount={visibleFindingCount}
+          activeFindingIndex={activeFindingIndex}
+        />
       )}
 
       <section
@@ -889,6 +1128,47 @@ evidence ${report.evidenceDirectory}`
           {error}
         </div>
       ) : null}
+      <style>{`
+        @keyframes kf-lab-line-enter {
+          from { opacity: 0; transform: translateY(7px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes kf-lab-pulse {
+          0%, 100% { opacity: 0.55; }
+          50% { opacity: 1; }
+        }
+        @keyframes kf-lab-verdict-emphasis {
+          0% { transform: scale(0.985); box-shadow: 0 0 0 rgba(78, 201, 176, 0); }
+          45% { transform: scale(1.015); box-shadow: 0 0 22px rgba(78, 201, 176, 0.28); }
+          100% { transform: scale(1); box-shadow: 0 0 0 rgba(78, 201, 176, 0); }
+        }
+        .kf-lab-event-line,
+        .kf-lab-result-enter,
+        .kf-lab-verdict-card {
+          animation: kf-lab-line-enter 280ms ease-out both;
+        }
+        .kf-lab-running-badge,
+        .kf-lab-live-dots,
+        .kf-lab-handoff-active {
+          animation: kf-lab-pulse 1.15s ease-in-out infinite;
+        }
+        .kf-lab-verdict-focus {
+          border-color: #4ec9b0 !important;
+          animation: kf-lab-verdict-emphasis 520ms ease-out both;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .kf-lab-event-line,
+          .kf-lab-result-enter,
+          .kf-lab-verdict-card,
+          .kf-lab-running-badge,
+          .kf-lab-live-dots,
+          .kf-lab-handoff-active,
+          .kf-lab-verdict-focus {
+            animation-duration: 1ms !important;
+            animation-iteration-count: 1 !important;
+          }
+        }
+      `}</style>
     </section>
   );
 }

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -171,6 +171,29 @@ export function openRendererQualificationLab(): QualificationLab {
       options: ExecOptions,
       callback: (error: Error | null, stdout: string, stderr: string) => void,
     ) => void;
+    spawn: (
+      file: string,
+      args: string[],
+      options: {
+        env: Record<string, string | undefined>;
+        stdio: ['ignore', 'pipe', 'pipe'];
+      },
+    ) => {
+      stdout: {
+        on: (event: 'data', listener: (chunk: unknown) => void) => void;
+      };
+      stderr: {
+        on: (event: 'data', listener: (chunk: unknown) => void) => void;
+      };
+      once: {
+        (event: 'error', listener: (error: Error) => void): void;
+        (
+          event: 'close',
+          listener: (code: number | null, signal: string | null) => void,
+        ): void;
+      };
+      kill: () => void;
+    };
   };
   const bindingPath = env.KFE_PATH || '';
   const bin =
@@ -191,6 +214,70 @@ export function openRendererQualificationLab(): QualificationLab {
         childProcess.execFile(file, args, options, (error, stdout, stderr) => {
           if (error) reject(new Error(stderr.trim() || error.message));
           else resolve(stdout);
+        });
+      }),
+    execFileEvents: (file, args, options, onLine) =>
+      new Promise<void>((resolve, reject) => {
+        const child = childProcess.spawn(file, args, {
+          env: options.env,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdoutBuffer = '';
+        let stderr = '';
+        let outputSize = 0;
+        let settled = false;
+        const fail = (error: Error) => {
+          if (settled) return;
+          settled = true;
+          child.kill();
+          reject(error);
+        };
+        const emitLine = (line: string) => {
+          if (!line.trim()) return true;
+          try {
+            onLine(line);
+            return true;
+          } catch (reason) {
+            fail(
+              reason instanceof Error
+                ? reason
+                : new Error(`invalid qualification event: ${String(reason)}`),
+            );
+            return false;
+          }
+        };
+        child.stdout.on('data', (chunk) => {
+          const text = String(chunk);
+          outputSize += text.length;
+          if (outputSize > options.maxBuffer) {
+            fail(new Error('qualification event stream exceeded maxBuffer'));
+            return;
+          }
+          stdoutBuffer += text;
+          const lines = stdoutBuffer.split(/\r?\n/);
+          stdoutBuffer = lines.pop() ?? '';
+          for (const line of lines) {
+            if (!emitLine(line)) return;
+          }
+        });
+        child.stderr.on('data', (chunk) => {
+          stderr += String(chunk);
+        });
+        child.once('error', fail);
+        child.once('close', (code, signal) => {
+          if (settled) return;
+          if (!emitLine(stdoutBuffer)) return;
+          if (code !== 0) {
+            fail(
+              new Error(
+                stderr.trim() ||
+                  `qualification event stream exited ${code ?? signal ?? 'unknown'}`,
+              ),
+            );
+            return;
+          }
+          settled = true;
+          resolve();
         });
       }),
   });


### PR DESCRIPTION
## Summary

Make Agent Qualification Lab feel live without fabricating progress. Core now publishes real qualification milestones as each boundary completes, CLI/API/GUI stream the same events, the two session columns reveal command-like safe output progressively, and the final assessment emphasizes each verdict in sequence.

## Related issue

Native Assignment `2026-07-26-kungfu-unified-ui-agent-qualification-entry` follow-up.

## Changes

- Publish plan, session start/completion, and assessment milestones directly from the Core demo and real-agent execution paths.
- Stream newline-delimited qualification events through CLI, TypeScript capability API, and the Electron renderer process instead of waiting for an atomic stdout buffer.
- Pace the two visual session streams from real events, keep the fresh-session handoff visible, and never expose raw provider output.
- Reveal final oracle checks, residuals, and value statements one at a time with focused pass/fail/warning emphasis.
- Respect reduced-motion preferences while preserving ordered state transitions.
- Fix the source CLI bootstrap guard so the two fresh demo processes run correctly under macOS/Python spawn semantics.
- Add Core, API, and GUI regression coverage for event order, report parity, safe rendering, animation, and fallback behavior.

## Verification

- `./shifu check:source` in a clean review worktree: passed; 636 Node tests passed, 10 environment-gated skips, 0 failures, plus Python, TypeScript, ruff, mypy, and source gates.
- `./shifu test:kfx-profile-suite`: passed, including 7 Agent Qualification Lab visual-contract tests.
- `./shifu --filter @kungfu-tech/core exec env PYTHONPATH=src/python:build/Release uv run --frozen pytest -q tests/python/test_qualification_lab.py`: 8 passed.
- `./shifu --filter @kungfu-tech/api test:query`: 29 passed.
- `./shifu --filter @kungfu-tech/gui build`: production Electron build passed.
- `./shifu --filter @kungfu-tech/core dev:kungfu qualification-lab demo --events-json`: emitted six ordered live milestones followed by the canonical qualified report.
- Staged repository gates and DCO hooks passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Bugfix and progressive presentation over the existing Agent Qualification Lab authority; no new product authority, schema ownership, release policy, or architecture contract is introduced."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Focused tests, clean source acceptance, and production GUI build passed
- [x] Documentation impact is contained in self-explanatory product UI copy
