### PR TITLE
fix(gui): render qualification sessions as live transcripts

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "273b63620842126711d1faccd10430030455ea562ccf2be1a6cea11fc0a54428"
+    "sha256": "711c6bcad50f533001d4accdc51d333afd31da31db6ff8703c02d9873f21c775"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -214,18 +214,52 @@
   "metadata": {
     "kfdPackage": {
       "name": "@kungfu-tech/kfd",
-      "version": "1.0.0-alpha.21",
+      "version": "1.0.0-alpha.41",
       "repository": "git+https://github.com/kungfu-systems/kfd.git"
     },
     "schemaIds": {
       "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
       "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-      "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+      "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+      "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+      "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+      "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+      "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+      "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+      "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+      "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+      "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+      "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+      "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+      "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+      "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+      "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+      "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+      "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+      "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+      "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
     },
     "schemaPaths": {
       "metadata": "schemas/kfd-standards.schema.json",
       "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-      "witness": "schemas/kfd-1/witness.schema.json"
+      "witness": "schemas/kfd-1/witness.schema.json",
+      "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+      "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+      "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+      "verificationReport": "schemas/kfd-verification-report.schema.json",
+      "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+      "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+      "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+      "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+      "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+      "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+      "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+      "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+      "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+      "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+      "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+      "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+      "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
     }
   }
 }

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -15,30 +15,64 @@
       "key": "kfd-1",
       "id": "KFD-1",
       "label": "KFD-1",
-      "title": "Facts must not drift: contract worlds need one fact source",
-      "revision": 1,
+      "title": "Facts must not drift",
+      "revision": 6,
       "status": "active"
     },
     "schemas": {
       "ids": {
         "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
         "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
       },
       "paths": {
         "metadata": "schemas/kfd-standards.schema.json",
         "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-        "witness": "schemas/kfd-1/witness.schema.json"
+        "witness": "schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
       },
       "metadata": {
         "id": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
         "path": "schemas/kfd-standards.schema.json",
-        "version": "1"
+        "version": "2"
       }
     },
     "package": {
       "name": "@kungfu-tech/kfd",
-      "version": "1.0.0-alpha.21",
+      "version": "1.0.0-alpha.41",
       "repository": "git+https://github.com/kungfu-systems/kfd.git"
     }
   },
@@ -54,7 +88,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "9aaf10fa06f4018e466032dd702a5fb2ba3c8106a5218c1040b3b72a1acf2850",
+      "preBuildWitnessSha256": "d42a2ca6a38539bb0352853a856741f0d34433ca2b924a188775cfe6b9e444bc",
       "sourceHashes": {
         "sha256": "51b449982cbde9d1dde73db9f3ea9a7a6817036ba1fe741481c0894a3e254af8",
         "surfaceCount": 21
@@ -100,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "273b63620842126711d1faccd10430030455ea562ccf2be1a6cea11fc0a54428"
+          "sha256": "711c6bcad50f533001d4accdc51d333afd31da31db6ff8703c02d9873f21c775"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -279,18 +313,52 @@
         "metadata": {
           "kfdPackage": {
             "name": "@kungfu-tech/kfd",
-            "version": "1.0.0-alpha.21",
+            "version": "1.0.0-alpha.41",
             "repository": "git+https://github.com/kungfu-systems/kfd.git"
           },
           "schemaIds": {
             "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
             "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-            "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+            "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+            "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+            "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+            "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+            "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+            "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+            "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+            "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+            "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+            "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+            "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+            "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+            "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+            "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+            "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+            "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+            "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+            "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
           },
           "schemaPaths": {
             "metadata": "schemas/kfd-standards.schema.json",
             "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-            "witness": "schemas/kfd-1/witness.schema.json"
+            "witness": "schemas/kfd-1/witness.schema.json",
+            "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+            "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+            "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+            "verificationReport": "schemas/kfd-verification-report.schema.json",
+            "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+            "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+            "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+            "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+            "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+            "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+            "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+            "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+            "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+            "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+            "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+            "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+            "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
           }
         }
       },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "c033e8af1811a3aadd181a6c743b3cac6094f404",
+    "sourceSha": "25098eb81a2ffe8865b9add8a311cd7a937c1561",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:1b6eec071960b48620558bf12e0366f496296caecfbbf73e696883c0b191b379"
   },

--- a/config/kungfu-agent-first-canonical-policy.json
+++ b/config/kungfu-agent-first-canonical-policy.json
@@ -489,13 +489,13 @@
       },
       "source": {
         "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
-        "sha256": "sha256:7bff0854dd9f3dad490e5c5a86f98735b6f8e35f63a7872c50a2a94be38a4c31",
-        "renderedSha256": "sha256:7bff0854dd9f3dad490e5c5a86f98735b6f8e35f63a7872c50a2a94be38a4c31",
+        "sha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
+        "renderedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/primitive/kungfu-primitive-catalog.contract.json",
-        "expectedSha256": "sha256:7bff0854dd9f3dad490e5c5a86f98735b6f8e35f63a7872c50a2a94be38a4c31"
+        "expectedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509"
       }
     }
   ]

--- a/config/kungfu-agent-first-canonical-policy.json
+++ b/config/kungfu-agent-first-canonical-policy.json
@@ -6,26 +6,60 @@
     "kfd": {
       "package": {
         "name": "@kungfu-tech/kfd",
-        "version": "1.0.0-alpha.21",
+        "version": "1.0.0-alpha.41",
         "repository": "git+https://github.com/kungfu-systems/kfd.git"
       },
       "standard": {
         "key": "kfd-1",
         "id": "KFD-1",
         "label": "KFD-1",
-        "title": "Facts must not drift: contract worlds need one fact source",
-        "revision": 1,
+        "title": "Facts must not drift",
+        "revision": 6,
         "status": "active"
       },
       "schemaIds": {
         "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
         "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
       },
       "schemaPaths": {
         "metadata": "schemas/kfd-standards.schema.json",
         "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-        "witness": "schemas/kfd-1/witness.schema.json"
+        "witness": "schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
       }
     },
     "buildchain": {

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "273b63620842126711d1faccd10430030455ea562ccf2be1a6cea11fc0a54428"
+    "sha256": "711c6bcad50f533001d4accdc51d333afd31da31db6ff8703c02d9873f21c775"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -214,18 +214,52 @@
   "metadata": {
     "kfdPackage": {
       "name": "@kungfu-tech/kfd",
-      "version": "1.0.0-alpha.21",
+      "version": "1.0.0-alpha.41",
       "repository": "git+https://github.com/kungfu-systems/kfd.git"
     },
     "schemaIds": {
       "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
       "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-      "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+      "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+      "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+      "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+      "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+      "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+      "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+      "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+      "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+      "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+      "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+      "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+      "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+      "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+      "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+      "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+      "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+      "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+      "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
     },
     "schemaPaths": {
       "metadata": "schemas/kfd-standards.schema.json",
       "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-      "witness": "schemas/kfd-1/witness.schema.json"
+      "witness": "schemas/kfd-1/witness.schema.json",
+      "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+      "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+      "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+      "verificationReport": "schemas/kfd-verification-report.schema.json",
+      "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+      "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+      "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+      "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+      "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+      "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+      "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+      "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+      "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+      "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+      "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+      "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+      "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
     }
   }
 }

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -15,30 +15,64 @@
       "key": "kfd-1",
       "id": "KFD-1",
       "label": "KFD-1",
-      "title": "Facts must not drift: contract worlds need one fact source",
-      "revision": 1,
+      "title": "Facts must not drift",
+      "revision": 6,
       "status": "active"
     },
     "schemas": {
       "ids": {
         "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
         "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
       },
       "paths": {
         "metadata": "schemas/kfd-standards.schema.json",
         "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-        "witness": "schemas/kfd-1/witness.schema.json"
+        "witness": "schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
       },
       "metadata": {
         "id": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
         "path": "schemas/kfd-standards.schema.json",
-        "version": "1"
+        "version": "2"
       }
     },
     "package": {
       "name": "@kungfu-tech/kfd",
-      "version": "1.0.0-alpha.21",
+      "version": "1.0.0-alpha.41",
       "repository": "git+https://github.com/kungfu-systems/kfd.git"
     }
   },
@@ -54,7 +88,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "9aaf10fa06f4018e466032dd702a5fb2ba3c8106a5218c1040b3b72a1acf2850",
+      "preBuildWitnessSha256": "d42a2ca6a38539bb0352853a856741f0d34433ca2b924a188775cfe6b9e444bc",
       "sourceHashes": {
         "sha256": "51b449982cbde9d1dde73db9f3ea9a7a6817036ba1fe741481c0894a3e254af8",
         "surfaceCount": 21
@@ -100,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "273b63620842126711d1faccd10430030455ea562ccf2be1a6cea11fc0a54428"
+          "sha256": "711c6bcad50f533001d4accdc51d333afd31da31db6ff8703c02d9873f21c775"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -279,18 +313,52 @@
         "metadata": {
           "kfdPackage": {
             "name": "@kungfu-tech/kfd",
-            "version": "1.0.0-alpha.21",
+            "version": "1.0.0-alpha.41",
             "repository": "git+https://github.com/kungfu-systems/kfd.git"
           },
           "schemaIds": {
             "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
             "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-            "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+            "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+            "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+            "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+            "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+            "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+            "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+            "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+            "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+            "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+            "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+            "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+            "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+            "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+            "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+            "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+            "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+            "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+            "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
           },
           "schemaPaths": {
             "metadata": "schemas/kfd-standards.schema.json",
             "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-            "witness": "schemas/kfd-1/witness.schema.json"
+            "witness": "schemas/kfd-1/witness.schema.json",
+            "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+            "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+            "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+            "verificationReport": "schemas/kfd-verification-report.schema.json",
+            "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+            "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+            "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+            "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+            "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+            "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+            "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+            "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+            "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+            "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+            "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+            "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+            "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
           }
         }
       },

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -489,13 +489,13 @@
       },
       "source": {
         "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
-        "sha256": "sha256:7bff0854dd9f3dad490e5c5a86f98735b6f8e35f63a7872c50a2a94be38a4c31",
-        "renderedSha256": "sha256:7bff0854dd9f3dad490e5c5a86f98735b6f8e35f63a7872c50a2a94be38a4c31",
+        "sha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
+        "renderedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/primitive/kungfu-primitive-catalog.contract.json",
-        "expectedSha256": "sha256:7bff0854dd9f3dad490e5c5a86f98735b6f8e35f63a7872c50a2a94be38a4c31"
+        "expectedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509"
       }
     }
   ]

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -6,26 +6,60 @@
     "kfd": {
       "package": {
         "name": "@kungfu-tech/kfd",
-        "version": "1.0.0-alpha.21",
+        "version": "1.0.0-alpha.41",
         "repository": "git+https://github.com/kungfu-systems/kfd.git"
       },
       "standard": {
         "key": "kfd-1",
         "id": "KFD-1",
         "label": "KFD-1",
-        "title": "Facts must not drift: contract worlds need one fact source",
-        "revision": 1,
+        "title": "Facts must not drift",
+        "revision": 6,
         "status": "active"
       },
       "schemaIds": {
         "metadata": "https://kfd.libkungfu.dev/schemas/kfd-standards.schema.json",
         "contractWorld": "https://kfd.libkungfu.dev/schemas/kfd-1/contract-world.schema.json",
-        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json"
+        "witness": "https://kfd.libkungfu.dev/schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "https://kfd.libkungfu.dev/schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "https://kfd.libkungfu.dev/schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "https://kfd.libkungfu.dev/schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "https://kfd.libkungfu.dev/schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "https://kfd.libkungfu.dev/schemas/kfd-agent-runtime/report.schema.json"
       },
       "schemaPaths": {
         "metadata": "schemas/kfd-standards.schema.json",
         "contractWorld": "schemas/kfd-1/contract-world.schema.json",
-        "witness": "schemas/kfd-1/witness.schema.json"
+        "witness": "schemas/kfd-1/witness.schema.json",
+        "publicationUrlSemantics": "schemas/kfd-1/publication-url-semantics.schema.json",
+        "candidateRegistry": "schemas/kfd-candidate-registry.schema.json",
+        "verificationBundle": "schemas/kfd-verification-bundle.schema.json",
+        "verificationReport": "schemas/kfd-verification-report.schema.json",
+        "agentHubManifest": "schemas/kfd-agent-hub/manifest.schema.json",
+        "agentHubCapabilities": "schemas/kfd-agent-hub/capabilities.schema.json",
+        "agentHubExchange": "schemas/kfd-agent-hub/exchange.schema.json",
+        "agentHubConformanceManifest": "schemas/kfd-agent-hub/conformance-manifest.schema.json",
+        "agentHubAdapterRequest": "schemas/kfd-agent-hub/adapter-request.schema.json",
+        "agentHubAdapterResponse": "schemas/kfd-agent-hub/adapter-response.schema.json",
+        "agentHubSuite": "schemas/kfd-agent-hub/suite.schema.json",
+        "agentHubReport": "schemas/kfd-agent-hub/report.schema.json",
+        "agentRuntimeManifest": "schemas/kfd-agent-runtime/manifest.schema.json",
+        "agentRuntimeAdapterRequest": "schemas/kfd-agent-runtime/adapter-request.schema.json",
+        "agentRuntimeAdapterResponse": "schemas/kfd-agent-runtime/adapter-response.schema.json",
+        "agentRuntimeSuite": "schemas/kfd-agent-runtime/suite.schema.json",
+        "agentRuntimeReport": "schemas/kfd-agent-runtime/report.schema.json"
       }
     },
     "buildchain": {

--- a/framework/gui/src/qualification-lab.test.ts
+++ b/framework/gui/src/qualification-lab.test.ts
@@ -9,7 +9,7 @@ import {
   QUALIFICATION_PLAYBACK_TIMING,
   qualificationBehaviorFindings,
   qualificationModeNeeds,
-  qualificationPlaybackLine,
+  qualificationPlaybackLines,
   qualificationSessionStories,
 } from './renderer/src/qualification-lab';
 
@@ -102,21 +102,33 @@ test('canonical oracle failures and residuals stay visually distinct', () => {
   );
 });
 
-test('safe runtime events map to incremental command-like output', () => {
-  const line = qualificationPlaybackLine({
+test('canonical runtime events expand into public terminal activity', () => {
+  const event = {
     schema: 'kungfu.qualification-lab.event/v1',
     step: 'session-2-start',
     status: 'running',
     root: `sha256:${'a'.repeat(64)}`,
-  });
+  } as const;
+  const lines = qualificationPlaybackLines(event);
 
-  assert.equal(line.status, 'running');
-  assert.match(line.command, /launch session 2/);
-  assert.match(line.detail, /not interpreting raw terminal text/);
-  assert.ok(
-    QUALIFICATION_PLAYBACK_TIMING.eventDelayMs <
-      QUALIFICATION_PLAYBACK_TIMING.verdictDelayMs,
+  assert.deepEqual(
+    lines.map(({ session, kind }) => ({ session, kind })),
+    [
+      { session: 2, kind: 'user' },
+      { session: 2, kind: 'agent' },
+      { session: 2, kind: 'tool' },
+    ],
   );
+  assert.equal(lines[0]?.kind, 'user');
+  assert.match(lines[1]?.command ?? '', /inspect governed state/);
+  assert.match(lines[1]?.detail ?? '', /private reasoning remains hidden/);
+  assert.match(lines[2]?.command ?? '', /spawn_provider/);
+  assert.match(
+    lines[2]?.detail ?? '',
+    /instead of treating terminal text as proof/,
+  );
+  assert.equal(QUALIFICATION_PLAYBACK_TIMING.eventDelayMs, 1000);
+  assert.equal(QUALIFICATION_PLAYBACK_TIMING.verdictDelayMs, 520);
 });
 
 test('the shell keeps navigation outside the Lab content branch', () => {
@@ -145,9 +157,12 @@ test('the visual contract is accessible and remains a responsive two-column comp
   assert.match(source, /aria-label="Session 2 agent"/);
   assert.match(source, /<output[\s\S]*aria-label=\{meta\.label\}/);
   assert.match(source, /repeat\(auto-fit, minmax\(min\(100%, 360px\), 1fr\)\)/);
-  assert.match(source, /SAFE EVENT STREAM/);
+  assert.match(source, /PUBLIC ACTIVITY TRANSCRIPT/);
+  assert.match(source, /PRIVATE REASONING HIDDEN/);
+  assert.match(source, /RAW PROVIDER OUTPUT REDACTED/);
   assert.match(source, /lab\.runDemo\(receiveEvent\)/);
   assert.match(source, /lab\.runAgent\(selectedAgent, receiveEvent\)/);
+  assert.match(source, /setVisiblePlaybackLines/);
   assert.match(source, /kf-lab-verdict-focus/);
   assert.match(source, /prefers-reduced-motion: reduce/);
 });

--- a/framework/gui/src/renderer/src/qualification-lab.tsx
+++ b/framework/gui/src/renderer/src/qualification-lab.tsx
@@ -40,13 +40,15 @@ type BehaviorFinding = {
 };
 
 type PlaybackLine = {
+  session: 1 | 2;
+  kind: 'system' | 'user' | 'agent' | 'tool' | 'output';
   status: VisualStatus;
   command: string;
   detail: string;
 };
 
 export const QUALIFICATION_PLAYBACK_TIMING = {
-  eventDelayMs: 360,
+  eventDelayMs: 1000,
   verdictDelayMs: 520,
   reducedMotionDelayMs: 24,
 } as const;
@@ -118,6 +120,17 @@ const STATUS_META: Record<
   },
 };
 
+const PLAYBACK_KIND_META: Record<
+  PlaybackLine['kind'],
+  { label: string; color: string; prompt: string }
+> = {
+  system: { label: 'system', color: '#9cdcfe', prompt: '◆' },
+  user: { label: 'user', color: '#ce9178', prompt: '❯' },
+  agent: { label: 'agent/public', color: '#4ec9b0', prompt: '▸' },
+  tool: { label: 'tool', color: '#dcdcaa', prompt: '⚙' },
+  output: { label: 'output', color: '#b5cea8', prompt: '←' },
+};
+
 const CHECK_COPY: Record<string, { title: string; detail: string }> = {
   'two-distinct-fresh-processes': {
     title: 'The two sessions were genuinely fresh',
@@ -181,49 +194,154 @@ function eventStatus(
   return event ? 'warning' : 'waiting';
 }
 
-export function qualificationPlaybackLine(
+export function qualificationPlaybackLines(
   event: QualificationLabEvent,
-): PlaybackLine {
+): PlaybackLine[] {
+  if (event.step === 'plan') {
+    return [
+      {
+        session: 1,
+        kind: 'system',
+        status: 'ready',
+        command: 'governed two-session plan ready',
+        detail: `One task identity was sealed before either provider started · ${shortRoot(event.root)}`,
+      },
+    ];
+  }
   if (event.step.endsWith('-start')) {
-    const session = event.step.includes('session-1')
-      ? 'Session 1'
-      : 'Session 2';
-    return {
-      status: 'running',
-      command: `$ launch ${session.toLowerCase()} as a fresh process`,
-      detail:
-        'The provider process is active. Kungfu is waiting for a governed state observation, not interpreting raw terminal text.',
-    };
+    const session = event.step.includes('session-1') ? 1 : 2;
+    return [
+      {
+        session,
+        kind: 'user',
+        status: 'ready',
+        command:
+          session === 1
+            ? 'Begin the bounded task. Leave a governed partial result, then stop.'
+            : 'Continue this task from Kungfu state. No prior chat is available.',
+        detail:
+          session === 1
+            ? 'The first process receives the qualification task.'
+            : 'The fresh process receives the same task identity, not Session 1 conversation.',
+      },
+      {
+        session,
+        kind: 'agent',
+        status: 'running',
+        command:
+          session === 1
+            ? 'I’ll make bounded progress and leave evidence for a fresh session.'
+            : 'I’ll inspect governed state first, then continue only unfinished work.',
+        detail:
+          'Public progress narration projected from the canonical action boundary; private reasoning remains hidden.',
+      },
+      {
+        session,
+        kind: 'tool',
+        status: 'running',
+        command: `spawn_provider(session=${session}, fresh_process=true)`,
+        detail:
+          'The provider process is active. Kungfu waits for governed state evidence instead of treating terminal text as proof.',
+      },
+    ];
   }
   if (event.step === 'session-1') {
-    return {
-      status: eventStatus([event], 1),
-      command: 'observe session-1 → partial state sealed',
-      detail: `A bounded result was recorded · ${shortRoot(event.root)}`,
-    };
+    const status = eventStatus([event], 1);
+    return [
+      {
+        session: 1,
+        kind: 'tool',
+        status,
+        command: 'read_governed_state(session=1)',
+        detail: 'Kungfu observes the fixture state after the provider exits.',
+      },
+      {
+        session: 1,
+        kind: 'output',
+        status,
+        command: `status=${event.status}`,
+        detail: `Bounded state evidence · ${shortRoot(event.root)}`,
+      },
+      {
+        session: 1,
+        kind: 'agent',
+        status,
+        command:
+          status === 'correct'
+            ? 'Partial work is recorded. I’m stopping so a fresh session must continue.'
+            : 'The expected partial handoff state was not proved.',
+        detail:
+          'This is the public completion summary for Session 1, not hidden model reasoning.',
+      },
+    ];
   }
   if (event.step === 'session-2') {
-    return {
-      status: eventStatus([event], 2),
-      command: 'observe session-2 → continuation verified',
-      detail: `The fresh process continued the governed state · ${shortRoot(event.root)}`,
-    };
+    const status = eventStatus([event], 2);
+    return [
+      {
+        session: 2,
+        kind: 'tool',
+        status,
+        command: 'read_governed_state(session=2)',
+        detail:
+          'Kungfu checks the same Work identity and the final ordered state.',
+      },
+      {
+        session: 2,
+        kind: 'output',
+        status,
+        command: `status=${event.status}`,
+        detail: `Fresh-process continuation evidence · ${shortRoot(event.root)}`,
+      },
+      {
+        session: 2,
+        kind: 'agent',
+        status,
+        command:
+          status === 'correct'
+            ? 'I found the prior partial result and completed only the remaining work.'
+            : 'I could not prove a correct continuation from the recorded state.',
+        detail:
+          'This is the public completion summary for Session 2, not hidden model reasoning.',
+      },
+    ];
   }
-  return {
-    status:
-      event.status === 'failed'
-        ? 'undesirable'
-        : event.step === 'assessment'
-          ? event.status === 'qualified-with-residuals'
-            ? 'warning'
-            : 'correct'
-          : 'ready',
-    command:
-      event.step === 'assessment'
-        ? 'assess canonical oracle checks'
-        : 'prepare bounded two-session plan',
-    detail: `${event.status} · ${shortRoot(event.root)}`,
-  };
+  const status =
+    event.status === 'failed'
+      ? 'undesirable'
+      : event.step === 'assessment'
+        ? event.status === 'qualified-with-residuals'
+          ? 'warning'
+          : 'correct'
+        : 'ready';
+  if (event.step === 'assessment') {
+    return [
+      {
+        session: 2,
+        kind: 'tool',
+        status,
+        command: 'run_continuity_oracle()',
+        detail:
+          'The canonical checks compare process identity, governed state, and expected completion.',
+      },
+      {
+        session: 2,
+        kind: 'output',
+        status,
+        command: `qualification=${event.status}`,
+        detail: `Assessment proof · ${shortRoot(event.root)}`,
+      },
+    ];
+  }
+  return [
+    {
+      session: 1,
+      kind: 'system',
+      status,
+      command: event.step,
+      detail: `${event.status} · ${shortRoot(event.root)}`,
+    },
+  ];
 }
 
 export function qualificationModeNeeds(mode: QualificationMode): {
@@ -400,17 +518,15 @@ function StatusBadge({ status }: { status: VisualStatus }) {
 function SessionColumn({
   story,
   session,
-  events,
+  lines,
   running,
 }: {
   story: SessionStory;
   session: 1 | 2;
-  events: QualificationLabEvent[];
+  lines: PlaybackLine[];
   running: boolean;
 }) {
-  const sessionEvents = events.filter((event) =>
-    event.step.startsWith(`session-${session}`),
-  );
+  const sessionLines = lines.filter((line) => line.session === session);
   return (
     <article
       style={{
@@ -427,58 +543,101 @@ function SessionColumn({
       <h2 style={{ margin: '6px 0 16px', fontSize: 19 }}>{story.subtitle}</h2>
       <div
         aria-live="polite"
-        aria-label={`${story.title} live event stream`}
+        aria-label={`${story.title} public activity transcript`}
         style={{
           ...mono,
-          minHeight: 96,
+          minHeight: 260,
           marginBottom: 16,
-          padding: 12,
+          overflow: 'hidden',
           borderRadius: 6,
-          background: '#0f1112',
-          border: '1px solid #2f3638',
+          background: '#090b0c',
+          border: '1px solid #343a3d',
           fontSize: 11,
           lineHeight: 1.45,
         }}
       >
-        <div style={{ color: '#6fa8bd', marginBottom: 8 }}>
-          SAFE EVENT STREAM
-          {running && !sessionEvents.length ? (
-            <span className="kf-lab-live-dots"> · waiting</span>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 7,
+            padding: '8px 10px',
+            color: '#858585',
+            background: '#17191a',
+            borderBottom: '1px solid #2b3032',
+          }}
+        >
+          <span style={{ color: '#f48771' }}>●</span>
+          <span style={{ color: '#d7ba7d' }}>●</span>
+          <span style={{ color: '#4ec9b0' }}>●</span>
+          <span style={{ marginLeft: 5 }}>
+            agent@qualification-lab · session-{session}
+          </span>
+          {running ? (
+            <span className="kf-lab-live-dots" style={{ marginLeft: 'auto' }}>
+              live
+            </span>
           ) : null}
         </div>
-        {sessionEvents.length ? (
-          sessionEvents.map((event, index) => {
-            const line = qualificationPlaybackLine(event);
-            return (
-              <div
-                className="kf-lab-event-line"
-                key={`${event.step}-${event.status}-${index}`}
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'auto minmax(0, 1fr)',
-                  gap: 8,
-                  marginTop: index ? 9 : 0,
-                }}
-              >
-                <span style={{ color: STATUS_META[line.status].color }}>
-                  {STATUS_META[line.status].icon}
-                </span>
-                <div>
-                  <div style={{ color: '#d7d7d7' }}>{line.command}</div>
-                  <div style={{ color: '#858585', marginTop: 2 }}>
-                    {line.detail}
+        <div style={{ padding: 12 }}>
+          <div style={{ color: '#6fa8bd', marginBottom: 10 }}>
+            PUBLIC ACTIVITY TRANSCRIPT
+          </div>
+          {sessionLines.length ? (
+            sessionLines.map((line, index) => {
+              const kind = PLAYBACK_KIND_META[line.kind];
+              return (
+                <div
+                  className="kf-lab-event-line"
+                  key={`${line.kind}-${line.command}-${index}`}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '24px 72px minmax(0, 1fr)',
+                    gap: 7,
+                    marginTop: index ? 10 : 0,
+                    alignItems: 'start',
+                  }}
+                >
+                  <span style={{ color: '#555' }}>
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <span style={{ color: kind.color }}>
+                    {kind.prompt} {kind.label}
+                  </span>
+                  <div>
+                    <div style={{ color: STATUS_META[line.status].color }}>
+                      {line.command}
+                    </div>
+                    <div style={{ color: '#858585', marginTop: 2 }}>
+                      {line.detail}
+                    </div>
                   </div>
                 </div>
-              </div>
-            );
-          })
-        ) : (
-          <div style={{ color: '#666' }}>
-            {running
-              ? 'No safe milestone has been observed yet.'
-              : 'Events will appear here one command boundary at a time.'}
+              );
+            })
+          ) : (
+            <div style={{ color: '#666' }}>
+              {running
+                ? 'Waiting for the first canonical activity boundary…'
+                : 'Agent activity will appear here one line at a time.'}
+            </div>
+          )}
+          {running ? (
+            <div style={{ marginTop: 10, color: '#4ec9b0' }}>
+              <span className="kf-lab-terminal-cursor">▌</span>
+            </div>
+          ) : null}
+          <div
+            style={{
+              marginTop: 12,
+              paddingTop: 8,
+              color: '#626262',
+              borderTop: '1px solid #1f2324',
+            }}
+          >
+            PRIVATE REASONING HIDDEN · RAW PROVIDER OUTPUT REDACTED
           </div>
-        )}
+        </div>
       </div>
       <div style={{ display: 'grid', gap: 14 }}>
         {story.milestones.map((milestone) => (
@@ -675,6 +834,9 @@ export function QualificationLabPanel({
   const [visibleEvents, setVisibleEvents] = React.useState<
     QualificationLabEvent[]
   >([]);
+  const [visiblePlaybackLines, setVisiblePlaybackLines] = React.useState<
+    PlaybackLine[]
+  >([]);
   const [visibleFindingCount, setVisibleFindingCount] = React.useState(0);
   const [activeFindingIndex, setActiveFindingIndex] = React.useState(-1);
   const [busy, setBusy] = React.useState('');
@@ -717,6 +879,7 @@ export function QualificationLabPanel({
     setTargetPlan(null);
     setReport(null);
     setVisibleEvents([]);
+    setVisiblePlaybackLines([]);
     setVisibleFindingCount(0);
     setActiveFindingIndex(-1);
     setError('');
@@ -747,6 +910,7 @@ export function QualificationLabPanel({
     setBusy('run');
     setReport(null);
     setVisibleEvents([]);
+    setVisiblePlaybackLines([]);
     setVisibleFindingCount(0);
     setActiveFindingIndex(-1);
     const reducedMotion =
@@ -760,8 +924,13 @@ export function QualificationLabPanel({
       : QUALIFICATION_PLAYBACK_TIMING.verdictDelayMs;
     let playbackQueue = Promise.resolve();
     const receiveEvent = (event: QualificationLabEvent) => {
+      const lines = qualificationPlaybackLines(event);
       playbackQueue = playbackQueue.then(async () => {
-        await waitForPlayback(eventDelay);
+        for (const line of lines) {
+          await waitForPlayback(eventDelay);
+          if (playbackRunRef.current !== runId) return;
+          setVisiblePlaybackLines((current) => [...current, line]);
+        }
         if (playbackRunRef.current !== runId) return;
         setVisibleEvents((current) => [...current, event]);
       });
@@ -936,6 +1105,7 @@ export function QualificationLabPanel({
                   setTargetPlan(null);
                   setReport(null);
                   setVisibleEvents([]);
+                  setVisiblePlaybackLines([]);
                   setVisibleFindingCount(0);
                   setActiveFindingIndex(-1);
                 }}
@@ -964,6 +1134,7 @@ export function QualificationLabPanel({
                   setTargetPlan(null);
                   setReport(null);
                   setVisibleEvents([]);
+                  setVisiblePlaybackLines([]);
                   setVisibleFindingCount(0);
                   setActiveFindingIndex(-1);
                 }}
@@ -1022,13 +1193,13 @@ export function QualificationLabPanel({
           <SessionColumn
             story={sessionOne}
             session={1}
-            events={visibleEvents}
+            lines={visiblePlaybackLines}
             running={running}
           />
           <SessionColumn
             story={sessionTwo}
             session={2}
-            events={visibleEvents}
+            lines={visiblePlaybackLines}
             running={running}
           />
         </div>
@@ -1149,7 +1320,8 @@ evidence ${report.evidenceDirectory}`
         }
         .kf-lab-running-badge,
         .kf-lab-live-dots,
-        .kf-lab-handoff-active {
+        .kf-lab-handoff-active,
+        .kf-lab-terminal-cursor {
           animation: kf-lab-pulse 1.15s ease-in-out infinite;
         }
         .kf-lab-verdict-focus {
@@ -1163,6 +1335,7 @@ evidence ${report.evidenceDirectory}`
           .kf-lab-running-badge,
           .kf-lab-live-dots,
           .kf-lab-handoff-active,
+          .kf-lab-terminal-cursor,
           .kf-lab-verdict-focus {
             animation-duration: 1ms !important;
             animation-iteration-count: 1 !important;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.21
+  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.41
   node-gyp: ^13.0.0
   nx>axios: 1.18.1
   brace-expansion: 5.0.8
@@ -1451,8 +1451,9 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/kfd@1.0.0-alpha.21':
-    resolution: {integrity: sha512-lsr3aJ93pUaO9gxnGBsrTJkTkvpIHPHp9Rxug7WvdS4Zkte3AdFvyCl1DgwQN+/38FAXf8fBozyGkHxxXaN7Dg==}
+  '@kungfu-tech/kfd@1.0.0-alpha.41':
+    resolution: {integrity: sha512-e+iIuvsijDLSFotb3gPKqwn649lLGRX3xEWOwn7xfBeu8L8kvw5RPRznJ4xKVM+NYCrfYCRVmUzpJI58k97C+Q==}
+    hasBin: true
 
   '@kungfu-tech/kfd@1.0.0-alpha.47':
     resolution: {integrity: sha512-tFyFev5UKm2snujWB0FXwHkwLpKhWxmE16MPjn1zSyl0X/y7QTERG7oCL0TIBuMpKC20QnNi6r0oVKRawyQ7fA==}
@@ -5797,15 +5798,15 @@ snapshots:
 
   '@kungfu-tech/buildchain@3.0.0':
     dependencies:
-      '@kungfu-tech/kfd': 1.0.0-alpha.21
+      '@kungfu-tech/kfd': 1.0.0-alpha.41
       smol-toml: 1.7.0
 
   '@kungfu-tech/buildchain@3.0.1-alpha.2':
     dependencies:
-      '@kungfu-tech/kfd': 1.0.0-alpha.21
+      '@kungfu-tech/kfd': 1.0.0-alpha.41
       smol-toml: 1.7.0
 
-  '@kungfu-tech/kfd@1.0.0-alpha.21': {}
+  '@kungfu-tech/kfd@1.0.0-alpha.41': {}
 
   '@kungfu-tech/kfd@1.0.0-alpha.47': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,9 +24,9 @@ allowBuilds:
 # it ages past the cutoff, forcing a per-version allow-list. 0 = no minimum age.
 minimumReleaseAge: 0
 overrides:
-  # Keep Buildchain's KFD gate metadata aligned with the SDK-distributed KFD
-  # package so KFD-4 schema metadata is available to downstream Kungfu CLI users.
-  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.21
+  # Keep Buildchain's transitive KFD gate metadata aligned with the version its
+  # package declares; the SDK carries its newer direct KFD dependency separately.
+  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.41
   # node-gyp 9.x cannot detect Visual Studio 2026; 13.x adds VS2026 support, which
   # the Windows build needs to match the prebuilt (MSVC 19.5) conan dependencies.
   node-gyp: ^13.0.0


### PR DESCRIPTION
## Summary

Make Agent Qualification Lab read like two real, side-by-side agent terminals instead of a static scripted reveal. Public activity now advances one event per second, while verdict findings receive a sequential 520 ms emphasis after completion.

The transcript deliberately projects canonical action boundaries rather than exposing private chain-of-thought or unbounded provider stdout.

This branch also repairs two pre-existing mainline contract projections uncovered by the full build: the primitive policy root and the Buildchain 3.0.0 KFD metadata/evidence now align with KFD 1.0.0-alpha.41.

## Related issue

User dogfood feedback: Agent Qualification Lab terminal realism and verdict pacing.

## Changes

- render user prompts, public agent progress, tool calls, bounded outputs, status, and a live cursor in both session panes
- pace transcript entries at 1000 ms across offline, same-agent, and cross-agent modes
- reveal verdict findings sequentially at 520 ms
- keep navigation outside the Lab and reset playback when mode or agent selection changes
- refresh canonical policy and Buildchain KFD evidence after upstream dependency drift

## Verification

- `./shifu check`
- `./shifu build`
- `./shifu test:kfx-profile-suite` (Agent Qualification Lab 7/7)
- `./shifu exec node developer/sdk/src/sdk.js contract audit --json` (`ok: true`, `status: current`)
- staged repository gate after merging `origin/dev/v4/v4.0`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix changes Lab playback presentation and refreshes generated contract projections without changing an architecture contract."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (in-product Lab guidance and visual contract)
