### PR TITLE
fix(ci): prefetch production membrane crates

### DIFF
--- a/scripts/qualify-embedding-membranes.mjs
+++ b/scripts/qualify-embedding-membranes.mjs
@@ -68,17 +68,19 @@ const cargoSourceArgs = [
   `source.kungfu-spike-mirror.registry="${cargoRegistry}"`,
 ];
 
-// Resolve every locked dependency before Ninja starts unrelated native work.
+// Resolve every spike and production dependency before Ninja starts native work.
 // The build below is deliberately offline so a registry failure cannot surface
 // late after C++ and product compilation have already consumed the runner.
-for (const engine of ['wasmtime', 'wasmer']) {
-  run('cargo', [
-    ...cargoSourceArgs,
-    'fetch',
-    '--locked',
-    '--manifest-path',
-    path.join(root, 'crates', 'libwasm-spike', engine, 'Cargo.toml'),
-  ]);
+for (const crateFamily of ['libwasm-spike', 'libwasm']) {
+  for (const engine of ['wasmtime', 'wasmer']) {
+    run('cargo', [
+      ...cargoSourceArgs,
+      'fetch',
+      '--locked',
+      '--manifest-path',
+      path.join(root, 'crates', crateFamily, engine, 'Cargo.toml'),
+    ]);
+  }
 }
 
 run('cmake', [

--- a/scripts/qualify-embedding-membranes.test.mjs
+++ b/scripts/qualify-embedding-membranes.test.mjs
@@ -18,5 +18,9 @@ test('locked Cargo fetch precedes the offline native build', () => {
   assert.ok(build > fetch, 'native build begins before Cargo fetch');
   assert.ok(offline > build, 'native build is not explicitly offline');
   assert.match(source, /for \(const engine of \['wasmtime', 'wasmer'\]\)/u);
+  assert.match(
+    source,
+    /for \(const crateFamily of \['libwasm-spike', 'libwasm'\]\)/u,
+  );
   assert.match(source, /'--locked'/u);
 });


### PR DESCRIPTION
## Summary

- prefetch both spike and production libwasm Cargo manifests before the offline native build
- prevent late missing-crate failures such as foldhash after C++ compilation has started
- regress the complete crate-family prefetch contract

## Evidence

- reproduces the exact Alpha release-tail failure from run 30249771030 / job 89924992257
- `node --test scripts/qualify-embedding-membranes.test.mjs`: pass
- `./shifu check:staged`: pass
- complete staged pre-commit gate: pass
- Project Cut merge-queue admission: qualified, one replayed commit

## Release impact

This is a release-tail CI correctness fix for the existing Alpha PR #1448. It creates no release intent and does not widen KFD shipped support.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix aligns dependency prefetch with the production Cargo manifests already consumed by the offline membrane build; it changes no ADR authority and does not widen KFD support claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs release qualification without adding publishing authority or weakening release gates.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; qualification now matches the existing offline-build contract)
