### PR TITLE
fix(ci): normalize MSVC patrol diagnostics

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -57,7 +57,7 @@ jobs:
         {"linux":["./shifu"],"macos":["./shifu"],"windows":["./shifu.cmd"]}
       gate-environment-json: >-
         {"SHIFU_NATIVE":"1","KUNGFU_BUILDCHAIN_NO_OPTIONAL":"1",
-        "KUNGFU_BUILDCHAIN_SOURCE_BUILD":"1"}
+        "KUNGFU_BUILDCHAIN_SOURCE_BUILD":"1","VSLANG":"1033"}
       shifu-cache-profile-ref: ${{ vars.SHIFU_CACHE_PROFILE_REF }}
       shifu-cache-profile-digest: ${{ vars.SHIFU_CACHE_PROFILE_DIGEST }}
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1434,7 +1434,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3f941c7c24942af04c1e7a1b6af2ae019240877d84c6199b59195525a4741f67",
+          "definitionDigest": "sha256:789be6dcf24e7f7b625ba2bc20898aa61a90a5b59ffef683f0ea7676e8bfc9ef",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -70,6 +70,14 @@ test('cross-platform full verification keeps Python resolution frozen and allows
   );
 });
 
+test('dev patrol normalizes MSVC diagnostics for bounded Gate output', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/dev-verify-patrol.yml'),
+    'utf8',
+  );
+  assert.match(workflow, /"VSLANG":"1033"/);
+});
+
 test('Python source checks use uvx when a bare ruff is unavailable', () => {
   const command = sourcePythonCommand(
     ['format', '--check'],


### PR DESCRIPTION
## Summary

Keep the Windows Dev Verify Patrol inside its bounded Gate output contract.

- set `VSLANG=1033` for the cross-platform Gate environment so MSVC emits the English `/showIncludes` prefix that Ninja recognizes and filters
- prevent localized dependency diagnostics from filling the 256 MiB synchronous process buffer
- bind the workflow change through source acceptance and refresh its governed workflow digest

## Related issue

- Follow-up to #1516
- Root cause observed in Dev Verify Patrol run 30206822276

## Verification

- `./shifu check:source`
- `node --test scripts/source-acceptance.test.mjs` (23/23)
- `git diff --check`
- staged documentation, Gate catalog, source acceptance, workflow authority, Biome, invariant, and KFD evidence checks

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This CI maintenance fix normalizes compiler diagnostics without changing an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Follow-up

After merge, dispatch Dev Verify Patrol on `dev/v4/v4.0`; a three-platform green receipt will close #1516 automatically.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
