### PR TITLE
fix(ci): pin cross-attempt demo runtime

### DIFF
--- a/.buildchain/alpha-contract-lock.json
+++ b/.buildchain/alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v3-alpha",
-    "resolvedSha": "4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb",
+    "resolvedSha": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:c794a99a101e2af38e8e7728c86986af84343e743a6cfd0c132aad85ddd786d3",
+    "contractDigest": "sha256:b267a2e659ab75433deca4d8f257cee075ca764497132be34c6d2c2f0a0a47c3",
     "compatibilityDigest": "sha256:008b1c5a90a787cf30106829ac7aca68ab501f6d9c375e415d9c5c6b89039f46",
     "majorLine": "v3",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-26T15:50:29.212Z",
+    "acceptedAt": "2026-07-26T17:51:08.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb # merged v3 runtime with structured cache evidence
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457 # v3.0.2-alpha.1 with cross-attempt artifact recovery
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
@@ -365,7 +365,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb # merged v3 runtime with structured cache evidence
+    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457 # v3.0.2-alpha.1 with cross-attempt artifact recovery
     with:
       source-ref: ${{ needs.build.outputs.publish-source-sha }}
       source-artifact-name: ${{ needs.resolve-auditable-demo-source.outputs.artifact-name }}
@@ -488,7 +488,7 @@ jobs:
           MEDIA_ARTIFACT_URL: ${{ needs.auditable-demo.outputs.media-artifact-url }}
           MEDIA_ARTIFACT_EXPIRES_AT: ${{ steps.artifact-expiry.outputs.media-artifact-expires-at }}
           MEDIA_ROOT: ${{ needs.auditable-demo.outputs.media-root }}
-          BUILDCHAIN_SHA: 4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb
+          BUILDCHAIN_SHA: bfe43b0fe5577f15d2af01bc542de8a8ce587457
           RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:cb5e1dec368d21c7d4e8baded99ac75f12f7eff0d19505751888cf974086efa6
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -109,10 +109,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb # merged v3 runtime with structured cache evidence
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457 # v3.0.2-alpha.1 with cross-attempt artifact recovery
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb
+      buildchain-ref: bfe43b0fe5577f15d2af01bc542de8a8ce587457
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/docs/qualification/auditable-demo-artifact-pipeline.md
+++ b/docs/qualification/auditable-demo-artifact-pipeline.md
@@ -41,7 +41,7 @@ disables the Gate.
 | --- | --- |
 | Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:cb5e1dec368d21c7d4e8baded99ac75f12f7eff0d19505751888cf974086efa6` |
 | Renderer release | `build-images v1.3.0-alpha.16` |
-| Buildchain Gate | `4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb` (merged v3 runtime with structured cache evidence) |
+| Buildchain Gate | `bfe43b0fe5577f15d2af01bc542de8a8ce587457` (`v3.0.2-alpha.1`, cross-attempt artifact recovery) |
 | Consumer adapter | `scripts/auditable-demo-adapter.py` from the exact qualified Kungfu source SHA |
 
 Buildchain's reusable build emits

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -14,8 +14,8 @@
     "runtimes": {
       "alpha": {
         "ref": "v3-alpha",
-        "runtimeSha": "4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb",
-        "contractDigest": "sha256:c794a99a101e2af38e8e7728c86986af84343e743a6cfd0c132aad85ddd786d3",
+        "runtimeSha": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
+        "contractDigest": "sha256:b267a2e659ab75433deca4d8f257cee075ca764497132be34c6d2c2f0a0a47c3",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },
       "release": {

--- a/docs/qualification/gates/release-admission.md
+++ b/docs/qualification/gates/release-admission.md
@@ -17,7 +17,7 @@ A qualifying capability must bind all of the following exact values:
 | --- | --- |
 | Source | one 40-character Kungfu revision and its release-candidate tree |
 | Gate policy | current `shifu.gates.json`, `release-promotion` matrix digest, complete passing rows and platform receipts |
-| Runtime | Stable release authority is `@kungfu-tech/buildchain@3.0.0`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@3.0.1-alpha.4`. `alpha` binds the merged v3 runtime at `4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb`, while `release` remains isolated on `v3` at `9e904de2c85dbea7c799780ee166510b3336d812`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
+| Runtime | Stable release authority is `@kungfu-tech/buildchain@3.0.0`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@3.0.2-alpha.1`. `alpha` binds the protected v3 runtime at `bfe43b0fe5577f15d2af01bc542de8a8ce587457`, while `release` remains isolated on `v3` at `9e904de2c85dbea7c799780ee166510b3336d812`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
 | Controller | qualifying source/runtime-bound Buildchain controller receipt referenced by the RC passport |
 | Runner | qualifying ephemeral, reimaged, or measured persistent-runner provenance; unqualified is denied |
 | Control plane | fresh passing Actions, branch/ruleset, Environment, OIDC, publisher, and runner audit facts |

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -756,7 +756,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:f76ac299bac932c7c7052cec118937848b1809dbfa71e83fec1abbab68f20a6e",
+          "definitionDigest": "sha256:4daeaa3648a337fbd66ce98e3793f3d43c26c490cbf8980e66841f8b7458c587",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -765,7 +765,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb"
+            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"
           ],
           "steps": []
         },
@@ -774,7 +774,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:21db2dddc05cd30efa905a7148d06cc1cee133e1892abc687d2327c1b288223b",
+          "definitionDigest": "sha256:73e179c7c82d8718327ebe36c3bbc124345028393fb233192154f4c0777d43ff",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -804,7 +804,7 @@
               "index": 3,
               "label": "name:Write exact auditable demo Release Passport",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:dc3189897560915bf1beab0a4de61dc172314dcaaac1b3a68110335000a0f510"
+              "definitionDigest": "sha256:0c1fd1b94d1b5f4a3a0330a86ca2db05bc06792ad2a7ce81451c7f77d4284e31"
             },
             {
               "index": 4,
@@ -819,7 +819,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:8fa0340164d6c2d6d87fab4d03ab6599e7b22c7b560bdee58d34f021421365c6",
+          "definitionDigest": "sha256:4cb9d25b2fa393bb28459829ad7228cc52b2b51320f7fdbb8960883f7bed29f5",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -832,7 +832,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"
           ],
           "steps": []
         },
@@ -2260,7 +2260,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:441f776461c06905c916baa34085b391201b96d602d101485f5342d223825d70",
+          "definitionDigest": "sha256:855e0194f26943fa313e3699fef8a812cbb23883591412741d746387c2a9b9c1",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -2275,7 +2275,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -446,7 +446,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -528,14 +528,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb",
+          "buildchain-ref": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb",
+    "workflow_shell_sha": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "3.0.0",
-    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@3.0.1-alpha.4",
+    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@3.0.2-alpha.1",
     "@kungfu-tech/kfd": "1.0.0-alpha.47",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@kungfu-tech/buildchain-alpha':
-        specifier: npm:@kungfu-tech/buildchain@3.0.1-alpha.4
-        version: '@kungfu-tech/buildchain@3.0.1-alpha.4'
+        specifier: npm:@kungfu-tech/buildchain@3.0.2-alpha.1
+        version: '@kungfu-tech/buildchain@3.0.2-alpha.1'
       '@kungfu-tech/kfd':
         specifier: 1.0.0-alpha.47
         version: 1.0.0-alpha.47
@@ -1446,8 +1446,8 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/buildchain@3.0.1-alpha.4':
-    resolution: {integrity: sha512-tOG2AnDtHpvxdr9vPWkYVxvsMqBY2sMZTNv6/mVN5GYekbpVeRu+9mbflBTFvuf7RvDIxJUtjT83u+ueqxbRHQ==}
+  '@kungfu-tech/buildchain@3.0.2-alpha.1':
+    resolution: {integrity: sha512-MfPs3tTnO00ZTk+JLANEC2BbZuNBr+Yanv+NyHCQuJL6cB2wdYJpZAA+d0zxtUtPZ/VJ4ag8/bXXCmpUclFaBg==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5801,7 +5801,7 @@ snapshots:
       '@kungfu-tech/kfd': 1.0.0-alpha.41
       smol-toml: 1.7.0
 
-  '@kungfu-tech/buildchain@3.0.1-alpha.4':
+  '@kungfu-tech/buildchain@3.0.2-alpha.1':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.41
       smol-toml: 1.7.0

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -118,7 +118,7 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
   );
   assert.equal(
     build.uses,
-    'kungfu-systems/buildchain/.github/workflows/.build.yml@4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb',
+    'kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457',
     'the build runtime must be the protected Buildchain release that owns artifact-coordinates-json',
   );
   assert.match(

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -38,11 +38,11 @@ import {
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
-const RUNTIME_SHA = '4c27ff2a82f18271b20f5ebafeb4f84ab4ebfcbb';
+const RUNTIME_SHA = 'bfe43b0fe5577f15d2af01bc542de8a8ce587457';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =
-  'c794a99a101e2af38e8e7728c86986af84343e743a6cfd0c132aad85ddd786d3';
+  'b267a2e659ab75433deca4d8f257cee075ca764497132be34c6d2c2f0a0a47c3';
 const STABLE_CONTRACT_DIGEST =
   '914720131f07664cd187a1033f357c4952ef1008f5553cb6b285a75f786a7fbc';
 const PREDICATE_COMMAND = 'node scripts/kungfu-release-qualification.mjs';


### PR DESCRIPTION
## Summary

Consume the immutable Buildchain `v3.0.2-alpha.1` source that repairs cross-attempt GitHub Artifact downloads for the auditable-demo controller while preserving the accepted v3 compatibility surface.

## Related issue

- https://github.com/kungfu-systems/buildchain/issues/1935

## Changes

- pin every alpha reusable build, auditable-demo, promotion, and Passport Buildchain surface to tag commit `bfe43b0fe5577f15d2af01bc542de8a8ce587457`
- update the alpha package to `@kungfu-tech/buildchain@3.0.2-alpha.1`
- update the alpha contract lock to `sha256:b267a2e659ab75433deca4d8f257cee075ca764497132be34c6d2c2f0a0a47c3`
- preserve compatibility digest `sha256:008b1c5a90a787cf30106829ac7aca68ab501f6d9c375e415d9c5c6b89039f46`
- refresh workflow authority and release-admission projections
- keep the standalone Shifu binary pin unchanged because this Buildchain release does not publish standalone platform archives

## Verification

- `./shifu test:auditable-demo` (19 passed)
- `./shifu test:release-admission` (5 passed)
- `./shifu check:gate-catalog`
- `./shifu release:promotion:rehearse -- --report /tmp/kungfu-alpha1-release-promotion-rehearsal.json`
- `./shifu check:source`
- `./shifu check` (changed-scope gate passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix consumes an already reviewed immutable Buildchain runtime and preserves the accepted v3 compatibility and Kungfu architecture contracts."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates immutable reusable-workflow, package, and contract coordinates only. Source acceptance, release admission, workflow authority, and promotion rehearsal all pass.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
