### PR TITLE
fix(product): admit installed Assignment with explicit identities

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:7df5cbc4775bbc6bb89d73e6dc1b3474a09ddc86d9695406c800ba5763720879",
+  "sourceRoot": "sha256:1496f5ee4480238b0602c3217c0cf219f432054baec52c8014b08c862bf898a1",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -520,7 +520,7 @@
           "path": "product/scripts/dist.mjs",
           "currentLines": 2528,
           "baselineLines": 2514,
-          "currentRoot": "sha256:939c5fccd5be8c0a1f3eedcb240f7aae00f96d6c6dba42af9654e4acd310f8d4",
+          "currentRoot": "sha256:181f551e0398612979ddbf7864af4a465b9e7bad4788b2d56dbc7cde3b2eefea",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1828,6 +1828,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
     installRoot,
     'assignment-admission-request.json',
   );
+  const initiativeId = 'installed-product-qualification';
   const assignmentId = 'installed-product-admission-smoke';
   const assignmentEnv = {
     ...env,
@@ -1857,7 +1858,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
         },
         workDefinition: {
           goal_id: assignmentId,
-          mission_id: 'installed-product-qualification',
+          mission_id: initiativeId,
           title: 'Verify installed Assignment admission',
           objective: 'Prove the packaged Mission Control Suite is closed.',
           owner_agent: 'product-qualification',
@@ -1897,6 +1898,10 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
         captured.requestPath,
         '--workspace',
         workspace,
+        '--initiative-id',
+        initiativeId,
+        '--assignment-id',
+        assignmentId,
         '--actor',
         'product-qualification',
         '--actor-type',

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1830,6 +1830,7 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
   );
   const initiativeId = 'installed-product-qualification';
   const assignmentId = 'installed-product-admission-smoke';
+  const retentionPolicy = 'explicit-expiry-retain-bytes-v1';
   const assignmentEnv = {
     ...env,
     HOME: userHome,
@@ -1848,14 +1849,8 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
     `${JSON.stringify(
       {
         schema: 'kungfu.assignment-request/v1',
-        source: {
-          kind: 'installed-product-qualification',
-          sourceId: assignmentId,
-        },
-        retention: {
-          policy: 'explicit-expiry-retain-bytes-v1',
-          expiresAt: null,
-        },
+        source: { kind: initiativeId, sourceId: assignmentId },
+        retention: { policy: retentionPolicy, expiresAt: null },
         workDefinition: {
           goal_id: assignmentId,
           mission_id: initiativeId,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -284,6 +284,18 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
       ['work', 'admit'],
     ],
   );
+  assert.deepEqual(
+    invocations[1].args.slice(
+      invocations[1].args.indexOf('--initiative-id'),
+      invocations[1].args.indexOf('--actor'),
+    ),
+    [
+      '--initiative-id',
+      'installed-product-qualification',
+      '--assignment-id',
+      'installed-product-admission-smoke',
+    ],
+  );
   for (const invocation of invocations) {
     assert.equal(
       invocation.env.HOME,


### PR DESCRIPTION
## Summary

- pass the canonical Initiative and Assignment identities to the installed-product admission smoke
- keep the work-definition projection and source identity aligned
- preserve the product distribution complexity budget and refresh the governed semantic-amplification report
- replace #1611 after its merge-queue preview became dirty behind newly merged dev work

## Validation

- `./shifu test:cli-surface-qualification` (32 tests passed)
- `./shifu maintainability:amplification --check`
- `node scripts/code-complexity-budget.mjs`
- staged repository gate (including invariant, docs, ADR, KFD-7, and Biome checks)

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This bug fix restores the installed qualification smoke to the already-governed Assignment admission contract and does not change an architecture decision."}
-->