### PR TITLE
ci(opencode): add local-model runner canary

### DIFF
--- a/.github/workflows/opencode-local-model-canary.yml
+++ b/.github/workflows/opencode-local-model-canary.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: OpenCode Local Model Canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: opencode-local-model-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: agent-120 / Qwen3-Coder
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - agent-120
+      - kungfu-build
+    timeout-minutes: 20
+    env:
+      OPENCODE_IMAGE: ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3
+      OPENCODE_MODEL: qwen3-coder:30b-opencode-64k
+      OPENCODE_BASE_URL: http://host.docker.internal:11435/v1
+      OPENCODE_HOST_PROBE_URL: http://172.17.0.1:11435/v1/models
+    steps:
+      - name: Verify trusted runner and preloaded image
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "agent-120-kungfu-systems"
+          docker image inspect "$OPENCODE_IMAGE" >/dev/null
+          curl -fsS --max-time 5 "$OPENCODE_HOST_PROBE_URL" >/dev/null
+
+      - name: Prepare deterministic fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          case_dir="$RUNNER_TEMP/opencode-ci-local-model-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          install -d -m 0755 "$case_dir/evidence"
+          printf '%s\n' "Read this fixed canary input before producing the requested artifacts." >"$case_dir/input.txt"
+          printf 'OPENCODE_CANARY_DIR=%s\n' "$case_dir" >>"$GITHUB_ENV"
+
+      - name: Run OpenCode with the local model
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --read-only \
+            --tmpfs /tmp:rw,noexec,nosuid,nodev,size=256m \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            --network bridge \
+            --add-host host.docker.internal:host-gateway \
+            -v "$OPENCODE_CANARY_DIR:/workspace" \
+            -w /workspace \
+            -e OPENCODE_BASE_URL \
+            -e OPENCODE_MODEL \
+            -e OPENCODE_CONTEXT=65536 \
+            -e OPENCODE_OUTPUT_DIR=/workspace/evidence \
+            -e OPENCODE_TIMEOUT_SECONDS=600 \
+            -e OPENCODE_PROMPT="Read /workspace/input.txt. Write exactly KUNGFU_OPENCODE_CI_OK and a trailing newline to /workspace/output.txt. Run a Bash command that writes exactly bash-ok and a trailing newline to /workspace/bash-ok.txt. Do not modify any other file." \
+            -e OPENCODE_VERIFY_COMMAND="opencode-ci-verify /workspace/evidence/events.jsonl /workspace/output.txt /opt/opencode-ci/expected.txt /workspace/bash-ok.txt" \
+            "$OPENCODE_IMAGE" \
+            opencode-ci-run
+
+          jq -e \
+            --arg model "$OPENCODE_MODEL" \
+            '.passed == true and .model == $model and .opencode_exit == 0 and .verifier_exit == 0' \
+            "$OPENCODE_CANARY_DIR/evidence/run.json" >/dev/null
+
+      - name: Upload bounded canary evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: opencode-local-model-canary-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/opencode-ci-local-model-${{ github.run_id }}-${{ github.run_attempt }}/evidence/run.json
+            ${{ runner.temp }}/opencode-ci-local-model-${{ github.run_id }}-${{ github.run_attempt }}/evidence/opencode.stderr
+            ${{ runner.temp }}/opencode-ci-local-model-${{ github.run_id }}-${{ github.run_attempt }}/output.txt
+            ${{ runner.temp }}/opencode-ci-local-model-${{ github.run_id }}-${{ github.run_attempt }}/bash-ok.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -20,9 +20,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -58,15 +56,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "actions/setup-node@v6.4.0",
-            "actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830",
-            "actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830",
-            "actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830",
-            "actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -227,14 +217,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "actions/setup-node@v6.4.0",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -305,10 +288,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "kungfu-systems/buildchain/actions/validate-config@v3"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","kungfu-systems/buildchain/actions/validate-config@v3"],
           "steps": [
             {
               "index": 1,
@@ -337,10 +317,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -387,9 +364,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4"
-          ],
+          "externalActions": ["actions/checkout@v4"],
           "steps": [
             {
               "index": 1,
@@ -418,10 +393,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"],
           "steps": [
             {
               "index": 1,
@@ -462,12 +434,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "actions/setup-node@v6.4.0",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
-          ],
+          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"],
           "steps": [
             {
               "index": 1,
@@ -538,10 +505,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "actions/setup-node@v6.4.0"
-          ],
+          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0"],
           "steps": [
             {
               "index": 1,
@@ -606,9 +570,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/check.yml@9e904de2c85dbea7c799780ee166510b3336d812"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@9e904de2c85dbea7c799780ee166510b3336d812"],
           "steps": []
         }
       ]
@@ -631,11 +593,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -676,11 +634,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/setup-node@v6.4.0",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@v6.4.0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -764,9 +718,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"],
           "steps": []
         },
         {
@@ -782,11 +734,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd",
-            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
           "steps": [
             {
               "index": 1,
@@ -831,9 +779,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"],
           "steps": []
         },
         {
@@ -855,12 +801,7 @@
             "inheritedSecrets": false,
             "environment": "alpha-macos-signing"
           },
-          "externalActions": [
-            "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
-            "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
-            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
-            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
-          ],
+          "externalActions": ["actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131","actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
           "steps": [
             {
               "index": 1,
@@ -913,9 +854,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@3056c23e70b83f5bb63062f04027a93e79039e4b"
-          ],
+          "externalActions": ["kungfu-systems/build-images/.github/workflows/comparator-kungfu-package-smoke.yml@3056c23e70b83f5bb63062f04027a93e79039e4b"],
           "steps": []
         },
         {
@@ -931,11 +870,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -982,11 +917,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
-            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
           "steps": [
             {
               "index": 1,
@@ -1027,9 +958,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -1058,10 +987,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd",
-            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
-          ],
+          "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
           "steps": [
             {
               "index": 1,
@@ -1097,9 +1023,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -1128,10 +1052,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "kungfu-systems/buildchain/actions/validate-config@v3"
-          ],
+          "externalActions": ["actions/checkout@v4","kungfu-systems/buildchain/actions/validate-config@v3"],
           "steps": [
             {
               "index": 1,
@@ -1169,9 +1090,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -1207,13 +1126,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "actions/setup-node@v6.4.0",
-            "actions/upload-artifact@v4",
-            "actions/upload-artifact@v4",
-            "actions/upload-artifact@v4"
-          ],
+          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/upload-artifact@v4","actions/upload-artifact@v4","actions/upload-artifact@v4"],
           "steps": [
             {
               "index": 1,
@@ -1381,9 +1294,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4"
-          ],
+          "externalActions": ["actions/checkout@v4"],
           "steps": [
             {
               "index": 1,
@@ -1419,9 +1330,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@e95c0251390f4948b7aa00de63c49f018ef1f6ff"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@e95c0251390f4948b7aa00de63c49f018ef1f6ff"],
           "steps": []
         }
       ]
@@ -1467,9 +1376,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984"],
           "steps": []
         }
       ]
@@ -1492,9 +1399,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -1538,10 +1443,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8"],
           "steps": [
             {
               "index": 1,
@@ -1577,11 +1479,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/setup-node@v6.4.0",
-            "actions/download-artifact@v4",
-            "actions/upload-artifact@v4"
-          ],
+          "externalActions": ["actions/setup-node@v6.4.0","actions/download-artifact@v4","actions/upload-artifact@v4"],
           "steps": [
             {
               "index": 1,
@@ -1700,9 +1598,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -1731,10 +1627,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "actions/upload-artifact@v4"
-          ],
+          "externalActions": ["actions/checkout@v4","actions/upload-artifact@v4"],
           "steps": [
             {
               "index": 1,
@@ -1835,9 +1728,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@9e904de2c85dbea7c799780ee166510b3336d812"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@9e904de2c85dbea7c799780ee166510b3336d812"],
           "steps": []
         }
       ]
@@ -1860,10 +1751,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"],
           "steps": [
             {
               "index": 1,
@@ -1894,6 +1782,54 @@
       ]
     },
     {
+      "path": ".github/workflows/opencode-local-model-canary.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:7d70ef34c7fd9bc2fd9e42d9b9aa5e500223527e10cbaa1f6f04ed7d5aef1c85",
+      "jobs": [
+        {
+          "id": "canary",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:b5c332864a9fbcef8afb4f6587d3273ba7a65808993c81964df6c5454f25a69b",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": ["actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Verify trusted runner and preloaded image",
+              "authority": "qualification",
+              "definitionDigest": "sha256:2a237279ba9fbf601cee91adf9c92be06a0f89ae3cbfada949ad13b937902867"
+            },
+            {
+              "index": 2,
+              "label": "name:Prepare deterministic fixture",
+              "authority": "qualification",
+              "definitionDigest": "sha256:d674b621fa175c03922e03243027d6ff5589f60bc99c865fb681271e4e51c03f"
+            },
+            {
+              "index": 3,
+              "label": "name:Run OpenCode with the local model",
+              "authority": "qualification",
+              "definitionDigest": "sha256:5f26709990943c65786ad2a3b5bb8df1ff9f9e42be6f7321ea37986706b4da12"
+            },
+            {
+              "index": 4,
+              "label": "name:Upload bounded canary evidence",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:83b8681f05d40eb268da160b5246293dd16791a823b28513ad0ccffa0ff6bfdc"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": ".github/workflows/publish-layer-artifacts.yml",
       "authority": "product-publication",
       "definitionDigest": "sha256:2a1f4fe360c74e3811ec1e1ad1a98d78d8218abbab6d6a209e0ccbdbd30cd55f",
@@ -1911,12 +1847,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-            "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5","actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -1999,13 +1930,7 @@
             "inheritedSecrets": false,
             "environment": "adr0049-production-publication"
           },
-          "externalActions": [
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-            "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5","actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -2076,10 +2001,7 @@
             "inheritedSecrets": false,
             "environment": "adr0049-production-publication"
           },
-          "externalActions": [
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"
-          ],
+          "externalActions": ["actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"],
           "steps": [
             {
               "index": 1,
@@ -2108,11 +2030,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -2153,11 +2071,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -2205,12 +2119,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -2299,9 +2208,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"],
           "steps": []
         },
         {
@@ -2317,11 +2224,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -2393,10 +2296,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
-          ],
+          "externalActions": ["actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -2463,9 +2363,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"
-          ],
+          "externalActions": ["actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"],
           "steps": [
             {
               "index": 1,
@@ -2507,10 +2405,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@v4",
-            "actions/setup-node@v6.4.0"
-          ],
+          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0"],
           "steps": [
             {
               "index": 1,
@@ -2581,9 +2476,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
-          ],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
             {
               "index": 1,
@@ -2619,9 +2512,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/check.yml@9e904de2c85dbea7c799780ee166510b3336d812"
-          ],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@9e904de2c85dbea7c799780ee166510b3336d812"],
           "steps": []
         }
       ]

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -76,6 +76,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/gate-measurement.yml` | `focused` | qualification | none | diagnostic | token:read | none | 7 |
 | `.github/workflows/gate-measurement.yml` | `measure` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/kfd-verifier-drift.yml` | `verify-owned-fixtures` | qualification | none | qualifying | token:read | none | 4 |
+| `.github/workflows/opencode-local-model-canary.yml` | `canary` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/publish-layer-artifacts.yml` | `prepare` | qualification | none | diagnostic | token:read | none | 11 |
 | `.github/workflows/publish-layer-artifacts.yml` | `publish` | product-publication | product | none | token:write, oidc | `adr0049-production-publication` | 9 |
 | `.github/workflows/publish-layer-artifacts.yml` | `publish-pypi` | product-publication | product | none | token:write, oidc | `adr0049-production-publication` | 2 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -184,6 +184,13 @@
           "sourceRoot": "sha256:b59d313837702193d551d655a944a74b86d6dbf91c4d99b5968cf2a6ceb08488"
         },
         {
+          "path": ".github/workflows/opencode-local-model-canary.yml",
+          "classification": "non-publication",
+          "owner": "kungfu-ci",
+          "surfaceIds": [],
+          "sourceRoot": "sha256:baf3ed36c209a804a24978ece7537399c2fa4b524ec25b283aa78f9f69f9403f"
+        },
+        {
           "path": ".github/workflows/publish-layer-artifacts.yml",
           "classification": "publication",
           "owner": "kungfu-layers",
@@ -767,5 +774,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:089613ac438146ed5438ab25e64586f2436fdf22e61e47345f796160695abea4"
+  "registryRoot": "sha256:4c6f3ffe068faf7112b466b99e5b766377ec02293ceadf6b8bb1826d46874157"
 }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -189,7 +189,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 9);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 20);
+  assert.equal(result.workflowAuthority.workflows.length, 21);
   const alphaPreflight = result.workflowAuthority.workflows.find(
     (workflow) =>
       workflow.path === '.github/workflows/alpha-promotion-preflight.yml',

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -295,6 +295,34 @@ export function renderWorkflowAuthorityMatrix(document) {
   ].join('\n');
 }
 
+export function serializeWorkflowAuthority(document) {
+  const lines = JSON.stringify(document, null, 2).split('\n');
+  const rendered = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(/^(\s*)"externalActions": \[$/);
+    if (!match) {
+      rendered.push(lines[index]);
+      continue;
+    }
+    const indent = match[1];
+    const values = [];
+    let closed = false;
+    for (index += 1; index < lines.length; index += 1) {
+      if (lines[index] === `${indent}],`) {
+        closed = true;
+        break;
+      }
+      const item = lines[index].trim().replace(/,$/, '');
+      if (!/^"(?:[^"\\]|\\.)*"$/.test(item))
+        throw new Error('unexpected external action serialization');
+      values.push(JSON.parse(item));
+    }
+    if (!closed) throw new Error('unterminated external action serialization');
+    rendered.push(`${indent}"externalActions": ${JSON.stringify(values)},`);
+  }
+  return `${rendered.join('\n')}\n`;
+}
+
 export function replaceWorkflowAuthorityMatrix(text, document) {
   const start = text.indexOf(MATRIX_BEGIN);
   const finish = text.indexOf(MATRIX_END);
@@ -517,10 +545,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       process.exit(1);
     }
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(
-      target,
-      `${JSON.stringify(projection.document, null, 2)}\n`,
-    );
+    fs.writeFileSync(target, serializeWorkflowAuthority(projection.document));
     const docTarget = path.join(ROOT, WORKFLOW_AUTHORITY_DOC);
     if (fs.existsSync(docTarget)) {
       fs.writeFileSync(

--- a/scripts/kungfu-workflow-authority.test.mjs
+++ b/scripts/kungfu-workflow-authority.test.mjs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { serializeWorkflowAuthority } from './kungfu-workflow-authority.mjs';
+
+test('workflow authority serialization keeps external action inventories compact and lossless', () => {
+  const document = {
+    schema: 'kungfu.workflow-authority/v1',
+    workflowRoot: '.github/workflows',
+    workflows: [
+      {
+        path: '.github/workflows/example.yml',
+        jobs: [
+          {
+            externalActions: ['actions/checkout@immutable', 'local/action@v1'],
+            steps: [],
+          },
+        ],
+      },
+    ],
+  };
+  const serialized = serializeWorkflowAuthority(document);
+  assert.deepEqual(JSON.parse(serialized), document);
+  assert.match(
+    serialized,
+    /"externalActions": \["actions\/checkout@immutable","local\/action@v1"\],/,
+  );
+  assert.doesNotMatch(serialized, /"externalActions": \[\n/);
+});

--- a/scripts/opencode-local-model-canary-workflow.test.mjs
+++ b/scripts/opencode-local-model-canary-workflow.test.mjs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workflow = fs.readFileSync(
+  path.join(root, '.github/workflows/opencode-local-model-canary.yml'),
+  'utf8',
+);
+
+test('local-model canary is manual, immutable, and bounded to agent-120', () => {
+  assert.match(workflow, /^on:\n {2}workflow_dispatch:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s+(?:pull_request|push|schedule):/m);
+  assert.match(workflow, /permissions:\n {2}contents: read/);
+  assert.match(
+    workflow,
+    /runs-on:\n {6}- self-hosted\n {6}- Linux\n {6}- X64\n {6}- agent-120\n {6}- kungfu-build/,
+  );
+  assert.match(workflow, /test "\$RUNNER_NAME" = "agent-120-kungfu-systems"/);
+  assert.match(
+    workflow,
+    /opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3/,
+  );
+  assert.match(workflow, /docker image inspect "\$OPENCODE_IMAGE"/);
+  assert.doesNotMatch(workflow, /docker pull|:latest\b/);
+});
+
+test('local-model canary preserves the narrow endpoint and verifier boundary', () => {
+  assert.match(
+    workflow,
+    /OPENCODE_BASE_URL: http:\/\/host\.docker\.internal:11435\/v1/,
+  );
+  assert.match(
+    workflow,
+    /OPENCODE_HOST_PROBE_URL: http:\/\/172\.17\.0\.1:11435\/v1\/models/,
+  );
+  assert.match(workflow, /OPENCODE_MODEL: qwen3-coder:30b-opencode-64k/);
+  assert.match(workflow, /--add-host host\.docker\.internal:host-gateway/);
+  assert.match(workflow, /--user "\$\(id -u\):\$\(id -g\)"/);
+  assert.match(workflow, /--read-only/);
+  assert.match(workflow, /--cap-drop ALL/);
+  assert.match(workflow, /--security-opt no-new-privileges/);
+  assert.match(workflow, /OPENCODE_VERIFY_COMMAND=/);
+  assert.match(workflow, /opencode-ci-verify/);
+  assert.match(
+    workflow,
+    /\.passed == true and \.model == \$model and \.opencode_exit == 0 and \.verifier_exit == 0/,
+  );
+  assert.doesNotMatch(workflow, /--network host|docker\.sock|privileged/);
+});
+
+test('local-model canary does not admit credentials or untrusted source', () => {
+  assert.doesNotMatch(workflow, /actions\/checkout|GITHUB_TOKEN|secrets\./);
+  assert.doesNotMatch(workflow, /api[_-]?key|authorization|password/i);
+  assert.match(
+    workflow,
+    /actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02/,
+  );
+});

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -341,6 +341,8 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
         'scripts/run-shifu-lifecycle.test.mjs',
         'scripts/check-typescript-files.test.mjs',
         'scripts/source-acceptance.test.mjs',
+        'scripts/opencode-local-model-canary-workflow.test.mjs',
+        'scripts/kungfu-workflow-authority.test.mjs',
         'scripts/code-complexity-budget.test.mjs',
         'framework/maintainability/semantic-amplification.test.mjs',
         'scripts/readonly-agent-bootstrap.test.mjs',


### PR DESCRIPTION
## Summary

Add a manual, fail-closed OpenCode canary for the trusted agent-120 self-hosted runner using the published immutable opencode-ci image and the local Qwen3-Coder endpoint.

## Related issue

Supersedes #1592, whose feature branch prefix incorrectly required product ADR delivery intent.

## Changes

- add a workflow_dispatch-only canary pinned to agent-120 and an immutable image digest
- require the preloaded image and narrow host-only Ollama tunnel endpoint
- run the container read-only with dropped capabilities and no credentials or source checkout
- verify model, OpenCode, tool-use, and deterministic output evidence independently
- register the workflow in the closed-world workflow and release-publication control planes

## Verification

- ./shifu check:source
- ./shifu check:release-publication-control-plane
- ./shifu test:release-publication-control-plane
- exact released-image canary on agent-120 with qwen3-coder:30b-opencode-64k: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded CI qualification canary does not alter a product architecture contract or publication surface"
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow reaches only the host-bound local OpenAI-compatible model endpoint, passes no API key, and uploads bounded diagnostic evidence. It is explicitly registered as non-publication.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed