### PR TITLE
fix(release): admit regenerated pull merge tree

### DIFF
--- a/framework/core/tests/episode-release-evidence.test.mjs
+++ b/framework/core/tests/episode-release-evidence.test.mjs
@@ -205,6 +205,63 @@ test('rejects a Buildchain source SHA that differs from the qualified revision',
   );
 });
 
+test('accepts a regenerated pull merge when the Buildchain source tree is unchanged', () => {
+  const buildContext = context();
+  buildContext.ci = {
+    provider: 'github-actions',
+    ref: 'refs/pull/1448/merge',
+    source_sha: '9'.repeat(40),
+    source_tree_sha: buildContext.sourceTree,
+  };
+  const evidence = buildReleaseEvidence(report(), buildContext);
+  const validation = validateReleaseEvidence(evidence, { profilePath });
+  const sourceGate = evidence.qualification.hard_gates.find(
+    (row) => row.id === 'ci_source_revision',
+  );
+  assert.equal(evidence.verdict, 'qualified');
+  assert.equal(sourceGate?.passed, true);
+  assert.match(sourceGate?.evidence || '', /mode=tree-equivalent-pull-merge/);
+  assert.equal(validation.ok, true, validation.errors.join('; '));
+});
+
+test('rejects tree equivalence outside a pull merge ref', () => {
+  const buildContext = context();
+  buildContext.ci = {
+    provider: 'github-actions',
+    ref: 'refs/heads/dev/v4/v4.0',
+    source_sha: '9'.repeat(40),
+    source_tree_sha: buildContext.sourceTree,
+  };
+  const evidence = buildReleaseEvidence(report(), buildContext);
+  const validation = validateReleaseEvidence(evidence, { profilePath });
+  const sourceGate = evidence.qualification.hard_gates.find(
+    (row) => row.id === 'ci_source_revision',
+  );
+  assert.equal(evidence.verdict, 'failed');
+  assert.equal(sourceGate?.passed, false);
+  assert.match(sourceGate?.evidence || '', /mode=mismatch/);
+  assert.equal(validation.ok, false);
+});
+
+test('rejects a regenerated pull merge whose Buildchain source tree differs', () => {
+  const buildContext = context();
+  buildContext.ci = {
+    provider: 'github-actions',
+    ref: 'refs/pull/1448/merge',
+    source_sha: '9'.repeat(40),
+    source_tree_sha: '8'.repeat(40),
+  };
+  const evidence = buildReleaseEvidence(report(), buildContext);
+  const validation = validateReleaseEvidence(evidence, { profilePath });
+  const sourceGate = evidence.qualification.hard_gates.find(
+    (row) => row.id === 'ci_source_revision',
+  );
+  assert.equal(evidence.verdict, 'failed');
+  assert.equal(sourceGate?.passed, false);
+  assert.match(sourceGate?.evidence || '', /mode=mismatch/);
+  assert.equal(validation.ok, false);
+});
+
 test('rejects a Windows absolute profile path in a resealed envelope', () => {
   const evidence = buildReleaseEvidence(report(), context());
   evidence.profile.path = 'C:\\outside\\mvp-baseline-v1.json';

--- a/framework/core/tests/qualification/episode/release_evidence.mjs
+++ b/framework/core/tests/qualification/episode/release_evidence.mjs
@@ -280,6 +280,7 @@ function ciRecord(env = process.env) {
     ref: env.GITHUB_REF || '',
     sha: env.GITHUB_SHA || '',
     source_sha: env.BUILDCHAIN_SOURCE_SHA || '',
+    source_tree_sha: env.BUILDCHAIN_SOURCE_TREE_SHA || '',
     buildchain_runtime_ref: env.BUILDCHAIN_RUNTIME_REF || '',
     buildchain_runtime_sha: env.BUILDCHAIN_RUNTIME_SHA || '',
     run_url:
@@ -328,6 +329,22 @@ export function evaluateHardGates(report, context) {
     'dependency_failure_containment',
     'projection_drift_and_rebuild',
   ];
+  const ciSourceSha = context.ci?.source_sha || '';
+  const ciSourceTreeSha = context.ci?.source_tree_sha || '';
+  const ciSourceRevisionMatches =
+    !ciSourceSha || ciSourceSha === context.sourceRevision;
+  const ciPullMergeTreeEquivalent =
+    Boolean(ciSourceSha) &&
+    ciSourceSha !== context.sourceRevision &&
+    /^refs\/pull\/\d+\/merge$/.test(context.ci?.ref || '') &&
+    Boolean(ciSourceTreeSha) &&
+    Boolean(context.sourceTree) &&
+    ciSourceTreeSha === context.sourceTree;
+  const ciSourceIdentityMode = ciSourceRevisionMatches
+    ? 'commit'
+    : ciPullMergeTreeEquivalent
+      ? 'tree-equivalent-pull-merge'
+      : 'mismatch';
   return [
     gate(
       'harness_exit',
@@ -363,9 +380,8 @@ export function evaluateHardGates(report, context) {
     ),
     gate(
       'ci_source_revision',
-      !context.ci?.source_sha ||
-        context.ci.source_sha === context.sourceRevision,
-      `ci=${context.ci?.source_sha || 'local'} expected=${context.sourceRevision}`,
+      ciSourceRevisionMatches || ciPullMergeTreeEquivalent,
+      `ci=${ciSourceSha || 'local'} expected=${context.sourceRevision} ci_tree=${ciSourceTreeSha || 'missing'} expected_tree=${context.sourceTree || 'missing'} mode=${ciSourceIdentityMode}`,
     ),
     gate(
       'trust_report_qualified',
@@ -525,6 +541,7 @@ export function validateReleaseEvidence(evidence, options = {}) {
     shifuEntrypoint: evidence.toolchain?.shifu?.entrypoint_provenance,
     profile: evidence.profile,
     sourceRevision: evidence.source?.revision,
+    sourceTree: evidence.source?.tree,
     runtimeArtifacts: evidence.runtime?.artifact_manifest?.artifacts || [],
     ci: evidence.ci || { provider: 'local' },
   };
@@ -689,6 +706,14 @@ async function runCommand(options) {
     console.log(
       `[episode-release-evidence] verdict=${evidence.verdict} gates=${evidence.qualification.hard_gates.filter((row) => row.passed).length}/${evidence.qualification.hard_gates.length} digest=${evidence.evidence_digest}`,
     );
+    const failedGates = evidence.qualification.hard_gates.filter(
+      (row) => !row.passed,
+    );
+    if (failedGates.length > 0) {
+      console.error(
+        `[episode-release-evidence] failed gates: ${failedGates.map((row) => `${row.id} (${row.evidence})`).join('; ')}`,
+      );
+    }
     if (!schemaValidation.ok) {
       console.error(
         `[episode-release-evidence] schema invalid: ${schemaValidation.output}`,

--- a/framework/core/tests/qualification/episode/schemas/release-evidence-v1.schema.json
+++ b/framework/core/tests/qualification/episode/schemas/release-evidence-v1.schema.json
@@ -177,6 +177,7 @@
         "ref": { "type": "string" },
         "sha": { "type": "string" },
         "source_sha": { "type": "string" },
+        "source_tree_sha": { "type": "string" },
         "buildchain_runtime_ref": { "type": "string" },
         "buildchain_runtime_sha": { "type": "string" },
         "run_url": { "type": "string" }


### PR DESCRIPTION
## Summary

- Persist the Buildchain source tree in Episode release evidence.
- Keep exact commit identity as the default, while admitting a regenerated refs/pull/N/merge commit only when its anchored tree matches the checked-out source tree.
- Fail closed for branch refs, missing trees, and mismatched trees, and print the exact failed gate evidence.

## Failure evidence

- Alpha Build attempt 2: https://github.com/kungfu-systems/kungfu/actions/runs/30223060587/attempts/2
- GitHub regenerated the PR merge commit from 3f2585bfbf1e3e7266dbd5031767c15843e21753 to 33cd317f766bc0ca91d082e4c4dacdb9d13e4013 with identical parents and tree 7ceaf3c3252762100d3d8d39601a08088b900456.
- Episode qualification passed 13/14 gates; ci_source_revision was the only failed gate.

## Validation

- node --test framework/core/tests/episode-release-evidence.test.mjs (9/9)
- biome check on the changed JavaScript files
- node --check on the changed JavaScript files
- release evidence schema parses with jq
- full staged pre-commit gate, including KFD-7, KFD Agent Runtime, invariants, ADR, and documentation gates

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Release-evidence identity correction that mirrors the existing Buildchain locked-source pull-merge tree rule; no KFD, format, or product semantics change."
}
-->