### PR TITLE
fix(product): bind installed admission identities

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:8306c9fe4d75e10ae381073e3c93139ffd1082dffbd2572aa172830e8aecdee9",
+  "sourceRoot": "sha256:e05e2e2779b32d9e8a7d4e0eb3b47b7b5f594d5d95dad37599bb2962c51426e1",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -518,7 +518,7 @@
           "path": "product/scripts/dist.mjs",
           "currentLines": 2528,
           "baselineLines": 2514,
-          "currentRoot": "sha256:939c5fccd5be8c0a1f3eedcb240f7aae00f96d6c6dba42af9654e4acd310f8d4",
+          "currentRoot": "sha256:406f7e215f57cab60730fe479eb936e925f4b0a1e6d4b06fc3b992d5ea17a1c9",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1814,7 +1814,6 @@ function runInstalledActionPrimitiveDiscovery({ installRoot, kungfuBin, env }) {
     }
   }
 }
-
 export function runInstalledKungfuAssignmentAdmissionSmoke({
   installRoot,
   kungfuBin,
@@ -1919,7 +1918,6 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
     );
   }
 }
-
 export function smokeCliProductArchive({ archivePath, archiveBase }) {
   return buildchainLogger.spanSync(
     'product.cli.smoke',

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1857,7 +1857,9 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
         },
         workDefinition: {
           goal_id: assignmentId,
+          assignment_id: assignmentId,
           mission_id: 'installed-product-qualification',
+          initiative_id: 'installed-product-qualification',
           title: 'Verify installed Assignment admission',
           objective: 'Prove the packaged Mission Control Suite is closed.',
           owner_agent: 'product-qualification',

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -284,6 +284,20 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
       ['work', 'admit'],
     ],
   );
+  const admissionRequest = JSON.parse(
+    fs.readFileSync(
+      path.join(installRoot, 'assignment-admission-request.json'),
+      'utf8',
+    ),
+  );
+  assert.equal(
+    admissionRequest.workDefinition.initiative_id,
+    'installed-product-qualification',
+  );
+  assert.equal(
+    admissionRequest.workDefinition.assignment_id,
+    'installed-product-admission-smoke',
+  );
   for (const invocation of invocations) {
     assert.equal(
       invocation.env.HOME,


### PR DESCRIPTION
## Summary

- bind the packaged Assignment admission smoke to explicit Initiative and Assignment identities
- lock the generated installed-product request with a direct regression assertion
- preserve the grandfathered distribution module line budget

## Evidence

- reproduces the fail-closed Alpha build diagnosis from run 30242582583
- `node --test product/scripts/dist.test.mjs`: 24/24 pass
- `node scripts/code-complexity-budget.mjs`: pass
- complete staged pre-commit gate: pass

## Release impact

This is a release-tail correctness fix for the existing Alpha PR #1448. It does not widen KFD shipped support or create a second release intent.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix makes the packaged Assignment admission smoke comply with the already-delivered explicit identity contract; it changes no ADR authority and does not widen KFD support claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs installed-product qualification without adding publishing authority or weakening release gates.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; the smoke now matches the existing Assignment identity contract)
