### PR TITLE
ci(release): serialize dev alpha candidates

### DIFF
--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -3,9 +3,15 @@
 name: Dev to Alpha Candidate Patrol
 
 on:
+  workflow_run:
+    workflows:
+      - Dev Verify Patrol
+      - Alpha promotion preflight
+    types:
+      - completed
   schedule:
-    # Daily at 22:00 UTC (06:00 Asia/Shanghai), after the 04:00 Dev Patrol.
-    - cron: "0 22 * * *"
+    # Offset 30-minute recovery patrol; avoids GitHub's top-of-hour load peak.
+    - cron: "17,47 * * * *"
   workflow_dispatch:
     inputs:
       buildchain-ref:
@@ -25,22 +31,29 @@ on:
 
 permissions:
   actions: read
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   candidate:
-    # This exact Buildchain source commit is replaced by the merged commit if
-    # review changes the reusable workflow before this PR is merged.
-    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@e95c0251390f4948b7aa00de63c49f018ef1f6ff
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.head_branch == 'dev/v4/v4.0'
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    # The reusable workflow is immutable; its streamed runtime is the reviewed
+    # v3 validation train so this consumer proves the train before stable refs move.
+    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@9090ef05d9c83bc6466831210acf85eaf1e8b2b1
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || 'e95c0251390f4948b7aa00de63c49f018ef1f6ff' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || 'train/v3/v3.0/dev-alpha-candidate-single-flight' }}
       source-branch: dev/v4/v4.0
       target-branch: alpha/v4/v4.0
       dev-workflow-path: .github/workflows/dev-verify-patrol.yml
       alpha-workflow-path: .github/workflows/alpha-promotion-preflight.yml
       max-age-seconds: 604800
-      create-pull-request: ${{ github.event_name == 'schedule' || inputs.create-pull-request }}
-      dry-run: ${{ github.event_name != 'schedule' && inputs.dry-run }}
+      settlement-authorized: ${{ github.event_name != 'workflow_dispatch' || inputs.create-pull-request }}
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
     secrets:
       promotion-token: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1315,14 +1315,14 @@
     {
       "path": ".github/workflows/dev-alpha-candidate-patrol.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:ae2d7fdf694774510f02c3b315c5eabe2bbdf738b0b35d53d2c590760ac51091",
+      "definitionDigest": "sha256:3ff18e83f04173578323efb2bc799758d3e193465b92ca70e120f1d2df899307",
       "jobs": [
         {
           "id": "candidate",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:16149888ed96c050fb421464ad037eb09152994e0aa82eb08604ee9f9e87333c",
+          "definitionDigest": "sha256:986d4391a6e48c9d8a55df68fc006e141e10a0c549ae39aaf90555e71bbea97e",
           "credentials": {
             "githubToken": "write",
             "oidc": false,
@@ -1332,7 +1332,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@e95c0251390f4948b7aa00de63c49f018ef1f6ff"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@9090ef05d9c83bc6466831210acf85eaf1e8b2b1"],
           "steps": []
         }
       ]

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -130,7 +130,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:d63c602571f0233d59729ea2be06c6b8470027a40d7676bdd79f97a1484fd3ba"
+          "sourceRoot": "sha256:c944f03541c12c412c2124ef4f5fe2c67bba086f95ce39cda464bb1e22f09b1a"
         },
         {
           "path": ".github/workflows/dev-verify-patrol.yml",
@@ -774,5 +774,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:1766677bf02aa873b8fe12a89e80b3af736ad0bf3b3b2c9942db9e021b49274c"
+  "registryRoot": "sha256:872eb2b57a575e55998b2bf9434781f88f1a4a20f370cfb535549ac274238ebb"
 }

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -24,12 +24,10 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
     /uses: kungfu-systems\/buildchain\/.github\/workflows\/dev-alpha-candidate-patrol\.yml@([0-9a-f]{40})/u,
   )?.[1];
   assert.match(reusableRef || '', /^[0-9a-f]{40}$/u);
+  assert.equal(reusableRef, '9090ef05d9c83bc6466831210acf85eaf1e8b2b1');
   assert.match(
     source,
-    new RegExp(
-      `buildchain-ref: \\$\\{\\{ inputs\\.buildchain-ref \\|\\| '${reusableRef}' \\}\\}`,
-      'u',
-    ),
+    /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'train\/v3\/v3\.0\/dev-alpha-candidate-single-flight' \}\}/u,
   );
   assert.match(source, /source-branch: dev\/v4\/v4\.0/u);
   assert.match(source, /target-branch: alpha\/v4\/v4\.0/u);
@@ -43,9 +41,18 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
   );
   assert.match(
     source,
-    /create-pull-request: \$\{\{ github\.event_name == 'schedule'/u,
+    /settlement-authorized: \$\{\{ github\.event_name != 'workflow_dispatch'/u,
   );
-  assert.match(source, /dry-run: \$\{\{ github\.event_name != 'schedule'/u);
+  assert.match(
+    source,
+    /dry-run: \$\{\{ github\.event_name == 'workflow_dispatch'/u,
+  );
+  assert.match(source, /cron: "17,47 \* \* \* \*"/u);
+  assert.match(source, /workflow_run:/u);
+  assert.match(source, /Dev Verify Patrol/u);
+  assert.match(source, /Alpha promotion preflight/u);
+  assert.match(source, /head_branch == 'dev\/v4\/v4\.0'/u);
+  assert.doesNotMatch(source, /cron: "0 22 \* \* \*"/u);
   assert.match(
     source,
     /promotion-token: \$\{\{ secrets\.KUNGFU_GITHUB_TOKEN \}\}/u,


### PR DESCRIPTION
## Outcome

Makes Dev to Alpha candidate patrol event-driven after both qualification workflows, with an offset 30-minute recovery patrol and single-flight settlement from Buildchain.

## Behavior

- workflow_run observes Dev Verify Patrol and Alpha promotion preflight completions for dev/v4/v4.0
- recovery schedule runs at minute 17 and 47 instead of once daily
- observer remains read-only; only the settlement job receives write permissions
- manual dry-runs remain non-mutating
- the reusable workflow is immutable and its runtime is pinned to the reviewed Buildchain validation train

## Evidence

- ./shifu check:source passed
- source acceptance included 679 Node contract tests, 116 runtime upgrade tests, and all publication/workflow authority gates
- targeted patrol tests passed
- actionlint passed
- live no-write run 30250144602 detected existing managed PR #1613 in state active
- settlement job was skipped and no second Alpha PR was created

Buildchain dependency: kungfu-systems/buildchain#1967.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This delivery changes release qualification scheduling and candidate settlement control without changing a product architecture decision."
}
-->