### PR TITLE
fix(ci): pin complete v3 gate workflow

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2
     with:
       # Resolve the last workflow/runtime pair proven by an actual dev patrol.
       # Trusted manual runs may still supply an exact SHA or train ref. Checkout

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1349,7 +1349,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:b7e1eb0ab300f3479d829baa352bf7a17d82347cf45152ea7ccd8f854c2c84a9",
+          "definitionDigest": "sha256:725e41fa43351529f2c2582229b3866f4048bdc9e0e3a25a39098b05a351b9ad",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1358,7 +1358,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9"
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2"
           ],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -321,7 +321,7 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2",
         "with": {
           "buildchain-ref": "${{ inputs.buildchain-ref || 'v2' }}",
           "checkout-cache-fallback": "github",

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -953,7 +953,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@619c3a3c786038e3a72394eb68d2e2a6e0455ff9',
+        '.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2',
         '.gate-profile.yml@v2-alpha',
       ),
   );


### PR DESCRIPTION
## Summary

Pin the dev Patrol to the complete Buildchain v3 Gate workflow that combines locked checkout/cache fallback with runner Cargo PATH exposure. This replaces the incomplete v3 SHA that failed workflow startup before any platform job could run.

## Related issue

- #1516
- Upstream: kungfu-systems/buildchain#1894

## Changes

- pin the reusable Gate workflow to Buildchain `a9e1826da969dc0932fdd9c5668a1c6363267ae2`
- refresh the closed-world workflow binding and authority projection
- update the drift fixture to enforce the complete v3 SHA

## Verification

- `./shifu check:gate-catalog`
- `./shifu check:source`
- upstream Buildchain complete check (860 tests) and merge-group: https://github.com/kungfu-systems/buildchain/actions/runs/30201397854
- reproduced predecessor startup failure: https://github.com/kungfu-systems/kungfu/actions/runs/30201044580

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance fix updates an exact reusable-workflow pin and its generated authority projection without changing an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The exact reusable-workflow SHA is covered by the Gate catalog, source acceptance, and the upstream v3 merge-group.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed