### PR TITLE
feat(ci): reuse exact PR proof in merge queue

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -161,6 +161,8 @@ jobs:
     outputs:
       reuse: ${{ steps.decision.outputs.reuse }}
       producer-run-id: ${{ steps.decision.outputs.producer-run-id }}
+      producer-event: ${{ steps.decision.outputs.producer-event }}
+      producer-head-sha: ${{ steps.decision.outputs.producer-head-sha }}
       artifact-name: ${{ steps.descriptor.outputs.artifact-name }}
       proof-id: ${{ steps.descriptor.outputs.proof-id }}
     env:
@@ -231,7 +233,7 @@ jobs:
           path: product/qualification/affected-native/proof-probe
           if-no-files-found: error
           retention-days: 14
-      - name: Find one exact prior queue proof
+      - name: Find one exact prior producer proof
         id: lookup
         if: >-
           ${{
@@ -247,10 +249,9 @@ jobs:
             --descriptor product/qualification/affected-native/proof-probe/descriptor.json \
             --api-url "$GITHUB_API_URL" \
             --repository "$GITHUB_REPOSITORY" \
-            --producer-event merge_group \
             --head-sha "$GITHUB_SHA" \
             --github-output "$GITHUB_OUTPUT"
-      - name: Download exact prior queue proof
+      - name: Download exact prior producer proof
         id: download
         if: ${{ steps.lookup.outputs.reusable == 'true' }}
         continue-on-error: true
@@ -261,7 +262,7 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.lookup.outputs.run-id }}
           github-token: ${{ github.token }}
-      - name: Verify exact prior queue proof
+      - name: Verify exact prior producer proof
         id: verify
         if: ${{ steps.download.outcome == 'success' }}
         continue-on-error: true
@@ -272,8 +273,8 @@ jobs:
             --bundle product/qualification/affected-native/proof-reuse \
             --repository "$GITHUB_REPOSITORY" \
             --producer-run-id "${{ steps.lookup.outputs.run-id }}" \
-            --producer-event merge_group \
-            --producer-head-sha "$GITHUB_SHA"
+            --producer-event "${{ steps.lookup.outputs.producer-event }}" \
+            --producer-head-sha "${{ steps.lookup.outputs.producer-head-sha }}"
       - name: Select authoritative queue execution
         id: decision
         if: ${{ always() }}
@@ -284,12 +285,16 @@ jobs:
           LOOKUP_OUTCOME: ${{ steps.lookup.outcome }}
           LOOKUP_REUSABLE: ${{ steps.lookup.outputs.reusable }}
           PRODUCER_RUN_ID: ${{ steps.lookup.outputs.run-id }}
+          PRODUCER_EVENT: ${{ steps.lookup.outputs.producer-event }}
+          PRODUCER_HEAD_SHA: ${{ steps.lookup.outputs.producer-head-sha }}
           DOWNLOAD_OUTCOME: ${{ steps.download.outcome }}
           VERIFY_OUTCOME: ${{ steps.verify.outcome }}
         run: |
           set -euo pipefail
           reuse=false
           producer_run_id=""
+          producer_event=""
+          producer_head_sha=""
           if [ "$GITHUB_EVENT_NAME" = "merge_group" ] && \
              { [ "$NATIVE_REQUIRED" = "true" ] || [ "$SDK_REQUIRED" = "true" ]; } && \
              [ "$LOOKUP_OUTCOME" = "success" ] && \
@@ -298,12 +303,16 @@ jobs:
              [ "$VERIFY_OUTCOME" = "success" ]; then
             reuse=true
             producer_run_id="$PRODUCER_RUN_ID"
+            producer_event="$PRODUCER_EVENT"
+            producer_head_sha="$PRODUCER_HEAD_SHA"
           fi
           {
             echo "reuse=${reuse}"
             echo "producer-run-id=${producer_run_id}"
+            echo "producer-event=${producer_event}"
+            echo "producer-head-sha=${producer_head_sha}"
           } >> "$GITHUB_OUTPUT"
-          echo "Merge Queue is the only native proof producer; exact same-SHA reuse=${reuse}."
+          echo "Exact PR or same-SHA queue proof reuse=${reuse}."
 
   affected_native_shards:
     name: affected-native shard ${{ matrix.partition }} of 2 / linux
@@ -313,7 +322,6 @@ jobs:
       - proof_probe
     if: >-
       ${{
-        github.event_name == 'merge_group' &&
         needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
         needs.proof_probe.result == 'success' &&
@@ -609,7 +617,6 @@ jobs:
       - proof_probe
     if: >-
       ${{
-        github.event_name == 'merge_group' &&
         needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
         needs.proof_probe.result == 'success' &&
@@ -663,7 +670,6 @@ jobs:
       - proof_probe
     if: >-
       ${{
-        github.event_name == 'merge_group' &&
         needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
         needs.proof_probe.result == 'success' &&
@@ -734,15 +740,6 @@ jobs:
           require_result "source acceptance" success "$SOURCE_RESULT"
           require_result "candidate preflight" success "$PREFLIGHT_RESULT"
           require_result "impact probe" success "$PROBE_RESULT"
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            require_result "PR DCO" success "$DCO_RESULT"
-            require_result "PR affected-native" skipped "$NATIVE_RESULT"
-            require_result "PR Shifu workspace" skipped "$SHIFU_RESULT"
-            require_result "PR KFD verifier" skipped "$KFD_RESULT"
-            echo "PR fast admission passed without compiler or installed-artifact work."
-            exit 0
-          fi
-          require_result "queue DCO" skipped "$DCO_RESULT"
           require_optional_gate() {
             label="$1"
             required="$2"
@@ -755,16 +752,24 @@ jobs:
           if [ "$NATIVE_REQUIRED" = "true" ] || [ "$SDK_REQUIRED" = "true" ]; then
             native_or_sdk=true
           fi
-          if [ "$REUSE" = "true" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            require_result "PR DCO" success "$DCO_RESULT"
+            require_optional_gate "PR affected-native" "$native_or_sdk" "$NATIVE_RESULT"
+            require_optional_gate "PR Shifu workspace" "$SHIFU_REQUIRED" "$SHIFU_RESULT"
+            require_optional_gate "PR KFD verifier" "$KFD_REQUIRED" "$KFD_RESULT"
+            echo "PR staged qualification passed."
+          elif [ "$REUSE" = "true" ]; then
+            require_result "queue DCO" skipped "$DCO_RESULT"
             require_result "reused queue affected-native" skipped "$NATIVE_RESULT"
             require_result "reused queue Shifu workspace" skipped "$SHIFU_RESULT"
             require_result "reused queue KFD verifier" skipped "$KFD_RESULT"
           else
+            require_result "queue DCO" skipped "$DCO_RESULT"
             require_optional_gate "queue affected-native" "$native_or_sdk" "$NATIVE_RESULT"
             require_optional_gate "queue Shifu workspace" "$SHIFU_REQUIRED" "$SHIFU_RESULT"
             require_optional_gate "queue KFD verifier" "$KFD_REQUIRED" "$KFD_RESULT"
           fi
-          echo "Merge Queue staged qualification passed."
+          echo "Staged candidate qualification passed."
       - name: Download current proof descriptor
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -813,7 +818,7 @@ jobs:
           cmp "$descriptor" "$admission/recomputed-descriptor.json"
           test "$PROBE_ARTIFACT_NAME" = "$(jq -r '.artifactName' "$descriptor")"
           cp "$descriptor" "$admission/descriptor.json"
-      - name: Download admitted queue proof
+      - name: Download admitted producer proof
         if: ${{ needs.proof_probe.outputs.reuse == 'true' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -825,7 +830,6 @@ jobs:
       - name: Download current partition evidence
         if: >-
           ${{
-            github.event_name == 'merge_group' &&
             needs.proof_probe.outputs.reuse != 'true' &&
             (needs.candidate_preflight.outputs.native-required == 'true' ||
              needs.candidate_preflight.outputs.sdk-required == 'true')
@@ -834,7 +838,7 @@ jobs:
         with:
           pattern: core-affected-native-${{ github.sha }}-partition-*-of-2
           path: product/qualification/affected-native/proof-input
-      - name: Admit exact queue partition set
+      - name: Admit exact producer partition set
         id: admit
         shell: bash
         env:
@@ -843,14 +847,11 @@ jobs:
           SDK_REQUIRED: ${{ needs.candidate_preflight.outputs.sdk-required }}
           REUSE: ${{ needs.proof_probe.outputs.reuse }}
           PRODUCER_RUN_ID: ${{ needs.proof_probe.outputs.producer-run-id }}
+          PRODUCER_EVENT: ${{ needs.proof_probe.outputs.producer-event }}
+          PRODUCER_HEAD_SHA: ${{ needs.proof_probe.outputs.producer-head-sha }}
         run: |
           set -euo pipefail
           descriptor=product/qualification/affected-native/proof-admission/descriptor.json
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            echo "PR admission intentionally has no native proof."
-            echo "proof-created=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           if [ "$NATIVE_REQUIRED" != "true" ] && [ "$SDK_REQUIRED" != "true" ]; then
             echo "The source-impact plan explicitly requires no native or SDK qualification."
             echo "proof-created=false" >> "$GITHUB_OUTPUT"
@@ -867,16 +868,21 @@ jobs:
               --bundle product/qualification/affected-native/proof-reuse \
               --repository "$GITHUB_REPOSITORY" \
               --producer-run-id "$PRODUCER_RUN_ID" \
-              --producer-event merge_group \
-              --producer-head-sha "$(git rev-parse HEAD)"
+              --producer-event "$PRODUCER_EVENT" \
+              --producer-head-sha "$PRODUCER_HEAD_SHA"
             echo "proof-created=false" >> "$GITHUB_OUTPUT"
-            echo "Exact same-SHA successful queue proof admitted; repeated heavy gates remained skipped."
+            echo "Exact successful producer proof admitted; repeated heavy gates remained skipped."
             exit 0
           fi
           if [ "$PARTITION_RESULT" != "success" ]; then
             echo "affected-native partition set is not complete: $PARTITION_RESULT" >&2
             exit 1
           fi
+          case "$GITHUB_EVENT_NAME" in
+            pull_request) trigger_head_sha="$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")" ;;
+            merge_group) trigger_head_sha="$(jq -r '.merge_group.head_sha' "$GITHUB_EVENT_PATH")" ;;
+            *) echo "unsupported producer event: $GITHUB_EVENT_NAME" >&2; exit 1 ;;
+          esac
           # shifu-entry-contract: allow source-bound proof sealing after both native partitions passed
           node scripts/affected-native-proof.mjs seal \
             --descriptor "$descriptor" \
@@ -885,10 +891,11 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --run-id "$GITHUB_RUN_ID" \
             --event "$GITHUB_EVENT_NAME" \
+            --trigger-head-sha "$trigger_head_sha" \
             --checkout-sha "$(git rev-parse HEAD)"
           echo "proof-created=true" >> "$GITHUB_OUTPUT"
           echo "All affected-native partitions passed."
-      - name: Upload authoritative queue proof
+      - name: Upload authoritative producer proof
         if: ${{ steps.admit.outputs.proof-created == 'true' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -570,7 +570,11 @@ jobs:
           seal dependency "$DEPENDENCY_MATCHED_KEY" "$DEPENDENCY_HIT"
           seal compiler "$COMPILER_MATCHED_KEY" "$COMPILER_HIT"
       - name: Seal cache promotion payload
-        if: ${{ steps.native-gate.outcome == 'success' }}
+        if: >-
+          ${{
+            github.event_name == 'merge_group' &&
+            steps.native-gate.outcome == 'success'
+          }}
         shell: bash
         run: |
           set -euo pipefail

--- a/docs/adr/SHIFU-ADR-019f86da-4f90-79a1-bc85-4b542fecf011.md
+++ b/docs/adr/SHIFU-ADR-019f86da-4f90-79a1-bc85-4b542fecf011.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-019f86da-4f90-79a1-bc85-4b542fecf011
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004, https://github.com/kungfu-systems/kungfu/pull/1014, https://github.com/kungfu-systems/kungfu/pull/1020, https://github.com/kungfu-systems/kungfu/pull/1095, https://github.com/kungfu-systems/kungfu/pull/1128, https://github.com/kungfu-systems/kungfu/pull/1240, https://github.com/kungfu-systems/kungfu/pull/1250, https://github.com/kungfu-systems/kungfu/pull/1556]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/762, https://github.com/kungfu-systems/kungfu/pull/765, https://github.com/kungfu-systems/kungfu/pull/767, https://github.com/kungfu-systems/kungfu/pull/769, https://github.com/kungfu-systems/kungfu/pull/773, https://github.com/kungfu-systems/kungfu/pull/781, https://github.com/kungfu-systems/kungfu/pull/786, https://github.com/kungfu-systems/kungfu/pull/1004, https://github.com/kungfu-systems/kungfu/pull/1014, https://github.com/kungfu-systems/kungfu/pull/1020, https://github.com/kungfu-systems/kungfu/pull/1095, https://github.com/kungfu-systems/kungfu/pull/1128, https://github.com/kungfu-systems/kungfu/pull/1240, https://github.com/kungfu-systems/kungfu/pull/1250, https://github.com/kungfu-systems/kungfu/pull/1556, https://github.com/kungfu-systems/kungfu/pull/1644]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/781
 qualification_refs: [scripts/shifu-gate-runtime.test.mjs, scripts/check-kungfu-gate-catalog.test.mjs, scripts/shifu-cache-runtime.test.mjs, scripts/candidate-timeline-events.test.mjs, scripts/cancel-dequeued-merge-group-runs.test.mjs, scripts/measure-dev-required-latency.test.mjs, scripts/run-core-affected-native.mjs, scripts/affected-native-cache-payload.test.mjs, scripts/affected-native-proof.test.mjs, scripts/write-affected-native-cache-manifests.test.mjs, scripts/dev-alpha-candidate-patrol.test.mjs, .github/workflows/affected-native-cache-promote.yml, .github/workflows/affected-native-pr.yml, .github/workflows/cancel-dequeued-merge-group.yml, .github/workflows/core-build-profiles.yml, .github/workflows/dev-verify-patrol.yml, .github/workflows/dev-alpha-candidate-patrol.yml]
 review_state: self-reviewed
@@ -14,7 +14,7 @@ period: ongoing
 theme: shifu-gate-control-plane
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-07-23
+last_reviewed: 2026-07-27
 ---
 
 # SHIFU-ADR-019f86da-4f90-79a1-bc85-4b542fecf011: Gate control plane contract
@@ -198,18 +198,20 @@ profile runs cannot omit dependencies. Kungfu uses that rule to avoid repeating
 required Source Acceptance workflow. The first compiler-cold cohort completed
 the queue-inclusive aggregate in 480 seconds with both cold fallbacks qualified.
 
-The earlier same-tree PR-proof reuse mechanism is now retired. Expensive native
-evidence is no longer produced on pull requests, so a merge group always runs
-the exact impact-selected candidate qualification after its fast preflight on
-the first execution of a synthetic merge-group SHA. Repeated workflow
-executions for that same SHA are serialized. A later execution may skip only
-the native partitions when it finds one successful queue-produced proof whose
-base, candidate tree, plan projection, partition contract, hosted-runner image,
-and observed compiler/CMake/Ninja facts all match exactly. Download, freshness,
-producer, or proof verification uncertainty falls back to a full run. PR
-evidence never enters this path, and SDK qualification is never skipped. This
-keeps the synthetic merge-group source as the single authority instead of
-asking PR evidence to survive a later queue ordering decision.
+The first PR-proof reuse mechanism was retired because it treated pull-request
+branch SHA as candidate identity and could not prove equivalence to GitHub's
+synthetic pull-request checkout or a later merge-group tree. The replacement
+produces the complete impact-selected native, SDK, Shifu, and KFD qualification
+on pull requests, then seals one proof only after every required dependency
+passes. The proof records the GitHub trigger head separately from the checked
+out synthetic commit and binds the exact base, candidate tree, Gate plan,
+partition contract, hosted-runner image, and observed compiler/CMake/Ninja
+facts. A merge group may skip those duplicate gates only when exactly one
+trusted, successful, fresh pull-request proof preserves every binding against
+the current synthetic candidate. Forks, ambiguity, source or plan drift,
+download failure, expiration, and any proof verification uncertainty fall back
+to the complete merge-group run. Queue-produced proof reuse remains restricted
+to the exact same merge-group SHA.
 
 The affected-native source plan also declares whether partition zero must run
 the installed four-language SDK wire qualification. Public ABI, schemas,
@@ -235,16 +237,15 @@ revision, candidate merge tree, plan projection, partition contract, and
 toolchain receipts. A new base therefore fails closed to `reuse: false` and a
 complete run even when the PR patch and affected plan appear unchanged.
 
-The dev candidate workflow now separates fast admission from authoritative
-candidate execution. Pull requests run only build-free source acceptance,
-governance preflight, and the exact source-impact plan. On `merge_group`, those
-source and governance jobs are hard dependencies of the affected-native
-partitions, the impact-selected three-platform Shifu matrix, and the
-impact-selected KFD verifier. Those independent jobs run in parallel, and one
-stable `affected-native / linux` aggregate validates every required or
-explicitly-not-required result. Candidate-equivalent dev push rebuilds are
-removed: a cold queue run is preferable to duplicated pre-queue and post-merge
-qualification.
+PR 1254 separated fast admission from authoritative candidate execution. At
+that stage pull requests ran only build-free source acceptance, governance
+preflight, and the exact source-impact plan. On `merge_group`, those source and
+governance jobs became hard dependencies of the affected-native partitions,
+the impact-selected three-platform Shifu matrix, and the impact-selected KFD
+verifier. Those independent jobs run in parallel, and one stable
+`affected-native / linux` aggregate validates every required or
+explicitly-not-required result. Candidate-equivalent dev push rebuilds remain
+removed.
 
 After PR 1254 proved the aggregate on both `pull_request` and a real
 `merge_group`, dev branch protection retained only `affected-native / linux` as
@@ -258,14 +259,15 @@ This retains closed enqueue/dequeue attempts that never produced a
 `merge_group` run, while ordinary recent PRs that never entered the queue remain
 outside the cohort. Completely paired rounds with no assigned Actions run
 contribute zero observed runner work; missing event or job evidence stays
-incomplete. This discovery correction does not change the affected-native
+incomplete. This discovery correction did not change the affected-native
 planner, staged candidate workflow, proof format, or exact
-base/candidate/toolchain identity boundary. The current staged workflow remains
-the authoritative merge-group producer and does not reuse pull-request native
-proofs. Its sole reuse exception is a repeated execution of the exact same
-merge-group SHA after the first execution has completed successfully; a changed
-base, source tree, plan, partition set, runner image, or observed toolchain
-continues to execute the complete native set.
+base/candidate/toolchain identity boundary. At that point the staged workflow
+remained the authoritative merge-group producer and reused only a repeated
+execution of the exact same merge-group SHA. PR 1644 replaces that queue-only
+limitation with the exact pull-request proof contract above while retaining
+source acceptance and governance preflight as independently executed
+merge-group dependencies. A changed base, source tree, plan, partition set,
+runner image, or observed toolchain still executes the complete candidate set.
 
 Buildchain's alpha channel now owns the project-neutral
 `buildchain.candidate-timeline/v1` observation contract, while the stable

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -231,11 +231,16 @@ but historical conflict and retry gaps remain part of the measured tail.
 These measurements do not relax affected-native proof identity. Reuse remains
 bound to the exact base, candidate source tree, plan projection, partitions,
 tier, receipt, hosted-runner image, and observed compiler/CMake/Ninja evidence.
-Only a serialized repeat of the same merge-group SHA may consume the one
-unambiguous successful queue proof; PR proof and SDK qualification are outside
-that reuse boundary. A changed merge-group base therefore continues to fail
-closed to a full run even when the PR patch and affected plan look unchanged;
-the delivery report measures that cost without authorizing base-forward reuse.
+A successful PR run may publish proof only after its complete required native,
+SDK, Shifu, and KFD dependency graph passes. The matching merge-group may
+consume that proof, and a serialized repeat may consume a same-SHA queue proof,
+only when lookup returns one unambiguous trusted producer and bundle
+verification preserves every identity binding. PR proof records its triggering
+head separately from the synthetic checkout; queue proof requires both SHAs to
+be identical. A changed merge-group base therefore continues to fail closed to
+a full run even when the PR patch and
+affected plan look unchanged; the delivery report measures that cost without
+authorizing base-forward reuse.
 
 The current dev objective is queue-inclusive P50 at most 300 seconds and P95 at
 most 600 seconds. A report is an observation, not a release credential, and a

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -121,7 +121,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:b2776671b77061c98d431f22f26aad76eed380769140ec38d993e326c56721ff",
+          "definitionDigest": "sha256:0a1fa9b22247f7de7aa7249716bcb0eaf7c363d7ff1b375049b96c360f54fd7c",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -254,7 +254,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:94bd4175978964e3664d2680bde4e08decf1be8d3acb04c556f6138af78c03fc",
+          "definitionDigest": "sha256:c26248a93398a31586f9e859cd042339cbbf522c82ee7a5c0ccaaa282eb1a756",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -277,7 +277,7 @@
             {
               "index": 3,
               "label": "name:Admit staged candidate dependency graph",
-              "definitionDigest": "sha256:ea24ceceb70496619b2db15371a51c414db00028f3e08db4c412a36325ed5e51"
+              "definitionDigest": "sha256:e1190d35b582e2200e0f25a7a5066cc6c86f44f3ef6193a84443cd2fb84045a2"
             },
             {
               "index": 4,
@@ -293,27 +293,27 @@
             },
             {
               "index": 6,
-              "label": "name:Download admitted queue proof",
+              "label": "name:Download admitted producer proof",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:6fdee1db5eda85fd52f7a3503768940d0116be8640b3882b697d35c2df8c2537"
+              "definitionDigest": "sha256:c6b84878600569041c7b0dabc910113f680d57237ecbb737b0c5114371d88c87"
             },
             {
               "index": 7,
               "label": "name:Download current partition evidence",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:cac95842496dd5c5a73d88a1fe28f9456fcb069a763d5747b254def7ad4e7d33"
+              "definitionDigest": "sha256:4b57bb62fe678978688b21349fe0af530202dfa888fb586f3fc2b7f008c5f324"
             },
             {
               "index": 8,
               "label": "id:admit",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:9acc3bb1a2412020d5000fa222bf27d13a8e9a93f639d9071f667b852889d1e3"
+              "definitionDigest": "sha256:8c96b54df7d092b5becf327ee3b0b7cb8ec87bc06c321a9ed30f61cbd463cc4d"
             },
             {
               "index": 9,
-              "label": "name:Upload authoritative queue proof",
+              "label": "name:Upload authoritative producer proof",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:c74d724fdd216e2d2653d723dd47f7bfecd58d3f044f222add022012500775d2"
+              "definitionDigest": "sha256:fe1606def564bd546877397a1b84e548fd45f241c958dbed56376fc448d85336"
             }
           ]
         },
@@ -419,7 +419,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:aaf2c35660e8ef1223801e7b78ae5272608885b1b51fa4216831fa7403ad824c",
+          "definitionDigest": "sha256:821e24c0aa6bd63f10be13721771a550035c3c50283d65e1913143e040f0cf89",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -456,7 +456,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:8797adab8a7787876072d7e91b2efa68d72fe0297aceb2436bcc080af5cd098c",
+          "definitionDigest": "sha256:a92d9e0145bce5000ecec19cb5d53a6d19552256beae2f110bf9729765eb5268",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -496,23 +496,23 @@
               "index": 6,
               "label": "id:lookup",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:7357c433b49e647153e7c6274d36fa32e305179d29597690a53f2d8e187367b7"
+              "definitionDigest": "sha256:c44e54386865d44506d6f7b814b1ac7f2839beb21569d8011cbfec0644604251"
             },
             {
               "index": 7,
               "label": "id:download",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:a4adcb3f2a224f2093c4279f981c7f82e3e1ac7945b85a7945cb6f61cca9cb01"
+              "definitionDigest": "sha256:2ccefb7f1f6cd536b00d478afd0677f3c84a6062cc4965eefc4b5fdafbb93b64"
             },
             {
               "index": 8,
               "label": "id:verify",
-              "definitionDigest": "sha256:28184a202a8abf94b933d37b2ab9770462adbb8fb5b540eea887d288e7fbc28a"
+              "definitionDigest": "sha256:41fac7638e19f00c28f159a2eaec37145408a985c013e80282f78a5a1aab172c"
             },
             {
               "index": 9,
               "label": "id:decision",
-              "definitionDigest": "sha256:605bf66857c5f7ca2a6c8882da2e1295f01a4e2258d66bacb3eb763b702d368d"
+              "definitionDigest": "sha256:2a011137ae2b9242a86196d0b22fbc3cc6e70536f2a199a99fd4807f0c0c7625"
             }
           ]
         },
@@ -521,7 +521,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4a33dfcec2664bc11953518d2ffe3b72a75a57f2654f597bc6d7be04756d83f3",
+          "definitionDigest": "sha256:3311b476456c79f491d192fbbd7c002c3924964490949bbe50bbe9d341bbf162",
           "credentials": {
             "githubToken": "read",
             "oidc": false,

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -121,7 +121,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0a1fa9b22247f7de7aa7249716bcb0eaf7c363d7ff1b375049b96c360f54fd7c",
+          "definitionDigest": "sha256:ae120c4e72309e2df03eec607999f337152dabd852fcf73b701fc9fc62770ce9",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -239,7 +239,7 @@
             {
               "index": 22,
               "label": "name:Seal cache promotion payload",
-              "definitionDigest": "sha256:bb228f735f4b1094ce7963277b6d3e1b14c4b7c4df5bce743ebc58f0ad0718a5"
+              "definitionDigest": "sha256:8df9b0df2db2468af1ce0466b5979bdfbde7abc42b6aa183c060fdab44d048b0"
             },
             {
               "index": 23,
@@ -1761,25 +1761,21 @@
             {
               "index": 1,
               "label": "name:Check out exact requested source",
-              "authority": "qualification",
               "definitionDigest": "sha256:8dadccb662572a36e399d8e49b2d322f8bfd05795c0ccfc318f9467d456738af"
             },
             {
               "index": 2,
               "label": "name:Verify trusted runner and local-model runtime",
-              "authority": "qualification",
               "definitionDigest": "sha256:5adf31a595ebc0f5a293750189dc15ca3ab7606595a87fbb551bb67ca0358cf7"
             },
             {
               "index": 3,
               "label": "name:Install and build exact Kungfu source",
-              "authority": "qualification",
               "definitionDigest": "sha256:815183de19d5ab01d9425cd24cb6b362832291eecd1c0332678171eb6bdbfe57"
             },
             {
               "index": 4,
               "label": "name:Run two fresh OpenCode sessions through Kungfu",
-              "authority": "qualification",
               "definitionDigest": "sha256:c631b34757f41ccc053a34122e4fba284a0453b6f1b30e924d5e930149a9fd5a"
             },
             {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:ee362b94f6e6c6eb790bf521634452dd7f76ab6d9ab34df3ef4c9bfafa0bc4dc"
+          "sourceRoot": "sha256:68bc12625bbd4326c17f136c9b38d2b07fad2ad4dc07c1c493e89fe83d54bc68"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:68bc12625bbd4326c17f136c9b38d2b07fad2ad4dc07c1c493e89fe83d54bc68"
+          "sourceRoot": "sha256:107e4669c8d5c290160d8d9fa7b73a347c94d7c36a6249f4e5d08097c6fca68e"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:7e4387658a5fdf61383618908377fed20fada312fbdaf8bf8174d6f4b363a04e"
+  "registryRoot": "sha256:5e3b29cc816d8ad1777234a438e294b42c73fa2d3a21da8ed2fc9711138cc053"
 }

--- a/scripts/affected-native-cache-payload.test.mjs
+++ b/scripts/affected-native-cache-payload.test.mjs
@@ -261,6 +261,17 @@ test('push promotion waits for the exact required Gate instead of whole-run comp
   assert.doesNotMatch(workflow, /status=completed/u);
 });
 
+test('pull-request proof producers never seal merge-group cache payloads', () => {
+  const workflow = fs.readFileSync(
+    '.github/workflows/affected-native-pr.yml',
+    'utf8',
+  );
+  assert.match(
+    workflow,
+    /name: Seal cache promotion payload[\s\S]*?if:\s*>-[\s\S]*?github\.event_name == 'merge_group' &&[\s\S]*?steps\.native-gate\.outcome == 'success'/u,
+  );
+});
+
 test('cache payload sealing accepts Conan-relative symlinks inside its root', (t) => {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-cache-promotion-conan-symlink-'),

--- a/scripts/affected-native-proof.mjs
+++ b/scripts/affected-native-proof.mjs
@@ -10,10 +10,10 @@ import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
 export const IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v3';
-export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v2';
+export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v3';
 export const WORKFLOW_PATH = '.github/workflows/affected-native-pr.yml';
 export const DEFAULT_MAX_AGE_SECONDS = 6 * 60 * 60;
-const QUEUE_PRODUCER_EVENT = 'merge_group';
+const PRODUCER_EVENTS = new Set(['pull_request', 'merge_group']);
 
 function ordered(value) {
   if (Array.isArray(value)) return value.map(ordered);
@@ -321,6 +321,7 @@ export function sealProof(descriptor, inputDir, producer) {
       runId: Number(producer.runId),
       event: producer.event,
       workflowPath: producer.workflowPath,
+      triggerHeadSha: requireSha(producer.triggerHeadSha, 'producer trigger'),
       checkoutSha: requireSha(producer.checkoutSha, 'producer checkout'),
       createdAt: producer.createdAt,
     },
@@ -336,12 +337,14 @@ export function sealProof(descriptor, inputDir, producer) {
 
 function validateProducer(producer, options) {
   if (
-    options.producerEvent !== QUEUE_PRODUCER_EVENT ||
+    !PRODUCER_EVENTS.has(options.producerEvent) ||
     producer.repository !== options.repository ||
-    producer.event !== QUEUE_PRODUCER_EVENT ||
+    producer.event !== options.producerEvent ||
     producer.workflowPath !== WORKFLOW_PATH ||
     producer.runId !== Number(options.producerRunId) ||
-    producer.checkoutSha !== options.producerHeadSha
+    producer.triggerHeadSha !== options.producerHeadSha ||
+    (producer.event === 'merge_group' &&
+      producer.checkoutSha !== producer.triggerHeadSha)
   ) {
     throw new Error('affected-native proof producer authority drift');
   }
@@ -386,19 +389,11 @@ export function selectReusableArtifact({
   runsById,
   artifactName,
   repositoryId,
-  producerEvent,
   headSha,
   now = Date.now(),
   maxAgeSeconds = DEFAULT_MAX_AGE_SECONDS,
 }) {
-  if (producerEvent !== QUEUE_PRODUCER_EVENT) {
-    return {
-      reusable: false,
-      reason: 'only merge-group queue proofs are reusable',
-      candidateCount: 0,
-    };
-  }
-  requireSha(headSha, 'producer head');
+  requireSha(headSha, 'consumer head');
   const candidates = artifacts.filter((artifact) => {
     const run = runsById.get(Number(artifact.workflow_run?.id));
     const age =
@@ -412,8 +407,8 @@ export function selectReusableArtifact({
       Number.isFinite(age) &&
       age >= -300 &&
       age <= maxAgeSeconds &&
-      run?.event === QUEUE_PRODUCER_EVENT &&
-      run?.head_sha === headSha &&
+      PRODUCER_EVENTS.has(run?.event) &&
+      (run.event === 'pull_request' || run.head_sha === headSha) &&
       run?.status === 'completed' &&
       run?.conclusion === 'success' &&
       run?.path === WORKFLOW_PATH
@@ -429,12 +424,15 @@ export function selectReusableArtifact({
       candidateCount: candidates.length,
     };
   }
+  const selectedRun = runsById.get(Number(candidates[0].workflow_run.id));
   return {
     reusable: true,
     reason: 'exact trusted producer proof artifact found',
     candidateCount: 1,
     runId: Number(candidates[0].workflow_run.id),
     artifactId: Number(candidates[0].id),
+    producerEvent: selectedRun.event,
+    producerHeadSha: selectedRun.head_sha,
   };
 }
 
@@ -456,7 +454,6 @@ export async function lookupReusableArtifact({
   apiUrl,
   repository,
   artifactName,
-  producerEvent,
   headSha,
   token,
   maxAgeSeconds = DEFAULT_MAX_AGE_SECONDS,
@@ -487,7 +484,6 @@ export async function lookupReusableArtifact({
     runsById: new Map(runs),
     artifactName,
     repositoryId: Number(repositoryDocument.id),
-    producerEvent,
     headSha,
     maxAgeSeconds,
   });
@@ -562,7 +558,6 @@ async function main() {
         apiUrl: options['api-url'],
         repository: options.repository,
         artifactName: descriptor.artifactName,
-        producerEvent: options['producer-event'],
         headSha: options['head-sha'],
         token: process.env.GITHUB_TOKEN || '',
         maxAgeSeconds: Number(
@@ -574,6 +569,8 @@ async function main() {
     }
     appendGithubOutput(options['github-output'], {
       'run-id': result.reusable ? result.runId : '',
+      'producer-event': result.reusable ? result.producerEvent : '',
+      'producer-head-sha': result.reusable ? result.producerHeadSha : '',
       reusable: result.reusable,
       reason: result.reason,
     });
@@ -589,6 +586,7 @@ async function main() {
       runId: options['run-id'],
       event: options.event,
       workflowPath: WORKFLOW_PATH,
+      triggerHeadSha: options['trigger-head-sha'],
       checkoutSha: options['checkout-sha'] || git('rev-parse', 'HEAD'),
       createdAt: options['created-at'] || new Date().toISOString(),
     });

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -20,6 +20,7 @@ const BASE = '1'.repeat(40);
 const HEAD = '2'.repeat(40);
 const OTHER_HEAD = '3'.repeat(40);
 const TREE = '4'.repeat(40);
+const QUEUE_HEAD = '5'.repeat(40);
 const TOOLCHAIN = {
   compiler: 'g++-14 (Ubuntu 14.2.0) 14.2.0',
   cmake: 'cmake version 3.31.6',
@@ -129,14 +130,15 @@ function producer(overrides = {}) {
     runId: 42,
     event: 'merge_group',
     workflowPath: '.github/workflows/affected-native-pr.yml',
+    triggerHeadSha: HEAD,
     checkoutSha: HEAD,
     createdAt: '2026-07-22T00:00:00Z',
     ...overrides,
   };
 }
 
-function writeBundle(descriptor, value) {
-  const proof = sealProof(descriptor, value.inputs, producer());
+function writeBundle(descriptor, value, proofProducer = producer()) {
+  const proof = sealProof(descriptor, value.inputs, proofProducer);
   fs.mkdirSync(value.bundle, { recursive: true });
   fs.writeFileSync(
     path.join(value.bundle, 'proof.json'),
@@ -241,6 +243,37 @@ test('complete partition evidence seals and verifies against the exact producer'
     now: '2026-07-22T01:00:00Z',
   });
   assert.equal(verified.proofRoot, proof.proofRoot);
+  fs.rmSync(value.root, { recursive: true, force: true });
+});
+
+test('exact PR proof survives the synthetic merge-group commit rewrite', () => {
+  const value = fixture();
+  const pullDescriptor = createProofDescriptor(value.value, TREE, 2, TOOLCHAIN);
+  const queueDescriptor = createProofDescriptor(
+    plan(QUEUE_HEAD),
+    TREE,
+    2,
+    TOOLCHAIN,
+  );
+  writeBundle(
+    pullDescriptor,
+    value,
+    producer({
+      event: 'pull_request',
+      triggerHeadSha: OTHER_HEAD,
+      checkoutSha: HEAD,
+    }),
+  );
+  assert.doesNotThrow(() =>
+    verifyProofBundle(queueDescriptor, value.bundle, {
+      repository: 'kungfu-systems/kungfu',
+      producerRunId: 42,
+      producerEvent: 'pull_request',
+      producerHeadSha: OTHER_HEAD,
+      maxAgeSeconds: 6 * 60 * 60,
+      now: '2026-07-22T01:00:00Z',
+    }),
+  );
   fs.rmSync(value.root, { recursive: true, force: true });
 });
 
@@ -374,6 +407,19 @@ test('tree, producer, and unsuccessful receipt drift cannot reuse proof', () => 
       }),
     /producer authority drift/,
   );
+  writeBundle(descriptor, value, producer({ triggerHeadSha: OTHER_HEAD }));
+  assert.throws(
+    () =>
+      verifyProofBundle(descriptor, value.bundle, {
+        repository: 'kungfu-systems/kungfu',
+        producerRunId: 42,
+        producerEvent: 'merge_group',
+        producerHeadSha: OTHER_HEAD,
+        maxAgeSeconds: 6 * 60 * 60,
+        now: '2026-07-22T01:00:00Z',
+      }),
+    /producer authority drift/,
+  );
 
   const failedPath = path.join(value.inputs, 'partition-1', 'receipt.json');
   const toolchainDrift = receipt(value.value, 1);
@@ -430,7 +476,6 @@ test('lookup admits one exact successful same-SHA merge-group artifact', () => {
       runsById,
       artifactName: 'proof-name',
       repositoryId: 100,
-      producerEvent: 'merge_group',
       headSha: HEAD,
       now: '2026-07-22T01:00:00Z',
     }),
@@ -440,11 +485,13 @@ test('lookup admits one exact successful same-SHA merge-group artifact', () => {
       candidateCount: 1,
       runId: 42,
       artifactId: 7,
+      producerEvent: 'merge_group',
+      producerHeadSha: HEAD,
     },
   );
 });
 
-test('lookup degrades duplicate, fork, failed, and expired artifacts to full run', () => {
+test('lookup admits PR proofs and degrades ambiguity or untrusted artifacts', () => {
   const run = {
     event: 'merge_group',
     head_sha: HEAD,
@@ -472,7 +519,6 @@ test('lookup degrades duplicate, fork, failed, and expired artifacts to full run
     ]),
     artifactName: 'proof-name',
     repositoryId: 100,
-    producerEvent: 'merge_group',
     headSha: HEAD,
     now: '2026-07-22T01:00:00Z',
   });
@@ -498,7 +544,6 @@ test('lookup degrades duplicate, fork, failed, and expired artifacts to full run
     ]),
     artifactName: 'proof-name',
     repositoryId: 100,
-    producerEvent: 'merge_group',
     headSha: HEAD,
     now: '2026-07-22T01:00:00Z',
   });
@@ -510,7 +555,6 @@ test('lookup degrades duplicate, fork, failed, and expired artifacts to full run
     runsById: new Map([[6, { ...run, head_sha: OTHER_HEAD }]]),
     artifactName: 'proof-name',
     repositoryId: 100,
-    producerEvent: 'merge_group',
     headSha: HEAD,
     now: '2026-07-22T01:00:00Z',
   });
@@ -519,18 +563,20 @@ test('lookup degrades duplicate, fork, failed, and expired artifacts to full run
 
   const pullRequestProducer = selectReusableArtifact({
     artifacts: [artifact(7)],
-    runsById: new Map([[7, { ...run, event: 'pull_request' }]]),
+    runsById: new Map([
+      [7, { ...run, event: 'pull_request', head_sha: OTHER_HEAD }],
+    ]),
     artifactName: 'proof-name',
     repositoryId: 100,
-    producerEvent: 'pull_request',
     headSha: HEAD,
     now: '2026-07-22T01:00:00Z',
   });
-  assert.equal(pullRequestProducer.reusable, false);
-  assert.match(pullRequestProducer.reason, /only merge-group queue proofs/);
+  assert.equal(pullRequestProducer.reusable, true);
+  assert.equal(pullRequestProducer.producerEvent, 'pull_request');
+  assert.equal(pullRequestProducer.producerHeadSha, OTHER_HEAD);
 });
 
-test('workflow keeps one required context while staging authoritative queue builds', () => {
+test('workflow keeps one context while PR proof replaces duplicate queue builds', () => {
   const workflow = fs.readFileSync(
     path.join(ROOT, '.github/workflows/affected-native-pr.yml'),
     'utf8',
@@ -548,14 +594,16 @@ test('workflow keeps one required context while staging authoritative queue buil
   assert.match(workflow, /^\s{2}proof_probe:$/mu);
   assert.match(
     workflow,
-    /affected_native_shards:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight[\s\S]*github\.event_name == 'merge_group'/u,
+    /affected_native_shards:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight[\s\S]*needs\.proof_probe\.outputs\.reuse != 'true'/u,
   );
   assert.match(
     workflow,
-    /name: affected-native \/ linux[\s\S]*DCO_RESULT:[\s\S]*SOURCE_RESULT:[\s\S]*PREFLIGHT_RESULT:[\s\S]*PR fast admission passed without compiler or installed-artifact work/u,
+    /name: affected-native \/ linux[\s\S]*DCO_RESULT:[\s\S]*SOURCE_RESULT:[\s\S]*PREFLIGHT_RESULT:[\s\S]*require_optional_gate "PR affected-native"[\s\S]*PR staged qualification passed/u,
   );
   assert.match(workflow, /producer-run-id/u);
-  assert.match(workflow, /Merge Queue is the only native proof producer/u);
+  assert.match(workflow, /producer-event/u);
+  assert.match(workflow, /producer-head-sha/u);
+  assert.match(workflow, /Exact PR or same-SHA queue proof reuse/u);
   assert.match(
     workflow,
     /name: Upload current proof descriptor[\s\S]*core-affected-native-proof-descriptor-\$\{\{ github\.run_id \}\}/u,
@@ -566,7 +614,10 @@ test('workflow keeps one required context while staging authoritative queue buil
   );
   const aggregate = workflow.slice(workflow.indexOf('  affected-native:\n'));
   assert.doesNotMatch(aggregate, /affected-native-proof\.mjs toolchain/u);
-  assert.match(workflow, /--producer-event merge_group/u);
+  assert.match(
+    workflow,
+    /--producer-event "\$\{\{ steps\.lookup\.outputs\.producer-event \}\}"/u,
+  );
   assert.match(workflow, /--head-sha "\$GITHUB_SHA"/u);
   assert.match(workflow, /needs\.proof_probe\.outputs\.reuse != 'true'/u);
   assert.doesNotMatch(
@@ -631,13 +682,20 @@ test('workflow keeps one required context while staging authoritative queue buil
     workflow,
     /reused queue Shifu workspace[\s\S]*reused queue KFD verifier/u,
   );
+  assert.match(
+    workflow,
+    /name: Upload authoritative producer proof[\s\S]*retention-days: 14/u,
+  );
   assert.doesNotMatch(workflow, /retention-days: 1$/mu);
   const verifier = fs.readFileSync(
     path.join(ROOT, 'scripts/affected-native-proof.mjs'),
     'utf8',
   );
   assert.match(verifier, /head_repository_id === repositoryId/u);
-  assert.match(verifier, /run\?\.head_sha === headSha/u);
+  assert.match(
+    verifier,
+    /run\.event === 'pull_request' \|\| run\.head_sha === headSha/u,
+  );
   assert.match(
     verifier,
     /stableJson\(nativeToolchainIdentity\(receipt\.toolchain, true\)\) !==\s+stableJson\(descriptor\.identity\.toolchain/u,

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -103,21 +103,21 @@ test('the single required dev workflow is merge-queue compatible', () => {
   }
 });
 
-test('dev candidate heavy work is queue-only and depends on both preflights', () => {
-  const relative = '.github/workflows/affected-native-pr.yml';
-  const source = fs.readFileSync(path.join(ROOT, relative), 'utf8');
-  assert.doesNotMatch(source, /^\s{2}push\s*:/m, relative);
-  assert.match(
-    source,
-    /affected_native_shards:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight[\s\S]*github\.event_name == 'merge_group'/,
-    relative,
+test('PR proof closes heavy gates before exact queue reuse', () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/affected-native-pr.yml'),
+    'utf8',
   );
-  assert.match(
-    source,
-    /shifu_workspace:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight/,
-    relative,
+  const native = source.slice(
+    source.indexOf('  affected_native_shards:\n'),
+    source.indexOf('  shifu_workspace:\n'),
   );
-  assert.match(source, /PR fast admission passed without compiler/, relative);
+  assert.match(native, /- source_acceptance[\s\S]*- candidate_preflight/);
+  assert.match(native, /needs\.proof_probe\.outputs\.reuse != 'true'/);
+  assert.doesNotMatch(native, /github\.event_name == 'merge_group'/);
+  assert.match(source, /require_optional_gate "PR affected-native"/);
+  assert.match(source, /producer-event[\s\S]*producer-head-sha/);
+  assert.match(source, /Upload authoritative producer proof/);
 });
 
 function readMeasurementCoverage(root) {

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -114,7 +114,7 @@ test('PR proof closes heavy gates before exact queue reuse', () => {
   );
   assert.match(native, /- source_acceptance[\s\S]*- candidate_preflight/);
   assert.match(native, /needs\.proof_probe\.outputs\.reuse != 'true'/);
-  assert.doesNotMatch(native, /github\.event_name == 'merge_group'/);
+  assert.doesNotMatch(native, /if:.*merge_group.*runs-on:/su);
   assert.match(source, /require_optional_gate "PR affected-native"/);
   assert.match(source, /producer-event[\s\S]*producer-head-sha/);
   assert.match(source, /Upload authoritative producer proof/);


### PR DESCRIPTION
## Summary

- run the complete affected native, SDK, Shifu, and KFD graph on pull requests and seal an authoritative v3 proof after every dependency passes
- reuse exactly one trusted PR proof in merge-group runs when base, checkout tree, plan, partition, tier, and toolchain identities still match
- distinguish the GitHub run trigger head from the checked-out synthetic merge SHA so pull-request proofs remain auditable without rejecting valid synthetic checkouts
- fail closed to the full required graph for forks, failed or expired producers, ambiguity, source drift, identity drift, or non-matching queue proofs

## Validation

- `node --test scripts/affected-native-proof.test.mjs scripts/check-kungfu-gate-catalog.test.mjs` (33/33)
- `./shifu test:gate-latency` (57/57 before latest base rebase; targeted post-rebase contracts pass)
- `node scripts/check-source-complexity.mjs`
- `node framework/release/publication-control-plane.mjs check --qualifying`
- `./shifu check:source` (685 source contract tests: 675 pass, 10 skip; 40 Core; 116 runtime upgrade; 69 desktop; TypeScript and Biome pass)

## Live acceptance

This PR is also the producer-side live test. After its full PR graph seals the proof, the merge-group run must reuse that exact proof and skip the duplicate native/SDK/Shifu/KFD execution while retaining source and preflight checks.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-019f86da-4f90-79a1-bc85-4b542fecf011"],
  "summary": "Restore exact PR-to-merge-group qualification proof reuse without weakening source, governance, plan, partition, or toolchain identity checks.",
  "verification": ["focused proof and gate-catalog tests", "complete build-free source acceptance", "live PR producer and merge-group reuse qualification"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects qualification evidence only. It does not publish a product, create a release, or introduce credentials.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated for the proof authority change
