### PR TITLE
feat(release): qualify Linux artifact attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@881e8e4ee063b184ad7db535829ebd3872b0323a # train/v3/v3.0/linux-github-attestation
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
@@ -94,6 +94,9 @@ jobs:
       artifact-name: kungfu
       artifact-paths: |
         product/release
+      github-artifact-attestation-subject-path: product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz
+      github-artifact-attestation-signer-sha: ad57ae0fee5072a1de7a0b0182f70c0c41e45abb
+      github-artifact-attestation-platform-id: linux-x64
       credential-island-macos-app-path: product/dist/desktop/mac-arm64/Kungfu Episodes.app
       credential-island-caller-owned: true
       credential-island-macos-platform-id: macos-arm64

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -124,13 +124,15 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     permissions:
       actions: read
+      artifact-metadata: write
+      attestations: write
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@881e8e4ee063b184ad7db535829ebd3872b0323a # train/v3/v3.0/linux-github-attestation
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 625384b4927222022a2cd0758399afbf9333ccdc
+      buildchain-ref: 881e8e4ee063b184ad7db535829ebd3872b0323a
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}
@@ -190,6 +192,8 @@ jobs:
       release-passport-invariant-passport-command: >-
         node scripts/kungfu-invariant.mjs --collect-evidence .
         --passport product/release/qualification/invariant-passport.json --json
+      github-artifact-attestation-policy-json: auto
+      github-artifact-attestation-environment: buildchain-artifact-attestation
       dry-run: ${{ github.event_name == 'workflow_dispatch' }}
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -819,7 +819,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3fddf14775032fd57eec557c5cff04901280bc1301424d50a0f4d472e9425364",
+          "definitionDigest": "sha256:af8e50737d344311e9ee99437569ef9283e81196db317a7c59a7485096056424",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -832,7 +832,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@881e8e4ee063b184ad7db535829ebd3872b0323a"
           ],
           "steps": []
         },
@@ -2285,7 +2285,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:e61db3b24e385ee80370c2df10f09edff269720296a28380851241061a53edab",
+          "definitionDigest": "sha256:3c2175f50913207a1b83590f91b613e525456b56f608b4ac27cf8488a2057dad",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -2300,7 +2300,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@881e8e4ee063b184ad7db535829ebd3872b0323a"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -446,7 +446,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@881e8e4ee063b184ad7db535829ebd3872b0323a",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -457,6 +457,9 @@
         },
         "with": {
           "runner-preset": "${{ inputs.platforms-json && 'custom' || 'kungfu-v4-self-hosted' }}",
+          "github-artifact-attestation-subject-path": "product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz",
+          "github-artifact-attestation-signer-sha": "ad57ae0fee5072a1de7a0b0182f70c0c41e45abb",
+          "github-artifact-attestation-platform-id": "linux-x64",
           "credential-island-macos-app-path": "product/dist/desktop/mac-arm64/Kungfu Episodes.app",
           "credential-island-caller-owned": true,
           "credential-island-macos-platform-id": "macos-arm64",
@@ -528,14 +531,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@881e8e4ee063b184ad7db535829ebd3872b0323a",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "625384b4927222022a2cd0758399afbf9333ccdc",
+          "buildchain-ref": "881e8e4ee063b184ad7db535829ebd3872b0323a",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,
@@ -550,6 +553,8 @@
           "release-passport-evidence-command": "node scripts/prepare-ungfu-release-evidence.mjs --release --receipts \"$BUILDCHAIN_RELEASE_ACTIVATION_RECEIPTS\" --output \"$BUILDCHAIN_RELEASE_EVIDENCE_PATH\" --readback --json",
           "release-passport-evidence-path": ".buildchain/release-evidence/ungfu-public-use.json",
           "release-passport-invariant-passport-command": "node scripts/kungfu-invariant.mjs --collect-evidence . --passport product/release/qualification/invariant-passport.json --json",
+          "github-artifact-attestation-policy-json": "auto",
+          "github-artifact-attestation-environment": "buildchain-artifact-attestation",
           "dry-run": "${{ github.event_name == 'workflow_dispatch' }}"
         }
       }

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "625384b4927222022a2cd0758399afbf9333ccdc",
+    "workflow_shell_sha": "881e8e4ee063b184ad7db535829ebd3872b0323a",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",
@@ -21,6 +21,13 @@
     },
     "required_status_check": "build",
     "required_artifact_count": 4,
+    "artifact_attestation": {
+      "subject_path": "product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz",
+      "signer_sha": "ad57ae0fee5072a1de7a0b0182f70c0c41e45abb",
+      "platform_id": "linux-x64",
+      "policy_json": "auto",
+      "environment": "buildchain-artifact-attestation"
+    },
     "required_surfaces": [
       "reusable-build",
       "release-candidate-promote",

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -54,6 +54,11 @@ function requirePattern(source, pattern, findings, message) {
   if (!pattern.test(source)) findings.push(finding(message));
 }
 
+/** @param {string} value */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** @param {string} source @param {RegExp} pattern @param {any[]} findings @param {string} message */
 function forbidPattern(source, pattern, findings, message) {
   if (pattern.test(source)) findings.push(finding(message));
@@ -74,6 +79,7 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   const preflight = extractWorkflowJob(promotion, 'promotion-contract');
   const promote = extractWorkflowJob(promotion, 'promote');
   const rehearsal = extractWorkflowJob(validation, 'promotion-rehearsal');
+  const attestation = contract.buildchain.artifact_attestation;
 
   requirePattern(
     build,
@@ -130,6 +136,30 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
     /release-candidate: true/,
     findings,
     'candidate build must remain a Buildchain release candidate',
+  );
+  requirePattern(
+    build,
+    new RegExp(
+      `github-artifact-attestation-subject-path: ${escapeRegExp(attestation.subject_path)}`,
+    ),
+    findings,
+    'release-candidate build must bind the exact Linux CLI attestation subject',
+  );
+  requirePattern(
+    build,
+    new RegExp(
+      `github-artifact-attestation-signer-sha: ${escapeRegExp(attestation.signer_sha)}`,
+    ),
+    findings,
+    'release-candidate build must pin the immutable Buildchain signer bootstrap',
+  );
+  requirePattern(
+    build,
+    new RegExp(
+      `github-artifact-attestation-platform-id: ${escapeRegExp(attestation.platform_id)}`,
+    ),
+    findings,
+    'release-candidate build must bind the Linux attestation platform manifest',
   );
 
   requirePattern(
@@ -192,6 +222,30 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
       ),
     );
   }
+  for (const permission of ['artifact-metadata', 'attestations']) {
+    requirePattern(
+      promote,
+      new RegExp(`${permission}: write`),
+      findings,
+      `promotion must grant ${permission}: write for GitHub keyless attestation`,
+    );
+  }
+  requirePattern(
+    promote,
+    new RegExp(
+      `github-artifact-attestation-policy-json: ${escapeRegExp(attestation.policy_json)}`,
+    ),
+    findings,
+    'promotion must consume the exact auto-discovered attestation policy',
+  );
+  requirePattern(
+    promote,
+    new RegExp(
+      `github-artifact-attestation-environment: ${escapeRegExp(attestation.environment)}`,
+    ),
+    findings,
+    'promotion must retain the protected attestation environment boundary',
+  );
   requirePattern(
     promote,
     /buildchain-contract-lock-path: \$\{\{ startsWith\(inputs\.target-ref \|\| github\.event\.pull_request\.base\.ref, 'alpha\/'\) && '\.buildchain\/alpha-contract-lock\.json' \|\| '\.buildchain\/contract-lock\.json' \}\}/,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -62,6 +62,45 @@ test('promotion workflow drift is rejected before Buildchain promotion', () => {
   );
 });
 
+test('Linux artifact attestation subject and provider permissions fail closed on drift', () => {
+  const build = fs.readFileSync(
+    path.join(ROOT, CONTRACT.workflows.build),
+    'utf8',
+  );
+  const promotion = fs.readFileSync(
+    path.join(ROOT, CONTRACT.workflows.promotion),
+    'utf8',
+  );
+  const result = validateWorkflowSources(ROOT, CONTRACT, {
+    build: build
+      .replace(
+        CONTRACT.buildchain.artifact_attestation.subject_path,
+        'product/release/cli/wrong-linux-subject.tar.gz',
+      )
+      .replace(
+        CONTRACT.buildchain.artifact_attestation.signer_sha,
+        'f'.repeat(40),
+      ),
+    promotion: promotion.replace('attestations: write', 'attestations: read'),
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.findings.some((entry) =>
+      entry.message.includes('exact Linux CLI attestation subject'),
+    ),
+  );
+  assert.ok(
+    result.findings.some((entry) =>
+      entry.message.includes('attestations: write'),
+    ),
+  );
+  assert.ok(
+    result.findings.some((entry) =>
+      entry.message.includes('immutable Buildchain signer bootstrap'),
+    ),
+  );
+});
+
 test('promotion rejects an event-scoped Buildchain runtime override', () => {
   const promotionPath = CONTRACT.workflows.promotion;
   const original = fs.readFileSync(path.join(ROOT, promotionPath), 'utf8');


### PR DESCRIPTION
## Summary

Bind the Kungfu v4 Linux CLI release candidate to Buildchain v3 GitHub keyless artifact attestation.

## Related issue

- Buildchain qualification: kungfu-systems/buildchain#1950

## Changes

- request attestation for the Linux x64 CLI tarball in the reusable build workflow
- grant the promotion workflow only the GitHub OIDC and attestation permissions required by the signer
- bind the release rehearsal contract to the exact Buildchain runtime, signer, platform, subject path, policy, and environment
- refresh workflow authority and binding evidence

## Verification

- `./shifu release:promotion:rehearse`
- `./shifu check:gate-catalog`
- staged pre-commit gate completed successfully

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f86da-4f90-7b6b-ae6d-76cea57487f2"],
  "summary": "Bind the v4 Linux CLI release candidate to Buildchain v3 keyless GitHub artifact attestation",
  "verification": ["./shifu release:promotion:rehearse", "./shifu check:gate-catalog", "staged pre-commit gate"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is bounded to GitHub-hosted OIDC artifact attestation and exact release-evidence bindings. No long-lived signing credential is introduced.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed