### PR TITLE
fix(verify): make dev patrol deterministic

### DIFF
--- a/developer/sdk/src/sdk.js
+++ b/developer/sdk/src/sdk.js
@@ -2594,6 +2594,7 @@ function resolveCorePython(coreDir) {
     'uv',
     [
       'run',
+      '--frozen',
       '--project',
       coreDir,
       'python',

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -214,12 +214,16 @@ function checkPythonFiles(label, files) {
   if (has('ruff')) {
     run(`${label} Python format check`, 'ruff', [
       'format',
+      '--config',
+      'framework/core/pyproject.toml',
       '--check',
       '--force-exclude',
       ...py,
     ]);
     run(`${label} Python lint check`, 'ruff', [
       'check',
+      '--config',
+      'framework/core/pyproject.toml',
       '--force-exclude',
       ...py,
     ]);
@@ -227,6 +231,8 @@ function checkPythonFiles(label, files) {
     run(`${label} Python format check`, 'uvx', [
       'ruff',
       'format',
+      '--config',
+      'framework/core/pyproject.toml',
       '--check',
       '--force-exclude',
       ...py,
@@ -234,6 +240,8 @@ function checkPythonFiles(label, files) {
     run(`${label} Python lint check`, 'uvx', [
       'ruff',
       'check',
+      '--config',
+      'framework/core/pyproject.toml',
       '--force-exclude',
       ...py,
     ]);

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -11,6 +11,7 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CPP = /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/;
 const WEB = /\.(?:ts|tsx|js|jsx|mjs|cjs|json|jsonc|css)$/;
 const GENERATED_EVIDENCE_ROOTS = ['.kungfu/', '.xinfa/'];
+const RUFF_CONFIG = 'framework/core/pyproject.toml';
 // Repo-relative roots of the mypy-checked surface. Mirrors `files` under
 // [tool.mypy] in framework/core/pyproject.toml, which stays the single source of
 // truth for what gets checked; this list only decides whether a changed file
@@ -477,11 +478,19 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
   if (python.length) {
     const format = sourcePythonCommand([
       'format',
+      '--config',
+      RUFF_CONFIG,
       '--check',
       '--force-exclude',
       ...python,
     ]);
-    const lint = sourcePythonCommand(['check', '--force-exclude', ...python]);
+    const lint = sourcePythonCommand([
+      'check',
+      '--config',
+      RUFF_CONFIG,
+      '--force-exclude',
+      ...python,
+    ]);
     plan.push(
       {
         label: 'changed Python format',

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -57,6 +57,19 @@ test('release verification reuses the exact mypy tool lane without project sync'
   assert.doesNotMatch(verify, /uv['"], \['run', '--frozen', 'mypy'/);
 });
 
+test('cross-platform full verification keeps Python resolution frozen and allows the bounded Episode workload', () => {
+  const verify = fs.readFileSync(path.join(ROOT, 'scripts/verify.mjs'), 'utf8');
+  const sdk = fs.readFileSync(
+    path.join(ROOT, 'developer/sdk/src/sdk.js'),
+    'utf8',
+  );
+  assert.match(verify, /timeout: 15 \* 60 \* 1000/);
+  assert.match(
+    sdk,
+    /'run',\s*'--frozen',\s*'--project',\s*coreDir,\s*'python'/,
+  );
+});
+
 test('Python source checks use uvx when a bare ruff is unavailable', () => {
   const command = sourcePythonCommand(
     ['format', '--check'],

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -414,6 +414,23 @@ test('Conan recipe Python is linted without widening into the product type basel
   assert.ok(!labels.includes('Python type baseline'));
 });
 
+test('changed Python format and lint use one explicit repository configuration', () => {
+  const plan = sourceAcceptancePlan([
+    'tests/fixtures/rewind-demo-langchain/check_capture.py',
+  ]);
+  for (const label of ['changed Python format', 'changed Python lint']) {
+    const step = plan.find((candidate) => candidate.label === label);
+    assert.ok(step);
+    assert.deepEqual(
+      step.args.slice(
+        step.args.indexOf('--config'),
+        step.args.indexOf('--config') + 2,
+      ),
+      ['--config', 'framework/core/pyproject.toml'],
+    );
+  }
+});
+
 test('changed GUI TypeScript receives a file-scoped semantic check', () => {
   const plan = sourceAcceptancePlan([
     'framework/gui/src/renderer/src/runtime.ts',

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -193,7 +193,10 @@ function runEpisodeQualificationSmoke() {
     {
       cwd: ROOT,
       encoding: 'utf8',
-      timeout: 5 * 60 * 1000,
+      // The smoke is intentionally load-bearing and exercises 1k-episode
+      // accumulation plus contended writers.  Slower Linux qualification
+      // runners can legitimately exceed five minutes without hanging.
+      timeout: 15 * 60 * 1000,
       maxBuffer: 10 * 1024 * 1024,
     },
   );

--- a/tests/fixtures/rewind-demo-langchain/check_capture.py
+++ b/tests/fixtures/rewind-demo-langchain/check_capture.py
@@ -13,6 +13,10 @@
 #
 # Usage: check_capture.py <runtime-dir> <run-id>
 
+# The runtime modules are intentionally imported after the fixture adds the
+# just-built Core binding to sys.path.
+# ruff: noqa: E402
+
 import hashlib
 import json
 import os

--- a/tests/fixtures/rewind-demo-langchain/check_capture.py
+++ b/tests/fixtures/rewind-demo-langchain/check_capture.py
@@ -3,8 +3,8 @@
 # Capture assertions for the real-LangChain fixture. Proves that an unmodified
 # third-party agent framework, run once under `kungfu trace`, lands a complete
 # fact set in ONE journal: both model turns captured at the wire, the tool call
-# captured in-process by the adapter, and the tool causally bracketed between
-# the turns. Runs inside the dev kfc environment (needs pykungfu).
+# captured in-process by the adapter, and the tool result consumed by the
+# second model turn. Runs inside the dev kfc environment (needs pykungfu).
 #
 # Honest scope: this is a single-runtime run, so it upgrades the *zero-code-
 # change real-framework capture* leg of the moat from the toy toolkit to a real
@@ -12,8 +12,6 @@
 # their own fixtures; this one does not restate those claims.
 #
 # Usage: check_capture.py <runtime-dir> <run-id>
-
-# ruff: noqa: E402
 
 import hashlib
 import json
@@ -27,7 +25,6 @@ sys.path.insert(0, os.path.join(_core, "src", "python"))
 sys.path.insert(0, os.path.join(_core, "dist", "kungfu"))
 
 import kungfu
-
 from kungfu.rewind import (
     ACTION_MODEL_REQUEST,
     ACTION_MODEL_RESPONSE,
@@ -39,7 +36,6 @@ from kungfu.rewind import (
     ACTION_TYPE_NAMES,
     CARRIER_REWIND_ACTION,
 )
-from kungfu.rewind.wire import unwrap_event
 from kungfu.rewind.fb.CallStatus import CallStatus
 from kungfu.rewind.fb.CaptureLayer import CaptureLayer
 from kungfu.rewind.fb.ModelRequest import ModelRequest
@@ -48,6 +44,7 @@ from kungfu.rewind.fb.RunBegin import RunBegin
 from kungfu.rewind.fb.RunEnd import RunEnd
 from kungfu.rewind.fb.ToolCall import ToolCall
 from kungfu.rewind.fb.ToolResult import ToolResult
+from kungfu.rewind.wire import unwrap_event
 
 schema = kungfu.__binding__.yijinjing
 yjj = kungfu.__binding__.runtime
@@ -93,11 +90,10 @@ if begin_frames:
 req_frames = frames(ACTION_MODEL_REQUEST)
 check("two ModelRequest frames (tool-call turn + final turn)", len(req_frames) == 2)
 req_spans = []
-req_times = []
-for hdr, payload in req_frames:
+request_bodies = []
+for _, payload in req_frames:
     req = ModelRequest.GetRootAs(bytes(payload), 0)
     req_spans.append((req.SpanId() or b"").decode())
-    req_times.append(hdr.gen_time)
     check("ModelRequest.run_id matches", (req.RunId() or b"").decode() == run_id)
     check("ModelRequest.layer == ModelWire", req.Layer() == CaptureLayer.ModelWire)
     check(
@@ -108,17 +104,16 @@ for hdr, payload in req_frames:
         (req.Model() or b"").decode() == "fixture-model",
     )
     body = json.loads((req.RequestBody() or b"{}").decode())
+    request_bodies.append(body)
     check("ModelRequest.request_body has messages", bool(body.get("messages")))
 
 resp_frames = frames(ACTION_MODEL_RESPONSE)
 check("two ModelResponse frames", len(resp_frames) == 2)
 finish_reasons = []
 resp_spans = []
-resp_times = []
-for hdr, payload in resp_frames:
+for _, payload in resp_frames:
     resp = ModelResponse.GetRootAs(bytes(payload), 0)
     resp_spans.append((resp.SpanId() or b"").decode())
-    resp_times.append(hdr.gen_time)
     finish_reasons.append((resp.FinishReason() or b"").decode())
     check("ModelResponse.status == Ok", resp.Status() == CallStatus.Ok)
     check("ModelResponse.latency_ns > 0", resp.LatencyNs() > 0)
@@ -140,12 +135,10 @@ check(
 call_frames = frames(ACTION_TOOL_CALL)
 check("one ToolCall frame from the real BaseTool seam", len(call_frames) == 1)
 call_span = None
-call_time = None
 if call_frames:
-    hdr, payload = call_frames[0]
+    _, payload = call_frames[0]
     call = ToolCall.GetRootAs(bytes(payload), 0)
     call_span = (call.SpanId() or b"").decode()
-    call_time = hdr.gen_time
     check("ToolCall.run_id matches", (call.RunId() or b"").decode() == run_id)
     check("ToolCall.layer == InProcessHook", call.Layer() == CaptureLayer.InProcessHook)
     check("ToolCall.tool_name == lookup", (call.ToolName() or b"").decode() == "lookup")
@@ -177,15 +170,31 @@ check(
 )
 
 # ── one journal, one causal timeline ─────────────────────────────────
-# the tool call must sit between the model turn that requested it and the turn
-# that consumed its result — the real agent's causal story, in event time
-if call_time is not None and len(req_times) == 2 and len(resp_times) == 2:
-    first_turn_end = min(resp_times)
-    last_turn_start = max(req_times)
+# The proxy and in-process adapter are independent writers, so their journal
+# commit timestamps need not preserve wall-clock ordering on a loaded runner.
+# Prove the causal edge semantically instead: exactly one model request must
+# consume the real tool output before the final model response.
+tool_result_requests = [
+    body
+    for body in request_bodies
+    if any(message.get("role") == "tool" for message in body.get("messages", []))
+]
+check(
+    "one model turn consumes the tool result",
+    len(tool_result_requests) == 1,
+    f"tool-result requests={len(tool_result_requests)}",
+)
+if tool_result_requests:
+    consumed_tool_messages = [
+        message
+        for message in tool_result_requests[0].get("messages", [])
+        if message.get("role") == "tool"
+    ]
     check(
-        "tool call is bracketed by the two model turns",
-        first_turn_end <= call_time <= last_turn_start,
-        f"resp0={first_turn_end} call={call_time} req1={last_turn_start}",
+        "final model turn carries the real tool output",
+        any(
+            "KUNGFU REWIND" in json.dumps(message) for message in consumed_tool_messages
+        ),
     )
 
 end_frames = frames(ACTION_RUN_END)


### PR DESCRIPTION
## Summary

Make the final Dev Verify Patrol product gate deterministic across Windows and Linux.

- keep the SDK fallback Python resolution explicitly frozen so Windows cannot update the canonical Core uv lock
- give the bounded 1k-Episode smoke workload enough time on the slower Linux qualification runner
- replace the LangChain cross-writer timestamp ordering assertion with stronger semantic evidence that the final model turn consumed the real tool output

## Related issue

- Closes #1516 after the next fully green three-platform Patrol
- Follow-up to #1545

## Verification

- `./shifu check:source`
- `pnpm --filter @kungfu-tech/sdk run build` (32/32)
- `node --test scripts/source-acceptance.test.mjs` (21/21)
- staged Ruff, Biome, documentation, invariant, Gate catalog, and KFD evidence checks
- Linux and Windows root causes reproduced from Patrol run 30204489159 receipts and full job logs

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance fix corrects cross-platform verification determinism without changing an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Follow-up

After merge, dispatch Dev Verify Patrol on `dev/v4/v4.0`; a three-platform green receipt will close #1516 automatically.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed