### PR TITLE
fix(spec): use pinned Python on Windows

### DIFF
--- a/framework/spec/index.test.js
+++ b/framework/spec/index.test.js
@@ -29,16 +29,53 @@ const {
   npmSpawnOptions,
 } = require('./scripts/pack.js');
 
-function pythonCommand(platform = process.platform) {
-  return (
-    process.env.PYTHON || (platform === 'win32' ? 'python.exe' : 'python3')
-  );
+function pythonInvocation(
+  args,
+  platform = process.platform,
+  configured = process.env.PYTHON,
+) {
+  if (platform !== 'win32' || configured)
+    return { command: configured || 'python3', args };
+  return {
+    command: 'uv',
+    args: [
+      'run',
+      '--project',
+      path.join(__dirname, '..', 'core'),
+      '--frozen',
+      'python',
+      ...args,
+    ],
+  };
 }
 
 test('uses platform command shims when qualifying and packing', () => {
-  assert.equal(pythonCommand('win32'), process.env.PYTHON || 'python.exe');
-  assert.equal(pythonCommand('darwin'), process.env.PYTHON || 'python3');
-  assert.equal(pythonCommand('linux'), process.env.PYTHON || 'python3');
+  assert.deepEqual(pythonInvocation(['reader.py'], 'win32', ''), {
+    command: 'uv',
+    args: [
+      'run',
+      '--project',
+      path.join(__dirname, '..', 'core'),
+      '--frozen',
+      'python',
+      'reader.py',
+    ],
+  });
+  assert.deepEqual(pythonInvocation(['reader.py'], 'darwin', ''), {
+    command: 'python3',
+    args: ['reader.py'],
+  });
+  assert.deepEqual(pythonInvocation(['reader.py'], 'linux', ''), {
+    command: 'python3',
+    args: ['reader.py'],
+  });
+  assert.deepEqual(
+    pythonInvocation(['reader.py'], 'win32', 'D:\\Python\\python.exe'),
+    {
+      command: 'D:\\Python\\python.exe',
+      args: ['reader.py'],
+    },
+  );
   assert.equal(npmCommand('win32'), 'npm.cmd');
   assert.equal(npmCommand('darwin'), 'npm');
   assert.equal(npmCommand('linux'), 'npm');
@@ -79,18 +116,12 @@ test('exposes rooted authority, compatibility, vectors, and non-claims', () => {
 });
 
 test('qualifies every retained vector through the packaged Python reader', () => {
+  const python = pythonInvocation([
+    path.join(__dirname, 'reference-readers/python/portable_format_reader.py'),
+    '--json',
+  ]);
   const report = JSON.parse(
-    execFileSync(
-      pythonCommand(),
-      [
-        path.join(
-          __dirname,
-          'reference-readers/python/portable_format_reader.py',
-        ),
-        '--json',
-      ],
-      { encoding: 'utf8' },
-    ),
+    execFileSync(python.command, python.args, { encoding: 'utf8' }),
   );
   assert.equal(report.package.name, '@kungfu-tech/spec');
   assert.equal(report.vectorCount, 16);

--- a/scripts/platform-command.mjs
+++ b/scripts/platform-command.mjs
@@ -18,7 +18,23 @@ export function pythonCommand(
   platform = process.platform,
   configured = process.env.PYTHON,
 ) {
-  return configured || (platform === 'win32' ? 'python.exe' : 'python3');
+  return configured || (platform === 'win32' ? 'uv' : 'python3');
+}
+
+export function pythonCommandArgs(
+  args,
+  {
+    platform = process.platform,
+    configured = process.env.PYTHON,
+    project = '',
+  } = {},
+) {
+  if (platform !== 'win32' || configured) return args;
+  if (!project)
+    throw new Error(
+      'a pinned uv project is required for the Windows Python command',
+    );
+  return ['run', '--project', project, '--frozen', 'python', ...args];
 }
 
 export function prependEnvironmentPath(

--- a/scripts/platform-command.test.mjs
+++ b/scripts/platform-command.test.mjs
@@ -7,6 +7,7 @@ import {
   platformCommandOptions,
   prependEnvironmentPath,
   pythonCommand,
+  pythonCommandArgs,
 } from './platform-command.mjs';
 
 test('resolves package-manager shims on Windows only', () => {
@@ -21,12 +22,50 @@ test('resolves package-manager shims on Windows only', () => {
 });
 
 test('resolves the Python executable on each platform', () => {
-  assert.equal(pythonCommand('win32', ''), 'python.exe');
+  assert.equal(pythonCommand('win32', ''), 'uv');
   assert.equal(pythonCommand('darwin', ''), 'python3');
   assert.equal(pythonCommand('linux', ''), 'python3');
   assert.equal(
     pythonCommand('win32', 'D:\\Python\\python.exe'),
     'D:\\Python\\python.exe',
+  );
+  assert.deepEqual(
+    pythonCommandArgs(['reader.py', '--json'], {
+      platform: 'win32',
+      configured: '',
+      project: 'D:\\repo\\framework\\core',
+    }),
+    [
+      'run',
+      '--project',
+      'D:\\repo\\framework\\core',
+      '--frozen',
+      'python',
+      'reader.py',
+      '--json',
+    ],
+  );
+  assert.deepEqual(
+    pythonCommandArgs(['reader.py'], {
+      platform: 'win32',
+      configured: 'D:\\Python\\python.exe',
+    }),
+    ['reader.py'],
+  );
+  assert.deepEqual(
+    pythonCommandArgs(['reader.py'], {
+      platform: 'linux',
+      configured: '',
+    }),
+    ['reader.py'],
+  );
+  assert.throws(
+    () =>
+      pythonCommandArgs(['reader.py'], {
+        platform: 'win32',
+        configured: '',
+      }),
+    /pinned uv project is required/,
   );
 });
 

--- a/scripts/qualify-portable-format-packages.mjs
+++ b/scripts/qualify-portable-format-packages.mjs
@@ -12,6 +12,7 @@ import {
   platformCommand,
   platformCommandOptions,
   pythonCommand,
+  pythonCommandArgs,
 } from './platform-command.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -126,10 +127,13 @@ function qualifyInstalledConsumer(archives) {
     const python = JSON.parse(
       run(
         pythonCommand(),
-        [
-          'node_modules/@kungfu-tech/spec/reference-readers/python/portable_format_reader.py',
-          '--json',
-        ],
+        pythonCommandArgs(
+          [
+            'node_modules/@kungfu-tech/spec/reference-readers/python/portable_format_reader.py',
+            '--json',
+          ],
+          { project: path.join(ROOT, 'framework', 'core') },
+        ),
         { cwd: consumer, capture: true },
       ),
     );

--- a/tests/qualification/layers/format/run.mjs
+++ b/tests/qualification/layers/format/run.mjs
@@ -12,6 +12,7 @@ import {
   platformCommand,
   platformCommandOptions,
   pythonCommand,
+  pythonCommandArgs,
 } from '../../../../scripts/platform-command.mjs';
 import { qualificationHoldMs, runMeasured } from '../process-metrics.mjs';
 
@@ -141,16 +142,19 @@ async function main() {
     );
     const pythonReader = await runMeasured(
       pythonCommand(),
-      [
-        path.join(HERE, 'python-reader-call.py'),
-        path.join(
-          packageRoot,
-          'reference-readers',
-          'python',
-          'portable_format_reader.py',
-        ),
-        '--json',
-      ],
+      pythonCommandArgs(
+        [
+          path.join(HERE, 'python-reader-call.py'),
+          path.join(
+            packageRoot,
+            'reference-readers',
+            'python',
+            'portable_format_reader.py',
+          ),
+          '--json',
+        ],
+        { project: path.join(ROOT, 'framework', 'core') },
+      ),
       { cwd: temp, env },
     );
     const outputs = [inspect, verify, preserve, authority, authorityVerify].map(


### PR DESCRIPTION
## Summary

- Route an unconfigured Windows Python reader invocation through the pinned Shifu uv project instead of assuming a system python.exe.
- Preserve explicit PYTHON executables and the existing POSIX python3 behavior.
- Apply the same invocation contract to source-package, clean-install, and layer-format qualification paths.

## Failure evidence

- Alpha Build attempt 2: https://github.com/kungfu-systems/kungfu/actions/runs/30219911489
- Windows failed after KFD-1/2/3 evidence passed because framework/spec/index.test.js raised spawnSync python.exe ENOENT.

## Validation

- Xinfa Task Chart: kungfu-format-contract-agent, projection sha256:8a04963faebfe937bdab8878f22b34c87c3807b79cf3328bdfdc66d4d89577df
- ./shifu --filter @kungfu-tech/spec run verify
- ./shifu pack:spec
- ./shifu qualify:portable-format-packages
- ./shifu check
- ./shifu check:source

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Cross-platform qualification fix for the pinned Python launcher; no format, KFD, or product semantics change."
}
-->