### PR TITLE
fix(release): require S3 artifact relay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,6 @@ on:
         required: false
         type: boolean
         default: false
-      artifact-transfer-mode:
-        description: "Transfer native artifacts directly or through the configured S3 relay"
-        required: false
-        type: choice
-        options:
-          - github-artifacts
-          - s3-to-github-artifacts
-        default: github-artifacts
       render-auditable-demo:
         description: "Render full media after the exact Linux artifact passes the required auditable-demo Gate"
         required: false
@@ -146,7 +138,10 @@ jobs:
       verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip
       release-candidate: true
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
-      artifact-transfer-mode: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact-transfer-mode || 's3-to-github-artifacts' }}
+      # Alpha and release evidence always crosses the configured S3 relay,
+      # including manual diagnostic runs. Keep this literal so a dispatch
+      # cannot silently fall back to direct GitHub artifact transfer.
+      artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14
       checkout-cache-mode: auto
       checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}

--- a/docs/development/buildchain.md
+++ b/docs/development/buildchain.md
@@ -82,6 +82,21 @@ private runner or local-network topology. Buildchain still resolves and verifies
 the immutable source commit and tree before running lifecycle commands, and it
 writes sanitized `source-checkout.json` diagnostics into the platform artifacts.
 
+## Alpha and release artifact relay
+
+Every Alpha or release candidate build transfers native platform artifacts
+through Buildchain's configured S3 relay before the collector rehydrates the
+exact artifacts for downstream GitHub Actions consumers. The same fail-closed
+route applies to manual diagnostic Build runs: the workflow exposes no direct
+GitHub artifact-transfer selector, so manually collected evidence exercises the
+same relay boundary as protected promotion.
+
+The relay changes transport, not artifact identity. Buildchain still binds the
+source SHA, platform, digest, and expiry in its artifact coordinates, and the
+publication workflows consume the rehydrated exact artifacts. Missing relay
+roles or a failed upload/download is therefore a failed build, never permission
+to fall back to an unrecorded direct transfer path.
+
 ## Maturity
 
 The local build path (`./shifu sync && ./shifu build`) is real and is

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -749,7 +749,7 @@
     {
       "path": ".github/workflows/build.yml",
       "authority": "product-publication",
-      "definitionDigest": "sha256:5c60682da8f4f610db1d6e85afda4e9f3617790ccf47ce80720e7127b7e158d1",
+      "definitionDigest": "sha256:aadbb97771ffd89eaec3f3ed67ef3925e1730472a5a722c1a8b956c8ee71b6c1",
       "jobs": [
         {
           "id": "auditable-demo",
@@ -819,7 +819,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:4cb9d25b2fa393bb28459829ad7228cc52b2b51320f7fdbb8960883f7bed29f5",
+          "definitionDigest": "sha256:6688ee0a4c5c508ca6ea35b3fca089eff48b9e78628d2d93b231ea60b57ba2c6",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -466,7 +466,7 @@
           "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip",
           "release-candidate": true,
           "publish-channel": "${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
-          "artifact-transfer-mode": "${{ github.event_name == 'workflow_dispatch' && inputs.artifact-transfer-mode || 's3-to-github-artifacts' }}",
+          "artifact-transfer-mode": "s3-to-github-artifacts",
           "shifu-cache-profile-ref": "${{ inputs.platforms-json && 'docs/shifu/qualification-portable-off.cache-profile.json' || vars.SHIFU_CACHE_PROFILE_REF }}",
           "buildchain-contract-lock-path": ".buildchain/contract-lock.json",
           "buildchain-contract-compatibility-policy": "major-compatible"

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -3,9 +3,9 @@
   "verdict": "pass",
   "authoritySemantics": "navigation-only-projection-over-existing-authorities",
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
-  "manifestRoot": "sha256:0e00a74ae1e728ebbb5f0616d44fc32b036ad82e6d9ec2ab94b008432e01a3c6",
+  "manifestRoot": "sha256:efcfcb1e91cbc43306edb2aef93188e1dbaca6714b54144340618a28f7ff81a7",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:4e8210faeeab5521dfeeb3e1d9787afa71527dfa22b23dd9440361954d55714c",
+  "sourceRoot": "sha256:7deba2385a15d5e36c6c267b8dd20c752055ef3bf21cc6ef098202aaec49d329",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -24,8 +24,8 @@
   "summary": {
     "families": 6,
     "authorities": 6,
-    "mappedSurfaces": 61,
-    "changedMappedSurfaces": 1,
+    "mappedSurfaces": 62,
+    "changedMappedSurfaces": 2,
     "blockingIssues": 0
   },
   "families": [
@@ -790,15 +790,18 @@
         "authority": 3,
         "conformance-oracle": 2,
         "generated-projection": 1,
+        "thin-binding": 1,
         "package-release": 1,
         "documentation": 1,
         "retained-evidence": 1
       },
       "amplification": {
-        "mappedSurfaces": 9,
-        "nonAuthoritySurfaces": 6,
-        "changedSurfaces": 0,
-        "changedPaths": []
+        "mappedSurfaces": 10,
+        "nonAuthoritySurfaces": 7,
+        "changedSurfaces": 1,
+        "changedPaths": [
+          "docs/qualification/gates/workflow-bindings.json"
+        ]
       },
       "surfaces": [
         {
@@ -812,6 +815,10 @@
         {
           "path": "scripts/release-promotion-rehearsal.mjs",
           "role": "conformance-oracle"
+        },
+        {
+          "path": "docs/qualification/gates/workflow-bindings.json",
+          "role": "thin-binding"
         },
         {
           "path": ".github/workflows/release-new-version.yml",
@@ -874,6 +881,14 @@
           "currentRoot": "sha256:12df72a7b881c2c3c83d5a19f1ab8d4189156a4d09ef759fe1e36328f5b4ed1d",
           "baselineRoot": "sha256:12df72a7b881c2c3c83d5a19f1ab8d4189156a4d09ef759fe1e36328f5b4ed1d",
           "changedSinceBaseline": false
+        },
+        {
+          "path": "docs/qualification/gates/workflow-bindings.json",
+          "currentLines": 580,
+          "baselineLines": 580,
+          "currentRoot": "sha256:03acc515ad4de4f331e21a873412685333cdb1cd8dff1c8dacc4080aedadeafb",
+          "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
+          "changedSinceBaseline": true
         },
         {
           "path": ".github/workflows/release-new-version.yml",

--- a/framework/maintainability/semantic-amplification.manifest.json
+++ b/framework/maintainability/semantic-amplification.manifest.json
@@ -347,6 +347,10 @@
           "role": "conformance-oracle"
         },
         {
+          "path": "docs/qualification/gates/workflow-bindings.json",
+          "role": "thin-binding"
+        },
+        {
           "path": ".github/workflows/release-new-version.yml",
           "role": "package-release"
         },

--- a/framework/maintainability/semantic-amplification.test.mjs
+++ b/framework/maintainability/semantic-amplification.test.mjs
@@ -30,7 +30,7 @@ test('current semantic amplification projection has one route per family', () =>
   assert.equal(report.verdict, 'pass');
   assert.equal(report.summary.families, 6);
   assert.equal(report.summary.authorities, 6);
-  assert.equal(report.summary.mappedSurfaces, 61);
+  assert.equal(report.summary.mappedSurfaces, 62);
   assert.deepEqual(report.issues, []);
 });
 

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -94,17 +94,15 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
   const build = WORKFLOW.jobs.build;
   const resolver = WORKFLOW.jobs['resolve-auditable-demo-source'];
   const gate = WORKFLOW.jobs['auditable-demo'];
-  const transferInput =
-    WORKFLOW.on.workflow_dispatch.inputs['artifact-transfer-mode'];
-  assert.equal(transferInput.default, 'github-artifacts');
-  assert.deepEqual(transferInput.options, [
-    'github-artifacts',
-    's3-to-github-artifacts',
-  ]);
+  assert.equal(
+    WORKFLOW.on.workflow_dispatch.inputs['artifact-transfer-mode'],
+    undefined,
+    'manual evidence runs must not expose a direct GitHub artifact-transfer escape hatch',
+  );
   assert.equal(
     build.with['artifact-transfer-mode'],
-    "${{ github.event_name == 'workflow_dispatch' && inputs.artifact-transfer-mode || 's3-to-github-artifacts' }}",
-    'manual evidence runs require explicit relay selection while protected promotion retains its relay path',
+    's3-to-github-artifacts',
+    'every Alpha, release, and manual evidence build must use the configured S3 relay',
   );
   assert.equal(
     resolver.env,


### PR DESCRIPTION
## Summary

Require every Kungfu Alpha, release, and manual evidence build to transfer native artifacts through the configured S3 relay. Direct GitHub artifact transfer is no longer selectable.

## Related issue

Continues `2026-07-25-kungfu-npm-core-platform-distribution-closure`.

## Changes

- remove the manual direct-GitHub artifact transfer input
- pin the Buildchain adapter to `s3-to-github-artifacts` for every activation path
- update the closed-world workflow binding, authority digest, and maintainability projection
- document the fail-closed relay and downstream rehydration boundary

## Verification

- `./shifu test:auditable-demo` (19 passed)
- `./shifu docs:check` (passed)
- `./shifu check:gate-catalog` (38 gates, 6 profiles, 25 invocations, 19 workflows aligned)
- `./shifu check:source` (passed; 656 tests passed, 10 platform-conditional skips)
- staged pre-commit gate (passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This release-transport hardening preserves the accepted Buildchain promotion architecture while removing a diagnostic fallback path."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow references the existing three relay role secrets without changing their values or widening permissions. Contract tests and source acceptance prove the transfer route is literal and fail-closed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
