### PR TITLE
fix(verify): align Work Control fixtures

### DIFF
--- a/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
+++ b/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
@@ -31,7 +31,7 @@ uvPython(coreDir, [
 const profile = openProfile({
   runtimeDir,
   execFileSync,
-  env: { KUNGFU_ATLAS_REPO: sampleRoot },
+  env: { ...process.env, KUNGFU_ATLAS_REPO: sampleRoot },
   bin,
 });
 const atlas = openMissionControlProfile(profile, sampleRoot);

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
@@ -46,7 +46,7 @@ uvPython(coreDir, [
 const profile = openProfile({
   runtimeDir,
   execFileSync,
-  env: { KUNGFU_ATLAS_REPO: sampleRoot },
+  env: { ...process.env, KUNGFU_ATLAS_REPO: sampleRoot },
   bin,
 });
 const atlas = openMissionControlProfile(profile, sampleRoot);
@@ -137,10 +137,10 @@ const html = ReactDomServer.renderToStaticMarkup(
 );
 
 for (const needle of [
-  'Work · Live global view',
-  'connecting live global Work…',
+  'Portfolio · Live federated view',
+  'connecting live Portfolio…',
   'active local project workspace',
-  'no current Work across active local workspaces',
+  'no current work across active local workspaces',
 ]) {
   if (!html.includes(needle)) fail(`live global Work view missing ${needle}`);
 }

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
@@ -162,10 +162,10 @@ const html = ReactDomServer.renderToStaticMarkup(
 );
 
 for (const needle of [
-  'Work · Live global view',
-  'connecting live global Work…',
+  'Portfolio · Live federated view',
+  'connecting live Portfolio…',
   'active local project workspace',
-  'no current Work across active local workspaces',
+  'no current work across active local workspaces',
 ]) {
   if (!html.includes(needle)) fail(`rendered global Work view missing ${needle}`);
 }


### PR DESCRIPTION
## Summary

- Preserve the inherited child process environment when fixture profiles override `KUNGFU_ATLAS_REPO`, so frozen trunk cache paths retain `HOME` and `KF_CACHE_HOME` resolution.
- Align the Work dashboard fixture assertions with the shipped native Work Control `Portfolio` copy.
- Repair the exact macOS and Linux fixture failures from Dev Verify Patrol run 30261612021; Windows was already qualifying in that run and independently proved the MSVC catalog-literal fix.

## Failure evidence

- Dev Verify Patrol 30261612021 failed only these three fixtures on macOS and Linux: `kfx-demo-atlas-capability`, `kfx-demo-work-dashboard-atlas-live`, and `kfx-demo-work-dashboard-atlas-view`.
- The first two replaced the complete child environment and caused frozen trunk to fail with `kungfu: cannot resolve KF_CACHE_HOME: HOME is unset`.
- The dashboard fixtures still asserted pre-cutover `Work · Live global view` copy after the product shipped `Portfolio · Live federated view`.

## Verification

- Focused execution of all three repaired fixtures against rebuilt Core and frozen product: passed.
- `node scripts/source-acceptance.mjs`: passed; 681 contract tests reported 671 pass, 10 skip, 0 fail, followed by 40 Work state, 116 runtime-upgrade, and 69 desktop-update tests passing.
- `git diff --check`: passed.
- Commit staged gate: passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repairs verification fixtures for the already-shipped native Work Control vocabulary and preserves the existing profile runtime environment without changing product semantics or public contracts."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; fixture-only repair)