### PR TITLE
fix(ci): reuse exact successful queue proof

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "4eea69f5a51eae999e8b0525f0985121e28f94b3",
+    "sourceSha": "f946c66bb6513cec8f55a1caaee9b3b8787b1c16",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:1b6eec071960b48620558bf12e0366f496296caecfbbf73e696883c0b191b379"
   },

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -236,8 +236,8 @@ jobs:
         if: >-
           ${{
             github.event_name == 'merge_group' &&
-            steps.descriptor.outputs.native-required == 'true' &&
-            steps.descriptor.outputs.sdk-required != 'true'
+            (steps.descriptor.outputs.native-required == 'true' ||
+             steps.descriptor.outputs.sdk-required == 'true')
           }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -291,8 +291,7 @@ jobs:
           reuse=false
           producer_run_id=""
           if [ "$GITHUB_EVENT_NAME" = "merge_group" ] && \
-             [ "$NATIVE_REQUIRED" = "true" ] && \
-             [ "$SDK_REQUIRED" != "true" ] && \
+             { [ "$NATIVE_REQUIRED" = "true" ] || [ "$SDK_REQUIRED" = "true" ]; } && \
              [ "$LOOKUP_OUTCOME" = "success" ] && \
              [ "$LOOKUP_REUSABLE" = "true" ] && \
              [ "$DOWNLOAD_OUTCOME" = "success" ] && \
@@ -607,11 +606,14 @@ jobs:
     needs:
       - source_acceptance
       - candidate_preflight
+      - proof_probe
     if: >-
       ${{
         github.event_name == 'merge_group' &&
         needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
+        needs.proof_probe.result == 'success' &&
+        needs.proof_probe.outputs.reuse != 'true' &&
         needs.candidate_preflight.outputs.shifu-required == 'true'
       }}
     strategy:
@@ -658,11 +660,14 @@ jobs:
     needs:
       - source_acceptance
       - candidate_preflight
+      - proof_probe
     if: >-
       ${{
         github.event_name == 'merge_group' &&
         needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
+        needs.proof_probe.result == 'success' &&
+        needs.proof_probe.outputs.reuse != 'true' &&
         needs.candidate_preflight.outputs.kfd-required == 'true'
       }}
     runs-on: ubuntu-24.04
@@ -752,11 +757,13 @@ jobs:
           fi
           if [ "$REUSE" = "true" ]; then
             require_result "reused queue affected-native" skipped "$NATIVE_RESULT"
+            require_result "reused queue Shifu workspace" skipped "$SHIFU_RESULT"
+            require_result "reused queue KFD verifier" skipped "$KFD_RESULT"
           else
             require_optional_gate "queue affected-native" "$native_or_sdk" "$NATIVE_RESULT"
+            require_optional_gate "queue Shifu workspace" "$SHIFU_REQUIRED" "$SHIFU_RESULT"
+            require_optional_gate "queue KFD verifier" "$KFD_REQUIRED" "$KFD_RESULT"
           fi
-          require_optional_gate "queue Shifu workspace" "$SHIFU_REQUIRED" "$SHIFU_RESULT"
-          require_optional_gate "queue KFD verifier" "$KFD_REQUIRED" "$KFD_RESULT"
           echo "Merge Queue staged qualification passed."
       - name: Download current proof descriptor
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -850,10 +857,6 @@ jobs:
             exit 0
           fi
           if [ "$REUSE" = "true" ]; then
-            if [ "$NATIVE_REQUIRED" != "true" ] || [ "$SDK_REQUIRED" = "true" ]; then
-              echo "queue proof reuse is outside the native-only contract" >&2
-              exit 1
-            fi
             if [ "$PARTITION_RESULT" != "skipped" ]; then
               echo "reused affected-native partitions must be skipped: $PARTITION_RESULT" >&2
               exit 1
@@ -867,7 +870,7 @@ jobs:
               --producer-event merge_group \
               --producer-head-sha "$(git rev-parse HEAD)"
             echo "proof-created=false" >> "$GITHUB_OUTPUT"
-            echo "Exact same-SHA queue proof admitted; native partitions remained skipped."
+            echo "Exact same-SHA successful queue proof admitted; repeated heavy gates remained skipped."
             exit 0
           fi
           if [ "$PARTITION_RESULT" != "success" ]; then

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -155,20 +155,23 @@ Each section is bound to the registry id by the catalog meta gate.
   executions sharing one synthetic merge-group SHA; `cancel-in-progress: false`
   preserves the active execution while GitHub may coalesce identical pending
   replacements. The first successful execution produces the authoritative queue
-  proof. A later execution
-  skips only the native partitions after a unique completed-success artifact
+  proof. A later execution skips the repeated native/SDK, Shifu workspace, and
+  KFD work after a unique completed-success artifact
   matches that exact SHA and its cryptographically verified identity binds the
   same base, candidate tree, plan projection, partition set, platform tier,
   hosted-runner image, and observed compiler/CMake/Ninja facts. PR producers,
-  SDK-required plans, moved bases, changed trees/toolchains, duplicate
-  artifacts, expired evidence, and every lookup/download/verification failure
-  run the full native set. The probe descriptor is handed unchanged to the
+  moved bases, changed trees/toolchains, duplicate artifacts, expired evidence,
+  and every lookup/download/verification failure run the full required set.
+  The producer workflow must itself be completed-success, so the source-bound
+  plan also proves that its SDK, Shifu, and KFD obligations passed before a
+  repeated run can skip them. The probe descriptor is handed unchanged to the
   aggregate job: that job independently recomputes the base, candidate tree,
   and plan projection with the probe's sealed toolchain facts instead of
   substituting facts from a later non-native runner. Every native shard receipt
   must still match the complete probe toolchain, including the hosted image
   version; cross-runner drift therefore remains fail-closed. Shifu workspace
-  and KFD jobs remain independent of native proof reuse.
+  and KFD remain independent on the first execution; only a later exact-SHA
+  execution backed by the completed-success producer may skip them.
 - **Dequeue repair admission:** the trusted-base dequeue controller cancels
   active work and writes one PR marker for deterministic `failed_checks`,
   `merge_conflict`, or `invalid_merge_commit` exits. The marker binds the exact

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -254,7 +254,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:b20b2fc3c5bb77c1d72d497cfc8a573cf27a0cb1c888593c1f167349c792036c",
+          "definitionDigest": "sha256:94bd4175978964e3664d2680bde4e08decf1be8d3acb04c556f6138af78c03fc",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -277,7 +277,7 @@
             {
               "index": 3,
               "label": "name:Admit staged candidate dependency graph",
-              "definitionDigest": "sha256:a138076d5d611bebda4e5f0663a8470c3c78119262041688961ad9f3f890dd62"
+              "definitionDigest": "sha256:ea24ceceb70496619b2db15371a51c414db00028f3e08db4c412a36325ed5e51"
             },
             {
               "index": 4,
@@ -307,7 +307,7 @@
               "index": 8,
               "label": "id:admit",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:fa78904b5253525209a5766394fa9095686cd07b448131a578a70b5217d16e73"
+              "definitionDigest": "sha256:9acc3bb1a2412020d5000fa222bf27d13a8e9a93f639d9071f667b852889d1e3"
             },
             {
               "index": 9,
@@ -419,7 +419,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:cff226f48ab18774a27feb0ad91f2001f6551a75ad62a68a4fed8c792072dc63",
+          "definitionDigest": "sha256:aaf2c35660e8ef1223801e7b78ae5272608885b1b51fa4216831fa7403ad824c",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -456,7 +456,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4dd795707f86083118628ca9446f327001e4f1aaeec33175c8d37a0065b15d82",
+          "definitionDigest": "sha256:8797adab8a7787876072d7e91b2efa68d72fe0297aceb2436bcc080af5cd098c",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -496,7 +496,7 @@
               "index": 6,
               "label": "id:lookup",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:301c7a9dc3567b33566c566d31507feac5c7af3cf3a3b7157c8cc19c0172ad48"
+              "definitionDigest": "sha256:7357c433b49e647153e7c6274d36fa32e305179d29597690a53f2d8e187367b7"
             },
             {
               "index": 7,
@@ -512,7 +512,7 @@
             {
               "index": 9,
               "label": "id:decision",
-              "definitionDigest": "sha256:b00d41210baf996b9273a6c5f734be7a340d63ab2b31de3b1bfd38c79d6781e0"
+              "definitionDigest": "sha256:605bf66857c5f7ca2a6c8882da2e1295f01a4e2258d66bacb3eb763b702d368d"
             }
           ]
         },
@@ -521,7 +521,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:edc52f7da49447feda564cb29d2b59665e30309778c90109af054e6489ad6cff",
+          "definitionDigest": "sha256:4a33dfcec2664bc11953518d2ffe3b72a75a57f2654f597bc6d7be04756d83f3",
           "credentials": {
             "githubToken": "read",
             "oidc": false,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:f42523e0d97970d88391f1d434b869d74ecbf83670d248f2e2f5accdbcdc9db1"
+          "sourceRoot": "sha256:ee362b94f6e6c6eb790bf521634452dd7f76ab6d9ab34df3ef4c9bfafa0bc4dc"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -785,5 +785,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:7a72cd4682eb30ec2b425f4d35e24871bbff13f071ad5f595fa1e3fc50881575"
+  "registryRoot": "sha256:e0c913921eddf9ce3880b5cab3b317a0fe3e4e92d6cebdb053b5ab838e92f2ef"
 }

--- a/scripts/affected-native-proof.mjs
+++ b/scripts/affected-native-proof.mjs
@@ -10,7 +10,7 @@ import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
 export const IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v3';
-export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v1';
+export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v2';
 export const WORKFLOW_PATH = '.github/workflows/affected-native-pr.yml';
 export const DEFAULT_MAX_AGE_SECONDS = 6 * 60 * 60;
 const QUEUE_PRODUCER_EVENT = 'merge_group';
@@ -328,6 +328,7 @@ export function sealProof(descriptor, inputDir, producer) {
     verdict: {
       status: 'passed',
       nativeRequired: descriptor.nativeRequired,
+      sdkRequired: descriptor.sdkRequired,
     },
   };
   return { ...proof, proofRoot: digest(proof) };
@@ -372,7 +373,8 @@ export function verifyProofBundle(descriptor, bundleDir, options) {
   }
   if (
     proof.verdict?.status !== 'passed' ||
-    proof.verdict.nativeRequired !== descriptor.nativeRequired
+    proof.verdict.nativeRequired !== descriptor.nativeRequired ||
+    proof.verdict.sdkRequired !== descriptor.sdkRequired
   ) {
     throw new Error('affected-native proof verdict drift');
   }

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -244,6 +244,53 @@ test('complete partition evidence seals and verifies against the exact producer'
   fs.rmSync(value.root, { recursive: true, force: true });
 });
 
+test('successful queue proof binds SDK qualification before repeat reuse', () => {
+  const value = fixture();
+  value.value = plan(HEAD, {
+    sdkQualification: { required: true, reasons: ['public-sdk-contract'] },
+  });
+  for (const index of [0, 1]) {
+    fs.writeFileSync(
+      path.join(value.inputs, `partition-${index}`, 'receipt.json'),
+      `${JSON.stringify(receipt(value.value, index), null, 2)}\n`,
+    );
+  }
+  const descriptor = createProofDescriptor(value.value, TREE, 2, TOOLCHAIN);
+  const proof = writeBundle(descriptor, value);
+  assert.equal(descriptor.sdkRequired, true);
+  assert.equal(proof.verdict.sdkRequired, true);
+  assert.doesNotThrow(() =>
+    verifyProofBundle(descriptor, value.bundle, {
+      repository: 'kungfu-systems/kungfu',
+      producerRunId: 42,
+      producerEvent: 'merge_group',
+      producerHeadSha: HEAD,
+      maxAgeSeconds: 6 * 60 * 60,
+      now: '2026-07-22T01:00:00Z',
+    }),
+  );
+  const proofPath = path.join(value.bundle, 'proof.json');
+  const incomplete = JSON.parse(fs.readFileSync(proofPath, 'utf8'));
+  const { sdkRequired: _sdkRequired, ...legacyVerdict } = incomplete.verdict;
+  incomplete.verdict = legacyVerdict;
+  const { proofRoot: _proofRoot, ...body } = incomplete;
+  incomplete.proofRoot = digest(body);
+  fs.writeFileSync(proofPath, `${JSON.stringify(incomplete, null, 2)}\n`);
+  assert.throws(
+    () =>
+      verifyProofBundle(descriptor, value.bundle, {
+        repository: 'kungfu-systems/kungfu',
+        producerRunId: 42,
+        producerEvent: 'merge_group',
+        producerHeadSha: HEAD,
+        maxAgeSeconds: 6 * 60 * 60,
+        now: '2026-07-22T01:00:00Z',
+      }),
+    /proof verdict drift/,
+  );
+  fs.rmSync(value.root, { recursive: true, force: true });
+});
+
 test('missing, tampered, or stale proof evidence fails closed', () => {
   const value = fixture();
   const descriptor = createProofDescriptor(value.value, TREE, 2, TOOLCHAIN);
@@ -522,6 +569,10 @@ test('workflow keeps one required context while staging authoritative queue buil
   assert.match(workflow, /--producer-event merge_group/u);
   assert.match(workflow, /--head-sha "\$GITHUB_SHA"/u);
   assert.match(workflow, /needs\.proof_probe\.outputs\.reuse != 'true'/u);
+  assert.doesNotMatch(
+    workflow,
+    /steps\.descriptor\.outputs\.sdk-required != 'true'/u,
+  );
   assert.match(workflow, /echo "native-required=\$\{native_required\}"/u);
   assert.match(workflow, /echo "sdk-required=\$\{sdk_required\}"/u);
   assert.match(workflow, /echo "shifu-required=\$\(jq/u);
@@ -529,6 +580,10 @@ test('workflow keeps one required context while staging authoritative queue buil
   const shifuWorkspace = workflow.slice(
     workflow.indexOf('  shifu_workspace:\n'),
     workflow.indexOf('  kfd_verifier:\n'),
+  );
+  assert.match(
+    shifuWorkspace,
+    /- proof_probe[\s\S]*needs\.proof_probe\.outputs\.reuse != 'true'/u,
   );
   assert.match(
     shifuWorkspace,
@@ -564,6 +619,18 @@ test('workflow keeps one required context while staging authoritative queue buil
   );
   assert.match(workflow, /^\s{2}shifu_workspace:$/mu);
   assert.match(workflow, /^\s{2}kfd_verifier:$/mu);
+  const kfdVerifier = workflow.slice(
+    workflow.indexOf('  kfd_verifier:\n'),
+    workflow.indexOf('  affected-native:\n'),
+  );
+  assert.match(
+    kfdVerifier,
+    /- proof_probe[\s\S]*needs\.proof_probe\.outputs\.reuse != 'true'/u,
+  );
+  assert.match(
+    workflow,
+    /reused queue Shifu workspace[\s\S]*reused queue KFD verifier/u,
+  );
   assert.doesNotMatch(workflow, /retention-days: 1$/mu);
   const verifier = fs.readFileSync(
     path.join(ROOT, 'scripts/affected-native-proof.mjs'),


### PR DESCRIPTION
## Summary

- reuse one exact, successful merge-group affected-native proof when native or SDK work is required
- bind proof v2 to sdkRequired and fail closed on missing, ambiguous, expired, drifted, or unsuccessful producer evidence
- skip duplicated native/SDK/Shifu/KFD heavy validation only after exact proof verification; keep first-run validation unchanged

## Why

PR #1590 produced two merge-group runs for the same exact SHA. Concurrency serialized them, but the second run still repeated the full native/SDK gate because proof reuse excluded sdk-required runs. This change closes that observed duplicate-validation jitter without weakening the required gate.

## Validation

- ./shifu check:source
- ./shifu check:release-publication-control-plane
- ./shifu kfd:buildchain:check
- ./shifu adr:map:check
- node --test scripts/affected-native-proof.test.mjs scripts/run-core-affected-native.test.mjs scripts/check-kungfu-gate-catalog.test.mjs
- node scripts/kungfu-workflow-authority.mjs
- git diff --check
- Project Cut: qualified, compositionChanged=false

## Safety

The first exact candidate run still executes the full required gate. Any lookup, artifact, producer, descriptor, schema, repository, SHA, workflow, or sdkRequired mismatch falls back to full validation.


<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1", "kind": "adr-neutral",
  "reason": "Exact fail-closed CI proof reuse closes duplicate validation jitter without changing an architecture contract"
}

-->