### PR TITLE
fix(product): accept governed KFD shipped support

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1480,6 +1480,18 @@ export function runInstalledCliSemanticSmoke({
   return { home, exportPath, episodeId };
 }
 
+export function isShippedKfdSupport(standard) {
+  if (standard?.status === 'supported') return true;
+  return (
+    standard?.status === 'source-supported' &&
+    standard?.verification?.status === 'passed' &&
+    standard?.buildchain?.gateStatus === 'passed' &&
+    standard?.claimClass === 'release-qualified-support' &&
+    standard?.releaseQualification?.status === 'alpha-release-passport' &&
+    standard?.releaseQualification?.shippedSupport === true
+  );
+}
+
 function runInstalledKungfuKfdSmoke({
   installRoot,
   kungfuBin,
@@ -1515,8 +1527,10 @@ function runInstalledKungfuKfdSmoke({
   if (data.contract !== 'kungfu-sdk-kfd-standards-status') {
     throw new Error(`unexpected kfd status contract: ${data.contract}`);
   }
-  if (data.standards?.['kfd-3']?.status !== 'supported') {
-    throw new Error('installed kungfu kfd status did not report KFD-3 support');
+  if (!isShippedKfdSupport(data.standards?.['kfd-3'])) {
+    throw new Error(
+      'installed kungfu kfd status did not report release-qualified KFD-3 support',
+    );
   }
   if (
     data.agentRuntime?.status !== 'available' ||

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -14,6 +14,7 @@ import {
   desktopUpdaterArtifact,
   esbuildPlatformBinaryPath,
   installedKungfuInvocation,
+  isShippedKfdSupport,
   kfxBundleExternalModules,
   requiresManagedEsbuildPlatform,
   runInstalledKungfuAssignmentAdmissionSmoke,
@@ -34,6 +35,49 @@ const {
   esmEntrypointArgs,
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
+
+test('installed KFD smoke accepts only release-qualified shipped support', () => {
+  assert.equal(isShippedKfdSupport({ status: 'supported' }), true);
+  assert.equal(
+    isShippedKfdSupport({
+      status: 'source-supported',
+      verification: { status: 'passed' },
+      buildchain: { gateStatus: 'passed' },
+      claimClass: 'release-qualified-support',
+      releaseQualification: {
+        status: 'alpha-release-passport',
+        shippedSupport: true,
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isShippedKfdSupport({
+      status: 'source-supported',
+      verification: { status: 'passed' },
+      buildchain: { gateStatus: 'failed' },
+      claimClass: 'release-qualified-support',
+      releaseQualification: {
+        status: 'alpha-release-passport',
+        shippedSupport: true,
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    isShippedKfdSupport({
+      status: 'candidate',
+      verification: { status: 'passed' },
+      buildchain: { gateStatus: 'passed' },
+      claimClass: 'adoption-candidate',
+      releaseQualification: {
+        status: 'not-qualified',
+        shippedSupport: false,
+      },
+    }),
+    false,
+  );
+});
 
 test('CLI authoring runtime resolves the exact Agent Hub KFD package', () => {
   const packageJson = require.resolve('@kungfu-tech/kfd/package.json', {


### PR DESCRIPTION
## Summary

Restore Alpha product qualification by aligning the installed KFD smoke with the governed support-matrix contract. The SDK intentionally reports KFD-3 as `source-supported` before Alpha settlement, with separate machine evidence proving that the support is release-qualified and shipped.

## Related issue

- Atlas go `2026-07-26-kungfu-kfd-support-governance`
- Follow-up to #1559
- Alpha promotion #1448

## Changes

- Accept the legacy `supported` status for compatibility.
- Accept `source-supported` only when KFD-3 also has passed verification, a passed Buildchain gate, the `release-qualified-support` claim class, an Alpha release-passport qualification, and `shippedSupport: true`.
- Add positive and fail-closed negative unit coverage for the installed-product predicate.

## Verification

- `./shifu test:cli-surface-qualification` — 32 passed
- `./shifu --filter @kungfu-tech/spec run verify` — 7 passed
- `./shifu check:source` — passed, including KFD evidence, the 13-row support matrix, and all support-matrix negative fixtures
- Commit-time staged gate — passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the governed KFD support contract and corrects a stale product-smoke expectation without changing architecture authority or widening support claims."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change tightens product qualification against the already-governed KFD release evidence. It adds no publishing authority and does not weaken the KFD product gates.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; the implementation now matches the documented support matrix)
