### PR TITLE
fix(governance): pin live candidate selector

### DIFF
--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -32,9 +32,9 @@ jobs:
   candidate:
     # This exact Buildchain source commit is replaced by the merged commit if
     # review changes the reusable workflow before this PR is merged.
-    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@7a6243537b902e1be0dca722b12cd459c2a4e697
+    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@e95c0251390f4948b7aa00de63c49f018ef1f6ff
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '7a6243537b902e1be0dca722b12cd459c2a4e697' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || 'e95c0251390f4948b7aa00de63c49f018ef1f6ff' }}
       source-branch: dev/v4/v4.0
       target-branch: alpha/v4/v4.0
       dev-workflow-path: .github/workflows/dev-verify-patrol.yml

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1411,7 +1411,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:6d00447ea4369752cd26d56532b24f8b81053e5381be82e9320e2c6033ca15d5",
+          "definitionDigest": "sha256:c4fd03d3a0a5c7c0d16ad4d9594d0f1e3f879f442fe976d5667b17b3737670c7",
           "credentials": {
             "githubToken": "write",
             "oidc": false,
@@ -1420,7 +1420,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@7a6243537b902e1be0dca722b12cd459c2a4e697"
+            "kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@e95c0251390f4948b7aa00de63c49f018ef1f6ff"
           ],
           "steps": []
         }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -130,7 +130,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:d9bbd764d67e5ecd2d4852cc096566516de77e82d81147958a43a9988a0683a6"
+          "sourceRoot": "sha256:ff9c5dc260e541871da9d45137b69316bc4395f4ed1026b8816c8ebaf585b361"
         },
         {
           "path": ".github/workflows/dev-verify-patrol.yml",
@@ -767,5 +767,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e845bea3dcfb052daec13bdffd4df53106a610973d28b16a30b013cd23cab4cd"
+  "registryRoot": "sha256:e5426d6a8e7f4d5af0a28dac3e84e0f16e883b485efd88379990662336d5385f"
 }


### PR DESCRIPTION
Summary

- Pin Dev to Alpha Candidate Patrol to merged Buildchain commit e95c0251390f4948b7aa00de63c49f018ef1f6ff.
- Refresh the closed-world workflow authority manifest.
- Refresh the release publication control-plane source root.

Why

The current-HEAD-only selector repeatedly became stale while native Dev Verify was still running. Buildchain PR 1949 now selects the newest qualified Dev ancestor while preserving exact same-SHA evidence and the no-merge/no-publication boundary.

Validation

- shifu test:alpha-promotion-preflight: 42 passed
- shifu check:gate-catalog: passed
- shifu check:source: passed
- staged pre-commit gates: passed
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Pin the merged Buildchain candidate selector and refresh derived authority roots without changing an architecture contract."
}
-->