### PR TITLE
fix(product): admit installed Assignment with explicit identities

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1828,6 +1828,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
     installRoot,
     'assignment-admission-request.json',
   );
+  const initiativeId = 'installed-product-qualification';
   const assignmentId = 'installed-product-admission-smoke';
   const assignmentEnv = {
     ...env,
@@ -1857,7 +1858,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
         },
         workDefinition: {
           goal_id: assignmentId,
-          mission_id: 'installed-product-qualification',
+          mission_id: initiativeId,
           title: 'Verify installed Assignment admission',
           objective: 'Prove the packaged Mission Control Suite is closed.',
           owner_agent: 'product-qualification',
@@ -1897,6 +1898,10 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
         captured.requestPath,
         '--workspace',
         workspace,
+        '--initiative-id',
+        initiativeId,
+        '--assignment-id',
+        assignmentId,
         '--actor',
         'product-qualification',
         '--actor-type',

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1830,6 +1830,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
   );
   const initiativeId = 'installed-product-qualification';
   const assignmentId = 'installed-product-admission-smoke';
+  const retentionPolicy = 'explicit-expiry-retain-bytes-v1';
   const assignmentEnv = {
     ...env,
     HOME: userHome,
@@ -1848,14 +1849,8 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
     `${JSON.stringify(
       {
         schema: 'kungfu.assignment-request/v1',
-        source: {
-          kind: 'installed-product-qualification',
-          sourceId: assignmentId,
-        },
-        retention: {
-          policy: 'explicit-expiry-retain-bytes-v1',
-          expiresAt: null,
-        },
+        source: { kind: initiativeId, sourceId: assignmentId },
+        retention: { policy: retentionPolicy, expiresAt: null },
         workDefinition: {
           goal_id: assignmentId,
           mission_id: initiativeId,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -284,6 +284,18 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
       ['work', 'admit'],
     ],
   );
+  assert.deepEqual(
+    invocations[1].args.slice(
+      invocations[1].args.indexOf('--initiative-id'),
+      invocations[1].args.indexOf('--actor'),
+    ),
+    [
+      '--initiative-id',
+      'installed-product-qualification',
+      '--assignment-id',
+      'installed-product-admission-smoke',
+    ],
+  );
   for (const invocation of invocations) {
     assert.equal(
       invocation.env.HOME,


### PR DESCRIPTION
## Summary

- pass the canonical Initiative and Assignment identities to the installed-product admission smoke
- keep the work-definition Mission projection aligned with the same Initiative identity
- cover the exact CLI identity arguments in the product distribution tests

## Validation

- `./shifu test:cli-surface-qualification` (32 tests passed)
- staged repository gate (including invariant, docs, ADR, KFD-7, and Biome checks)

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This bug fix restores the installed qualification smoke to the already-governed Assignment admission contract and does not change an architecture decision."}
-->