### PR TITLE
fix(ci): pin cargo-aware gate workflow

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9
     with:
       # Resolve the last workflow/runtime pair proven by an actual dev patrol.
       # Trusted manual runs may still supply an exact SHA or train ref. Checkout

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1349,7 +1349,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:e381e8979a2ced342f7d0c964cd7d31ede302c0b59c1190aeb65623d9a55fc1c",
+          "definitionDigest": "sha256:b7e1eb0ab300f3479d829baa352bf7a17d82347cf45152ea7ccd8f854c2c84a9",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1358,7 +1358,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824"
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9"
           ],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -321,7 +321,7 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9",
         "with": {
           "buildchain-ref": "${{ inputs.buildchain-ref || 'v2' }}",
           "checkout-cache-fallback": "github",

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -953,7 +953,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@f2bc5bfdcba495e78460ceb9f5556e5ccbf91824',
+        '.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9',
         '.gate-profile.yml@v2-alpha',
       ),
   );


### PR DESCRIPTION
## Summary

Pin the dev Patrol Gate profile to the merged Buildchain revision that exposes user Cargo toolchains on Windows and POSIX runners. This lets source-fresh Shifu bootstrap use the runner's installed Rust toolchain instead of falling back to a missing prebuilt release.

## Related issue

- Closes #1516 after the next fully green three-platform Patrol
- Upstream: kungfu-systems/buildchain#1890

## Changes

- pin the reusable Gate workflow to Buildchain `619c3a3c786038e3a72394eb68d2e2a6e0455ff9`
- refresh the closed-world workflow binding and authority projection
- update the drift fixture to enforce the new exact SHA

## Verification

- `./shifu check:gate-catalog`
- `./shifu check:source`
- Buildchain workflow fixtures and Windows x64 job: https://github.com/kungfu-systems/buildchain/actions/runs/30200047293

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance fix updates an exact reusable-workflow pin and its generated authority projection without changing an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The exact reusable-workflow SHA is covered by the Gate catalog, source acceptance, and the upstream Buildchain Windows fixture.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed