### PR TITLE
fix(product): bind installed admission identities

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:1496f5ee4480238b0602c3217c0cf219f432054baec52c8014b08c862bf898a1",
+  "sourceRoot": "sha256:cccfc2f1fa59613919b67b01a09fc3d92178520579558c35d054f8834e6da8a6",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -520,7 +520,7 @@
           "path": "product/scripts/dist.mjs",
           "currentLines": 2528,
           "baselineLines": 2514,
-          "currentRoot": "sha256:181f551e0398612979ddbf7864af4a465b9e7bad4788b2d56dbc7cde3b2eefea",
+          "currentRoot": "sha256:37bb70b173bba4c639ea430ae6d87d57c095acb6595a200c6207984fcd841dc1",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1814,7 +1814,6 @@ function runInstalledActionPrimitiveDiscovery({ installRoot, kungfuBin, env }) {
     }
   }
 }
-
 export function runInstalledKungfuAssignmentAdmissionSmoke({
   installRoot,
   kungfuBin,
@@ -1853,7 +1852,9 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
         retention: { policy: retentionPolicy, expiresAt: null },
         workDefinition: {
           goal_id: assignmentId,
+          assignment_id: assignmentId,
           mission_id: initiativeId,
+          initiative_id: initiativeId,
           title: 'Verify installed Assignment admission',
           objective: 'Prove the packaged Mission Control Suite is closed.',
           owner_agent: 'product-qualification',
@@ -1917,7 +1918,6 @@ export function runInstalledKungfuAssignmentAdmissionSmoke({
     );
   }
 }
-
 export function smokeCliProductArchive({ archivePath, archiveBase }) {
   return buildchainLogger.spanSync(
     'product.cli.smoke',

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -284,6 +284,20 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
       ['work', 'admit'],
     ],
   );
+  const admissionRequest = JSON.parse(
+    fs.readFileSync(
+      path.join(installRoot, 'assignment-admission-request.json'),
+      'utf8',
+    ),
+  );
+  assert.equal(
+    admissionRequest.workDefinition.initiative_id,
+    'installed-product-qualification',
+  );
+  assert.equal(
+    admissionRequest.workDefinition.assignment_id,
+    'installed-product-admission-smoke',
+  );
   assert.deepEqual(
     invocations[1].args.slice(
       invocations[1].args.indexOf('--initiative-id'),


### PR DESCRIPTION
## Summary

- bind the packaged Assignment admission smoke to explicit Initiative and Assignment identities
- lock the generated installed-product request with a direct regression assertion
- preserve the grandfathered distribution module line budget
- supersede #1610 and #1615 without force-pushing their published histories

## Evidence

- reproduces the fail-closed Alpha build diagnosis from run 30242582583
- `node --test product/scripts/dist.test.mjs`: 24/24 pass
- `node scripts/code-complexity-budget.mjs`: pass
- `./shifu maintainability:amplification --check`: pass
- complete staged pre-commit gate: pass
- Project Cut merge-queue admission: qualified, one replayed commit

## Release impact

This is a release-tail correctness fix for the existing Alpha PR #1448. It does not widen KFD shipped support or create a second release intent.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix makes the packaged Assignment admission smoke comply with the already-delivered explicit identity contract; it changes no ADR authority and does not widen KFD support claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs installed-product qualification without adding publishing authority or weakening release gates.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; the smoke now matches the existing Assignment identity contract)
