### PR TITLE
test(verify): align Portfolio qualification fixtures

### DIFF
--- a/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
+++ b/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { openProfile } from '../../../framework/api/src/capability/profile.ts';
-import { openMissionControlProfile } from '../../../extensions/work-dashboard/src/view/mission-control-profile.ts';
+import { openWorkControlProfile } from '../../../extensions/work-dashboard/src/view/mission-control-profile.ts';
 import { fail, locate, tmpDir, uvPython } from '../_harness.mjs';
 
 const { fixtureDir, coreDir } = locate(import.meta.url);
@@ -34,7 +34,7 @@ const profile = openProfile({
   env: { KUNGFU_ATLAS_REPO: sampleRoot },
   bin,
 });
-const atlas = openMissionControlProfile(profile, sampleRoot);
+const atlas = openWorkControlProfile(profile, sampleRoot);
 
 function ck(label, ok) {
   if (!ok) fail(label);

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
@@ -137,12 +137,12 @@ const html = ReactDomServer.renderToStaticMarkup(
 );
 
 for (const needle of [
-  'Work · Live global view',
-  'connecting live global Work…',
+  'Portfolio · Live federated view',
+  'connecting live Portfolio…',
   'active local project workspace',
-  'no current Work across active local workspaces',
+  'no current work across active local workspaces',
 ]) {
-  if (!html.includes(needle)) fail(`live global Work view missing ${needle}`);
+  if (!html.includes(needle)) fail(`live Portfolio view missing ${needle}`);
 }
 
-console.log('[kfx-demo-work-dashboard-atlas-live] profile + global Work render ok');
+console.log('[kfx-demo-work-dashboard-atlas-live] profile + Portfolio render ok');

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Render-smoke the current read-only global Work view without opening Electron.
+// Render-smoke the current read-only Portfolio view without opening Electron.
 // The kfx bundle is loaded the same CommonJS-wrapped way the GUI loader consumes
 // it, while this fixture injects React and the Electron IPC boundary.
 //
@@ -162,12 +162,12 @@ const html = ReactDomServer.renderToStaticMarkup(
 );
 
 for (const needle of [
-  'Work · Live global view',
-  'connecting live global Work…',
+  'Portfolio · Live federated view',
+  'connecting live Portfolio…',
   'active local project workspace',
-  'no current Work across active local workspaces',
+  'no current work across active local workspaces',
 ]) {
-  if (!html.includes(needle)) fail(`rendered global Work view missing ${needle}`);
+  if (!html.includes(needle)) fail(`rendered Portfolio view missing ${needle}`);
 }
 
-console.log('[kfx-demo-work-dashboard-atlas-view] global Work render ok');
+console.log('[kfx-demo-work-dashboard-atlas-view] Portfolio render ok');


### PR DESCRIPTION
## Summary

Align the existing qualification fixtures with the shipped Work Control and Portfolio terminology. This repairs Dev Verify Patrol coverage without changing product behavior or public compatibility aliases.

## Related issue

Follow-up to the KFD support governance release qualification.

## Changes

- exercise the primary `openWorkControlProfile` API in the Atlas capability fixture
- refresh Portfolio render expectations in the live and bundled Work Dashboard fixtures

## Verification

- `./shifu check:source`
- `git diff --check`
- historical Dev Verify Patrol run 30261612021 reproduces the three stale fixture failures on macOS and Linux

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Refresh existing qualification fixtures after the Work Control and Portfolio cutover; product behavior and architecture contracts are unchanged"}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed