### PR TITLE
fix(release): close alpha publication tail

### DIFF
--- a/.buildchain/alpha-contract-lock.json
+++ b/.buildchain/alpha-contract-lock.json
@@ -3,13 +3,13 @@
   "contract": "kungfu-buildchain-contract-lock",
   "buildchain": {
     "ref": "v3-alpha",
-    "resolvedSha": "625384b4927222022a2cd0758399afbf9333ccdc",
+    "resolvedSha": "ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2",
     "contract": "kungfu-buildchain-runtime-contract-world",
-    "contractDigest": "sha256:d27853cb9230d3288b3c8ce62522e7ad61be04f09890846da01ca22b304584e2",
+    "contractDigest": "sha256:33cde8db3883afe7d7695d2c2e332a8c6753a804e14db0c8e3d2e5d2eb492271",
     "compatibilityDigest": "sha256:008b1c5a90a787cf30106829ac7aca68ab501f6d9c375e415d9c5c6b89039f46",
     "majorLine": "v3",
     "compatibilityPolicy": "major-compatible",
-    "acceptedAt": "2026-07-26T21:08:33.000Z",
+    "acceptedAt": "2026-07-27T01:18:49.000Z",
     "surfaces": [
       {
         "id": "reusable-build",

--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "4ed32814b5338320adc99b0baaddc69127b386f73416f5f862e2b8ed96f7cff6"
+    "sha256": "38367f5f108195168eb2c247762cba4d6118213d52fc7da1fbf612620c0e3ed1"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -88,7 +88,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "80f6b98ac298706f7f7cc554723d1c24a406631db0bcd757898c8dc04469c4a0",
+      "preBuildWitnessSha256": "972b7cc147e24ac23a296161fa472ee5e5bcdaaa9c4033c601dcdd62df9bfab9",
       "sourceHashes": {
         "sha256": "ab6d3b4f193cc4b0aa443bccfdb7e12eb46abbb9450d3bcf63204211a3c82037",
         "surfaceCount": 21
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "4ed32814b5338320adc99b0baaddc69127b386f73416f5f862e2b8ed96f7cff6"
+          "sha256": "38367f5f108195168eb2c247762cba4d6118213d52fc7da1fbf612620c0e3ed1"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "af716523a202a807b8404f37b92fa978d25ec618",
+    "sourceSha": "4a3703c2eef8560049198837393cef1e043db313",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:1b6eec071960b48620558bf12e0366f496296caecfbbf73e696883c0b191b379"
   },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
   build:
     needs: preflight
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2 # v3.0.2-alpha.3 with bundled macOS entitlements
     secrets:
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
@@ -360,7 +360,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
+    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2 # v3.0.2-alpha.3 with bundled macOS entitlements
     with:
       source-ref: ${{ needs.build.outputs.publish-source-sha }}
       source-artifact-name: ${{ needs.resolve-auditable-demo-source.outputs.artifact-name }}
@@ -495,7 +495,7 @@ jobs:
           MEDIA_ARTIFACT_URL: ${{ needs.auditable-demo.outputs.media-artifact-url }}
           MEDIA_ARTIFACT_EXPIRES_AT: ${{ steps.artifact-expiry.outputs.media-artifact-expires-at }}
           MEDIA_ROOT: ${{ needs.auditable-demo.outputs.media-root }}
-          BUILDCHAIN_SHA: 625384b4927222022a2cd0758399afbf9333ccdc
+          BUILDCHAIN_SHA: ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2
           RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:cb5e1dec368d21c7d4e8baded99ac75f12f7eff0d19505751888cf974086efa6
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 
@@ -526,7 +526,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up pinned Node.js
-        uses: actions/setup-node@48b55a011ce3ff2d5eaaf3c4fba94b0c6f8b2a7c # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           check-latest: false

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -127,10 +127,10 @@ jobs:
       contents: write
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc # v3.0.2-alpha.2 with renderer input normalization
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2 # v3.0.2-alpha.3 with bundled macOS entitlements
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
-      buildchain-ref: 625384b4927222022a2cd0758399afbf9333ccdc
+      buildchain-ref: ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2
       target-ref: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
       target-sha: ${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}
       buildchain-contract-lock-path: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && '.buildchain/alpha-contract-lock.json' || '.buildchain/contract-lock.json' }}

--- a/config/kungfu-agent-first-canonical-policy.json
+++ b/config/kungfu-agent-first-canonical-policy.json
@@ -523,13 +523,13 @@
       },
       "source": {
         "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
-        "sha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
-        "renderedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
+        "sha256": "sha256:ef81edbbf0da9b6c63843da289315b7d6a070b09e849cdd9a71e9f7199e44e0c",
+        "renderedSha256": "sha256:ef81edbbf0da9b6c63843da289315b7d6a070b09e849cdd9a71e9f7199e44e0c",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/primitive/kungfu-primitive-catalog.contract.json",
-        "expectedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509"
+        "expectedSha256": "sha256:ef81edbbf0da9b6c63843da289315b7d6a070b09e849cdd9a71e9f7199e44e0c"
       }
     }
   ]

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "4ed32814b5338320adc99b0baaddc69127b386f73416f5f862e2b8ed96f7cff6"
+    "sha256": "38367f5f108195168eb2c247762cba4d6118213d52fc7da1fbf612620c0e3ed1"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -88,7 +88,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "80f6b98ac298706f7f7cc554723d1c24a406631db0bcd757898c8dc04469c4a0",
+      "preBuildWitnessSha256": "972b7cc147e24ac23a296161fa472ee5e5bcdaaa9c4033c601dcdd62df9bfab9",
       "sourceHashes": {
         "sha256": "ab6d3b4f193cc4b0aa443bccfdb7e12eb46abbb9450d3bcf63204211a3c82037",
         "surfaceCount": 21
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "4ed32814b5338320adc99b0baaddc69127b386f73416f5f862e2b8ed96f7cff6"
+          "sha256": "38367f5f108195168eb2c247762cba4d6118213d52fc7da1fbf612620c0e3ed1"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",

--- a/docs/qualification/auditable-demo-artifact-pipeline.md
+++ b/docs/qualification/auditable-demo-artifact-pipeline.md
@@ -41,7 +41,7 @@ disables the Gate.
 | --- | --- |
 | Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:cb5e1dec368d21c7d4e8baded99ac75f12f7eff0d19505751888cf974086efa6` |
 | Renderer release | `build-images v1.3.0-alpha.16` |
-| Buildchain Gate | `625384b4927222022a2cd0758399afbf9333ccdc` (`v3.0.2-alpha.2`, renderer input normalization) |
+| Buildchain Gate | `ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2` (`v3.0.2-alpha.3`, bundled macOS entitlements) |
 | Consumer adapter | `scripts/auditable-demo-adapter.py` from the exact qualified Kungfu source SHA |
 
 Buildchain's reusable build emits

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -14,8 +14,8 @@
     "runtimes": {
       "alpha": {
         "ref": "v3-alpha",
-        "runtimeSha": "625384b4927222022a2cd0758399afbf9333ccdc",
-        "contractDigest": "sha256:d27853cb9230d3288b3c8ce62522e7ad61be04f09890846da01ca22b304584e2",
+        "runtimeSha": "ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2",
+        "contractDigest": "sha256:33cde8db3883afe7d7695d2c2e332a8c6753a804e14db0c8e3d2e5d2eb492271",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },
       "release": {

--- a/docs/qualification/gates/release-admission.md
+++ b/docs/qualification/gates/release-admission.md
@@ -17,7 +17,7 @@ A qualifying capability must bind all of the following exact values:
 | --- | --- |
 | Source | one 40-character Kungfu revision and its release-candidate tree |
 | Gate policy | current `shifu.gates.json`, `release-promotion` matrix digest, complete passing rows and platform receipts |
-| Runtime | Stable release authority is `@kungfu-tech/buildchain@3.0.0`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@3.0.2-alpha.2`. `alpha` binds the protected v3 runtime at `625384b4927222022a2cd0758399afbf9333ccdc`, while `release` remains isolated on `v3` at `9e904de2c85dbea7c799780ee166510b3336d812`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
+| Runtime | Stable release authority is `@kungfu-tech/buildchain@3.0.0`; dev/MQ telemetry uses the isolated npm alias `@kungfu-tech/buildchain-alpha@npm:@kungfu-tech/buildchain@3.0.2-alpha.3`. `alpha` binds the protected v3 runtime at `ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2`, while `release` remains isolated on `v3` at `9e904de2c85dbea7c799780ee166510b3336d812`, each with its exact contract lock and digest; the standalone Shifu tool pin is tracked separately in `.buildchain-version` |
 | Controller | qualifying source/runtime-bound Buildchain controller receipt referenced by the RC passport |
 | Runner | qualifying ephemeral, reimaged, or measured persistent-runner provenance; unqualified is denied |
 | Control plane | fresh passing Actions, branch/ruleset, Environment, OIDC, publisher, and runner audit facts |

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -756,7 +756,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3fbd5e77e61815736cd495cef9171f57a858325a5e29a291cf746d165c5188a2",
+          "definitionDigest": "sha256:531254f64baf0b783ab07fb1d4e2b6fcf214a50e173cc867d90d2761379db51a",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -765,7 +765,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@625384b4927222022a2cd0758399afbf9333ccdc"
+            "kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"
           ],
           "steps": []
         },
@@ -774,7 +774,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3a2fb8ae784a8a65927b7396f1a244a579c6f117d0565fe2f0791e2ca4a4de3d",
+          "definitionDigest": "sha256:dcc146827287e4e9f077899a958af409e9d31edcb4feb441be1f31ddf033b177",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -804,7 +804,7 @@
               "index": 3,
               "label": "name:Write exact auditable demo Release Passport",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:6653dcbf5eb4a05acdfa2fb0d62fdabb359ba6795f7ec3c2525da5dd4bc79b70"
+              "definitionDigest": "sha256:2bc352d18ad868d8e839d8f95b41eba250f08b7a0f73511312c09ad66e4fe0aa"
             },
             {
               "index": 4,
@@ -819,7 +819,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3fddf14775032fd57eec557c5cff04901280bc1301424d50a0f4d472e9425364",
+          "definitionDigest": "sha256:a0c3d9446fc91d36ca8d50f718283713ef851bb8b6cea3dde3ca10f687528686",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -832,7 +832,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc"
+            "kungfu-systems/buildchain/.github/workflows/.build.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"
           ],
           "steps": []
         },
@@ -974,7 +974,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c5ea8d035640c1c4778ed53ae7b4208202e519f585d85547ace756e6a98d72ee",
+          "definitionDigest": "sha256:1706cf4b0fc846e994a747aabad6779eaec5883c116dc0719e5cf95ec3d6ed5e",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -984,7 +984,7 @@
           },
           "externalActions": [
             "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-            "actions/setup-node@48b55a011ce3ff2d5eaaf3c4fba94b0c6f8b2a7c",
+            "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
             "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
           ],
           "steps": [
@@ -998,7 +998,7 @@
               "index": 2,
               "label": "name:Set up pinned Node.js",
               "authority": "qualification",
-              "definitionDigest": "sha256:fa4008478ea00030e1ecf5cf9d5b8a216ea49b0c31f91f4912535f098bac8222"
+              "definitionDigest": "sha256:93f3675945caff80d4b510964b74f50d37e770eade12d52d8600f9da040518ad"
             },
             {
               "index": 3,
@@ -2285,7 +2285,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:e61db3b24e385ee80370c2df10f09edff269720296a28380851241061a53edab",
+          "definitionDigest": "sha256:34b4506fcc6f3c2ab8eaecacf2f9bdfadb79e3acc914d8f7881da61bed5950ed",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -2300,7 +2300,7 @@
             "environment": null
           },
           "externalActions": [
-            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc"
+            "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2"
           ],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -446,7 +446,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2",
         "job": {
           "needs": "preflight",
           "secrets": {
@@ -528,14 +528,14 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@625384b4927222022a2cd0758399afbf9333ccdc",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
-          "buildchain-ref": "625384b4927222022a2cd0758399afbf9333ccdc",
+          "buildchain-ref": "ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2",
           "target-sha": "${{ inputs.target-sha || github.event.pull_request.merge_commit_sha || github.sha }}",
           "required-status-check": "build",
           "publication-auto-admission": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -6,7 +6,7 @@
     "validation": ".github/workflows/buildchain-validate.yml"
   },
   "buildchain": {
-    "workflow_shell_sha": "625384b4927222022a2cd0758399afbf9333ccdc",
+    "workflow_shell_sha": "ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -523,13 +523,13 @@
       },
       "source": {
         "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
-        "sha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
-        "renderedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509",
+        "sha256": "sha256:ef81edbbf0da9b6c63843da289315b7d6a070b09e849cdd9a71e9f7199e44e0c",
+        "renderedSha256": "sha256:ef81edbbf0da9b6c63843da289315b7d6a070b09e849cdd9a71e9f7199e44e0c",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/primitive/kungfu-primitive-catalog.contract.json",
-        "expectedSha256": "sha256:39070c5380c7d0a30d98652d7e74f1860bca14252f9fbfe8c7ec879f9a197509"
+        "expectedSha256": "sha256:ef81edbbf0da9b6c63843da289315b7d6a070b09e849cdd9a71e9f7199e44e0c"
       }
     }
   ]

--- a/framework/kfx/src/profile-suite.test.ts
+++ b/framework/kfx/src/profile-suite.test.ts
@@ -164,7 +164,7 @@ test('KFX plan projects the declared Work Control GUI experience', () => {
     planDeps,
   );
   const profile = plan.profiles.find(
-    (candidate) => candidate.id === 'kungfu.mission-control',
+    (candidate) => candidate.id === 'kungfu.work-control',
   );
   assert.deepEqual(profile, {
     id: 'kungfu.work-control',

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:d50f41ae4943940c66a06a5a9905d9f58318ec41e4adc754863430bb70d89182",
+  "sourceRoot": "sha256:8306c9fe4d75e10ae381073e3c93139ffd1082dffbd2572aa172830e8aecdee9",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -965,7 +965,7 @@
           "path": "docs/qualification/gates/release-admission-policy.json",
           "currentLines": 41,
           "baselineLines": 41,
-          "currentRoot": "sha256:28d7b573361ff317d5446860fe20d4b76f0fdf63cd8de176279f12538fc13722",
+          "currentRoot": "sha256:15de2b50c03becfe15daae41af2539076cc94f875e83fc86db86ff394ee92bbc",
           "baselineRoot": "sha256:e8a0f7037f2331610f3b9c07e7cdf5e47ea701045c73d0f67bf909372e77e0ac",
           "changedSinceBaseline": true
         },
@@ -997,7 +997,7 @@
           "path": "docs/qualification/gates/workflow-bindings.json",
           "currentLines": 580,
           "baselineLines": 580,
-          "currentRoot": "sha256:9046b06f49afa58946d6066a94380b80247a4b6ec231760b508d3bf87d4f4485",
+          "currentRoot": "sha256:547d388661be8bbacf923ff5c72b6db25679b17ce54ebef3dc60e7f1e138b8d8",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },
@@ -1005,7 +1005,7 @@
           "path": ".github/workflows/release-new-version.yml",
           "currentLines": 380,
           "baselineLines": 362,
-          "currentRoot": "sha256:46b1f5435d40378f7ef205c1a1f8e3991c02ca5752e8c113375025f1fbcf4779",
+          "currentRoot": "sha256:63f908db60382d683250c7070b90945161cc1ae8e01f0554ab93e22d20f50d91",
           "baselineRoot": "sha256:3bdd847c80a05030de1d826282cef2e76a85e31dc0904df02c7f0cdda7a5eb74",
           "changedSinceBaseline": true
         },
@@ -1021,7 +1021,7 @@
           "path": "docs/qualification/gates/release-admission.md",
           "currentLines": 75,
           "baselineLines": 75,
-          "currentRoot": "sha256:f0383f440164a76bed1d530dd301a9a2b77a8882fda5f51ad1946f6abc6cc71f",
+          "currentRoot": "sha256:4f988c0cb62a77335dd1dd66d1cfff4656ba2c78b7d3451a88c5486b2c68b970",
           "baselineRoot": "sha256:69f293fefb3c94df44051dc86ba4435416f5ea4348f2ffb245bef19bb494a280",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -89,7 +89,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:96bd4e0409c96c75f7b7bf762ed7318808e1bb3dc6b5506a465107582b4c2fbe"
+          "sourceRoot": "sha256:bf0562c5203a036d3b8d1fe913d8719e54247216f738d2d27674bb49ae28966a"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -203,7 +203,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:46b1f5435d40378f7ef205c1a1f8e3991c02ca5752e8c113375025f1fbcf4779"
+          "sourceRoot": "sha256:63f908db60382d683250c7070b90945161cc1ae8e01f0554ab93e22d20f50d91"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -237,8 +237,8 @@
     "buildchain": {
       "repository": "kungfu-systems/buildchain",
       "owner": "kungfu-systems/buildchain",
-      "sourceRevision": "625384b4927222022a2cd0758399afbf9333ccdc",
-      "version": "3.0.2-alpha.2",
+      "sourceRevision": "ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2",
+      "version": "3.0.2-alpha.3",
       "compatibilityMode": "stable-v3-contract-plus-exact-additive-runtime",
       "stableContractLock": ".buildchain/contract-lock.json",
       "runtimeContractLock": ".buildchain/alpha-contract-lock.json",
@@ -767,5 +767,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e5426d6a8e7f4d5af0a28dac3e84e0f16e883b485efd88379990662336d5385f"
+  "registryRoot": "sha256:089613ac438146ed5438ab25e64586f2436fdf22e61e47345f796160695abea4"
 }

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "3.0.0",
-    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@3.0.2-alpha.2",
+    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@3.0.2-alpha.3",
     "@kungfu-tech/kfd": "1.0.0-alpha.47",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@kungfu-tech/buildchain-alpha':
-        specifier: npm:@kungfu-tech/buildchain@3.0.2-alpha.2
-        version: '@kungfu-tech/buildchain@3.0.2-alpha.2'
+        specifier: npm:@kungfu-tech/buildchain@3.0.2-alpha.3
+        version: '@kungfu-tech/buildchain@3.0.2-alpha.3'
       '@kungfu-tech/kfd':
         specifier: 1.0.0-alpha.47
         version: 1.0.0-alpha.47
@@ -1446,8 +1446,8 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/buildchain@3.0.2-alpha.2':
-    resolution: {integrity: sha512-phNnd7LxdifzHX/Vuk06u59MFpg4g9HpM06OKNJuzVQVoAOGh3GWJ/edDfL4TQ9fhbwNfbMfeq6LVxu5QKBkXA==}
+  '@kungfu-tech/buildchain@3.0.2-alpha.3':
+    resolution: {integrity: sha512-B8CFwm/IzZPK/VHJsJSHzr6qvi08YxC8VP/1HZ8eATJvwShBtj0JPknna97gcJ0QO+uP4RZYpmiKaMPCS8CGAw==}
     engines: {node: '>=22.14.0'}
     hasBin: true
 
@@ -5801,7 +5801,7 @@ snapshots:
       '@kungfu-tech/kfd': 1.0.0-alpha.41
       smol-toml: 1.7.0
 
-  '@kungfu-tech/buildchain@3.0.2-alpha.2':
+  '@kungfu-tech/buildchain@3.0.2-alpha.3':
     dependencies:
       '@kungfu-tech/kfd': 1.0.0-alpha.47
       smol-toml: 1.7.0

--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -24,6 +24,8 @@ MAX_JSON_BYTES = 8 * 1024 * 1024
 MAX_ARCHIVE_BYTES = 2 * 1024 * 1024 * 1024
 MAX_MEMBER_BYTES = 512 * 1024 * 1024
 MAX_MEMBERS = 100_000
+EPISODE_RELEASE_EVIDENCE = "qualification/episode-release-evidence.json"
+PULL_MERGE_REF = re.compile(r"^refs/pull/[1-9][0-9]*/merge$")
 
 REPORTS = (
     (
@@ -139,6 +141,93 @@ def source_revision(report: dict[str, Any]) -> str:
     if len(values) != 1 or not SHA40.fullmatch(values[0]):
         fail("qualification report must bind exactly one 40-character source revision")
     return values[0]
+
+
+def canonical_evidence_digest(path: Path) -> str:
+    script = r"""
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+function sortValue(value) {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, item]) => item !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, sortValue(item)]),
+    );
+  }
+  return value;
+}
+const evidence = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+delete evidence.evidence_digest;
+const canonical = JSON.stringify(sortValue(evidence));
+process.stdout.write(`sha256:${crypto.createHash("sha256").update(canonical).digest("hex")}`);
+"""
+    result = subprocess.run(
+        ["node", "-e", script, str(path)],
+        text=True,
+        encoding="utf-8",
+        errors="strict",
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    if result.returncode != 0 or not SHA256.fullmatch(result.stdout):
+        fail("Episode release evidence canonical digest could not be verified")
+    return result.stdout
+
+
+def qualified_source_revision(release_root: Path, coordinate_source: str) -> str:
+    evidence_path = release_root / EPISODE_RELEASE_EVIDENCE
+    if not evidence_path.exists():
+        return coordinate_source
+    evidence = read_json(evidence_path, EPISODE_RELEASE_EVIDENCE)
+    evidence_source = evidence.get("source", {}).get("revision")
+    if evidence_source == coordinate_source:
+        return coordinate_source
+    evidence_tree = evidence.get("source", {}).get("tree")
+    ci = evidence.get("ci")
+    gates = evidence.get("qualification", {}).get("hard_gates")
+    trust_report = evidence.get("trust_report")
+    if (
+        evidence.get("schema") != "kungfu.episode.release-evidence/v1"
+        or evidence.get("verdict") != "qualified"
+        or not SHA40.fullmatch(str(evidence_source))
+        or not SHA40.fullmatch(str(evidence_tree))
+        or evidence.get("source", {}).get("dirty") is not False
+        or not isinstance(ci, dict)
+        or ci.get("provider") != "github-actions"
+        or ci.get("sha") != evidence_source
+        or ci.get("source_sha") != coordinate_source
+        or ci.get("source_tree_sha") != evidence_tree
+        or not PULL_MERGE_REF.fullmatch(str(ci.get("ref", "")))
+        or not isinstance(trust_report, dict)
+        or trust_report.get("source_revision") != evidence_source
+        or trust_report.get("source_dirty") is not False
+        or not isinstance(gates, list)
+        or not gates
+        or any(
+            not isinstance(row, dict) or row.get("passed") is not True for row in gates
+        )
+    ):
+        fail(
+            "Episode release evidence does not prove a qualified pull-merge tree equivalence"
+        )
+    source_gates = [row for row in gates if row.get("id") == "ci_source_revision"]
+    expected_gate_evidence = (
+        f"ci={coordinate_source} expected={evidence_source} "
+        f"ci_tree={evidence_tree} expected_tree={evidence_tree} "
+        "mode=tree-equivalent-pull-merge"
+    )
+    if (
+        len(source_gates) != 1
+        or source_gates[0].get("evidence") != expected_gate_evidence
+        or not SHA256.fullmatch(str(evidence.get("evidence_digest", "")))
+        or canonical_evidence_digest(evidence_path) != evidence.get("evidence_digest")
+    ):
+        fail("Episode release evidence tree-equivalence seal is invalid")
+    return str(evidence_source)
 
 
 def validate_coordinate(path: Path) -> dict[str, Any]:
@@ -506,7 +595,8 @@ def write_outputs(output: Path, lines: list[str], projection: dict[str, Any]) ->
 def adapt(artifact_root: Path, output: Path, source_coordinate: Path) -> None:
     coordinate = validate_coordinate(source_coordinate)
     release_root = find_release_root(artifact_root)
-    validate_reports(release_root, coordinate["sourceSha"])
+    qualified_source = qualified_source_revision(release_root, coordinate["sourceSha"])
+    validate_reports(release_root, qualified_source)
     archives = sorted(
         path
         for path in release_root.rglob(ARCHIVE_NAME)
@@ -520,7 +610,7 @@ def adapt(artifact_root: Path, output: Path, source_coordinate: Path) -> None:
         temporary_root = Path(temporary)
         installed = extract_cli(archive, temporary_root / "installed")
         launcher, product_version = validate_product(
-            installed, archive, coordinate["sourceSha"]
+            installed, archive, qualified_source
         )
         executable_digest = sha256_file(launcher)
         stdout, stderr, exit_code = run_brief(launcher, temporary_root / "home")

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -11,10 +12,65 @@ const ROOT = path.resolve(import.meta.dirname, '..');
 const ADAPTER = path.join(ROOT, 'scripts', 'auditable-demo-adapter.py');
 const SOURCE_SHA = '1'.repeat(40);
 const DIGEST = `sha256:${'2'.repeat(64)}`;
+const SOURCE_TREE = '4'.repeat(40);
 
 function json(pathname, value) {
   fs.mkdirSync(path.dirname(pathname), { recursive: true });
   fs.writeFileSync(pathname, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sortValue(value) {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, sortValue(item)]),
+    );
+  }
+  return value;
+}
+
+function sealEvidence(evidence) {
+  return {
+    ...evidence,
+    evidence_digest: `sha256:${createHash('sha256')
+      .update(JSON.stringify(sortValue(evidence)))
+      .digest('hex')}`,
+  };
+}
+
+function episodeEvidence(source, coordinateSource, overrides = {}) {
+  const gateEvidence = `ci=${coordinateSource} expected=${source} ci_tree=${SOURCE_TREE} expected_tree=${SOURCE_TREE} mode=tree-equivalent-pull-merge`;
+  return sealEvidence({
+    schema: 'kungfu.episode.release-evidence/v1',
+    verdict: 'qualified',
+    source: {
+      repository: 'kungfu-systems/kungfu',
+      revision: source,
+      tree: SOURCE_TREE,
+      dirty: false,
+    },
+    ci: {
+      provider: 'github-actions',
+      ref: 'refs/pull/1448/merge',
+      sha: source,
+      source_sha: coordinateSource,
+      source_tree_sha: SOURCE_TREE,
+      ...overrides.ci,
+    },
+    qualification: {
+      hard_gates: [
+        { id: 'harness_exit', passed: true, evidence: 'exit=0' },
+        {
+          id: 'ci_source_revision',
+          passed: true,
+          evidence: gateEvidence,
+        },
+      ],
+    },
+    trust_report: { source_revision: source, source_dirty: false },
+  });
 }
 
 function report(source, schema, extra = {}) {
@@ -28,7 +84,13 @@ function report(source, schema, extra = {}) {
 
 function fixture(
   root,
-  { source = SOURCE_SHA, unsafeArchive = false, stdoutLineCount = 0 } = {},
+  {
+    source = SOURCE_SHA,
+    coordinateSource = source,
+    sourceEvidence = null,
+    unsafeArchive = false,
+    stdoutLineCount = 0,
+  } = {},
 ) {
   const artifact = path.join(root, 'artifact', 'product', 'release');
   const qualification = path.join(artifact, 'qualification');
@@ -54,16 +116,22 @@ function fixture(
     source: { revision: source },
     summary: { verdict: 'verified' },
   });
+  if (sourceEvidence) {
+    json(
+      path.join(qualification, 'episode-release-evidence.json'),
+      sourceEvidence,
+    );
+  }
   const coordinate = path.join(root, 'coordinate.json');
   json(coordinate, {
     schema: 'buildchain.github-artifact-coordinate/v1',
     repository: 'kungfu-systems/kungfu',
     runId: '123',
     runAttempt: '1',
-    sourceSha: source,
+    sourceSha: coordinateSource,
     id: '456',
     nodeId: 'A_kwDOFixture',
-    name: `kungfu-linux-x64-${source}`,
+    name: `kungfu-linux-x64-${coordinateSource}`,
     digest: DIGEST,
     sizeInBytes: 1024,
     createdAt: '2026-07-25T00:00:00Z',
@@ -216,6 +284,37 @@ test('adapter fails closed on source mismatch', () => {
     );
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /source mismatch/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('adapter accepts a resealed pull merge only through qualified tree-equivalence evidence', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'auditable-demo-adapter-'),
+  );
+  try {
+    const coordinateSource = '3'.repeat(40);
+    const sourceEvidence = episodeEvidence(SOURCE_SHA, coordinateSource);
+    const { result } = run(root, { coordinateSource, sourceEvidence });
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('adapter rejects tree-equivalence evidence outside a pull merge ref', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'auditable-demo-adapter-'),
+  );
+  try {
+    const coordinateSource = '3'.repeat(40);
+    const sourceEvidence = episodeEvidence(SOURCE_SHA, coordinateSource, {
+      ci: { ref: 'refs/heads/dev/v4/v4.0' },
+    });
+    const { result } = run(root, { coordinateSource, sourceEvidence });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /does not prove a qualified pull-merge/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -167,7 +167,7 @@ test('every produced Linux artifact enters the required exact-output Gate', () =
   );
   assert.equal(
     build.uses,
-    'kungfu-systems/buildchain/.github/workflows/.build.yml@625384b4927222022a2cd0758399afbf9333ccdc',
+    'kungfu-systems/buildchain/.github/workflows/.build.yml@ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2',
     'the build runtime must be the protected Buildchain release that owns artifact-coordinates-json',
   );
   assert.match(

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -38,11 +38,11 @@ import {
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
-const RUNTIME_SHA = '625384b4927222022a2cd0758399afbf9333ccdc';
+const RUNTIME_SHA = 'ebc7b2d86ecce1de835c8f8ba4436bcac65a62c2';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =
-  'd27853cb9230d3288b3c8ce62522e7ad61be04f09890846da01ca22b304584e2';
+  '33cde8db3883afe7d7695d2c2e332a8c6753a804e14db0c8e3d2e5d2eb492271';
 const STABLE_CONTRACT_DIGEST =
   '914720131f07664cd187a1033f357c4952ef1008f5553cb6b285a75f786a7fbc';
 const PREDICATE_COMMAND = 'node scripts/kungfu-release-qualification.mjs';


### PR DESCRIPTION
Linear replacement for #1596 after GitHub merge queue repeatedly rejected its non-linear branch topology as `merge_conflict`. This candidate is based directly on current dev `71e15894fc9b68298d6f479dd73eb66f6fa83398` and preserves the exact clean merged tree `86ea3e23c9d870734f1ff457c729434ef0891a2a`.

## Summary

Close the remaining Alpha publication failures after the KFD support-governance delivery. This upgrades the pinned Buildchain Alpha runtime to v3.0.2-alpha.3 with bundled macOS entitlements, corrects the immutable setup-node reference, and admits regenerated pull-merge SHAs only through sealed Episode tree-equivalence evidence.

## Related issue

- KFD support governance Alpha release follow-up

## Changes

- pin Buildchain Alpha workflows, package alias, lock, and release-admission policy to v3.0.2-alpha.3
- refresh workflow authority and semantic-amplification projections
- validate resealed pull-merge evidence before adapting the auditable demo artifact
- retain fail-closed rejection for arbitrary source mismatches and non-pull refs

## Verification

- candidate DCO, source acceptance, and affected-native proof probe: run 30240230318
- clean merged tree against current dev: `86ea3e23c9d870734f1ff457c729434ef0891a2a`
- staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This linear replacement changes no ADR record; it preserves the already-delivered Work Control and KFD release-tail implementation tree while repairing merge-queue topology."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The release-evidence boundary is covered by sealed canonical-digest verification, exact pull-merge/tree bindings, negative fixtures, release-admission tests, source acceptance, and the full changed-scope gate.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed