### PR TITLE
fix(ci): extend Episode qualification budget

### DIFF
--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -63,7 +63,7 @@ test('cross-platform full verification keeps Python resolution frozen and allows
     path.join(ROOT, 'developer/sdk/src/sdk.js'),
     'utf8',
   );
-  assert.match(verify, /timeout: 15 \* 60 \* 1000/);
+  assert.match(verify, /timeout: 30 \* 60 \* 1000/);
   assert.match(
     sdk,
     /'run',\s*'--frozen',\s*'--project',\s*coreDir,\s*'python'/,

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -195,8 +195,8 @@ function runEpisodeQualificationSmoke() {
       encoding: 'utf8',
       // The smoke is intentionally load-bearing and exercises 1k-episode
       // accumulation plus contended writers.  Slower Linux qualification
-      // runners can legitimately exceed five minutes without hanging.
-      timeout: 15 * 60 * 1000,
+      // runners can legitimately exceed fifteen minutes without hanging.
+      timeout: 30 * 60 * 1000,
       maxBuffer: 10 * 1024 * 1024,
     },
   );


### PR DESCRIPTION
## Summary

Give the unchanged load-bearing Episode qualification smoke a bounded 30-minute budget on slower Linux Patrol runners.

- retain the exact MVP smoke profile, seed, 1,000-Episode accumulation, and contention matrix
- raise only the subprocess timeout from 15 to 30 minutes
- update the source contract assertion so the budget cannot drift silently

## Related issue

- Follow-up to #1516
- Patrol run 30213113136 reached the final workers=10 contention lane and then timed out exactly at the prior 15-minute bound
- macOS and Windows passed on the same exact source SHA; Linux produced complete streamed receipt artifacts and failed only this bounded timeout

## Verification

- `node --test scripts/source-acceptance.test.mjs` (23/23)
- `./shifu check:source` (651 Node tests: 641 pass, 10 environment skips; Python 40 + 116 pass; documentation, contracts, type checks, and Biome pass)
- staged governance, documentation, invariant, Gate catalog, Biome, and KFD evidence checks

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This CI maintenance change adjusts only a bounded qualification timeout without changing the workload or an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Follow-up

After merge, dispatch Dev Verify Patrol on `dev/v4/v4.0`; a three-platform green receipt is the completion gate.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workload shape and deterministic seed remain unchanged