### PR TITLE
fix(ci): normalize auditable demo renderer inputs

### DIFF
--- a/.buildchain/alpha-contract-lock.json
+++ b/.buildchain/alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v3-alpha",
-    "resolvedSha": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
+    "resolvedSha": "625384b4927222022a2cd0758399afbf9333ccdc",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:b267a2e659ab75433deca4d8f257cee075ca764497132be34c6d2c2f0a0a47c3",
+    "contractDigest": "sha256:d27853cb9230d3288b3c8ce62522e7ad61be04f09890846da01ca22b304584e2",
     "compatibilityDigest": "sha256:008b1c5a90a787cf30106829ac7aca68ab501f6d9c375e415d9c5c6b89039f46",
     "majorLine": "v3",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-26T17:51:08.000Z",
+    "acceptedAt": "2026-07-26T21:08:33.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457 # v3.0.2-alpha.1 with cross-attempt artifact recovery
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
@@ -360,7 +360,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457 # v3.0.2-alpha.1 with cross-attempt artifact recovery
+    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
     with:
       source-ref: ${{ needs.build.outputs.publish-source-sha }}
       source-artifact-name: ${{ needs.resolve-auditable-demo-source.outputs.artifact-name }}
@@ -483,7 +483,7 @@ jobs:
           MEDIA_ARTIFACT_URL: ${{ needs.auditable-demo.outputs.media-artifact-url }}
           MEDIA_ARTIFACT_EXPIRES_AT: ${{ steps.artifact-expiry.outputs.media-artifact-expires-at }}
           MEDIA_ROOT: ${{ needs.auditable-demo.outputs.media-root }}
-          BUILDCHAIN_SHA: bfe43b0fe5577f15d2af01bc542de8a8ce587457
+          BUILDCHAIN_SHA: 625384b4927222022a2cd0758399afbf9333ccdc
           RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:cb5e1dec368d21c7d4e8baded99ac75f12f7eff0d19505751888cf974086efa6
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -109,10 +109,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457 # v3.0.2-alpha.1 with cross-attempt artifact recovery
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: bfe43b0fe5577f15d2af01bc542de8a8ce587457
+      buildchain-ref: 625384b4927222022a2cd0758399afbf9333ccdc
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/docs/qualification/auditable-demo-artifact-pipeline.md
+++ b/docs/qualification/auditable-demo-artifact-pipeline.md
@@ -41,7 +41,7 @@ disables the Gate.
 | --- | --- |
 | Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:cb5e1dec368d21c7d4e8baded99ac75f12f7eff0d19505751888cf974086efa6` |
 | Renderer release | `build-images v1.3.0-alpha.16` |
-| Buildchain Gate | `bfe43b0fe5577f15d2af01bc542de8a8ce587457` (`v3.0.2-alpha.1`, cross-attempt artifact recovery) |
+| Buildchain Gate | `625384b4927222022a2cd0758399afbf9333ccdc` (`v3.0.2-alpha.2`, renderer input normalization) |
 | Consumer adapter | `scripts/auditable-demo-adapter.py` from the exact qualified Kungfu source SHA |
 
 Buildchain's reusable build emits

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -14,8 +14,8 @@
     "runtimes": {
       "alpha": {
         "ref": "v3-alpha",
-        "runtimeSha": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
-        "contractDigest": "sha256:b267a2e659ab75433deca4d8f257cee075ca764497132be34c6d2c2f0a0a47c3",
+        "runtimeSha": "625384b4927222022a2cd0758399afbf9333ccdc",
+        "contractDigest": "sha256:d27853cb9230d3288b3c8ce62522e7ad61be04f09890846da01ca22b304584e2",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },
       "release": {

--- a/docs/qualification/gates/release-admission.md
+++ b/docs/qualification/gates/release-admission.md
@@ -17,7 +17,7 @@ A qualifying capability must bind all of the following exact values:
 | --- | --- |
 | Source | one 40-character Kungfu revision and its release-candidate tree |
 | Gate policy | current `shifu.gates.json`, `release-promotion` matrix digest, complete passing rows and platform receipts |
-| Runtime | Stable release authority is `@kungfu-tech/buildchain@3.0.0`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@3.0.2-alpha.1`. `alpha` binds the protected v3 runtime at `bfe43b0fe5577f15d2af01bc542de8a8ce587457`, while `release` remains isolated on `v3` at `9e904de2c85dbea7c799780ee166510b3336d812`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
+| Runtime | Stable release authority is `@kungfu-tech/buildchain@3.0.0`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@3.0.2-alpha.2`. `alpha` binds the protected v3 runtime at `625384b4927222022a2cd0758399afbf9333ccdc`, while `release` remains isolated on `v3` at `9e904de2c85dbea7c799780ee166510b3336d812`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
 | Controller | qualifying source/runtime-bound Buildchain controller receipt referenced by the RC passport |
 | Runner | qualifying ephemeral, reimaged, or measured persistent-runner provenance; unqualified is denied |
 | Control plane | fresh passing Actions, branch/ruleset, Environment, OIDC, publisher, and runner audit facts |

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -819,7 +819,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:6688ee0a4c5c508ca6ea35b3fca089eff48b9e78628d2d93b231ea60b57ba2c6",
+          "definitionDigest": "sha256:3fddf14775032fd57eec557c5cff04901280bc1301424d50a0f4d472e9425364",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -756,7 +756,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:4daeaa3648a337fbd66ce98e3793f3d43c26c490cbf8980e66841f8b7458c587",
+          "definitionDigest": "sha256:3fbd5e77e61815736cd495cef9171f57a858325a5e29a291cf746d165c5188a2",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -765,7 +765,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"
+            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@625384b4927222022a2cd0758399afbf9333ccdc"
           ],
           "steps": []
         },
@@ -774,7 +774,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:73e179c7c82d8718327ebe36c3bbc124345028393fb233192154f4c0777d43ff",
+          "definitionDigest": "sha256:ef30440f027a568c983d10679e1825b86879a411035ed107f0e77285a8bcbc3e",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -804,7 +804,7 @@
               "index": 3,
               "label": "name:Write exact auditable demo Release Passport",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:0c1fd1b94d1b5f4a3a0330a86ca2db05bc06792ad2a7ce81451c7f77d4284e31"
+              "definitionDigest": "sha256:b25ae4625ef24821eff017ce43e4f62bbfb85473f857285c6c684dbd6e82790f"
             },
             {
               "index": 4,
@@ -832,7 +832,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc"
           ],
           "steps": []
         },
@@ -2260,7 +2260,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3b06daa6c3d568ed4aceb0d02c3d50186744ae35f969dba9610e46393938780d",
+          "definitionDigest": "sha256:e61db3b24e385ee80370c2df10f09edff269720296a28380851241061a53edab",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -2275,7 +2275,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -446,7 +446,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -528,14 +528,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
+          "buildchain-ref": "625384b4927222022a2cd0758399afbf9333ccdc",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "bfe43b0fe5577f15d2af01bc542de8a8ce587457",
+    "workflow_shell_sha": "625384b4927222022a2cd0758399afbf9333ccdc",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -3,9 +3,9 @@
   "verdict": "pass",
   "authoritySemantics": "navigation-only-projection-over-existing-authorities",
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
-  "manifestRoot": "sha256:efcfcb1e91cbc43306edb2aef93188e1dbaca6714b54144340618a28f7ff81a7",
+  "manifestRoot": "sha256:f7294c5e23cfbaa75432394d61d4c860a8ca647bd71ed378a7b89404d6b44cb4",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:7deba2385a15d5e36c6c267b8dd20c752055ef3bf21cc6ef098202aaec49d329",
+  "sourceRoot": "sha256:9022f747d5a16f1708f9ec3eada262a75c427078f9642c030b50be1ad9868316",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -24,8 +24,8 @@
   "summary": {
     "families": 6,
     "authorities": 6,
-    "mappedSurfaces": 62,
-    "changedMappedSurfaces": 2,
+    "mappedSurfaces": 64,
+    "changedMappedSurfaces": 5,
     "blockingIssues": 0
   },
   "families": [
@@ -782,25 +782,29 @@
         "sources": [
           "shifu.gates.json",
           "framework/release/kungfu-trademark-public-use.contract.json",
-          "product/release-channel-trust.json"
+          "product/release-channel-trust.json",
+          "docs/qualification/gates/release-admission-policy.json"
         ]
       },
       "authorityCount": 1,
       "roles": {
-        "authority": 3,
+        "authority": 4,
         "conformance-oracle": 2,
         "generated-projection": 1,
         "thin-binding": 1,
         "package-release": 1,
-        "documentation": 1,
+        "documentation": 2,
         "retained-evidence": 1
       },
       "amplification": {
-        "mappedSurfaces": 10,
-        "nonAuthoritySurfaces": 7,
-        "changedSurfaces": 1,
+        "mappedSurfaces": 12,
+        "nonAuthoritySurfaces": 8,
+        "changedSurfaces": 4,
         "changedPaths": [
-          "docs/qualification/gates/workflow-bindings.json"
+          "docs/qualification/gates/release-admission-policy.json",
+          "docs/qualification/gates/workflow-bindings.json",
+          ".github/workflows/release-new-version.yml",
+          "docs/qualification/gates/release-admission.md"
         ]
       },
       "surfaces": [
@@ -826,6 +830,10 @@
         },
         {
           "path": "docs/qualification/gates/release-and-promotion.md",
+          "role": "documentation"
+        },
+        {
+          "path": "docs/qualification/gates/release-admission.md",
           "role": "documentation"
         },
         {
@@ -859,6 +867,14 @@
           "changedSinceBaseline": false
         },
         {
+          "path": "docs/qualification/gates/release-admission-policy.json",
+          "currentLines": 41,
+          "baselineLines": 41,
+          "currentRoot": "sha256:28d7b573361ff317d5446860fe20d4b76f0fdf63cd8de176279f12538fc13722",
+          "baselineRoot": "sha256:e8a0f7037f2331610f3b9c07e7cdf5e47ea701045c73d0f67bf909372e77e0ac",
+          "changedSinceBaseline": true
+        },
+        {
           "path": "scripts/verify-kungfu-release-admission.mjs",
           "currentLines": 325,
           "baselineLines": 325,
@@ -886,7 +902,7 @@
           "path": "docs/qualification/gates/workflow-bindings.json",
           "currentLines": 580,
           "baselineLines": 580,
-          "currentRoot": "sha256:03acc515ad4de4f331e21a873412685333cdb1cd8dff1c8dacc4080aedadeafb",
+          "currentRoot": "sha256:9046b06f49afa58946d6066a94380b80247a4b6ec231760b508d3bf87d4f4485",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },
@@ -894,9 +910,9 @@
           "path": ".github/workflows/release-new-version.yml",
           "currentLines": 362,
           "baselineLines": 362,
-          "currentRoot": "sha256:3bdd847c80a05030de1d826282cef2e76a85e31dc0904df02c7f0cdda7a5eb74",
+          "currentRoot": "sha256:7f6c48e7801189520758ff94e653bd88126fc3196453e2fbe8abf90ed7c1fa1e",
           "baselineRoot": "sha256:3bdd847c80a05030de1d826282cef2e76a85e31dc0904df02c7f0cdda7a5eb74",
-          "changedSinceBaseline": false
+          "changedSinceBaseline": true
         },
         {
           "path": "docs/qualification/gates/release-and-promotion.md",
@@ -905,6 +921,14 @@
           "currentRoot": "sha256:5eb20fe886635e0464313023daa1a2b62529ad1d6977202dce9c91c6b8aacf9e",
           "baselineRoot": "sha256:5eb20fe886635e0464313023daa1a2b62529ad1d6977202dce9c91c6b8aacf9e",
           "changedSinceBaseline": false
+        },
+        {
+          "path": "docs/qualification/gates/release-admission.md",
+          "currentLines": 75,
+          "baselineLines": 75,
+          "currentRoot": "sha256:f0383f440164a76bed1d530dd301a9a2b77a8882fda5f51ad1946f6abc6cc71f",
+          "baselineRoot": "sha256:69f293fefb3c94df44051dc86ba4435416f5ea4348f2ffb245bef19bb494a280",
+          "changedSinceBaseline": true
         },
         {
           "path": "framework/release/kungfu-ungfu-release-evidence.candidate.json",

--- a/framework/maintainability/semantic-amplification.manifest.json
+++ b/framework/maintainability/semantic-amplification.manifest.json
@@ -330,7 +330,8 @@
         "sources": [
           "shifu.gates.json",
           "framework/release/kungfu-trademark-public-use.contract.json",
-          "product/release-channel-trust.json"
+          "product/release-channel-trust.json",
+          "docs/qualification/gates/release-admission-policy.json"
         ]
       },
       "surfaces": [
@@ -356,6 +357,10 @@
         },
         {
           "path": "docs/qualification/gates/release-and-promotion.md",
+          "role": "documentation"
+        },
+        {
+          "path": "docs/qualification/gates/release-admission.md",
           "role": "documentation"
         },
         {

--- a/framework/maintainability/semantic-amplification.test.mjs
+++ b/framework/maintainability/semantic-amplification.test.mjs
@@ -30,7 +30,7 @@ test('current semantic amplification projection has one route per family', () =>
   assert.equal(report.verdict, 'pass');
   assert.equal(report.summary.families, 6);
   assert.equal(report.summary.authorities, 6);
-  assert.equal(report.summary.mappedSurfaces, 62);
+  assert.equal(report.summary.mappedSurfaces, 64);
   assert.deepEqual(report.issues, []);
 });
 

--- a/package.json
+++ b/package.json
@@ -293,7 +293,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "3.0.0",
-    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@3.0.2-alpha.1",
+    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@3.0.2-alpha.2",
     "@kungfu-tech/kfd": "1.0.0-alpha.47",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@kungfu-tech/buildchain-alpha':
-        specifier: npm:@kungfu-tech/buildchain@3.0.2-alpha.1
-        version: '@kungfu-tech/buildchain@3.0.2-alpha.1'
+        specifier: npm:@kungfu-tech/buildchain@3.0.2-alpha.2
+        version: '@kungfu-tech/buildchain@3.0.2-alpha.2'
       '@kungfu-tech/kfd':
         specifier: 1.0.0-alpha.47
         version: 1.0.0-alpha.47
@@ -1446,8 +1446,8 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/buildchain@3.0.2-alpha.1':
-    resolution: {integrity: sha512-MfPs3tTnO00ZTk+JLANEC2BbZuNBr+Yanv+NyHCQuJL6cB2wdYJpZAA+d0zxtUtPZ/VJ4ag8/bXXCmpUclFaBg==}
+  '@kungfu-tech/buildchain@3.0.2-alpha.2':
+    resolution: {integrity: sha512-phNnd7LxdifzHX/Vuk06u59MFpg4g9HpM06OKNJuzVQVoAOGh3GWJ/edDfL4TQ9fhbwNfbMfeq6LVxu5QKBkXA==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5801,7 +5801,7 @@ snapshots:
       '@kungfu-tech/kfd': 1.0.0-alpha.41
       smol-toml: 1.7.0
 
-  '@kungfu-tech/buildchain@3.0.2-alpha.1':
+  '@kungfu-tech/buildchain@3.0.2-alpha.2':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.47
       smol-toml: 1.7.0

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -116,7 +116,7 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
   );
   assert.equal(
     build.uses,
-    'kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457',
+    'kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc',
     'the build runtime must be the protected Buildchain release that owns artifact-coordinates-json',
   );
   assert.match(

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -38,11 +38,11 @@ import {
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
-const RUNTIME_SHA = 'bfe43b0fe5577f15d2af01bc542de8a8ce587457';
+const RUNTIME_SHA = '625384b4927222022a2cd0758399afbf9333ccdc';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =
-  'b267a2e659ab75433deca4d8f257cee075ca764497132be34c6d2c2f0a0a47c3';
+  'd27853cb9230d3288b3c8ce62522e7ad61be04f09890846da01ca22b304584e2';
 const STABLE_CONTRACT_DIGEST =
   '914720131f07664cd187a1033f357c4952ef1008f5553cb6b285a75f786a7fbc';
 const PREDICATE_COMMAND = 'node scripts/kungfu-release-qualification.mjs';


### PR DESCRIPTION
## Summary

Consume immutable Buildchain `v3.0.2-alpha.2`, close the auditable-demo Gate over renderer-normalized retained inputs, and preserve the release-admission mappings required by the current maintainability governance floor. This is a linear-history replacement for #1568; the net patch is byte-for-byte equivalent by stable patch-id, while avoiding the merge-queue replay conflict caused by the prior branch history.

## Related evidence

- Superseded PR: https://github.com/kungfu-systems/kungfu/pull/1568
- Buildchain incident: https://github.com/kungfu-systems/buildchain/issues/1940
- Buildchain fix: https://github.com/kungfu-systems/buildchain/pull/1941
- Immutable release: https://github.com/kungfu-systems/buildchain/releases/tag/v3.0.2-alpha.2
- Prior exact Kungfu run exposing the mismatch: https://github.com/kungfu-systems/kungfu/actions/runs/30216301917

## Changes

- pin every alpha reusable build, auditable-demo, promotion, and Passport Buildchain surface to tag commit `625384b4927222022a2cd0758399afbf9333ccdc`
- update the alpha package to `@kungfu-tech/buildchain@3.0.2-alpha.2`
- update the alpha contract lock to `sha256:d27853cb9230d3288b3c8ce62522e7ad61be04f09890846da01ca22b304584e2`
- preserve compatibility digest `sha256:008b1c5a90a787cf30106829ac7aca68ab501f6d9c375e415d9c5c6b89039f46`
- regenerate workflow authority digests and release-admission projections
- map the three governed release-admission surfaces
- keep the standalone Shifu binary pin and renderer image digest unchanged

## Verification

- stable patch-id matches #1568 exactly: `82731cba063810ec8f02f7979ee9e7d695842b6c`
- `./shifu node --test framework/maintainability/semantic-amplification.test.mjs scripts/auditable-demo-workflow.test.mjs scripts/verify-kungfu-release-admission.test.mjs` (16 passed)
- `./shifu run check:gate-catalog` (38 gates, 6 profiles, 25 invocations, 19 workflows)
- staged pre-commit gate passed, including deterministic documentation and governance rehearsals
- full source acceptance is enforced by required PR checks

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix consumes an already reviewed immutable Buildchain runtime and preserves the accepted v3 compatibility, Kungfu architecture contracts, and maintainability governance already present on the protected baseline."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates immutable reusable-workflow, package, contract, and governance coordinates only. It grants no publication or deployment authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
