### PR TITLE
fix(spec): normalize canonical LF projections

### DIFF
--- a/framework/spec/index.test.js
+++ b/framework/spec/index.test.js
@@ -19,17 +19,37 @@ const {
 const {
   buildArtifacts,
   checkArtifacts,
+  normalizeLf,
   renderArtifacts,
   writeArtifacts,
 } = require('./scripts/generate.js');
-const { npmCommand, npmSpawnOptions } = require('./scripts/pack.js');
+const {
+  npmCommand,
+  npmPackArgs,
+  npmSpawnOptions,
+} = require('./scripts/pack.js');
 
-test('uses the platform npm shim when packing the artifact', () => {
+function pythonCommand(platform = process.platform) {
+  return (
+    process.env.PYTHON || (platform === 'win32' ? 'python.exe' : 'python3')
+  );
+}
+
+test('uses platform command shims when qualifying and packing', () => {
+  assert.equal(pythonCommand('win32'), process.env.PYTHON || 'python.exe');
+  assert.equal(pythonCommand('darwin'), process.env.PYTHON || 'python3');
+  assert.equal(pythonCommand('linux'), process.env.PYTHON || 'python3');
   assert.equal(npmCommand('win32'), 'npm.cmd');
   assert.equal(npmCommand('darwin'), 'npm');
   assert.equal(npmCommand('linux'), 'npm');
   assert.deepEqual(npmSpawnOptions('win32'), { shell: true });
   assert.deepEqual(npmSpawnOptions('linux'), { shell: false });
+  assert.deepEqual(npmPackArgs('release-spec'), [
+    'pack',
+    '--foreground-scripts',
+    '--pack-destination',
+    'release-spec',
+  ]);
 });
 
 test('exposes rooted authority, compatibility, vectors, and non-claims', () => {
@@ -61,7 +81,7 @@ test('exposes rooted authority, compatibility, vectors, and non-claims', () => {
 test('qualifies every retained vector through the packaged Python reader', () => {
   const report = JSON.parse(
     execFileSync(
-      'python3',
+      pythonCommand(),
       [
         path.join(
           __dirname,
@@ -111,6 +131,28 @@ test('generates byte-identical authority artifacts and detects hand edits', () =
     assert.throws(
       () => checkArtifacts(second, root),
       /capabilities\.json: generated artifact drift/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('treats Windows checkout line endings as canonical LF', () => {
+  assert.equal(normalizeLf('first\r\nsecond\r\n'), 'first\nsecond\n');
+  const rendered = new Map([
+    ['authority.json', '{\n  "status": "current"\n}\n'],
+  ]);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-spec-crlf-'));
+  try {
+    fs.writeFileSync(
+      path.join(root, 'authority.json'),
+      '{\r\n  "status": "current"\r\n}\r\n',
+    );
+    assert.doesNotThrow(() => checkArtifacts(rendered, root));
+    fs.appendFileSync(path.join(root, 'authority.json'), ' ');
+    assert.throws(
+      () => checkArtifacts(rendered, root),
+      /authority\.json: generated artifact drift/,
     );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/framework/spec/scripts/generate.js
+++ b/framework/spec/scripts/generate.js
@@ -47,10 +47,26 @@ function sha256(value) {
   return `sha256:${createHash('sha256').update(value).digest('hex')}`;
 }
 
+/**
+ * Git declares the portable-format JSON authorities as canonical LF text, but
+ * a Windows checkout may still expose CRLF bytes when runner-global settings
+ * or an older worktree predate that declaration. Normalize only these JSON
+ * text inputs so their opaque-byte roots and committed projections remain
+ * independent of the checkout host.
+ *
+ * @param {string} value
+ */
+function normalizeLf(value) {
+  return value.replace(/\r\n?/g, '\n');
+}
+
 /** @param {string} relative */
 function readSource(relative) {
   const absolute = path.join(repoRoot, relative);
-  const bytes = fs.readFileSync(absolute);
+  const worktreeBytes = fs.readFileSync(absolute);
+  const bytes = relative.endsWith('.json')
+    ? Buffer.from(normalizeLf(worktreeBytes.toString('utf8')), 'utf8')
+    : worktreeBytes;
   let value = null;
   if (relative.endsWith('.json')) value = JSON.parse(bytes.toString('utf8'));
   return {
@@ -284,7 +300,7 @@ function checkArtifacts(rendered, root = generatedRoot) {
     const target = path.join(root, relative);
     if (!fs.existsSync(target))
       failures.push(`${relative}: missing; run generate`);
-    else if (fs.readFileSync(target, 'utf8') !== expected)
+    else if (normalizeLf(fs.readFileSync(target, 'utf8')) !== expected)
       failures.push(`${relative}: generated artifact drift; run generate`);
   }
   const expectedPaths = new Set(rendered.keys());
@@ -360,6 +376,7 @@ module.exports = {
   canonical,
   checkArtifacts,
   main,
+  normalizeLf,
   renderArtifacts,
   renderJson,
   sha256,

--- a/framework/spec/scripts/pack.js
+++ b/framework/spec/scripts/pack.js
@@ -19,19 +19,27 @@ function npmSpawnOptions(platform = process.platform) {
   return { shell: platform === 'win32' };
 }
 
+/** @param {string} packDestination */
+function npmPackArgs(packDestination) {
+  return [
+    'pack',
+    '--foreground-scripts',
+    '--pack-destination',
+    packDestination,
+  ];
+}
+
 function main() {
   fs.mkdirSync(destination, { recursive: true });
-  const result = spawnSync(
-    npmCommand(),
-    ['pack', '--pack-destination', destination],
-    {
-      cwd: specRoot,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'inherit'],
-      ...npmSpawnOptions(),
-    },
-  );
+  const result = spawnSync(npmCommand(), npmPackArgs(destination), {
+    cwd: specRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    ...npmSpawnOptions(),
+  });
   if (result.error || result.status !== 0) {
+    const output = result.stdout?.trim();
+    if (output) console.error(output);
     console.error(
       `[spec:pack] failed: ${result.error?.message || `npm pack exited ${result.status}`}`,
     );
@@ -47,4 +55,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { main, npmCommand, npmSpawnOptions };
+module.exports = { main, npmCommand, npmPackArgs, npmSpawnOptions };

--- a/scripts/platform-command.mjs
+++ b/scripts/platform-command.mjs
@@ -14,6 +14,13 @@ export function platformCommandOptions(command, platform = process.platform) {
   };
 }
 
+export function pythonCommand(
+  platform = process.platform,
+  configured = process.env.PYTHON,
+) {
+  return configured || (platform === 'win32' ? 'python.exe' : 'python3');
+}
+
 export function prependEnvironmentPath(
   environment,
   directory,

--- a/scripts/platform-command.test.mjs
+++ b/scripts/platform-command.test.mjs
@@ -6,6 +6,7 @@ import {
   platformCommand,
   platformCommandOptions,
   prependEnvironmentPath,
+  pythonCommand,
 } from './platform-command.mjs';
 
 test('resolves package-manager shims on Windows only', () => {
@@ -17,6 +18,16 @@ test('resolves package-manager shims on Windows only', () => {
   assert.deepEqual(platformCommandOptions('npm', 'win32'), { shell: true });
   assert.deepEqual(platformCommandOptions('cargo', 'win32'), { shell: false });
   assert.deepEqual(platformCommandOptions('npm', 'linux'), { shell: false });
+});
+
+test('resolves the Python executable on each platform', () => {
+  assert.equal(pythonCommand('win32', ''), 'python.exe');
+  assert.equal(pythonCommand('darwin', ''), 'python3');
+  assert.equal(pythonCommand('linux', ''), 'python3');
+  assert.equal(
+    pythonCommand('win32', 'D:\\Python\\python.exe'),
+    'D:\\Python\\python.exe',
+  );
 });
 
 test('prepends Windows Path without creating a case-variant duplicate', () => {

--- a/scripts/qualify-portable-format-packages.mjs
+++ b/scripts/qualify-portable-format-packages.mjs
@@ -8,6 +8,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  platformCommand,
+  platformCommandOptions,
+  pythonCommand,
+} from './platform-command.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PACKAGE_SOURCES = [
@@ -26,16 +31,12 @@ function sha256(file) {
     .digest('hex');
 }
 
-function command(name) {
-  return process.platform === 'win32' ? `${name}.cmd` : name;
-}
-
 function run(executable, args, options = {}) {
-  const result = spawnSync(command(executable), args, {
+  const result = spawnSync(platformCommand(executable), args, {
     cwd: options.cwd || ROOT,
     encoding: 'utf8',
     stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
-    shell: process.platform === 'win32',
+    ...platformCommandOptions(executable),
     env: options.env || process.env,
   });
   if (result.error || result.status !== 0) {
@@ -124,7 +125,7 @@ function qualifyInstalledConsumer(archives) {
     );
     const python = JSON.parse(
       run(
-        'python3',
+        pythonCommand(),
         [
           'node_modules/@kungfu-tech/spec/reference-readers/python/portable_format_reader.py',
           '--json',

--- a/tests/qualification/layers/format/python-reader-call.py
+++ b/tests/qualification/layers/format/python-reader-call.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+import time
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: python-reader-call.py READER [ARG...]", file=sys.stderr)
+        return 2
+    result = subprocess.run([sys.executable, *sys.argv[1:]], check=False)
+    time.sleep(int(os.environ.get("KUNGFU_QUALIFICATION_HOLD_MS", "0")) / 1000)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/qualification/layers/format/run.mjs
+++ b/tests/qualification/layers/format/run.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import {
   platformCommand,
   platformCommandOptions,
+  pythonCommand,
 } from '../../../../scripts/platform-command.mjs';
 import { qualificationHoldMs, runMeasured } from '../process-metrics.mjs';
 
@@ -139,8 +140,9 @@ async function main() {
       { cwd: temp, env },
     );
     const pythonReader = await runMeasured(
-      'python3',
+      pythonCommand(),
       [
+        path.join(HERE, 'python-reader-call.py'),
         path.join(
           packageRoot,
           'reference-readers',


### PR DESCRIPTION
Fix the Windows-only portable Spec projection and qualification failures exposed by Build run 30212554008. The generator normalizes declared canonical-LF JSON authorities and committed projections before byte-rooting/comparison while retaining strict rejection of semantic drift. Package-manager and Python launchers now resolve native Windows commands, failed npm pack output remains observable, and the independent Python-reader measurement uses an explicit qualification hold wrapper.

Validation:
- node framework/spec/scripts/generate.js --check
- node framework/spec/scripts/aggregate.js
- node framework/spec/scripts/verify.js
- node --test framework/spec/index.test.js scripts/platform-command.test.mjs
- ./shifu pack:spec
- ./shifu layers:qualify:format -- --report product/release/qualification/layer-format-report.json
- ./shifu qualify:portable-format-packages
- npm pack --dry-run --foreground-scripts --json
- full staged pre-commit gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Cross-platform correctness fix for canonical portable Spec projections and their qualification harness; no ADR status or product semantics change."
}
-->