### PR TITLE
fix(ci): pin streamed Gate runtime

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -34,14 +34,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984
     with:
-      # Pin the reviewed Gate capability contract while retaining the proven v2
-      # runtime by default. Trusted manual runs may still supply an exact SHA or
-      # train ref. Checkout
+      # Keep the reviewed Gate workflow shell and its streamed runtime aligned
+      # by default. Trusted manual runs may still supply an exact SHA or train
+      # ref. Checkout
       # cache hits are optional: every source/runtime checkout verifies the
       # locked SHA and falls back to GitHub when a retained bundle is stale.
-      buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || 'f8ef93be41b0badd75eb35cc1506c2be12198984' }}
       checkout-cache-mode: auto
       checkout-cache-fallback: github
       rust-toolchain: "1.96.0"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1434,7 +1434,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:789be6dcf24e7f7b625ba2bc20898aa61a90a5b59ffef683f0ea7676e8bfc9ef",
+          "definitionDigest": "sha256:423ea47d9104d4c8891a2d28d15d0d1dae4acdaf6b6999028d6a723ba2c8284e",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -1443,7 +1443,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b"
+            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984"
           ],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -321,9 +321,9 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984",
         "with": {
-          "buildchain-ref": "${{ inputs.buildchain-ref || 'v2' }}",
+          "buildchain-ref": "${{ inputs.buildchain-ref || 'f8ef93be41b0badd75eb35cc1506c2be12198984' }}",
           "cargo-registry-index": "${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}",
           "checkout-cache-fallback": "github",
           "checkout-cache-mode": "auto",

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -953,7 +953,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@6ddbca28231ecfc1eb62d9d3764a21a3f8813b0b',
+        '.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984',
         '.gate-profile.yml@v2-alpha',
       ),
   );
@@ -997,7 +997,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRuntimeWorkflow, 'utf8')
       .replace(
-        "buildchain-ref: ${{ inputs.buildchain-ref || 'v2' }}",
+        "buildchain-ref: ${{ inputs.buildchain-ref || 'f8ef93be41b0badd75eb35cc1506c2be12198984' }}",
         "buildchain-ref: ${{ inputs.buildchain-ref || '' }}",
       ),
   );


### PR DESCRIPTION
## Summary

Pin Dev Verify Patrol to the Buildchain runtime that streams long Gate output.

- align the reusable workflow shell and default runtime at Buildchain merge `f8ef93be41b0badd75eb35cc1506c2be12198984`
- update the closed-world Gate binding and governed workflow digest
- retain trusted manual exact-SHA/train overrides

## Related issue

- Follow-up to #1516
- Consumes kungfu-systems/buildchain#1934
- Patrol run 30210195339 proved Windows `product.verify-full` passes but the prior outer 16 MiB wrapper failed before receipt validation

## Verification

- `./shifu check:source`
- `node scripts/check-kungfu-gate-catalog.mjs`
- `node --test scripts/check-kungfu-gate-catalog.test.mjs` (23/23)
- `node --test scripts/source-acceptance.test.mjs` (23/23)
- staged governance, documentation, invariant, Gate catalog, Biome, and KFD evidence checks

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This CI maintenance pin consumes a bounded output-transport fix without changing an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Follow-up

After merge, dispatch Dev Verify Patrol on `dev/v4/v4.0`; a three-platform green receipt is the completion gate.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Governance projections updated
