### PR TITLE
fix(ci): provision Rust for dev patrol gates

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -34,15 +34,20 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b
     with:
-      # Resolve the last workflow/runtime pair proven by an actual dev patrol.
-      # Trusted manual runs may still supply an exact SHA or train ref. Checkout
+      # Pin the reviewed Gate capability contract while retaining the proven v2
+      # runtime by default. Trusted manual runs may still supply an exact SHA or
+      # train ref. Checkout
       # cache hits are optional: every source/runtime checkout verifies the
       # locked SHA and falls back to GitHub when a retained bundle is stale.
       buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}
       checkout-cache-mode: auto
       checkout-cache-fallback: github
+      rust-toolchain: "1.96.0"
+      rustup-dist-server: https://rsproxy.cn
+      rustup-update-root: https://rsproxy.cn/rustup
+      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
       gate-profile: dev-patrol
       runner-preset: kungfu-v4-self-hosted
       artifact-name: kungfu-dev-patrol-gates

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1389,7 +1389,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:725e41fa43351529f2c2582229b3866f4048bdc9e0e3a25a39098b05a351b9ad",
+          "definitionDigest": "sha256:3f941c7c24942af04c1e7a1b6af2ae019240877d84c6199b59195525a4741f67",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1398,7 +1398,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2"
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b"
           ],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -321,12 +321,16 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b",
         "with": {
           "buildchain-ref": "${{ inputs.buildchain-ref || 'v2' }}",
+          "cargo-registry-index": "${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}",
           "checkout-cache-fallback": "github",
           "checkout-cache-mode": "auto",
           "gate-profile": "dev-patrol",
+          "rust-toolchain": "1.96.0",
+          "rustup-dist-server": "https://rsproxy.cn",
+          "rustup-update-root": "https://rsproxy.cn/rustup",
           "runner-preset": "kungfu-v4-self-hosted",
           "gate-command-json": "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}"
         }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -953,7 +953,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@a9e1826da969dc0932fdd9c5668a1c6363267ae2',
+        '.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b',
         '.gate-profile.yml@v2-alpha',
       ),
   );


### PR DESCRIPTION
## Summary

Bind Dev Verify Patrol to the Buildchain Gate capability contract merged in buildchain#1904 and explicitly request Kungfu’s Rust toolchain inputs.

- pin `.gate-profile.yml` to Buildchain commit `6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b`
- request Rust 1.96.0 with the existing rsproxy rustup mirrors and Cargo registry variable
- refresh the closed-world Gate invocation binding and workflow authority digest

This closes the remaining Windows failure observed in Patrol run 30202335420: the Gate runner declared `rust`, but the prior workflow exposed paths without provisioning the toolchain.

## Related issue

- Closes #1516 after the next fully green three-platform Patrol
- Upstream: kungfu-systems/buildchain#1904

## Verification

- `./shifu gate:workflow-authority:refresh`
- `./shifu check:gate-catalog`
- `./shifu check:source`
- commit hooks (Gate catalog, workflow authority, docs, invariant checks)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance fix updates an exact reusable-workflow pin and its generated authority projection without changing an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The exact reusable-workflow SHA is covered by the Gate catalog, local source acceptance, and the upstream Buildchain three-platform fixture and merge-group.

## Follow-up

After merge, dispatch Dev Verify Patrol on `dev/v4/v4.0`; a three-platform green receipt will close #1516 automatically.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed