### PR TITLE
fix(ci): prefetch production libwasm crates

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -196,12 +196,20 @@ jobs:
           test -z "$(git -C "$SOURCE_ROOT" status --porcelain)"
           test -f "$SOURCE_ROOT/shifu"
 
-      - name: Verify pinned spike Rust toolchain
+      - name: Verify Rust toolchain and fetch locked libwasm dependencies
         shell: bash
         run: |
           cd "$SOURCE_ROOT/crates/libwasm-spike"
           rustc --version
           cargo --version
+          registry_args=(
+            --config 'source.crates-io.replace-with="kungfu-embedding-mirror"'
+            --config 'source.kungfu-embedding-mirror.registry="sparse+https://rsproxy.cn/index/"'
+          )
+          for engine in wasmtime wasmer; do
+            cargo "${registry_args[@]}" fetch --locked \
+              --manifest-path "$SOURCE_ROOT/crates/libwasm/$engine/Cargo.toml"
+          done
 
       - name: Install frozen workspace (POSIX)
         if: ${{ runner.os != 'Windows' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1473,7 +1473,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5067a806e4d8dbbf194387c062741f272cf205e95b535518a59f75ec31fa8244",
+          "definitionDigest": "sha256:59225f5deb39bbdaff9edc2d41d3dfa04b953d43e67f3685df60d2509a20d32e",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -1515,9 +1515,9 @@
             },
             {
               "index": 6,
-              "label": "name:Verify pinned spike Rust toolchain",
+              "label": "name:Verify Rust toolchain and fetch locked libwasm dependencies",
               "authority": "qualification",
-              "definitionDigest": "sha256:32fd42c280abcb64c25877dd920f9e95637132dacce97fdd10528dcf4cf2aed2"
+              "definitionDigest": "sha256:125b64ddf252c71d54c37d4f18823e095badcbd9751311b12097edd63d1e15c5"
             },
             {
               "index": 7,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -161,7 +161,7 @@
           "classification": "non-publication",
           "owner": "kungfu-runtime",
           "surfaceIds": [],
-          "sourceRoot": "sha256:e564f05af8911af07dbdc61e628a57f39d94c3389211a56b7f33a8161e8ba169"
+          "sourceRoot": "sha256:44120649eea24fa5053c6fe29e5dcd0009b604e9b13e21fc5ae262946e0b99d2"
         },
         {
           "path": ".github/workflows/gate-measurement.yml",
@@ -774,5 +774,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:1766677bf02aa873b8fe12a89e80b3af736ad0bf3b3b2c9942db9e021b49274c"
+  "registryRoot": "sha256:d07bd01929baa0e648741c2769f37ce415fae36922e0d03685deeff84834c5a5"
 }

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -103,6 +103,29 @@ test('automatic hosted preflight does not inherit a private Cargo mirror', () =>
   );
 });
 
+test('embedding qualification fetches production libwasm crates before the offline gate', () => {
+  const workflow = fs.readFileSync(
+    path.join(process.cwd(), '.github/workflows/embedding-membrane-spike.yml'),
+    'utf8',
+  );
+  const fetchIndex = workflow.indexOf(
+    'cargo "${registry_args[@]}" fetch --locked',
+  );
+  const gateIndex = workflow.indexOf(
+    '- name: Build and run membrane consumers (POSIX)',
+  );
+  assert.ok(fetchIndex >= 0);
+  assert.ok(gateIndex > fetchIndex);
+  assert.match(
+    workflow,
+    /cargo "\$\{registry_args\[@\]\}" fetch --locked[\s\S]*crates\/libwasm\/\$engine\/Cargo\.toml/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /fetch --locked\s+\\\s+--manifest-path "\$SOURCE_ROOT\/crates\/libwasm-spike/u,
+  );
+});
+
 test('custom Linux-only builds do not start the macOS credential island', () => {
   const workflow = fs.readFileSync(
     path.join(process.cwd(), '.github/workflows/build.yml'),


### PR DESCRIPTION
## Summary

- prefetch the locked production `crates/libwasm/{wasmtime,wasmer}` dependency graphs before the embedding qualification turns Cargo offline
- keep the fetch on the governed mirror and preserve the existing 17-step authority inventory
- add a regression test that binds the production manifests and their ordering before the membrane gate
- refresh the governed workflow and publication source roots

## Failure evidence

- Alpha Embedding membrane spikes run: `30248858999`
- failing macOS job: `89922123096`
- deterministic error: `foldhash v0.1.5` was unavailable after `CARGO_NET_OFFLINE=true`

## Validation

- `node --test scripts/alpha-promotion-preflight.test.mjs scripts/source-acceptance.test.mjs` (31 passed)
- `./shifu check:gate-catalog`
- `node framework/release/publication-control-plane.mjs check`
- `./shifu check:source` (build-free source gate passed; 679 Node tests, 40 Python tests, 116 runtime-upgrade tests, 69 desktop-update tests)
- staged repository gate (including KFD support matrix and negative fixtures)

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This CI fix restores dependency availability for the existing offline embedding qualification and does not change an architecture decision."}
-->