### PR TITLE
fix(governance): authorize candidate pull request

### DIFF
--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -42,3 +42,5 @@ jobs:
       max-age-seconds: 604800
       create-pull-request: ${{ github.event_name == 'schedule' || inputs.create-pull-request }}
       dry-run: ${{ github.event_name != 'schedule' && inputs.dry-run }}
+    secrets:
+      promotion-token: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1411,11 +1411,13 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c4fd03d3a0a5c7c0d16ad4d9594d0f1e3f879f442fe976d5667b17b3737670c7",
+          "definitionDigest": "sha256:16149888ed96c050fb421464ad037eb09152994e0aa82eb08604ee9f9e87333c",
           "credentials": {
             "githubToken": "write",
             "oidc": false,
-            "repositorySecrets": [],
+            "repositorySecrets": [
+              "KUNGFU_GITHUB_TOKEN"
+            ],
             "inheritedSecrets": false,
             "environment": null
           },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -65,7 +65,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/cancel-dequeued-merge-group.yml` | `cancel` | qualification | none | diagnostic | token:write, repo-secret:GITHUB_TOKEN | none | 2 |
 | `.github/workflows/core-build-profiles.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 24 |
 | `.github/workflows/dco.yml` | `signoff` | qualification | none | diagnostic | token:read | none | 2 |
-| `.github/workflows/dev-alpha-candidate-patrol.yml` | `candidate` | qualification | none | diagnostic | token:write | none | 0 |
+| `.github/workflows/dev-alpha-candidate-patrol.yml` | `candidate` | qualification | none | diagnostic | token:write, repo-secret:KUNGFU_GITHUB_TOKEN | none | 0 |
 | `.github/workflows/dev-verify-patrol.yml` | `report` | diagnostic | none | none | token:write | none | 1 |
 | `.github/workflows/dev-verify-patrol.yml` | `verify` | qualification | none | qualifying | token:write, oidc | none | 0 |
 | `.github/workflows/docs-check.yml` | `docs-check` | qualification | none | diagnostic | token:read | none | 3 |

--- a/framework/maintainability/waivers/dev-alpha-candidate-workflow-authority.json
+++ b/framework/maintainability/waivers/dev-alpha-candidate-workflow-authority.json
@@ -5,11 +5,11 @@
   ],
   "file_class": "declarative-schema-or-table",
   "baseline_measurement": 2605,
-  "requested_measurement": 2630,
-  "allowed_delta": 25,
+  "requested_measurement": 2632,
+  "allowed_delta": 27,
   "owner": "kungfu/docs",
   "responsibility_boundary": "The single closed-world manifest projects every GitHub workflow, job, credential surface, immutable external action, and authority classification.",
-  "cohesion_rationale": "The Dev-to-Alpha candidate patrol is one additional governed workflow. Its 25 projected lines belong in the same closed-world authority manifest so omission and cross-file substitution remain fail-closed.",
+  "cohesion_rationale": "The Dev-to-Alpha candidate patrol and its repository-owned promotion credential are one governed workflow. Their 27 projected lines belong in the same closed-world authority manifest so omission and cross-file substitution remain fail-closed.",
   "rejected_split_alternatives": [
     "Splitting one workflow into a second manifest would weaken the single-inventory comparison and add composition authority solely to avoid a line-count threshold.",
     "Dropping credential, digest, action, or receipt fields would weaken the existing authority contract.",
@@ -21,8 +21,8 @@
     "./shifu check:source"
   ],
   "requested_by": "codex/pro-9598/root",
-  "approved_by": "kungfu-origin",
-  "approved_at": "2026-07-26T22:27:22Z",
+  "approved_by": "dongkeren",
+  "approved_at": "2026-07-27T05:57:08Z",
   "expires_at_or_review_by": "2026-10-31T00:00:00Z",
   "retirement_or_decomposition_ref": "docs/qualification/gates/workflow-authority.md#change-procedure"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -130,7 +130,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:ff9c5dc260e541871da9d45137b69316bc4395f4ed1026b8816c8ebaf585b361"
+          "sourceRoot": "sha256:d63c602571f0233d59729ea2be06c6b8470027a40d7676bdd79f97a1484fd3ba"
         },
         {
           "path": ".github/workflows/dev-verify-patrol.yml",
@@ -767,5 +767,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e5426d6a8e7f4d5af0a28dac3e84e0f16e883b485efd88379990662336d5385f"
+  "registryRoot": "sha256:a36188d7e4d57c03b391bf7d727e3748e2df0864ff6027acc1c911a3d8076f2e"
 }

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -46,6 +46,10 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
     /create-pull-request: \$\{\{ github\.event_name == 'schedule'/u,
   );
   assert.match(source, /dry-run: \$\{\{ github\.event_name != 'schedule'/u);
+  assert.match(
+    source,
+    /promotion-token: \$\{\{ secrets\.KUNGFU_GITHUB_TOKEN \}\}/u,
+  );
   assert.doesNotMatch(
     source,
     /npm publish|gh release create|git tag|auto-merge/iu,


### PR DESCRIPTION
## Summary

- pass the repository-owned promotion token to the Buildchain candidate patrol
- retain the exact source-lock-only mutation boundary
- refresh workflow authority and publication roots with a bounded complexity waiver

## Why

The organization forbids GitHub Actions from creating pull requests with the default workflow token. The existing repository-owned promotion credential is already used by the release controller; this thin caller now passes it to Buildchain without widening publication authority.

## Validation

- ./shifu test:alpha-promotion-preflight
- ./shifu check:gate-catalog
- ./shifu check:release-publication-control-plane
- ./shifu check:source
- staged pre-commit gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Pass the existing repository-owned promotion token to the candidate patrol without changing an architecture contract."
}
-->