### PR TITLE
fix(workspace): isolate catalog identity verification failures

### DIFF
--- a/framework/core/src/python/kungfu/workspace.py
+++ b/framework/core/src/python/kungfu/workspace.py
@@ -777,30 +777,40 @@ def verify_workspace_catalog(
     results: list[dict[str, Any]] = []
     for entry in catalog["entries"]:
         locator = entry.get("locator")
-        if entry["workspace_kind"] == "home":
-            identity = _home_identity(
-                os.environ if env is None else env,
-                "catalog-verification",
-            )
-        elif isinstance(locator, str) and locator:
-            identity = _project_identity(locator, "catalog-verification", env=env)
-        else:
+        problem: dict[str, str] | None = None
+        try:
+            if entry["workspace_kind"] == "home":
+                identity = _home_identity(
+                    os.environ if env is None else env,
+                    "catalog-verification",
+                )
+            elif isinstance(locator, str) and locator:
+                identity = _project_identity(locator, "catalog-verification", env=env)
+            else:
+                identity = None
+        except (OSError, ValueError) as error:
             identity = None
+            problem = {
+                "code": "workspace-identity-unreadable",
+                "message": str(error),
+            }
         available = bool(identity and _workspace_available(identity))
         actual_root = identity.identity_root if identity else ""
-        results.append(
-            {
-                "identity_root": entry["identity_root"],
-                "workspace_id": entry["workspace_id"],
-                "available": available,
-                "identity_matches": bool(
-                    available and actual_root == entry["identity_root"]
-                ),
-                "actual_identity_root": actual_root,
-            }
-        )
+        result = {
+            "identity_root": entry["identity_root"],
+            "workspace_id": entry["workspace_id"],
+            "available": available,
+            "identity_matches": bool(
+                available and actual_root == entry["identity_root"]
+            ),
+            "actual_identity_root": actual_root,
+        }
+        if problem is not None:
+            result["problem"] = problem
+        results.append(result)
     ok = not catalog["issues"] and all(
-        not row["available"] or row["identity_matches"] for row in results
+        ("problem" not in row) and (not row["available"] or row["identity_matches"])
+        for row in results
     )
     return {
         "schema": CATALOG_VERIFICATION_SCHEMA,

--- a/framework/core/tests/python/test_workspace.py
+++ b/framework/core/tests/python/test_workspace.py
@@ -234,6 +234,44 @@ def test_catalog_damage_degrades_discovery_without_changing_workspace_authority(
     assert verify_workspace_catalog(str(config_home), env={"HOME": str(tmp_path)})["ok"]
 
 
+def test_catalog_verify_isolates_unreadable_workspace_identity(tmp_path):
+    config_home = tmp_path / "config"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {"HOME": str(tmp_path)}
+    candidate = inspect_workspace(str(repo), env=env)
+    assert candidate is not None
+    ensure_workspace_data_home(candidate, "catalog-verify-fixture")
+    qualified = inspect_workspace(str(repo), env=env)
+    assert qualified is not None
+    select_workspace(qualified, config_home=str(config_home), env=env)
+
+    identity_path = repo / ".kungfu" / "workspace-identity.json"
+    identity_path.write_text(
+        json.dumps({"identityRoot": "sha256:" + "8" * 64}),
+        encoding="utf-8",
+    )
+
+    report = verify_workspace_catalog(str(config_home), env=env)
+
+    assert report["ok"] is False
+    assert report["authority"] is False
+    assert report["writes"] == []
+    assert report["entries"] == [
+        {
+            "identity_root": qualified.identity_root,
+            "workspace_id": qualified.workspace_id,
+            "available": False,
+            "identity_matches": False,
+            "actual_identity_root": "",
+            "problem": {
+                "code": "workspace-identity-unreadable",
+                "message": f"workspace identity material field mismatch: {identity_path}",
+            },
+        }
+    ]
+
+
 def test_catalog_lifecycle_is_dry_run_reversible_and_retains_authority(tmp_path):
     config_home = tmp_path / "config"
     identity = inspect_workspace(str(tmp_path / "repo"), env={"HOME": str(tmp_path)})


### PR DESCRIPTION
## Summary

Prevent one malformed or unreadable Workspace identity from aborting verification of the entire Catalog. The verifier now reports a structured per-entry problem and remains read-only.

## Verification

- `./shifu build:core`
- `./shifu test:workspace-continuation`
- `./shifu check:workspace-continuation`
- `./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix preserves Workspace and Catalog authority semantics; it only isolates diagnostics for invalid locator identity material."
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation impact reviewed; no contract change required
