### PR TITLE
fix(ci): allow manual S3 artifact relay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,14 @@ on:
         required: false
         type: boolean
         default: false
+      artifact-transfer-mode:
+        description: "Transfer native artifacts directly or through the configured S3 relay"
+        required: false
+        type: choice
+        options:
+          - github-artifacts
+          - s3-to-github-artifacts
+        default: github-artifacts
       render-auditable-demo:
         description: "Render full media after the exact Linux artifact passes the required auditable-demo Gate"
         required: false
@@ -133,7 +141,7 @@ jobs:
       verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip
       release-candidate: true
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
-      artifact-transfer-mode: ${{ github.event_name == 'workflow_dispatch' && 'github-artifacts' || 's3-to-github-artifacts' }}
+      artifact-transfer-mode: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact-transfer-mode || 's3-to-github-artifacts' }}
       artifact-retention-days: 14
       checkout-cache-mode: auto
       checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -749,7 +749,7 @@
     {
       "path": ".github/workflows/build.yml",
       "authority": "product-publication",
-      "definitionDigest": "sha256:aadbb97771ffd89eaec3f3ed67ef3925e1730472a5a722c1a8b956c8ee71b6c1",
+      "definitionDigest": "sha256:5c60682da8f4f610db1d6e85afda4e9f3617790ccf47ce80720e7127b7e158d1",
       "jobs": [
         {
           "id": "auditable-demo",
@@ -819,7 +819,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:1557d3227208a7b22af58666c137ac85b6e80a51ef847d6c370c9713d9a457c5",
+          "definitionDigest": "sha256:16775a94d712e83e0f739fb004aaadc1d297a7d048462c1953a839e1d9f60c73",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -466,7 +466,7 @@
           "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip",
           "release-candidate": true,
           "publish-channel": "${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
-          "artifact-transfer-mode": "${{ github.event_name == 'workflow_dispatch' && 'github-artifacts' || 's3-to-github-artifacts' }}",
+          "artifact-transfer-mode": "${{ github.event_name == 'workflow_dispatch' && inputs.artifact-transfer-mode || 's3-to-github-artifacts' }}",
           "shifu-cache-profile-ref": "${{ inputs.platforms-json && 'docs/shifu/qualification-portable-off.cache-profile.json' || vars.SHIFU_CACHE_PROFILE_REF }}",
           "buildchain-contract-lock-path": ".buildchain/contract-lock.json",
           "buildchain-contract-compatibility-policy": "major-compatible"

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -94,10 +94,17 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
   const build = WORKFLOW.jobs.build;
   const resolver = WORKFLOW.jobs['resolve-auditable-demo-source'];
   const gate = WORKFLOW.jobs['auditable-demo'];
+  const transferInput =
+    WORKFLOW.on.workflow_dispatch.inputs['artifact-transfer-mode'];
+  assert.equal(transferInput.default, 'github-artifacts');
+  assert.deepEqual(transferInput.options, [
+    'github-artifacts',
+    's3-to-github-artifacts',
+  ]);
   assert.equal(
     build.with['artifact-transfer-mode'],
-    "${{ github.event_name == 'workflow_dispatch' && 'github-artifacts' || 's3-to-github-artifacts' }}",
-    'manual evidence runs must not enter the AWS relay while protected promotion retains its existing transfer path',
+    "${{ github.event_name == 'workflow_dispatch' && inputs.artifact-transfer-mode || 's3-to-github-artifacts' }}",
+    'manual evidence runs require explicit relay selection while protected promotion retains its relay path',
   );
   assert.equal(
     resolver.env,


### PR DESCRIPTION
## Summary

- expose the existing Buildchain `s3-to-github-artifacts` transport as an explicit manual Build input
- keep `github-artifacts` as the manual default while preserving S3 relay for protected alpha/release events
- refresh workflow authority bindings and lock the input contract with tests

Supersedes #1552 with a linear, merge-queue-rebase-compatible branch.

## Evidence

- `./shifu test:auditable-demo` (19/19)
- `./shifu check:gate-catalog` (38 gates, 19 workflows aligned)
- full managed staged gate passed at `c562b0ccae`
- prior exact-source Build run `30195629750` completed all Linux, Windows, and macOS lifecycle qualification; only direct GitHub artifact upload failed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Expose an explicit existing artifact-transfer adapter for trusted manual diagnostics; no package, product, or ADR semantics change"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change selects an already protected relay using existing least-privilege OIDC roles. It adds no secret material, publication authority, deployment authority, or package write.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact failed Build and annotations cited
