### PR TITLE
fix(ci): normalize Passport artifact digests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,13 +430,21 @@ jobs:
               artifacts.map((artifact) => [String(artifact.id), artifact]),
             );
             for (const coordinate of declared) {
+              if (/^[0-9a-f]{64}$/.test(coordinate.digest)) {
+                coordinate.digest = `sha256:${coordinate.digest}`;
+              }
               const present = [coordinate.id, coordinate.name, coordinate.digest]
                 .filter(Boolean).length;
               if (!coordinate.required && present === 0) {
+                core.setOutput(`${coordinate.kind}-artifact-digest`, "");
                 core.setOutput(`${coordinate.kind}-artifact-expires-at`, "");
                 continue;
               }
-              if (present !== 3 || !/^[1-9][0-9]*$/.test(coordinate.id)) {
+              if (
+                present !== 3 ||
+                !/^[1-9][0-9]*$/.test(coordinate.id) ||
+                !/^sha256:[0-9a-f]{64}$/.test(coordinate.digest)
+              ) {
                 throw new Error(`${coordinate.kind} artifact coordinate is partial or invalid`);
               }
               const artifact = byId.get(coordinate.id);
@@ -458,6 +466,10 @@ jobs:
                 throw new Error(`${coordinate.kind} artifact is expired or has no live expiry`);
               }
               core.setOutput(
+                `${coordinate.kind}-artifact-digest`,
+                artifact.digest,
+              );
+              core.setOutput(
                 `${coordinate.kind}-artifact-expires-at`,
                 new Date(expiresAt).toISOString(),
               );
@@ -473,13 +485,13 @@ jobs:
           SOURCE_ARTIFACT_EXPIRES_AT: ${{ needs.resolve-auditable-demo-source.outputs.artifact-expires-at }}
           GATE_ARTIFACT_ID: ${{ needs.auditable-demo.outputs.gate-artifact-id }}
           GATE_ARTIFACT_NAME: ${{ needs.auditable-demo.outputs.gate-artifact-name }}
-          GATE_ARTIFACT_DIGEST: ${{ needs.auditable-demo.outputs.gate-artifact-digest }}
+          GATE_ARTIFACT_DIGEST: ${{ steps.artifact-expiry.outputs.gate-artifact-digest }}
           GATE_ARTIFACT_URL: ${{ needs.auditable-demo.outputs.gate-artifact-url }}
           GATE_ARTIFACT_EXPIRES_AT: ${{ steps.artifact-expiry.outputs.gate-artifact-expires-at }}
           GATE_ROOT: ${{ needs.auditable-demo.outputs.gate-root }}
           MEDIA_ARTIFACT_ID: ${{ needs.auditable-demo.outputs.media-artifact-id }}
           MEDIA_ARTIFACT_NAME: ${{ needs.auditable-demo.outputs.media-artifact-name }}
-          MEDIA_ARTIFACT_DIGEST: ${{ needs.auditable-demo.outputs.media-artifact-digest }}
+          MEDIA_ARTIFACT_DIGEST: ${{ steps.artifact-expiry.outputs.media-artifact-digest }}
           MEDIA_ARTIFACT_URL: ${{ needs.auditable-demo.outputs.media-artifact-url }}
           MEDIA_ARTIFACT_EXPIRES_AT: ${{ steps.artifact-expiry.outputs.media-artifact-expires-at }}
           MEDIA_ROOT: ${{ needs.auditable-demo.outputs.media-root }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -774,7 +774,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:ef30440f027a568c983d10679e1825b86879a411035ed107f0e77285a8bcbc3e",
+          "definitionDigest": "sha256:3a2fb8ae784a8a65927b7396f1a244a579c6f117d0565fe2f0791e2ca4a4de3d",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -798,13 +798,13 @@
               "index": 2,
               "label": "id:artifact-expiry",
               "authority": "qualification",
-              "definitionDigest": "sha256:88c9afd277e1ccb9be342a312b8d3bc428c02400fb7189b881047a32b7bb482b"
+              "definitionDigest": "sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"
             },
             {
               "index": 3,
               "label": "name:Write exact auditable demo Release Passport",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:b25ae4625ef24821eff017ce43e4f62bbfb85473f857285c6c684dbd6e82790f"
+              "definitionDigest": "sha256:6653dcbf5eb4a05acdfa2fb0d62fdabb359ba6795f7ec3c2525da5dd4bc79b70"
             },
             {
               "index": 4,

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -90,6 +90,57 @@ async function runResolver({ declaredExpiry, observedExpiry }) {
   return outputs;
 }
 
+async function runPassportArtifactBinding({
+  gateDigest = '3'.repeat(64),
+  mediaDigest = '4'.repeat(64),
+  observedGateDigest = `sha256:${'3'.repeat(64)}`,
+  observedMediaDigest = `sha256:${'4'.repeat(64)}`,
+}) {
+  const passport = WORKFLOW.jobs['auditable-demo-passport'];
+  const script = passport.steps.find(({ id }) => id === 'artifact-expiry').with
+    .script;
+  const runId = '30225695823';
+  const gateId = '8639472306';
+  const mediaId = '8639492343';
+  const gateName = 'auditable-demo-gate-source-root';
+  const mediaName = 'auditable-demo-media-source-root';
+  const outputs = new Map();
+  await new AsyncFunction('process', 'github', 'context', 'core', script)(
+    {
+      env: {
+        GATE_ARTIFACT_ID: gateId,
+        GATE_ARTIFACT_NAME: gateName,
+        GATE_ARTIFACT_DIGEST: gateDigest,
+        MEDIA_ARTIFACT_ID: mediaId,
+        MEDIA_ARTIFACT_NAME: mediaName,
+        MEDIA_ARTIFACT_DIGEST: mediaDigest,
+      },
+    },
+    {
+      paginate: async () => [
+        {
+          id: Number(gateId),
+          name: gateName,
+          digest: observedGateDigest,
+          expired: false,
+          expires_at: '2026-08-10T01:08:00Z',
+        },
+        {
+          id: Number(mediaId),
+          name: mediaName,
+          digest: observedMediaDigest,
+          expired: false,
+          expires_at: '2026-08-10T01:09:31Z',
+        },
+      ],
+      rest: { actions: { listWorkflowRunArtifacts: () => undefined } },
+    },
+    { repo: { owner: 'kungfu-systems', repo: 'kungfu' }, runId },
+    { setOutput: (key, value) => outputs.set(key, value) },
+  );
+  return outputs;
+}
+
 test('every produced Linux artifact enters the required exact-output Gate', () => {
   const build = WORKFLOW.jobs.build;
   const resolver = WORKFLOW.jobs['resolve-auditable-demo-source'];
@@ -173,6 +224,14 @@ test('Gate runtime and renderer are immutable and Passport uses the same runtime
     /listWorkflowRunArtifacts[\s\S]*artifact\.digest !== coordinate\.digest/u,
   );
   assert.equal(
+    passportStep.env.GATE_ARTIFACT_DIGEST,
+    '${{ steps.artifact-expiry.outputs.gate-artifact-digest }}',
+  );
+  assert.equal(
+    passportStep.env.MEDIA_ARTIFACT_DIGEST,
+    '${{ steps.artifact-expiry.outputs.media-artifact-digest }}',
+  );
+  assert.equal(
     passportStep.env.GATE_ARTIFACT_EXPIRES_AT,
     '${{ steps.artifact-expiry.outputs.gate-artifact-expires-at }}',
   );
@@ -181,6 +240,26 @@ test('Gate runtime and renderer are immutable and Passport uses the same runtime
     '${{ steps.artifact-expiry.outputs.media-artifact-expires-at }}',
   );
   assert.match(passport.if, /needs\.auditable-demo\.result == 'success'/u);
+});
+
+test('Passport binding normalizes upload digests to exact API coordinates', async () => {
+  const outputs = await runPassportArtifactBinding({});
+  assert.equal(outputs.get('gate-artifact-digest'), `sha256:${'3'.repeat(64)}`);
+  assert.equal(
+    outputs.get('media-artifact-digest'),
+    `sha256:${'4'.repeat(64)}`,
+  );
+  await assert.rejects(
+    runPassportArtifactBinding({
+      gateDigest: '3'.repeat(64),
+      observedGateDigest: `sha256:${'5'.repeat(64)}`,
+    }),
+    /gate artifact name or digest differs from the retained artifact/u,
+  );
+  await assert.rejects(
+    runPassportArtifactBinding({ gateDigest: 'not-a-digest' }),
+    /gate artifact coordinate is partial or invalid/u,
+  );
 });
 
 test('full media is selective while the Gate remains unconditional when applicable', () => {


### PR DESCRIPTION
## Summary

Normalize raw 64-hex `actions/upload-artifact` digests before comparing them with the GitHub API canonical `sha256:<hex>` coordinates. The Passport generator now consumes the verified API digest rather than the provider-specific raw representation.

Closes #1579.

## Failure evidence

- Build run: https://github.com/kungfu-systems/kungfu/actions/runs/30225695823
- Gate artifact `8639472306` and media artifact `8639492343` both completed successfully.
- Passport failed closed because reusable-workflow output exposed raw 64-hex while the same-run API returned canonical `sha256:<hex>`.

## Validation

- `./shifu test:auditable-demo` — 20 passed
- `./shifu check:staged` — passed, including workflow authority refresh and governance checks
- Test executes the embedded workflow script and proves raw normalization, canonical output, malformed-digest rejection, and real mismatch rejection.

## Safety

- Existing same-run artifact id/name/digest binding remains fail closed.
- No claim-scope, publication-authority, deployment, or production behavior change.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix normalizes one provider digest representation at the existing Passport boundary without changing product architecture, claim scope, publication authority, or deployment behavior."
}
-->