### PR TITLE
feat(kfx): establish Fact and Work authority

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "045246d5470dd5a4a8c5ca492cc6c7ee7158b73acfeb7e86abb999e704dedecb"
+    "sha256": "734c933ca95e941235b314aa66857ebe29efc61d7222097ede29b92647e94c34"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+      "sourceSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+      "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -88,13 +88,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "cd81a42668e2d44553da60c2aac893462f1efd48eb4c28873fb320a85472b2a2",
+      "preBuildWitnessSha256": "7ef480c6ac1bc9f0c2623ab12678c4452405394f3456df409ee1464a34ff2c89",
       "sourceHashes": {
-        "sha256": "cbb923bbbcade4046bd9e22d37172484f8d5d3e560639ad34bf49f60fa47fd37",
+        "sha256": "8b49e11408f8e94ee5da7719130777792f3dd631a32706280e29390c92eb2c7f",
         "surfaceCount": 21
       },
       "artifactHashes": {
-        "sha256": "ee02616a1efc92f57012d49992ac3514a24dfbf590e054ca545967e24afc8644",
+        "sha256": "cf395346070c2312186ba864a676c0ab8e60587d62545af1220a2cda4290ca94",
         "surfaceCount": 21
       },
       "witness": {
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "045246d5470dd5a4a8c5ca492cc6c7ee7158b73acfeb7e86abb999e704dedecb"
+          "sha256": "734c933ca95e941235b314aa66857ebe29efc61d7222097ede29b92647e94c34"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -152,9 +152,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "sourceSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "byteForByte": true
           },
           {
@@ -397,8 +397,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
-            "actualSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
+            "actualSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "status": "passed",
             "reason": ""
           },
@@ -574,10 +574,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "sourceSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
-            "actualSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
+            "actualSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "467f97e93ad44fa7688134aa1df5d87e2e3f2d8b",
+    "sourceSha": "327b866650d647b94d84fe466274c907584eb2e1",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:1b6eec071960b48620558bf12e0366f496296caecfbbf73e696883c0b191b379"
   },

--- a/config/kungfu-agent-first-canonical-policy.json
+++ b/config/kungfu-agent-first-canonical-policy.json
@@ -238,13 +238,13 @@
       },
       "source": {
         "path": "framework/kfx/kungfu-kfx.contract.json",
-        "sha256": "sha256:bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
-        "renderedSha256": "sha256:bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+        "sha256": "sha256:56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
+        "renderedSha256": "sha256:56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-kfx.contract.json",
-        "expectedSha256": "sha256:bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1"
+        "expectedSha256": "sha256:56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990"
       }
     },
     {

--- a/config/kungfu-kfx.contract.json
+++ b/config/kungfu-kfx.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.kfx.contract/v1",
   "id": "kungfu-kfx",
-  "version": 9,
+  "version": 10,
   "weldedSurface": "kfx-contract",
   "description": "Single source for KFX package manifests, discovery rules, trust inputs, and build detection.",
   "contractSchema": {
@@ -895,16 +895,17 @@
     }
   },
   "nativeRuntime": {
-    "schema": "kungfu.kfx.native-contract/v2",
-    "contractVersion": 2,
+    "schema": "kungfu.kfx.native-contract/v3",
+    "contractVersion": 3,
     "versionNegotiation": {
-      "current": 2,
+      "current": 3,
       "supported": [
         1,
-        2
+        2,
+        3
       ],
       "minimumReader": 1,
-      "minimumWriter": 2,
+      "minimumWriter": 3,
       "policy": "exact-supported-version-or-refuse"
     },
     "authority": {
@@ -1257,7 +1258,8 @@
       "schema": "kungfu.kfx.lifecycle/v1",
       "authority": "one-libkungfu-writer-per-runtime-directory",
       "fences": [
-        "expectedGeneration",
+        "expectedCutRoot",
+        "expectedRevision",
         "expectedRegistryRoot",
         "expectedGraphRoot",
         "expectedPlanRoot",
@@ -1270,7 +1272,8 @@
         "remove",
         "enable",
         "disable",
-        "activate"
+        "activate",
+        "qualify"
       ],
       "receiptOutcomes": [
         "applied",
@@ -1278,7 +1281,7 @@
       ],
       "payloadRetention": "content-addressed-retain-no-gc",
       "replacement": "stage-then-atomic-rename",
-      "history": "append-only-receipt-chain"
+      "history": "immutable-work-episode-settlement-facts-at-named-cut"
     },
     "experienceFlowHost": {
       "schema": "kungfu.kfx.experience-flow-host/v1",
@@ -1312,6 +1315,7 @@
       "KF_KFX_GRAPH_STALE",
       "KF_KFX_PLAN_STALE",
       "KF_KFX_WRITER_BUSY",
+      "KF_KFX_CUT_STALE",
       "KF_KFX_GENERATION_MISMATCH",
       "KF_KFX_REQUIRED_PROVIDER_MISSING",
       "KF_KFX_PROVIDER_VERSION_MISMATCH",
@@ -1328,9 +1332,9 @@
       "KF_KFX_AUTHORITY_CLAIM_FORBIDDEN"
     ],
     "compatibility": {
-      "typescriptLoader": "retained-shadow-adapter",
-      "pythonInstaller": "retained-shadow-adapter",
-      "mutationCutover": "native-service-edge-after-exact-plan-fence",
+      "typescriptLoader": "thin-native-service-adapter",
+      "pythonInstaller": "thin-native-service-adapter",
+      "mutationCutover": "named-fact-cut-after-exact-cut-and-revision-fence",
       "unknownFields": "reject",
       "migration": "validate-existing-documents-before-authority-cutover"
     },
@@ -1503,6 +1507,95 @@
             "receiptId",
             "planId",
             "generation",
+            "verified"
+          ]
+        }
+      },
+      "3": {
+        "request": {
+          "schema": "kungfu.kfx.native-request/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "operation",
+            "packagePath",
+            "requestedCapabilities"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "operation",
+            "packagePath",
+            "requestedCapabilities",
+            "actor"
+          ]
+        },
+        "inspection": {
+          "schema": "kungfu.kfx.native-inspection/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "packageKey",
+            "packageRoot",
+            "runtimeTier",
+            "admissionGrade",
+            "owners",
+            "closure",
+            "declaredCapabilities"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "packageKey",
+            "packageRoot",
+            "runtimeTier",
+            "admissionGrade",
+            "owners",
+            "closure",
+            "declaredCapabilities"
+          ]
+        },
+        "plan": {
+          "schema": "kungfu.kfx.native-plan/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "planId",
+            "basis",
+            "nextRevision",
+            "requestedCapabilities",
+            "grantedCapabilities",
+            "effects"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "planId",
+            "basis",
+            "nextRevision",
+            "requestedCapabilities",
+            "grantedCapabilities",
+            "effects"
+          ]
+        },
+        "receipt": {
+          "schema": "kungfu.kfx.native-receipt/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "receiptId",
+            "planId",
+            "cutRoot",
+            "revision",
+            "verified"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "receiptId",
+            "planId",
+            "cutRoot",
+            "revision",
             "verified"
           ]
         }

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "045246d5470dd5a4a8c5ca492cc6c7ee7158b73acfeb7e86abb999e704dedecb"
+    "sha256": "734c933ca95e941235b314aa66857ebe29efc61d7222097ede29b92647e94c34"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+      "sourceSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+      "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -88,13 +88,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "cd81a42668e2d44553da60c2aac893462f1efd48eb4c28873fb320a85472b2a2",
+      "preBuildWitnessSha256": "7ef480c6ac1bc9f0c2623ab12678c4452405394f3456df409ee1464a34ff2c89",
       "sourceHashes": {
-        "sha256": "cbb923bbbcade4046bd9e22d37172484f8d5d3e560639ad34bf49f60fa47fd37",
+        "sha256": "8b49e11408f8e94ee5da7719130777792f3dd631a32706280e29390c92eb2c7f",
         "surfaceCount": 21
       },
       "artifactHashes": {
-        "sha256": "ee02616a1efc92f57012d49992ac3514a24dfbf590e054ca545967e24afc8644",
+        "sha256": "cf395346070c2312186ba864a676c0ab8e60587d62545af1220a2cda4290ca94",
         "surfaceCount": 21
       },
       "witness": {
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "045246d5470dd5a4a8c5ca492cc6c7ee7158b73acfeb7e86abb999e704dedecb"
+          "sha256": "734c933ca95e941235b314aa66857ebe29efc61d7222097ede29b92647e94c34"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -152,9 +152,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "sourceSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "byteForByte": true
           },
           {
@@ -397,8 +397,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
-            "actualSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
+            "actualSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "status": "passed",
             "reason": ""
           },
@@ -574,10 +574,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "sourceSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
-            "actualSha256": "bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+            "expectedSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
+            "actualSha256": "56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/framework/api/src/capability/kfx-host.ts
+++ b/framework/api/src/capability/kfx-host.ts
@@ -16,7 +16,8 @@ export type KfxExperienceFlowDescriptor = {
   graphRoot: string;
   planRoot: string;
   receiptDependencyRoot: string;
-  generation: number;
+  cutRoot: string | null;
+  revision: number;
   contributions: KfxHostContribution[];
 };
 
@@ -27,7 +28,8 @@ export type KfxHostProjection = {
   graphRoot: string;
   planRoot: string;
   receiptDependencyRoot: string;
-  generation: number;
+  cutRoot: string | null;
+  revision: number;
   contributions: Array<
     KfxHostContribution & {
       semanticState: KfxNodeState;
@@ -53,7 +55,8 @@ export function projectKfxExperienceFlowHost(
     graphRoot: descriptor.graphRoot,
     planRoot: descriptor.planRoot,
     receiptDependencyRoot: descriptor.receiptDependencyRoot,
-    generation: descriptor.generation,
+    cutRoot: descriptor.cutRoot,
+    revision: descriptor.revision,
     contributions: descriptor.contributions.map((contribution) => {
       const supported =
         contribution.presentation?.hosts?.includes(host) === true;

--- a/framework/api/tests/kfx-host.test.ts
+++ b/framework/api/tests/kfx-host.test.ts
@@ -11,7 +11,8 @@ const descriptor: KfxExperienceFlowDescriptor = {
   graphRoot: `sha256:${'2'.repeat(64)}`,
   planRoot: `sha256:${'3'.repeat(64)}`,
   receiptDependencyRoot: `sha256:${'4'.repeat(64)}`,
-  generation: 7,
+  cutRoot: `sha256:${'5'.repeat(64)}`,
+  revision: 7,
   contributions: [
     {
       contributionId: 'workbench',
@@ -33,7 +34,8 @@ test('GUI, TUI, CLI, and Agent adapters retain the same Core identities', () => 
       projection.receiptDependencyRoot,
       descriptor.receiptDependencyRoot,
     );
-    assert.equal(projection.generation, descriptor.generation);
+    assert.equal(projection.cutRoot, descriptor.cutRoot);
+    assert.equal(projection.revision, descriptor.revision);
     assert.equal(projection.contributions[0]?.semanticState, 'active');
   }
   assert.equal(projections[0]?.contributions[0]?.presentationState, 'active');

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -238,13 +238,13 @@
       },
       "source": {
         "path": "framework/kfx/kungfu-kfx.contract.json",
-        "sha256": "sha256:bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
-        "renderedSha256": "sha256:bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1",
+        "sha256": "sha256:56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
+        "renderedSha256": "sha256:56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-kfx.contract.json",
-        "expectedSha256": "sha256:bac1a188204c03e25acb418ad0afab53e5a2d1272dc53a07ee455a0cbce0f8c1"
+        "expectedSha256": "sha256:56be047ca42cb26e284c932cb5e14532aff6c79b7ef1591c290f0602fdf8c990"
       }
     },
     {

--- a/framework/core/src/libkungfu/CMakeLists.txt
+++ b/framework/core/src/libkungfu/CMakeLists.txt
@@ -41,6 +41,17 @@ configure_file(
   @ONLY
 )
 
+# The KFX Domain Profile is the bounded semantic mapping from KFX lifecycle
+# concerns to the existing Fact/Work kernel. Embed the checked-in contract so
+# installed Core runtimes do not depend on a source checkout.
+file(READ "${PROJECT_SOURCE_DIR}/../../../kfx/kungfu-kfx-domain-profile.contract.json" KFX_DOMAIN_PROFILE_JSON)
+file(MAKE_DIRECTORY "${KUNGFU_GENERATED_INCLUDE_DIR}/kungfu/runtime/kfx")
+configure_file(
+  "${PROJECT_SOURCE_DIR}/schemas/kfx_domain_profile_contract.h.in"
+  "${KUNGFU_GENERATED_INCLUDE_DIR}/kungfu/runtime/kfx/kfx_domain_profile_contract.h"
+  @ONLY
+)
+
 # KF-ADR-019f86da-4f90-7b3f-9ef3-84f5a878f302 assessment jobs use an independent FlatBuffers authority while
 # sharing the ActionEnvelope and Episode substrates with KF-ADR-019f86da-4f90-7d81-90a0-d144fc27fe03.
 file(READ "${PROJECT_SOURCE_DIR}/schemas/assessment_event.fbs" ASSESSMENT_EVENT_FBS)

--- a/framework/core/src/libkungfu/include/kungfu/runtime/kfx/native_contract.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/kfx/native_contract.h
@@ -11,8 +11,10 @@ namespace kungfu::runtime::kfx {
 
 inline constexpr const char *NATIVE_KFX_CONTRACT_V1 = "kungfu.kfx.native-contract/v1";
 inline constexpr const char *NATIVE_KFX_CONTRACT_V2 = "kungfu.kfx.native-contract/v2";
+inline constexpr const char *NATIVE_KFX_CONTRACT_V3 = "kungfu.kfx.native-contract/v3";
 inline constexpr const char *NATIVE_KFX_VALIDATION_V1 = "kungfu.kfx.native-validation/v1";
 inline constexpr const char *NATIVE_KFX_VALIDATION_V2 = "kungfu.kfx.native-validation/v2";
+inline constexpr const char *NATIVE_KFX_VALIDATION_V3 = "kungfu.kfx.native-validation/v3";
 
 [[nodiscard]] nlohmann::json native_kfx_contract();
 

--- a/framework/core/src/libkungfu/include/kungfu/runtime/kfx/native_registry.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/kfx/native_registry.h
@@ -9,8 +9,13 @@
 
 namespace kungfu::runtime::kfx {
 
-// Build one immutable, read-only registry snapshot from explicit roots. Every
-// call re-derives its result from content; no process-local cache is authority.
+// Return the embedded KFX Domain Profile and its deterministic root.
+[[nodiscard]] nlohmann::json native_kfx_domain_profile();
+
+// Read-only calls project a pinned named Fact Cut when runtime_dir is present.
+// Explicit roots are bounded discovery observations used for planning or
+// bootstrap; they never become lifecycle authority without Work settlement and
+// an exact expected-old/revision Fact ref CAS.
 [[nodiscard]] nlohmann::json query_native_kfx_registry(const std::string &action, const nlohmann::json &request,
                                                        const std::string &runtime_dir = {});
 

--- a/framework/core/src/libkungfu/schemas/kfx_domain_profile_contract.h.in
+++ b/framework/core/src/libkungfu/schemas/kfx_domain_profile_contract.h.in
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <string_view>
+
+namespace kungfu::runtime::kfx::generated {
+
+inline constexpr std::string_view KFX_DOMAIN_PROFILE_CONTRACT =
+    R"KFKFXPROFILE(@KFX_DOMAIN_PROFILE_JSON@)KFKFXPROFILE";
+
+} // namespace kungfu::runtime::kfx::generated

--- a/framework/core/src/libkungfu/src/runtime/kfx/native_contract.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_contract.cpp
@@ -303,7 +303,7 @@ void validate_inspection(const json &document) {
   if (std::find(tiers.begin(), tiers.end(), tier) == tiers.end()) {
     refuse("KF_KFX_SCHEMA_INVALID", "inspection runtime tier is not in the native contract");
   }
-  if (version == 2) {
+  if (version >= 2) {
     const auto &grades = native_contract_source().at("admissionGrades");
     if (std::find(grades.begin(), grades.end(), document.at("admissionGrade")) == grades.end()) {
       refuse("KF_KFX_SCHEMA_INVALID", "inspection.admissionGrade is not in the native contract");
@@ -315,12 +315,21 @@ void validate_plan(const json &document) {
   require_string(document, "planId", "plan");
   require_object(document.at("basis"), "plan.basis");
   const auto &basis = document.at("basis");
-  if (basis.size() != 2 || !basis.contains("packageRoot") || !basis.contains("generation")) {
-    refuse("KF_KFX_SCHEMA_INVALID", "plan.basis must contain only packageRoot and generation");
-  }
+  const auto version = document.at("contractVersion").get<int64_t>();
   require_string(basis, "packageRoot", "plan.basis");
-  require_non_negative_integer(basis, "generation", "plan.basis");
-  require_non_negative_integer(document, "nextGeneration", "plan");
+  if (version == 3) {
+    if (basis.size() != 3 || !basis.contains("cutRoot") || !basis.contains("revision"))
+      refuse("KF_KFX_SCHEMA_INVALID", "plan.basis must contain only packageRoot, cutRoot, and revision");
+    if (!basis.at("cutRoot").is_null() && !basis.at("cutRoot").is_string())
+      refuse("KF_KFX_SCHEMA_INVALID", "plan.basis.cutRoot must be null or a content root");
+    require_non_negative_integer(basis, "revision", "plan.basis");
+    require_non_negative_integer(document, "nextRevision", "plan");
+  } else {
+    if (basis.size() != 2 || !basis.contains("generation"))
+      refuse("KF_KFX_SCHEMA_INVALID", "legacy plan.basis must contain only packageRoot and generation");
+    require_non_negative_integer(basis, "generation", "plan.basis");
+    require_non_negative_integer(document, "nextGeneration", "plan");
+  }
   const auto requested = string_array(document, "requestedCapabilities", "plan");
   const auto granted = string_array(document, "grantedCapabilities", "plan");
   if (!document.at("effects").is_array()) {
@@ -332,16 +341,27 @@ void validate_plan(const json &document) {
       refuse("KF_KFX_CAPABILITY_BROADENING", "plan grants an undeclared capability: " + capability);
     }
   }
-  const auto expected = basis.at("generation").get<int64_t>() + (document.at("effects").empty() ? 0 : 1);
-  if (document.at("nextGeneration").get<int64_t>() != expected) {
-    refuse("KF_KFX_GENERATION_MISMATCH", "nextGeneration does not match the basis and effects");
+  if (version == 3) {
+    const auto expected = basis.at("revision").get<int64_t>() + (document.at("effects").empty() ? 0 : 1);
+    if (document.at("nextRevision").get<int64_t>() != expected)
+      refuse("KF_KFX_CUT_STALE", "nextRevision does not match the named Cut basis and effects");
+  } else {
+    const auto expected = basis.at("generation").get<int64_t>() + (document.at("effects").empty() ? 0 : 1);
+    if (document.at("nextGeneration").get<int64_t>() != expected)
+      refuse("KF_KFX_GENERATION_MISMATCH", "nextGeneration does not match the legacy basis and effects");
   }
 }
 
 void validate_receipt(const json &document) {
   require_string(document, "receiptId", "receipt");
   require_string(document, "planId", "receipt");
-  require_non_negative_integer(document, "generation", "receipt");
+  if (document.at("contractVersion") == 3) {
+    if (!document.at("cutRoot").is_string() || document.at("cutRoot").get<std::string>().empty())
+      refuse("KF_KFX_SCHEMA_INVALID", "receipt.cutRoot must be a non-empty content root");
+    require_non_negative_integer(document, "revision", "receipt");
+  } else {
+    require_non_negative_integer(document, "generation", "receipt");
+  }
   if (!document.at("verified").is_boolean()) {
     refuse("KF_KFX_SCHEMA_INVALID", "receipt.verified must be a boolean");
   }
@@ -381,7 +401,10 @@ json validate_native_kfx_document(const std::string &kind, const json &document)
     refuse("KF_KFX_DOCUMENT_KIND_UNKNOWN", "unknown native KFX document kind: " + kind);
   }
   const auto version = document.at("contractVersion").get<int64_t>();
-  return {{"schema", version == 1 ? NATIVE_KFX_VALIDATION_V1 : NATIVE_KFX_VALIDATION_V2},
+  const auto validation_schema = version == 1   ? NATIVE_KFX_VALIDATION_V1
+                                 : version == 2 ? NATIVE_KFX_VALIDATION_V2
+                                                : NATIVE_KFX_VALIDATION_V3;
+  return {{"schema", validation_schema},
           {"kind", kind},
           {"contractVersion", version},
           {"nativeContractRoot", native_kfx_contract().at("nativeContractRoot")},

--- a/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
@@ -16,8 +16,10 @@
 #include <string>
 #include <vector>
 
+#include <kungfu/runtime/kfx/kfx_domain_profile_contract.h>
 #include <kungfu/runtime/kfx/native_contract.h>
 #include <kungfu/runtime/profile/profile_lifecycle.h>
+#include <kungfu/runtime/storage/fact_kernel.h>
 #include <kungfu/yijinjing/storage/content_hash.h>
 
 namespace kungfu::runtime::kfx {
@@ -41,6 +43,11 @@ std::string sha256(const std::string &value) {
 }
 
 std::string root_of(const json &value) { return "sha256:" + sha256(value.dump()); }
+
+json embedded_domain_profile() {
+  const auto &source = generated::KFX_DOMAIN_PROFILE_CONTRACT;
+  return json::parse(source.begin(), source.end());
+}
 
 std::string read_file(const fs::path &path) {
   std::ifstream input(path, std::ios::binary);
@@ -1129,11 +1136,20 @@ json assess_package(const json &package, const std::string &registry_root, const
           {"admissionPlan", plan}};
 }
 
+inline constexpr const char *KFX_REGISTRY_REF = "profiles/kfx/registry";
+inline constexpr const char *KFX_PROFILE_ID = "kungfu-kfx-domain-profile";
+
 struct lifecycle_view {
-  json receipts = json::array();
-  uint64_t generation = 0;
-  std::string history_root;
-  std::map<std::string, std::string> package_states;
+  bool present = false;
+  uint64_t revision = 0;
+  std::string cut_root;
+  json cut = json::object();
+  snapshot authoritative;
+  std::map<std::string, std::string> desired_states;
+  std::map<std::string, std::string> observed_states;
+  json work_history = json::array();
+  std::map<std::string, std::string> current_versions;
+  std::set<std::string> relation_roots;
 };
 
 fs::path lifecycle_root(const std::string &runtime_dir) {
@@ -1142,55 +1158,106 @@ fs::path lifecycle_root(const std::string &runtime_dir) {
   return fs::absolute(runtime_dir) / "kfx";
 }
 
+json fact_call(const std::string &runtime_dir, const std::string &action, json request) {
+  request["action"] = action;
+  auto response = storage_service_api::run_fact_kernel_operation(runtime_dir, request);
+  if (!response.value("ok", false)) {
+    refuse(action == "ref-cas" && response.value("failure_code", "") == "stale-ref" ? "KF_KFX_CUT_STALE"
+                                                                                    : "KF_KFX_FACT_REJECTED",
+           response.value("failure_code", "unknown") + ": " + response.value("message", "Fact kernel rejected KFX"));
+  }
+  return response;
+}
+
+std::string fact_id(const std::string &kind, const std::string &identity) {
+  return "fact:" + sha256(std::string(KFX_PROFILE_ID) + ":" + kind + ":" + identity).substr(0, 32);
+}
+
+std::string relation_id(const std::string &kind, const std::string &source, const std::string &target) {
+  return fact_id("relation", kind + ":" + source + ":" + target);
+}
+
+json snapshot_projection(const snapshot &value) {
+  return {{"packages", value.packages},          {"suites", value.suites},
+          {"diagnostics", value.diagnostics},    {"graph", value.graph},
+          {"registryRoot", value.registry_root}, {"graphRoot", value.graph_root}};
+}
+
+snapshot snapshot_from_projection(const json &value) {
+  if (!value.is_object() || !value.contains("packages") || !value.at("packages").is_array() ||
+      !value.contains("suites") || !value.at("suites").is_array() || !value.contains("diagnostics") ||
+      !value.at("diagnostics").is_array() || !value.contains("graph") || !value.at("graph").is_object() ||
+      !value.contains("registryRoot") || !value.at("registryRoot").is_string() || !value.contains("graphRoot") ||
+      !value.at("graphRoot").is_string())
+    refuse("KF_KFX_SCHEMA_INVALID", "KFX registry projection Fact body is incomplete");
+  snapshot result;
+  result.packages = value.at("packages");
+  result.suites = value.at("suites");
+  result.diagnostics = value.at("diagnostics");
+  result.graph = value.at("graph");
+  result.registry_root = value.at("registryRoot").get<std::string>();
+  result.graph_root = value.at("graphRoot").get<std::string>();
+  if (result.graph.value("graphRoot", "") != result.graph_root)
+    refuse("KF_KFX_SCHEMA_INVALID", "KFX registry projection graph root is inconsistent");
+  return result;
+}
+
+json parse_fact_body(const json &member) {
+  if (!member.is_object() || member.value("body_status", "") != "present" || !member.contains("body") ||
+      !member.at("body").is_string())
+    return nullptr;
+  try {
+    return json::parse(member.at("body").get<std::string>());
+  } catch (const json::exception &error) {
+    refuse("KF_KFX_SCHEMA_INVALID", "KFX Fact body is not canonical JSON: " + std::string(error.what()));
+  }
+}
+
 lifecycle_view load_lifecycle(const std::string &runtime_dir) {
   lifecycle_view result;
-  json receipt_roots = json::array();
-  const auto path = lifecycle_root(runtime_dir) / "registry-history.jsonl";
-  if (!fs::exists(path)) {
-    result.history_root = root_of(receipt_roots);
+  if (runtime_dir.empty())
     return result;
+  const auto response = storage_service_api::run_fact_kernel_operation(
+      runtime_dir, {{"action", "query"}, {"ref_name", KFX_REGISTRY_REF}, {"include_bodies", true}});
+  if (!response.value("ok", false)) {
+    if (response.value("failure_code", "") == "unknown-cut")
+      return result;
+    refuse("KF_KFX_FACT_REJECTED",
+           response.value("failure_code", "unknown") + ": " + response.value("message", "Fact query failed"));
   }
-  std::ifstream input(path);
-  if (!input)
-    refuse("KF_KFX_SCHEMA_INVALID", "cannot read native KFX lifecycle history");
-  std::string line;
-  size_t expected_sequence = 1;
-  std::string previous_root;
-  while (std::getline(input, line)) {
-    if (line.empty())
+  result.present = true;
+  result.cut_root = response.at("cut_root").get<std::string>();
+  result.cut = response.at("cut");
+  const auto &resolution = response.at("ref_resolution");
+  result.revision = resolution.at("revision").get<uint64_t>();
+  for (const auto &member : result.cut.at("objectVersions")) {
+    result.current_versions[member.at(0).get<std::string>()] = member.at(1).get<std::string>();
+  }
+  for (const auto &root : result.cut.at("activeRelationRoots"))
+    result.relation_roots.insert(root.get<std::string>());
+  for (const auto &member : response.at("objects")) {
+    const auto body = parse_fact_body(member);
+    if (body.is_null() || !body.contains("schema") || !body.at("schema").is_string())
       continue;
-    json receipt;
-    try {
-      receipt = json::parse(line);
-    } catch (const json::exception &error) {
-      refuse("KF_KFX_SCHEMA_INVALID", "native KFX lifecycle history is not valid JSONL: " + std::string(error.what()));
+    const auto schema = body.at("schema").get<std::string>();
+    if (schema == "kungfu.kfx.registry-projection-fact/v1") {
+      if (body.value("domainProfileRoot", "") != native_kfx_domain_profile().at("domainProfileRoot").get<std::string>())
+        refuse("KF_KFX_SCHEMA_INVALID", "KFX registry projection binds a different Domain Profile");
+      result.authoritative = snapshot_from_projection(body.at("projection"));
+    } else if (schema == "kungfu.kfx.package-fact/v1") {
+      result.desired_states[body.at("transport").at("packageKey").get<std::string>()] =
+          body.at("desiredState").get<std::string>();
+    } else if (schema == "kungfu.kfx.episode-fact/v1") {
+      const auto key = body.value("packageKey", "");
+      if (!key.empty())
+        result.observed_states[key] = body.value("observedState", "unknown");
+      result.work_history.push_back(body);
+    } else if (schema == "kungfu.kfx.work-fact/v1" || schema == "kungfu.kfx.settlement-fact/v1") {
+      result.work_history.push_back(body);
     }
-    if (receipt.value("schema", "") != "kungfu.kfx.lifecycle-receipt/v1" ||
-        receipt.value("sequence", size_t{0}) != expected_sequence ||
-        receipt.value("previousReceiptRoot", "") != previous_root || !receipt.contains("receiptRoot") ||
-        !receipt.at("receiptRoot").is_string())
-      refuse("KF_KFX_SCHEMA_INVALID", "native KFX lifecycle receipt chain is invalid");
-    auto identity = receipt;
-    const auto receipt_root = identity.at("receiptRoot").get<std::string>();
-    identity.erase("receiptRoot");
-    if (root_of(identity) != receipt_root)
-      refuse("KF_KFX_SCHEMA_INVALID", "native KFX lifecycle receipt root is invalid");
-    result.receipts.push_back(receipt);
-    receipt_roots.push_back(receipt_root);
-    previous_root = receipt_root;
-    ++expected_sequence;
-    if (receipt.value("outcome", "") != "applied")
-      continue;
-    const auto generation = receipt.value("generation", uint64_t{0});
-    if (generation != result.generation + 1)
-      refuse("KF_KFX_SCHEMA_INVALID", "native KFX applied generation chain is invalid");
-    result.generation = generation;
-    const auto package_key = receipt.value("packageKey", "");
-    const auto state = receipt.value("state", "");
-    if (!package_key.empty() && !state.empty())
-      result.package_states[package_key] = state;
   }
-  result.history_root = root_of(receipt_roots);
+  if (result.authoritative.registry_root.empty())
+    refuse("KF_KFX_SCHEMA_INVALID", "named KFX Fact Cut has no registry projection Fact");
   return result;
 }
 
@@ -1219,31 +1286,20 @@ private:
   bool held_ = false;
 };
 
-json append_lifecycle_receipt(const std::string &runtime_dir, const lifecycle_view &current, json identity) {
-  identity["schema"] = "kungfu.kfx.lifecycle-receipt/v1";
-  identity["sequence"] = current.receipts.size() + 1;
-  identity["previousReceiptRoot"] =
-      current.receipts.empty() ? "" : current.receipts.back().at("receiptRoot").get<std::string>();
-  const auto receipt_root = root_of(identity);
-  identity["receiptRoot"] = receipt_root;
-  const auto path = lifecycle_root(runtime_dir) / "registry-history.jsonl";
-  fs::create_directories(path.parent_path());
-  std::ofstream output(path, std::ios::app);
-  if (!output)
-    refuse("KF_KFX_SCHEMA_INVALID", "cannot append native KFX lifecycle receipt");
-  output << identity.dump() << '\n';
-  output.flush();
-  if (!output)
-    refuse("KF_KFX_SCHEMA_INVALID", "cannot durably flush native KFX lifecycle receipt");
-  return identity;
-}
-
 const json &provider_for(const snapshot &value, const std::string &provider_id) {
   for (const auto &provider : value.graph.at("providers")) {
     if (provider.at("providerId") == provider_id)
       return provider;
   }
   refuse("KF_KFX_MEMBER_MISSING", "KFX provider is not present in the semantic graph: " + provider_id);
+}
+
+std::string derived_verdict(const json &provider, const std::string &desired, const std::string &observed) {
+  if (provider.value("state", "active") == "degraded" || observed == "failed" || observed == "degraded")
+    return "degraded";
+  if (desired == "dormant" || desired == "removed" || desired == "disabled")
+    return "dormant";
+  return observed == "unknown" ? "dormant" : "active";
 }
 
 json experience_flow_descriptor(const snapshot &value, const lifecycle_view &lifecycle, const std::string &plan_root) {
@@ -1254,16 +1310,23 @@ json experience_flow_descriptor(const snapshot &value, const lifecycle_view &lif
       continue;
     json projected = contribution;
     const auto provider_id = contribution.at("ownerProviderId").get<std::string>();
-    projected["providerState"] =
-        lifecycle.package_states.contains(provider_id) ? lifecycle.package_states.at(provider_id) : "dormant";
+    const auto desired =
+        lifecycle.desired_states.contains(provider_id) ? lifecycle.desired_states.at(provider_id) : "dormant";
+    const auto observed =
+        lifecycle.observed_states.contains(provider_id) ? lifecycle.observed_states.at(provider_id) : "unknown";
+    projected["providerState"] = derived_verdict(provider_for(value, provider_id), desired, observed);
     contributions.push_back(projected);
   }
-  const json receipt_dependency = {
-      {"graphRoot", value.graph_root}, {"planRoot", plan_root}, {"generation", lifecycle.generation}};
+  const json cut_root = lifecycle.present ? json(lifecycle.cut_root) : json(nullptr);
+  const json receipt_dependency = {{"graphRoot", value.graph_root},
+                                   {"planRoot", plan_root},
+                                   {"cutRoot", cut_root},
+                                   {"revision", lifecycle.revision}};
   const json identity = {{"schema", "kungfu.kfx.experience-flow-host/v1"},
                          {"graphRoot", value.graph_root},
                          {"planRoot", plan_root},
-                         {"generation", lifecycle.generation},
+                         {"cutRoot", cut_root},
+                         {"revision", lifecycle.revision},
                          {"receiptDependencyRoot", root_of(receipt_dependency)},
                          {"hosts", json::array({"gui", "tui", "cli", "agent"})},
                          {"contributions", contributions}};
@@ -1277,9 +1340,11 @@ json lifecycle_plan(const snapshot &value, const lifecycle_view &lifecycle, cons
   for (const auto &package : value.packages) {
     const auto key = package.at("key").get<std::string>();
     const auto &provider = provider_for(value, key);
-    const auto lifecycle_state =
-        lifecycle.package_states.contains(key) ? lifecycle.package_states.at(key) : std::string{"dormant"};
-    const auto effective_state = provider.at("state") == "degraded" ? "degraded" : lifecycle_state;
+    const auto desired_state =
+        lifecycle.desired_states.contains(key) ? lifecycle.desired_states.at(key) : std::string{"dormant"};
+    const auto observed_state =
+        lifecycle.observed_states.contains(key) ? lifecycle.observed_states.at(key) : std::string{"unknown"};
+    const auto verdict = derived_verdict(provider, desired_state, observed_state);
     package_plan.push_back({{"key", package.at("key")},
                             {"providerRoot", provider.at("providerRoot")},
                             {"rootKind", package.at("rootKind")},
@@ -1293,8 +1358,10 @@ json lifecycle_plan(const snapshot &value, const lifecycle_view &lifecycle, cons
                             {"hosts", package.at("hosts")},
                             {"declaredCapabilities", package.at("declaredCapabilities")},
                             {"semanticState", provider.at("state")},
-                            {"lifecycleState", lifecycle_state},
-                            {"state", effective_state},
+                            {"desiredState", desired_state},
+                            {"observedState", observed_state},
+                            {"verdict", verdict},
+                            {"state", verdict},
                             {"causes", provider.at("causes")},
                             {"recoveryGuidance", provider.at("recoveryGuidance")}});
   }
@@ -1302,10 +1369,14 @@ json lifecycle_plan(const snapshot &value, const lifecycle_view &lifecycle, cons
   if (request.contains("operation") || request.contains("packageKey")) {
     intent = {{"operation", request.value("operation", "")}, {"packageKey", request.value("packageKey", "")}};
   }
+  const json cut_root = lifecycle.present ? json(lifecycle.cut_root) : json(nullptr);
   json identity = {{"schema", "kungfu.kfx.load-plan/v2"},
                    {"registryRoot", value.registry_root},
                    {"graphRoot", value.graph_root},
-                   {"generation", lifecycle.generation},
+                   {"authorityMode", lifecycle.present ? "pinned-fact-cut" : "observation-preview"},
+                   {"cutRef", KFX_REGISTRY_REF},
+                   {"cutRoot", cut_root},
+                   {"revision", lifecycle.revision},
                    {"packages", package_plan},
                    {"suites", value.suites},
                    {"diagnostics", value.diagnostics},
@@ -1315,7 +1386,7 @@ json lifecycle_plan(const snapshot &value, const lifecycle_view &lifecycle, cons
   const auto plan_root = root_of(identity);
   result["planRoot"] = plan_root;
   result["graph"] = value.graph;
-  result["nextGeneration"] = intent.is_null() ? lifecycle.generation : lifecycle.generation + 1;
+  result["nextRevision"] = intent.is_null() ? lifecycle.revision : lifecycle.revision + 1;
   result["hostContract"] = experience_flow_descriptor(value, lifecycle, plan_root);
   return result;
 }
@@ -1331,82 +1402,363 @@ int64_t receipt_time(const json &request) {
 }
 
 json lifecycle_history(const std::string &runtime_dir, const json &request) {
-  const auto lifecycle = load_lifecycle(runtime_dir);
-  json receipts = json::array();
+  if (runtime_dir.empty())
+    refuse("KF_KFX_SCHEMA_INVALID", "KFX history requires an explicit runtime directory");
+  const auto state = storage_service_api::run_fact_kernel_operation(
+      runtime_dir, {{"action", "query"}, {"include_inventory", true}, {"include_bodies", true}});
+  if (!state.value("ok", false))
+    refuse("KF_KFX_FACT_REJECTED", state.value("message", "Fact inventory query failed"));
+  json events = json::array();
   const auto package_key = request.value("packageKey", "");
-  for (const auto &receipt : lifecycle.receipts) {
-    if (package_key.empty() || receipt.value("packageKey", "") == package_key)
-      receipts.push_back(receipt);
+  const auto &inventory = state.at("inventory");
+  if (inventory.contains("bodies") && inventory.at("bodies").is_object()) {
+    for (const auto &[ignored, body_entry] : inventory.at("bodies").items()) {
+      (void)ignored;
+      if (!body_entry.is_object() || body_entry.value("status", "") != "available" || !body_entry.contains("body") ||
+          !body_entry.at("body").is_string())
+        continue;
+      json body;
+      try {
+        body = json::parse(body_entry.at("body").get<std::string>());
+      } catch (const json::exception &) {
+        continue;
+      }
+      const auto schema = body.value("schema", "");
+      if (schema != "kungfu.kfx.work-fact/v1" && schema != "kungfu.kfx.warrant-fact/v1" &&
+          schema != "kungfu.kfx.episode-fact/v1" && schema != "kungfu.kfx.settlement-fact/v1")
+        continue;
+      if (package_key.empty() || body.value("packageKey", "") == package_key)
+        events.push_back(body);
+    }
   }
-  return {{"schema", "kungfu.kfx.lifecycle-history/v1"},
-          {"authority", "libkungfu"},
-          {"generation", lifecycle.generation},
-          {"historyRoot", lifecycle.history_root},
-          {"receipts", receipts}};
+  std::sort(events.begin(), events.end(), [](const auto &left, const auto &right) {
+    if (left.value("recordedAt", int64_t{0}) != right.value("recordedAt", int64_t{0}))
+      return left.value("recordedAt", int64_t{0}) < right.value("recordedAt", int64_t{0});
+    return left.value("actionId", "") < right.value("actionId", "");
+  });
+  const auto lifecycle = load_lifecycle(runtime_dir);
+  return {{"schema", "kungfu.kfx.lifecycle-history/v2"},
+          {"authority", "yijinjing-hana-pod-journal"},
+          {"cutRef", KFX_REGISTRY_REF},
+          {"cutRoot", lifecycle.present ? json(lifecycle.cut_root) : json(nullptr)},
+          {"revision", lifecycle.revision},
+          {"historyRoot", root_of(events)},
+          {"events", events}};
+}
+
+struct fact_work_builder {
+  std::string runtime_dir;
+  std::map<std::string, std::string> versions;
+  std::set<std::string> relations;
+  json steps = json::array();
+  std::string profile_root;
+  std::string admission_root;
+
+  fact_work_builder(std::string runtime, const lifecycle_view &current)
+      : runtime_dir(std::move(runtime)), versions(current.current_versions), relations(current.relation_roots),
+        profile_root(native_kfx_domain_profile().at("domainProfileRoot").get<std::string>()),
+        admission_root(
+            root_of({{"schema", "kungfu.kfx-domain-profile-admission/v1"}, {"domainProfileRoot", profile_root}})) {}
+
+  json invoke(const std::string &action, const json &request) {
+    auto response = fact_call(runtime_dir, action, request);
+    if (response.value("status", "") == "idempotent-replay" && response.contains("result") &&
+        response.at("result").contains("record_root")) {
+      static const std::map<std::string, std::string> replay_root_fields = {{"object-put", "object_root"},
+                                                                            {"version-put", "version_root"},
+                                                                            {"relation-add", "relation_root"},
+                                                                            {"cut-put", "cut_root"}};
+      if (replay_root_fields.contains(action))
+        response["result"][replay_root_fields.at(action)] = response.at("result").at("record_root");
+    }
+    steps.push_back({{"action", action},
+                     {"status", response.value("status", "accepted")},
+                     {"writeOccurred", response.value("write_occurred", false)},
+                     {"receiptRoot", response.contains("receipt_root") ? response.at("receipt_root") : json(nullptr)}});
+    return response;
+  }
+
+  json put(const std::string &object_id, const std::string &object_type, const json &body) {
+    const auto created_by = root_of({{"schema", "kungfu.kfx-object-declaration/v1"},
+                                     {"domainProfileRoot", profile_root},
+                                     {"objectId", object_id},
+                                     {"objectType", object_type}});
+    invoke("object-put",
+           {{"object_id", object_id}, {"object_type", object_type}, {"created_by_receipt_root", created_by}});
+    json parents = json::array();
+    if (versions.contains(object_id))
+      parents.push_back(versions.at(object_id));
+    const auto response = invoke(
+        "version-put",
+        {{"object_id", object_id},
+         {"body", body.dump()},
+         {"schema_root", root_of({{"schema", "kungfu.kfx-fact-body-schema/v1"}, {"bodySchema", body.at("schema")}})},
+         {"parent_version_roots", parents},
+         {"declaration_roots", json::array({profile_root})},
+         {"admission_roots", json::array({admission_root})}});
+    versions[object_id] = response.at("result").at("version_root").get<std::string>();
+    return response.at("result");
+  }
+
+  void relate(const std::string &type, const std::string &source, const std::string &target, const json &attributes) {
+    const auto attributes_root = root_of(attributes);
+    const auto response = invoke("relation-add", {{"relation_id", relation_id(type, source, target)},
+                                                  {"relation_type", type},
+                                                  {"source", {{"kind", "logical-object"}, {"id", source}}},
+                                                  {"target", {{"kind", "logical-object"}, {"id", target}}},
+                                                  {"attributes_root", attributes_root},
+                                                  {"admission_roots", json::array({admission_root})}});
+    relations.insert(response.at("result").at("relation_root").get<std::string>());
+  }
+};
+
+std::string package_identity_root(const json &package) {
+  return root_of(
+      {{"schema", "kungfu.kfx.package-identity/v1"},
+       {"name", package.value("name", "")},
+       {"manifestIdentity", package.value("name", "").empty() ? package.at("manifestRoot") : package.at("name")}});
+}
+
+json commit_fact_work(const std::string &runtime_dir, const snapshot &value, const lifecycle_view &current,
+                      const json &request, const std::string &operation, const std::string &desired_state,
+                      const std::string &observed_state, const json &materialization) {
+  const auto key = required_text(request, "packageKey", "request");
+  const auto recorded_at = receipt_time(request);
+  const auto action_id =
+      "kfx-action:" + sha256(json({{"operation", operation},
+                                   {"packageKey", key},
+                                   {"expectedCutRoot", current.present ? json(current.cut_root) : json(nullptr)},
+                                   {"expectedRevision", current.revision},
+                                   {"planRoot", request.value("expectedPlanRoot", "")},
+                                   {"actor", request.value("actor", "anonymous")},
+                                   {"recordedAt", recorded_at}})
+                                 .dump())
+                          .substr(0, 32);
+  fact_work_builder builder(runtime_dir, current);
+  const auto projection_id = fact_id("registry-projection", KFX_REGISTRY_REF);
+  const auto profile_root = native_kfx_domain_profile().at("domainProfileRoot");
+  builder.put(projection_id, "kungfu.kfx.registry-projection",
+              {{"schema", "kungfu.kfx.registry-projection-fact/v1"},
+               {"profile", KFX_PROFILE_ID},
+               {"domainProfileRoot", profile_root},
+               {"cutRef", KFX_REGISTRY_REF},
+               {"projection", snapshot_projection(value)}});
+
+  std::map<std::string, std::string> package_objects;
+  std::map<std::string, std::string> provider_objects;
+  for (const auto &package : value.packages) {
+    const auto package_key = package.at("key").get<std::string>();
+    const auto identity_root = package_identity_root(package);
+    const auto package_id = fact_id("package", identity_root);
+    package_objects[package_key] = package_id;
+    const auto package_desired =
+        package_key == key
+            ? desired_state
+            : (current.desired_states.contains(package_key) ? current.desired_states.at(package_key) : "dormant");
+    builder.put(package_id, "kungfu.kfx.package",
+                {{"schema", "kungfu.kfx.package-fact/v1"},
+                 {"profile", KFX_PROFILE_ID},
+                 {"domainProfileRoot", profile_root},
+                 {"identity", {{"objectId", package_id}, {"logicalIdentityRoot", identity_root}}},
+                 {"name", package.value("name", "")},
+                 {"version", package.value("version", "")},
+                 {"manifestRoot", package.at("manifestRoot")},
+                 {"packageRoot", package.at("packageRoot")},
+                 {"desiredState", package_desired},
+                 {"transport", {{"packageKey", package_key}, {"path", package.value("path", "")}}},
+                 {"lastActionId", action_id}});
+  }
+  for (const auto &provider : value.graph.at("providers")) {
+    const auto provider_key = provider.at("providerId").get<std::string>();
+    const auto provider_id = fact_id("provider", package_identity_root(find_package(value.packages, provider_key)));
+    provider_objects[provider_key] = provider_id;
+    builder.put(provider_id, "kungfu.kfx.provider",
+                {{"schema", "kungfu.kfx.provider-fact/v1"},
+                 {"profile", KFX_PROFILE_ID},
+                 {"domainProfileRoot", profile_root},
+                 {"provider", provider}});
+    if (package_objects.contains(provider_key))
+      builder.relate("kfx-package-provides", package_objects.at(provider_key), provider_id,
+                     {{"schema", "kungfu.kfx.relation-attributes/v1"}, {"kind", "provider"}});
+  }
+  for (const auto &contribution : value.graph.at("contributions")) {
+    const auto contribution_id = fact_id("contribution", contribution.at("contributionRoot").get<std::string>());
+    builder.put(contribution_id, "kungfu.kfx.contribution",
+                {{"schema", "kungfu.kfx.contribution-fact/v1"},
+                 {"profile", KFX_PROFILE_ID},
+                 {"domainProfileRoot", profile_root},
+                 {"contribution", contribution}});
+    const auto owner = contribution.value("ownerProviderId", "");
+    if (provider_objects.contains(owner))
+      builder.relate("kfx-provider-contributes", provider_objects.at(owner), contribution_id,
+                     {{"schema", "kungfu.kfx.relation-attributes/v1"}, {"kind", "contribution"}});
+  }
+  for (const auto &dependency : value.graph.at("dependencies")) {
+    const auto dependency_id = fact_id("dependency", dependency.at("dependencyRoot").get<std::string>());
+    builder.put(dependency_id, "kungfu.kfx.dependency",
+                {{"schema", "kungfu.kfx.dependency-fact/v1"},
+                 {"profile", KFX_PROFILE_ID},
+                 {"domainProfileRoot", profile_root},
+                 {"dependency", dependency}});
+    const auto source = dependency.value("providerId", "");
+    const auto target = dependency.value("targetProviderId", dependency.value("requiresProviderId", ""));
+    if (provider_objects.contains(source)) {
+      const auto target_id = provider_objects.contains(target) ? provider_objects.at(target) : dependency_id;
+      builder.relate("kfx-provider-depends-on", provider_objects.at(source), target_id,
+                     {{"schema", "kungfu.kfx.relation-attributes/v1"}, {"mode", dependency.value("mode", "required")}});
+    }
+  }
+
+  const auto work_id = fact_id("work", action_id);
+  const auto warrant_id = fact_id("warrant", action_id);
+  const auto episode_id = fact_id("episode", action_id);
+  const auto settlement_id = fact_id("settlement", action_id);
+  builder.put(
+      work_id, "kungfu.kfx.work",
+      {{"schema", "kungfu.kfx.work-fact/v1"},
+       {"profile", KFX_PROFILE_ID},
+       {"domainProfileRoot", profile_root},
+       {"actionId", action_id},
+       {"operation", operation},
+       {"packageKey", key},
+       {"actor", request.value("actor", "anonymous")},
+       {"recordedAt", recorded_at},
+       {"basis",
+        {{"cutRoot", current.present ? json(current.cut_root) : json(nullptr)}, {"revision", current.revision}}},
+       {"status", "settled"}});
+  builder.put(warrant_id, "kungfu.kfx.warrant",
+              {{"schema", "kungfu.kfx.warrant-fact/v1"},
+               {"profile", KFX_PROFILE_ID},
+               {"domainProfileRoot", profile_root},
+               {"actionId", action_id},
+               {"packageKey", key},
+               {"allowedOperation", operation},
+               {"state", "consumed"},
+               {"recordedAt", recorded_at}});
+  const auto episode_result = builder.put(episode_id, "kungfu.kfx.episode",
+                                          {{"schema", "kungfu.kfx.episode-fact/v1"},
+                                           {"profile", KFX_PROFILE_ID},
+                                           {"domainProfileRoot", profile_root},
+                                           {"actionId", action_id},
+                                           {"operation", operation},
+                                           {"packageKey", key},
+                                           {"outcome", "applied"},
+                                           {"observedState", observed_state},
+                                           {"materialization", materialization},
+                                           {"recordedAt", recorded_at}});
+  builder.put(settlement_id, "kungfu.kfx.settlement",
+              {{"schema", "kungfu.kfx.settlement-fact/v1"},
+               {"profile", KFX_PROFILE_ID},
+               {"domainProfileRoot", profile_root},
+               {"actionId", action_id},
+               {"operation", operation},
+               {"packageKey", key},
+               {"outcome", "accepted"},
+               {"desiredState", desired_state},
+               {"observedState", observed_state},
+               {"recordedAt", recorded_at}});
+  builder.relate("kfx-work-authorized-by", work_id, warrant_id,
+                 {{"schema", "kungfu.kfx.relation-attributes/v1"}, {"actionId", action_id}});
+  builder.relate("kfx-work-observed-in", work_id, episode_id,
+                 {{"schema", "kungfu.kfx.relation-attributes/v1"}, {"actionId", action_id}});
+  builder.relate("kfx-work-settled-by", work_id, settlement_id,
+                 {{"schema", "kungfu.kfx.relation-attributes/v1"}, {"actionId", action_id}});
+  if (package_objects.contains(key))
+    builder.relate("kfx-settlement-updates-package", settlement_id, package_objects.at(key),
+                   {{"schema", "kungfu.kfx.relation-attributes/v1"}, {"desiredState", desired_state}});
+
+  json object_versions = json::array();
+  for (const auto &[object_id, version_root] : builder.versions)
+    object_versions.push_back({{"object_id", object_id}, {"version_root", version_root}});
+  json relation_roots = json::array();
+  for (const auto &root : builder.relations)
+    relation_roots.push_back(root);
+  json parent_cuts = json::array();
+  if (current.present)
+    parent_cuts.push_back(current.cut_root);
+  const auto episode_number = std::stoull(sha256(action_id).substr(0, 16), nullptr, 16);
+  const auto cut_response = builder.invoke(
+      "cut-put",
+      {{"parent_cut_roots", parent_cuts},
+       {"object_versions", object_versions},
+       {"active_relation_roots", relation_roots},
+       {"declaration_roots", json::array({builder.profile_root})},
+       {"admission_roots", json::array({builder.admission_root})},
+       {"episode_frontier", json::array({{{"episode_id", episode_number},
+                                          {"sealed_content_root", episode_result.at("body_root")},
+                                          {"accepted_manifest_frame_uid", std::string("kfx:") + action_id}}})},
+       {"omission_roots", json::array()},
+       {"conflict_roots", json::array()}});
+  const auto new_cut_root = cut_response.at("result").at("cut_root");
+  const auto ref_response = builder.invoke(
+      "ref-cas",
+      {{"transition_id", action_id},
+       {"ref_name", KFX_REGISTRY_REF},
+       {"expected_old_cut_root", current.present ? json(current.cut_root) : json(nullptr)},
+       {"expected_old_revision", current.revision},
+       {"new_cut_root", new_cut_root},
+       {"kind", current.present ? "advance" : "create"},
+       {"reason_root", root_of({{"schema", "kungfu.kfx.settlement-reason/v1"}, {"settlementId", settlement_id}})}});
+  const auto result = ref_response.at("result");
+  const json receipt_identity = {{"schema", "kungfu.kfx.work-settlement-receipt/v1"},
+                                 {"actionId", action_id},
+                                 {"operation", operation},
+                                 {"packageKey", key},
+                                 {"outcome", "applied"},
+                                 {"workObjectId", work_id},
+                                 {"warrantObjectId", warrant_id},
+                                 {"episodeObjectId", episode_id},
+                                 {"settlementObjectId", settlement_id},
+                                 {"priorCutRoot", current.present ? json(current.cut_root) : json(nullptr)},
+                                 {"cutRoot", result.at("current_cut_root")},
+                                 {"priorRevision", current.revision},
+                                 {"revision", result.at("current_revision")},
+                                 {"kernelReceiptRoot", ref_response.at("receipt_root")},
+                                 {"recordedAt", recorded_at},
+                                 {"materialization", materialization}};
+  auto receipt = receipt_identity;
+  receipt["receiptRoot"] = root_of(receipt_identity);
+  receipt["steps"] = builder.steps;
+  return receipt;
 }
 
 json apply_lifecycle_mutation(const snapshot &value, const lifecycle_view &lifecycle, const json &plan,
                               const json &request, const std::string &runtime_dir) {
   const auto operation = required_text(request, "operation", "request");
-  static const std::set<std::string> operations = {"install", "update", "remove", "enable", "disable", "activate"};
+  static const std::set<std::string> operations = {"install", "update",   "remove", "enable",
+                                                   "disable", "activate", "qualify"};
   validate_enum(operation, operations, "lifecycle operation");
   const auto package_key = required_text(request, "packageKey", "request");
   const auto package = find_package(value.packages, package_key);
   if (package.is_null())
     refuse("KF_KFX_MEMBER_MISSING", "KFX package is not present in the registry: " + package_key);
   const auto &provider = provider_for(value, package_key);
-  const auto prior_state = lifecycle.package_states.contains(package_key) ? lifecycle.package_states.at(package_key)
+  const auto prior_state = lifecycle.desired_states.contains(package_key) ? lifecycle.desired_states.at(package_key)
                                                                           : std::string{"dormant"};
-
-  auto refuse_with_receipt = [&](const std::string &code, const std::string &message) -> void {
-    const json identity = {{"outcome", "refused"},
-                           {"previousGeneration", lifecycle.generation},
-                           {"generation", lifecycle.generation},
-                           {"operation", operation},
-                           {"packageKey", package_key},
-                           {"packageRoot", package.at("packageRoot")},
-                           {"registryRoot", value.registry_root},
-                           {"graphRoot", value.graph_root},
-                           {"planRoot", plan.at("planRoot")},
-                           {"trustRoot", provider.at("trustRoot")},
-                           {"priorState", prior_state},
-                           {"nextState", prior_state},
-                           {"state", prior_state},
-                           {"actor", request.value("actor", "anonymous")},
-                           {"recordedAt", receipt_time(request)},
-                           {"code", code},
-                           {"message", message},
-                           {"expected",
-                            {{"generation", request.value("expectedGeneration", uint64_t{0})},
-                             {"registryRoot", request.value("expectedRegistryRoot", "")},
-                             {"graphRoot", request.value("expectedGraphRoot", "")},
-                             {"planRoot", request.value("expectedPlanRoot", "")},
-                             {"trustRoot", request.value("expectedTrustRoot", "")},
-                             {"packageRoot", request.value("expectedPackageRoot", "")}}}};
-    (void)append_lifecycle_receipt(runtime_dir, lifecycle, identity);
-    refuse(code, message);
-  };
-
-  if (!request.contains("expectedGeneration") || !request.at("expectedGeneration").is_number_integer() ||
-      request.at("expectedGeneration").get<int64_t>() < 0 ||
-      static_cast<uint64_t>(request.at("expectedGeneration").get<int64_t>()) != lifecycle.generation)
-    refuse_with_receipt("KF_KFX_GENERATION_MISMATCH", "lifecycle generation changed since planning");
+  if (!request.contains("expectedRevision") || !request.at("expectedRevision").is_number_integer() ||
+      request.at("expectedRevision").get<int64_t>() < 0 ||
+      static_cast<uint64_t>(request.at("expectedRevision").get<int64_t>()) != lifecycle.revision)
+    refuse("KF_KFX_CUT_STALE", "named KFX Fact Cut revision changed since planning");
+  const json expected_cut = request.contains("expectedCutRoot") ? request.at("expectedCutRoot") : json(nullptr);
+  const json actual_cut = lifecycle.present ? json(lifecycle.cut_root) : json(nullptr);
+  if (expected_cut != actual_cut)
+    refuse("KF_KFX_CUT_STALE", "named KFX Fact Cut root changed since planning");
   if (request.value("expectedRegistryRoot", "") != value.registry_root)
-    refuse_with_receipt("KF_KFX_REGISTRY_STALE", "registry root changed since planning");
+    refuse("KF_KFX_REGISTRY_STALE", "registry projection changed since planning");
   if (request.value("expectedGraphRoot", "") != value.graph_root)
-    refuse_with_receipt("KF_KFX_GRAPH_STALE", "semantic graph root changed since planning");
+    refuse("KF_KFX_GRAPH_STALE", "semantic graph root changed since planning");
   if (request.value("expectedPlanRoot", "") != plan.at("planRoot").get<std::string>())
-    refuse_with_receipt("KF_KFX_PLAN_STALE", "load plan root changed since planning");
+    refuse("KF_KFX_PLAN_STALE", "load plan root changed since planning");
   if (request.value("expectedTrustRoot", "") != provider.at("trustRoot").get<std::string>())
-    refuse_with_receipt("KF_KFX_ASSESSMENT_STALE", "provider trust root changed since planning");
+    refuse("KF_KFX_ASSESSMENT_STALE", "provider trust root changed since planning");
   if (request.value("expectedPackageRoot", "") != package.at("packageRoot").get<std::string>())
-    refuse_with_receipt("KF_KFX_REGISTRY_STALE", "package root changed since planning");
+    refuse("KF_KFX_REGISTRY_STALE", "package root changed since planning");
 
   const auto runtime_root = lifecycle_root(runtime_dir);
   const auto install_root = fs::absolute(runtime_dir).parent_path() / "extensions";
   const auto destination = install_root / package_key;
   const auto source = fs::path(package.at("path").get<std::string>());
-  const auto generation = lifecycle.generation + 1;
+  const auto next_revision = lifecycle.revision + 1;
   fs::path retained_path;
   fs::path staged_path;
   fs::path content_path;
@@ -1434,16 +1786,16 @@ json apply_lifecycle_mutation(const snapshot &value, const lifecycle_view &lifec
         refuse("KF_KFX_SCHEMA_INVALID", "retained KFX content does not match its package root");
       }
       fs::create_directories(install_root);
-      staged_path = install_root / (".kfx-stage-" + package_key + "-" + std::to_string(generation));
+      staged_path = install_root / (".kfx-stage-" + package_key + "-" + std::to_string(next_revision));
       if (fs::exists(staged_path))
-        refuse("KF_KFX_WRITER_BUSY", "a staged KFX package already exists for this generation");
+        refuse("KF_KFX_WRITER_BUSY", "a staged KFX package already exists for this Fact Cut revision");
       fs::copy(content_path, staged_path, fs::copy_options::recursive);
       if (fs::exists(destination)) {
         if (operation == "install" && !request.value("replaceExisting", false))
           refuse("KF_KFX_PACKAGE_DUPLICATE", "KFX package is already installed: " + package_key);
         retained_path =
             runtime_root / "retained" /
-            (std::to_string(generation) + "-" + package_key + "-" + root_of(package_closure(destination)).substr(7));
+            (std::to_string(next_revision) + "-" + package_key + "-" + root_of(package_closure(destination)).substr(7));
         fs::create_directories(retained_path.parent_path());
         fs::rename(destination, retained_path);
         destination_replaced = true;
@@ -1458,43 +1810,43 @@ json apply_lifecycle_mutation(const snapshot &value, const lifecycle_view &lifec
       if (canonical_destination.parent_path() != canonical_install_root)
         refuse("KF_KFX_PATH_TRAVERSAL", "remove is confined to the managed KFX install root");
       retained_path = runtime_root / "retained" /
-                      (std::to_string(generation) + "-" + package_key + "-" +
+                      (std::to_string(next_revision) + "-" + package_key + "-" +
                        package.at("packageRoot").get<std::string>().substr(7));
       fs::create_directories(retained_path.parent_path());
       fs::rename(canonical_destination, retained_path);
       destination_replaced = true;
     }
 
-    const auto state = operation == "remove" || operation == "disable" ? "dormant"
-                       : provider.at("state") == "degraded"            ? "degraded"
-                                                                       : "active";
-    const json dependency_identity = {
-        {"registryRoot", value.registry_root},      {"graphRoot", value.graph_root},
-        {"planRoot", plan.at("planRoot")},          {"trustRoot", provider.at("trustRoot")},
-        {"packageRoot", package.at("packageRoot")}, {"generation", generation}};
-    const json identity = {{"outcome", "applied"},
-                           {"previousGeneration", lifecycle.generation},
-                           {"generation", generation},
-                           {"operation", operation},
-                           {"packageKey", package_key},
-                           {"packageRoot", package.at("packageRoot")},
-                           {"registryRoot", value.registry_root},
-                           {"graphRoot", value.graph_root},
-                           {"planRoot", plan.at("planRoot")},
-                           {"trustRoot", provider.at("trustRoot")},
-                           {"receiptDependencyRoot", root_of(dependency_identity)},
-                           {"priorState", prior_state},
-                           {"nextState", state},
-                           {"state", state},
-                           {"actor", request.value("actor", "anonymous")},
-                           {"recordedAt", receipt_time(request)},
-                           {"contentPath", content_path.empty() ? nullptr : json(content_path.string())},
-                           {"retainedPath", retained_path.empty() ? nullptr : json(retained_path.string())}};
+    const auto desired_state = operation == "remove" || operation == "disable" ? "dormant"
+                               : operation == "qualify"                        ? prior_state
+                                                                               : "active";
+    const auto observed_state = provider.at("state") == "degraded" ? "degraded" : "applied";
+    snapshot accepted = value;
+    for (auto &accepted_package : accepted.packages) {
+      if (accepted_package.at("key") != package_key)
+        continue;
+      if (operation == "remove" && !retained_path.empty())
+        accepted_package["path"] = retained_path.string();
+      else if (!destination.empty() && fs::exists(destination))
+        accepted_package["path"] = destination.string();
+      accepted_package["candidate"] = false;
+      accepted_package["installed"] = operation != "remove";
+    }
+    const json materialization = {{"contentPath", content_path.empty() ? nullptr : json(content_path.string())},
+                                  {"retainedPath", retained_path.empty() ? nullptr : json(retained_path.string())},
+                                  {"destinationPath", destination.string()}};
     appending_receipt = true;
-    auto receipt = append_lifecycle_receipt(runtime_dir, lifecycle, identity);
-    return {{"schema", "kungfu.kfx.lifecycle-application/v1"},
+    auto receipt = commit_fact_work(runtime_dir, accepted, lifecycle, request, operation, desired_state, observed_state,
+                                    materialization);
+    return {{"schema", "kungfu.kfx.lifecycle-application/v2"},
             {"applied", true},
-            {"generation", generation},
+            {"cutRoot", receipt.at("cutRoot")},
+            {"revision", receipt.at("revision")},
+            {"desiredState", desired_state},
+            {"observedState", observed_state},
+            {"verdict", provider.at("state") == "degraded" ? "degraded"
+                        : desired_state == "dormant"       ? "dormant"
+                                                           : "active"},
             {"receipt", receipt}};
   } catch (const std::invalid_argument &error) {
     rollback();
@@ -1503,19 +1855,74 @@ json apply_lifecycle_mutation(const snapshot &value, const lifecycle_view &lifec
     const std::string detail = error.what();
     const auto separator = detail.find(':');
     const auto code = detail.starts_with("KF_") ? detail.substr(0, separator) : "KF_KFX_SCHEMA_INVALID";
-    refuse_with_receipt(code, detail);
+    refuse(code, detail);
   } catch (const std::exception &error) {
     rollback();
     if (appending_receipt)
       throw;
-    refuse_with_receipt("KF_KFX_SCHEMA_INVALID", error.what());
+    refuse("KF_KFX_SCHEMA_INVALID", error.what());
   } catch (...) {
     rollback();
     if (appending_receipt)
       throw;
-    refuse_with_receipt("KF_KFX_SCHEMA_INVALID", "unknown native KFX lifecycle failure");
+    refuse("KF_KFX_SCHEMA_INVALID", "unknown native KFX lifecycle failure");
   }
   return json::object();
+}
+
+snapshot merge_candidate_observation(const snapshot &authority, const snapshot &candidate) {
+  snapshot result = authority;
+  std::map<std::string, json> packages;
+  for (const auto &package : authority.packages)
+    packages[package.at("key").get<std::string>()] = package;
+  for (const auto &package : candidate.packages)
+    packages[package.at("key").get<std::string>()] = package;
+  result.packages = json::array();
+  for (const auto &[ignored, package] : packages) {
+    (void)ignored;
+    result.packages.push_back(package);
+  }
+  std::map<std::string, json> suites;
+  for (const auto &suite : authority.suites)
+    suites[suite.at("suiteKey").get<std::string>()] = suite;
+  for (const auto &suite : candidate.suites)
+    suites[suite.at("suiteKey").get<std::string>()] = suite;
+  result.suites = json::array();
+  for (const auto &[ignored, suite] : suites) {
+    (void)ignored;
+    result.suites.push_back(suite);
+  }
+  result.diagnostics = candidate.diagnostics;
+  result.graph = semantic_graph(result.packages, result.diagnostics);
+  result.graph_root = result.graph.at("graphRoot").get<std::string>();
+  json package_identity = json::array();
+  for (const auto &package : result.packages) {
+    package_identity.push_back({{"key", package.at("key")},
+                                {"rootKind", package.at("rootKind")},
+                                {"packageRoot", package.at("packageRoot")},
+                                {"manifestRoot", package.at("manifestRoot")},
+                                {"apiCompatibility", package.at("apiCompatibility")},
+                                {"facets", package.at("facets")},
+                                {"runtimeTier", package.at("runtimeTier")},
+                                {"admissionGrade", package.at("admissionGrade")},
+                                {"hosts", package.at("hosts")}});
+  }
+  result.registry_root = root_of({{"schema", "kungfu.kfx-registry-snapshot/v1"},
+                                  {"packages", package_identity},
+                                  {"suites", result.suites},
+                                  {"diagnostics", result.diagnostics}});
+  return result;
+}
+
+snapshot empty_observation() {
+  snapshot result;
+  result.graph = semantic_graph(result.packages, result.diagnostics);
+  result.graph_root = result.graph.at("graphRoot").get<std::string>();
+  result.registry_root = root_of({{"schema", "kungfu.kfx-registry-snapshot/v1"},
+                                  {"packages", json::array()},
+                                  {"suites", json::array()},
+                                  {"diagnostics", json::array()}});
+  return result;
 }
 
 } // namespace
@@ -1533,94 +1940,138 @@ static json query_native_kfx_registry_unchecked(const std::string &action, const
   std::optional<lifecycle_writer_lock> writer_lock;
   if (action == "apply")
     writer_lock.emplace(runtime_dir);
+  const auto lifecycle = load_lifecycle(runtime_dir);
   auto snapshot_request = request;
   if (action == "apply")
     snapshot_request.erase("expectedRegistryRoot");
-  const auto snapshot = build_snapshot(snapshot_request);
-  lifecycle_view lifecycle;
-  if (runtime_dir.empty()) {
-    lifecycle.history_root = root_of(json::array());
+  const bool has_observation = snapshot_request.contains("roots") && snapshot_request.at("roots").is_array() &&
+                               !snapshot_request.at("roots").empty();
+  snapshot selected;
+  if (lifecycle.present) {
+    selected = lifecycle.authoritative;
+    const auto operation = request.value("operation", "");
+    if (has_observation && (operation == "install" || operation == "update")) {
+      selected = merge_candidate_observation(selected, build_snapshot(snapshot_request));
+    }
+  } else if (has_observation) {
+    selected = build_snapshot(snapshot_request);
+  } else if (action == "list" || action == "status") {
+    selected = empty_observation();
   } else {
-    lifecycle = load_lifecycle(runtime_dir);
+    refuse("KF_KFX_CUT_MISSING", "no named KFX Fact Cut exists; provide a bounded discovery observation to plan");
   }
-  const auto load_plan = lifecycle_plan(snapshot, lifecycle, request);
+  const auto load_plan = lifecycle_plan(selected, lifecycle, request);
   if (action == "apply")
-    return apply_lifecycle_mutation(snapshot, lifecycle, load_plan, request, runtime_dir);
+    return apply_lifecycle_mutation(selected, lifecycle, load_plan, request, runtime_dir);
+  const json cut_root = lifecycle.present ? json(lifecycle.cut_root) : json(nullptr);
   if (action == "status") {
-    return {{"schema", "kungfu.kfx.registry-status/v2"},
-            {"authority", "libkungfu"},
+    return {{"schema", "kungfu.kfx.registry-status/v3"},
+            {"authority", lifecycle.present ? "yijinjing-hana-pod-journal" : "observation-preview"},
+            {"domainProfileRoot", native_kfx_domain_profile().at("domainProfileRoot")},
+            {"cutRef", KFX_REGISTRY_REF},
+            {"cutRoot", cut_root},
+            {"revision", lifecycle.revision},
             {"writer", "one-libkungfu-writer-per-runtime-directory"},
             {"readOnly", false},
             {"cacheAuthority", false},
-            {"registryRoot", snapshot.registry_root},
-            {"graphRoot", snapshot.graph_root},
-            {"generation", lifecycle.generation},
-            {"historyRoot", lifecycle.history_root},
-            {"packageCount", snapshot.packages.size()},
-            {"suiteCount", snapshot.suites.size()},
-            {"diagnostics", snapshot.diagnostics}};
+            {"registryRoot", selected.registry_root},
+            {"graphRoot", selected.graph_root},
+            {"packageCount", selected.packages.size()},
+            {"suiteCount", selected.suites.size()},
+            {"diagnostics", selected.diagnostics}};
   }
   if (action == "list") {
     json packages = json::array();
-    for (const auto &package : snapshot.packages) {
+    for (const auto &package : selected.packages) {
       auto projected = public_package(package);
       const auto key = package.at("key").get<std::string>();
-      projected["state"] =
-          lifecycle.package_states.contains(key) ? lifecycle.package_states.at(key) : std::string{"dormant"};
-      projected["providerRoot"] = provider_for(snapshot, key).at("providerRoot");
+      const auto desired =
+          lifecycle.desired_states.contains(key) ? lifecycle.desired_states.at(key) : std::string{"dormant"};
+      const auto observed =
+          lifecycle.observed_states.contains(key) ? lifecycle.observed_states.at(key) : std::string{"unknown"};
+      projected["desiredState"] = desired;
+      projected["observedState"] = observed;
+      projected["verdict"] = derived_verdict(provider_for(selected, key), desired, observed);
+      projected["state"] = projected["verdict"];
+      projected["providerRoot"] = provider_for(selected, key).at("providerRoot");
       packages.push_back(projected);
     }
-    return {{"schema", "kungfu.kfx.registry-list/v2"},
-            {"registryRoot", snapshot.registry_root},
-            {"graphRoot", snapshot.graph_root},
-            {"generation", lifecycle.generation},
+    return {{"schema", "kungfu.kfx.registry-list/v3"},
+            {"authority", lifecycle.present ? "pinned-fact-cut" : "observation-preview"},
+            {"cutRef", KFX_REGISTRY_REF},
+            {"cutRoot", cut_root},
+            {"revision", lifecycle.revision},
+            {"registryRoot", selected.registry_root},
+            {"graphRoot", selected.graph_root},
             {"packages", packages},
-            {"diagnostics", snapshot.diagnostics}};
+            {"diagnostics", selected.diagnostics}};
   }
   if (action == "inspect") {
     const auto key = required_text(request, "packageKey", "request");
-    const auto package = find_package(snapshot.packages, key);
+    const auto package = find_package(selected.packages, key);
     if (package.is_null())
       refuse("KF_KFX_MEMBER_MISSING", "KFX package is not present in the registry: " + key);
     auto projected = package;
     projected.erase("semantic");
-    projected["provider"] = provider_for(snapshot, key);
-    projected["state"] =
-        lifecycle.package_states.contains(key) ? lifecycle.package_states.at(key) : std::string{"dormant"};
-    return {{"schema", "kungfu.kfx.registry-inspection/v2"},
-            {"registryRoot", snapshot.registry_root},
-            {"graphRoot", snapshot.graph_root},
-            {"generation", lifecycle.generation},
+    projected["provider"] = provider_for(selected, key);
+    const auto desired =
+        lifecycle.desired_states.contains(key) ? lifecycle.desired_states.at(key) : std::string{"dormant"};
+    const auto observed =
+        lifecycle.observed_states.contains(key) ? lifecycle.observed_states.at(key) : std::string{"unknown"};
+    projected["desiredState"] = desired;
+    projected["observedState"] = observed;
+    projected["verdict"] = derived_verdict(projected.at("provider"), desired, observed);
+    projected["state"] = projected["verdict"];
+    return {{"schema", "kungfu.kfx.registry-inspection/v3"},
+            {"authority", lifecycle.present ? "pinned-fact-cut" : "observation-preview"},
+            {"cutRef", KFX_REGISTRY_REF},
+            {"cutRoot", cut_root},
+            {"revision", lifecycle.revision},
+            {"registryRoot", selected.registry_root},
+            {"graphRoot", selected.graph_root},
             {"package", projected},
-            {"diagnostics", snapshot.diagnostics}};
+            {"diagnostics", selected.diagnostics}};
   }
   if (action == "assess") {
     const auto key = required_text(request, "packageKey", "request");
-    const auto package = find_package(snapshot.packages, key);
+    const auto package = find_package(selected.packages, key);
     if (package.is_null())
       refuse("KF_KFX_MEMBER_MISSING", "KFX package is not present in the registry: " + key);
-    auto result = assess_package(package, snapshot.registry_root, request);
-    result["registryRoot"] = snapshot.registry_root;
-    result["graphRoot"] = snapshot.graph_root;
-    result["generation"] = lifecycle.generation;
-    result["diagnostics"] = snapshot.diagnostics;
+    auto result = assess_package(package, selected.registry_root, request);
+    result["authority"] = lifecycle.present ? "pinned-fact-cut" : "observation-preview";
+    result["cutRef"] = KFX_REGISTRY_REF;
+    result["cutRoot"] = cut_root;
+    result["revision"] = lifecycle.revision;
+    result["registryRoot"] = selected.registry_root;
+    result["graphRoot"] = selected.graph_root;
+    result["diagnostics"] = selected.diagnostics;
     return result;
   }
   if (action == "resolve") {
     const auto key = required_text(request, "suiteKey", "request");
-    for (const auto &suite : snapshot.suites) {
+    for (const auto &suite : selected.suites) {
       if (suite.at("suiteKey") == key)
-        return {{"schema", "kungfu.kfx.registry-resolution/v2"},
-                {"registryRoot", snapshot.registry_root},
-                {"graphRoot", snapshot.graph_root},
-                {"generation", lifecycle.generation},
+        return {{"schema", "kungfu.kfx.registry-resolution/v3"},
+                {"authority", lifecycle.present ? "pinned-fact-cut" : "observation-preview"},
+                {"cutRef", KFX_REGISTRY_REF},
+                {"cutRoot", cut_root},
+                {"revision", lifecycle.revision},
+                {"registryRoot", selected.registry_root},
+                {"graphRoot", selected.graph_root},
                 {"suite", suite},
-                {"diagnostics", snapshot.diagnostics}};
+                {"diagnostics", selected.diagnostics}};
     }
     refuse("KF_KFX_MEMBER_MISSING", "KFX Suite is not present in the registry: " + key);
   }
 
   return load_plan;
+}
+
+json native_kfx_domain_profile() {
+  const auto profile = embedded_domain_profile();
+  auto result = profile;
+  result["domainProfileRoot"] = root_of(profile);
+  return result;
 }
 
 json query_native_kfx_registry(const std::string &action, const json &request, const std::string &runtime_dir) {

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json
@@ -225,6 +225,6 @@
   "expected": {
     "envelopeRoot": "sha256:d46314fbc2e999e31216f677d2e6f5fa7c39ff00e69f7a1687af8da90165724c",
     "kfdReportRoot": "sha256:63670117b00f6a5de4a2af48aa0aa3cc06337b2768d611a67039dbf50d8cf444",
-    "coreReportRoot": "sha256:d444f8e6425d4ac18024b53fa2e42d07faf546d0d4e3b8f64e262674ab19d75e"
+    "coreReportRoot": "sha256:6008c0e6456edf067d8866582e8df653aa9498c832ac1ad030e3f8dcf7ba8366"
   }
 }

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/negative-cases.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/negative-cases.json
@@ -222,5 +222,28 @@
       ],
       "declaredCapabilities": []
     }
+  },
+  {
+    "name": "v3 wrong named-Cut revision",
+    "kind": "plan",
+    "expectedCode": "KF_KFX_CUT_STALE",
+    "document": {
+      "schema": "kungfu.kfx.native-plan/v3",
+      "contractVersion": 3,
+      "planId": "sha256:fact-plan",
+      "basis": {
+        "packageRoot": "sha256:package",
+        "cutRoot": "sha256:cut",
+        "revision": 3
+      },
+      "nextRevision": 9,
+      "requestedCapabilities": [],
+      "grantedCapabilities": [],
+      "effects": [
+        {
+          "kind": "install"
+        }
+      ]
+    }
   }
 ]

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/positive-cases.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/positive-cases.json
@@ -106,5 +106,45 @@
       "generation": 4,
       "verified": true
     }
+  },
+  {
+    "name": "v3 named-Cut plan",
+    "kind": "plan",
+    "document": {
+      "schema": "kungfu.kfx.native-plan/v3",
+      "contractVersion": 3,
+      "planId": "sha256:fact-plan",
+      "basis": {
+        "packageRoot": "sha256:package",
+        "cutRoot": "sha256:cut",
+        "revision": 3
+      },
+      "nextRevision": 4,
+      "requestedCapabilities": [
+        "marketData"
+      ],
+      "grantedCapabilities": [
+        "marketData"
+      ],
+      "effects": [
+        {
+          "kind": "install",
+          "packageKey": "example-kfx"
+        }
+      ]
+    }
+  },
+  {
+    "name": "v3 Fact Work settlement receipt",
+    "kind": "receipt",
+    "document": {
+      "schema": "kungfu.kfx.native-receipt/v3",
+      "contractVersion": 3,
+      "receiptId": "sha256:receipt",
+      "planId": "sha256:fact-plan",
+      "cutRoot": "sha256:next-cut",
+      "revision": 4,
+      "verified": true
+    }
   }
 ]

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
@@ -1,9 +1,9 @@
 {
   "lifecycleGraphRoot": "sha256:500a0bb57f4040c66f86e60fc454d10e9ebd7778d8acf7608308716e28825b56",
-  "lifecyclePlanRoot": "sha256:d221ad76c8d894b2a2ad21b26c9f12d1d59cb14046bed88dbc2216e098d81fc3",
-  "lifecycleReceiptDependencyRoot": "sha256:e78c6aa627c7e8f09c9ba82549c5f3efc168e027f362d596ea2cc28d4c733dc5",
-  "lifecycleRegistryRoot": "sha256:2a197e33b9a3074202c30563bcb732740b8c8302e09bd0ea7cd44576423a2413",
+  "lifecyclePlanRoot": "sha256:40925a540ec5bb98c922f05e1cb89009a5e271f626ab095235b0001eb2b2cf96",
+  "lifecycleReceiptDependencyRoot": "sha256:683bbc2f5d8d6bbbaa6acefba35681b0999c7b80b1d83a9e6d7d633863dfc33f",
+  "lifecycleRegistryRoot": "sha256:7be373f60bbad5fc9dea25623e5d94ffbddc7cf426bcce0682c3f91e8b27cfd2",
   "semanticGraphRoot": "sha256:18955819ef0c42e541666d88f5f6f951485f47034f5d137f34cd2bb5be21e6fd",
-  "semanticHostReceiptDependencyRoot": "sha256:a22675b24c37a4435e4906e39384fa2f3eead19ddad9f61d2a253cd19112c476",
-  "semanticPlanRoot": "sha256:efdf381a04b1c717f66a6cc126612464c3399ec7e52e6260e36fc2810c039cad"
+  "semanticHostReceiptDependencyRoot": "sha256:fb309c54e9faae8d7297f294539d46773be89368273b7c5a4fdeec5d10ac36e1",
+  "semanticPlanRoot": "sha256:23abcb9530839f169f7ea757c1f055a91d2ea5e13be5b6b8f611e9f907c1c708"
 }

--- a/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
@@ -84,11 +84,11 @@ bool contains_text(const nlohmann::json &values, const std::string &expected) {
 void test_contract_is_versioned_and_core_owned() {
   const auto first = kfx::native_kfx_contract();
   const auto second = kfx::native_kfx_contract();
-  require(first.at("schema") == kfx::NATIVE_KFX_CONTRACT_V2, "native contract schema drifted");
-  require(first.at("contractVersion") == 2, "native contract version drifted");
-  require(first.at("versionNegotiation").at("supported") == nlohmann::json::array({1, 2}),
-          "native contract stopped accepting frozen v1 documents");
-  require(first.at("sourceContractVersion") == 9, "native contract did not expose its source compatibility version");
+  require(first.at("schema") == kfx::NATIVE_KFX_CONTRACT_V3, "native contract schema drifted");
+  require(first.at("contractVersion") == 3, "native contract version drifted");
+  require(first.at("versionNegotiation").at("supported") == nlohmann::json::array({1, 2, 3}),
+          "native contract stopped accepting frozen v1/v2 documents");
+  require(first.at("sourceContractVersion") == 10, "native contract did not expose its source compatibility version");
   require(first.at("runtimeTiers") != first.at("admissionGrades"),
           "runtime tier and admission grade were collapsed into one authority field");
   require(first.at("authority").at("owner") == "libkungfu", "native contract did not assign Core authority");
@@ -110,8 +110,16 @@ void test_contract_is_versioned_and_core_owned() {
           "native contract allowed contribution composition to become ownership");
   require(first.at("lifecycle").at("authority") == "one-libkungfu-writer-per-runtime-directory",
           "native contract did not freeze one runtime-directory writer");
+  require(first.at("lifecycle").at("fences").front() == "expectedCutRoot" &&
+              first.at("lifecycle").at("fences").at(1) == "expectedRevision",
+          "native lifecycle still fences on an independent generation");
   require(first.at("experienceFlowHost").at("renderingAuthority") == "host-native",
           "native contract claimed host rendering authority");
+  const auto profile = kfx::native_kfx_domain_profile();
+  require(profile.at("authority").at("namedCutRef") == "profiles/kfx/registry" &&
+              profile.at("authority").at("factKernel") == "yijinjing-hana-pod-journal" &&
+              profile.at("domainProfileRoot").get<std::string>().starts_with("sha256:"),
+          "KFX Domain Profile did not bind the native Fact/Cut authority");
   require(first.at("nativeContractRoot") == second.at("nativeContractRoot"), "native contract root was unstable");
   require(first.at("sourceContractRoot").get<std::string>().rfind("sha256:", 0) == 0,
           "source contract root was not content-addressed");
@@ -495,10 +503,12 @@ void test_semantic_graph_and_host_contract_are_canonical() {
   const auto second = kfx::query_native_kfx_registry("plan", request);
   const auto expected = expected_registry_roots();
   require(first == second, "semantic graph and plan roots are not deterministic");
-  require(first.at("graphRoot") == expected.at("semanticGraphRoot") &&
-              first.at("planRoot") == expected.at("semanticPlanRoot") &&
-              first.at("hostContract").at("receiptDependencyRoot") == expected.at("semanticHostReceiptDependencyRoot"),
-          "C++ semantic graph, plan, or host receipt dependency root drifted from the cross-language fixture");
+  require(first.at("graphRoot") == expected.at("semanticGraphRoot"),
+          "C++ semantic graph drifted from the cross-language fixture");
+  require(first.at("authorityMode") == "observation-preview" && first.at("cutRoot").is_null() &&
+              first.at("revision") == 0 && first.at("planRoot").get<std::string>().starts_with("sha256:") &&
+              first.at("hostContract").at("receiptDependencyRoot").get<std::string>().starts_with("sha256:"),
+          "uncommitted scan was presented as authority or lost its rooted plan");
   require(first.at("graph").at("providers").size() == 2, "semantic graph lost a provider");
   require(first.at("graphRoot").get<std::string>().starts_with("sha256:"), "semantic graph is not rooted");
   const auto &dependencies = first.at("graph").at("dependencies");
@@ -600,7 +610,8 @@ nlohmann::json mutation_request(const nlohmann::json &request, const nlohmann::j
   auto mutation = request;
   mutation["packageKey"] = package_key;
   mutation["operation"] = operation;
-  mutation["expectedGeneration"] = plan.at("generation");
+  mutation["expectedCutRoot"] = plan.at("cutRoot");
+  mutation["expectedRevision"] = plan.at("revision");
   mutation["expectedRegistryRoot"] = plan.at("registryRoot");
   mutation["expectedGraphRoot"] = plan.at("graphRoot");
   mutation["expectedPlanRoot"] = plan.at("planRoot");
@@ -612,11 +623,16 @@ nlohmann::json mutation_request(const nlohmann::json &request, const nlohmann::j
     break;
   }
   mutation["actor"] = "native-kfx-test";
-  mutation["systemTime"] = 100 + plan.at("generation").get<uint64_t>();
+  mutation["systemTime"] = 100 + plan.at("revision").get<uint64_t>();
   return mutation;
 }
 
-void test_native_lifecycle_fences_mutations_and_retains_history() {
+size_t count_schema(const nlohmann::json &events, const std::string &schema) {
+  return static_cast<size_t>(std::count_if(events.begin(), events.end(),
+                                           [&](const auto &event) { return event.value("schema", "") == schema; }));
+}
+
+void test_native_lifecycle_uses_fact_work_and_named_cut_authority() {
   const auto home = temp_root("lifecycle");
   const auto source_root = home / "sources";
   const auto package_source = source_root / "optional-view";
@@ -634,50 +650,61 @@ void test_native_lifecycle_fences_mutations_and_retains_history() {
       "apply", mutation_request(source_request, install_plan, "optional-view", "install"), runtime_dir.string());
   const auto expected = expected_registry_roots();
   require(install_plan.at("registryRoot") == expected.at("lifecycleRegistryRoot") &&
-              install_plan.at("graphRoot") == expected.at("lifecycleGraphRoot") &&
-              install_plan.at("planRoot") == expected.at("lifecyclePlanRoot") &&
-              install.at("receipt").at("receiptDependencyRoot") == expected.at("lifecycleReceiptDependencyRoot"),
-          "C++ lifecycle roots drifted from the cross-language fixture");
-  require(install.at("generation") == 1 && install.at("receipt").at("outcome") == "applied",
-          "late install did not produce generation one");
+              install_plan.at("graphRoot") == expected.at("lifecycleGraphRoot"),
+          "C++ observation snapshot drifted before Fact admission");
+  require(install.at("revision") == 1 && install.at("cutRoot").get<std::string>().starts_with("sha256:") &&
+              install.at("receipt").at("schema") == "kungfu.kfx.work-settlement-receipt/v1" &&
+              install.at("receipt").at("outcome") == "applied",
+          "late install did not settle Work into named Fact Cut revision one");
   require(fs::is_regular_file(home / "extensions" / "optional-view" / "kungfu.kfx.json"),
           "native lifecycle did not atomically materialize the package");
+  require(!fs::exists(runtime_dir / "kfx" / "registry-history.jsonl"),
+          "native lifecycle recreated a KFX-specific authority journal");
 
-  require_refusal("KF_KFX_GENERATION_MISMATCH", [&] {
+  require_refusal("KF_KFX_CUT_STALE", [&] {
     (void)kfx::query_native_kfx_registry(
         "apply", mutation_request(source_request, install_plan, "optional-view", "install"), runtime_dir.string());
   });
   auto history = kfx::query_native_kfx_registry("history", nlohmann::json::object(), runtime_dir.string());
-  require(history.at("generation") == 1 && history.at("receipts").size() == 2 &&
-              history.at("receipts").back().at("outcome") == "refused",
-          "stale caller did not retain one immutable refused receipt");
+  require(history.at("schema") == "kungfu.kfx.lifecycle-history/v2" &&
+              history.at("authority") == "yijinjing-hana-pod-journal" && history.at("revision") == 1 &&
+              count_schema(history.at("events"), "kungfu.kfx.work-fact/v1") == 1 &&
+              count_schema(history.at("events"), "kungfu.kfx.warrant-fact/v1") == 1 &&
+              count_schema(history.at("events"), "kungfu.kfx.episode-fact/v1") == 1 &&
+              count_schema(history.at("events"), "kungfu.kfx.settlement-fact/v1") == 1,
+          "Fact inventory did not reconstruct the settled Work/Warrant/Episode/Settlement");
 
-  const nlohmann::json installed_request = {
-      {"roots", nlohmann::json::array({{{"kind", "user"}, {"path", (home / "extensions").string()}}})},
-      {"runtimeTiers", {{"optional-view", "verified-third-party"}}},
-      {"packageKey", "optional-view"},
-      {"operation", "remove"}};
+  fs::remove_all(source_root);
+  const auto fact_list = kfx::query_native_kfx_registry("list", nlohmann::json::object(), runtime_dir.string());
+  const auto fact_status = kfx::query_native_kfx_registry("status", nlohmann::json::object(), runtime_dir.string());
+  require(fact_list.at("authority") == "pinned-fact-cut" && fact_list.at("packages").size() == 1 &&
+              fact_list.at("cutRoot") == install.at("cutRoot") && fact_status.at("revision") == 1 &&
+              fact_list.at("packages").front().at("desiredState") == "active" &&
+              fact_list.at("packages").front().at("observedState") == "applied" &&
+              fact_list.at("packages").front().at("verdict") == "active",
+          "named Fact Cut could not rebuild desired, observed, and derived registry views without scanning");
+
+  const nlohmann::json installed_request = {{"packageKey", "optional-view"}, {"operation", "remove"}};
   const auto remove_plan = kfx::query_native_kfx_registry("plan", installed_request, runtime_dir.string());
   const auto removed = kfx::query_native_kfx_registry(
       "apply", mutation_request(installed_request, remove_plan, "optional-view", "remove"), runtime_dir.string());
-  require(removed.at("generation") == 2 && !fs::exists(home / "extensions" / "optional-view"),
+  require(removed.at("revision") == 2 && !fs::exists(home / "extensions" / "optional-view"),
           "native lifecycle did not apply the bounded remove transition");
-  require(fs::exists(removed.at("receipt").at("retainedPath").get<std::string>()),
+  require(fs::exists(removed.at("receipt").at("materialization").at("retainedPath").get<std::string>()),
           "remove discarded referenced package bytes");
 
+  fs::create_directories(source_root);
+  fs::copy(registry_root() / "example-suite" / "members" / "optional-view", package_source,
+           fs::copy_options::recursive);
   const auto restore_plan = kfx::query_native_kfx_registry("plan", source_request, runtime_dir.string());
   const auto restored = kfx::query_native_kfx_registry(
       "apply", mutation_request(source_request, restore_plan, "optional-view", "install"), runtime_dir.string());
-  require(restored.at("generation") == 3 && fs::exists(home / "extensions" / "optional-view"),
+  require(restored.at("revision") == 3 && fs::exists(home / "extensions" / "optional-view"),
           "late restoration did not produce a complete next state");
   history = kfx::query_native_kfx_registry("history", {{"packageKey", "optional-view"}}, runtime_dir.string());
-  require(history.at("generation") == 3 && history.at("receipts").size() == 4 &&
+  require(history.at("revision") == 3 && history.at("events").size() == 12 &&
               history.at("historyRoot").get<std::string>().starts_with("sha256:"),
-          "lifecycle history did not reconstruct applied and refused transitions");
-  require(history.at("receipts").front().at("previousGeneration") == 0 &&
-              history.at("receipts").front().at("priorState") == "dormant" &&
-              history.at("receipts").front().at("nextState") == "active",
-          "applied receipt did not retain its complete prior and next state");
+          "lifecycle history did not reconstruct all immutable Fact versions");
 
   const auto duplicate_plan = kfx::query_native_kfx_registry("plan", source_request, runtime_dir.string());
   require_refusal("KF_KFX_PACKAGE_DUPLICATE", [&] {
@@ -685,15 +712,12 @@ void test_native_lifecycle_fences_mutations_and_retains_history() {
         "apply", mutation_request(source_request, duplicate_plan, "optional-view", "install"), runtime_dir.string());
   });
   history = kfx::query_native_kfx_registry("history", {{"packageKey", "optional-view"}}, runtime_dir.string());
-  require(history.at("generation") == 3 && history.at("receipts").size() == 5 &&
-              history.at("receipts").back().at("outcome") == "refused" &&
-              history.at("receipts").back().at("priorState") == history.at("receipts").back().at("nextState"),
-          "failed materialization did not retain an immutable no-transition receipt");
+  require(history.at("revision") == 3 && history.at("events").size() == 12,
+          "refused precondition incorrectly advanced Fact/Work authority");
   require(!fs::exists(home / "extensions" / ".kfx-stage-optional-view-4"),
           "failed materialization left a staged package behind");
 
-  auto enable_request = source_request;
-  enable_request["operation"] = "enable";
+  const nlohmann::json enable_request = {{"packageKey", "optional-view"}, {"operation", "enable"}};
   const auto enable_plan = kfx::query_native_kfx_registry("plan", enable_request, runtime_dir.string());
   const auto enable_mutation = mutation_request(enable_request, enable_plan, "optional-view", "enable");
   auto invoke_enable = [enable_mutation, runtime_dir]() {
@@ -711,12 +735,12 @@ void test_native_lifecycle_fences_mutations_and_retains_history() {
   const auto applied_count =
       static_cast<int>(first_outcome == "applied") + static_cast<int>(second_outcome == "applied");
   const auto refused_outcome = first_outcome == "applied" ? second_outcome : first_outcome;
-  require(applied_count == 1 && (refused_outcome.starts_with("KF_KFX_WRITER_BUSY") ||
-                                 refused_outcome.starts_with("KF_KFX_GENERATION_MISMATCH")),
+  require(applied_count == 1 &&
+              (refused_outcome.starts_with("KF_KFX_WRITER_BUSY") || refused_outcome.starts_with("KF_KFX_CUT_STALE")),
           "concurrent lifecycle writers did not serialize behind the Core-owned runtime fence");
   history = kfx::query_native_kfx_registry("history", {{"packageKey", "optional-view"}}, runtime_dir.string());
-  require(history.at("generation") == 4 && history.at("receipts").size() >= 6,
-          "serialized lifecycle mutation did not preserve a complete generation-four history");
+  require(history.at("revision") == 4 && history.at("events").size() == 16,
+          "serialized lifecycle mutation did not preserve complete Fact/Work history");
   fs::remove_all(home);
 }
 
@@ -732,7 +756,7 @@ int main() {
     test_registry_negative_and_concurrent_reads();
     test_exact_buildchain_attestation_and_operation_admission();
     test_semantic_graph_and_host_contract_are_canonical();
-    test_native_lifecycle_fences_mutations_and_retains_history();
+    test_native_lifecycle_uses_fact_work_and_named_cut_authority();
     std::cout << "native KFX contract tests passed\n";
     return 0;
   } catch (const std::exception &error) {

--- a/framework/core/src/python/kungfu/cli/commands/kfx.py
+++ b/framework/core/src/python/kungfu/cli/commands/kfx.py
@@ -139,14 +139,15 @@ def _libwasm_host():
 
 def _native_mutation(ctx, package_root, key, operation, trusted, **values):
     request = {
-        "roots": [{"kind": "user", "path": str(Path(package_root).resolve())}],
-        "runtimeTiers": {
-            key: "first-party-pinned" if trusted else "untrusted",
-        },
         "packageKey": key,
         "operation": operation,
         **values,
     }
+    if package_root is not None:
+        request["roots"] = [{"kind": "user", "path": str(Path(package_root).resolve())}]
+        request["runtimeTiers"] = {
+            key: "first-party-pinned" if trusted else "untrusted",
+        }
     plan = storage_service.kfx_registry("plan", request, ctx.runtime_dir)
     package = next(
         (item for item in plan["packages"] if item.get("key") == key),
@@ -156,7 +157,8 @@ def _native_mutation(ctx, package_root, key, operation, trusted, **values):
         raise ValueError(f"native KFX plan did not contain package {key}")
     mutation = {
         **request,
-        "expectedGeneration": plan["generation"],
+        "expectedCutRoot": plan["cutRoot"],
+        "expectedRevision": plan["revision"],
         "expectedRegistryRoot": plan["registryRoot"],
         "expectedGraphRoot": plan["graphRoot"],
         "expectedPlanRoot": plan["planRoot"],
@@ -241,7 +243,7 @@ def install(ctx, source, force):
     click.echo(
         f"[kfx] installed {manifest.get('name', key)}@{manifest.get('version', '?')} "
         f"({_kind(manifest)}) -> {dest} "
-        f"(generation {application['generation']})"
+        f"(Fact Cut revision {application['revision']})"
     )
     for line in _trust_notice(manifest):
         click.echo(line)
@@ -252,31 +254,27 @@ def install(ctx, source, force):
 @kfx_command_context
 def list_installed(ctx, as_json):
     root = _install_root(ctx)
-    rows = []
-    if os.path.isdir(root):
-        for name in sorted(os.listdir(root)):
-            package_dir = os.path.join(root, name)
-            manifest_path = os.path.join(
-                package_dir, kfx_contract.PACKAGE_MANIFEST_FILE
-            )
-            if not os.path.isfile(manifest_path):
-                continue
-            try:
-                manifest = _read_manifest_from_dir(package_dir)
-            except (OSError, ValueError, json.JSONDecodeError):
-                rows.append({"key": name, "error": "unreadable kungfu.kfx.json"})
-                continue
-            key = kfx_contract.package_key(manifest) or name
-            rows.append(
-                {
-                    "key": key,
-                    "package": manifest.get("name"),
-                    "version": manifest.get("version"),
-                    "kind": kfx_contract.package_kind(manifest, package_dir),
-                    "trusted": _trusted(manifest),
-                    "path": package_dir,
-                }
-            )
+    authority = storage_service.kfx_registry("list", {}, ctx.runtime_dir)
+    rows = [
+        {
+            "key": package["key"],
+            "package": package.get("name"),
+            "version": package.get("version"),
+            "kind": (
+                "suite"
+                if "profile-suite" in package.get("facets", [])
+                else ",".join(package.get("facets", [])) or "package"
+            ),
+            "trusted": package.get("runtimeTier") == "first-party-pinned",
+            "path": package.get("path"),
+            "desiredState": package["desiredState"],
+            "observedState": package["observedState"],
+            "verdict": package["verdict"],
+            "cutRoot": authority["cutRoot"],
+            "revision": authority["revision"],
+        }
+        for package in authority["packages"]
+    ]
     if as_json:
         click.echo(json.dumps(rows, indent=2, sort_keys=True))
         return
@@ -377,14 +375,14 @@ def remove(ctx, key):
         manifest = _read_manifest_from_dir(dest)
         application = _native_mutation(
             ctx,
-            _install_root(ctx),
+            None,
             key,
             "remove",
             _trusted(manifest),
         )
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         raise click.ClickException(str(error)) from error
-    click.echo(f"[kfx] removed {key} (generation {application['generation']})")
+    click.echo(f"[kfx] removed {key} (Fact Cut revision {application['revision']})")
 
 
 @kfx.command(help="print the kfx contract metadata")

--- a/framework/core/src/python/kungfu/kfx_host.py
+++ b/framework/core/src/python/kungfu/kfx_host.py
@@ -22,7 +22,8 @@ def project_experience_flow_host(
         "graphRoot",
         "planRoot",
         "receiptDependencyRoot",
-        "generation",
+        "cutRoot",
+        "revision",
         "contributions",
     ):
         if field not in descriptor:
@@ -51,6 +52,7 @@ def project_experience_flow_host(
         "graphRoot": descriptor["graphRoot"],
         "planRoot": descriptor["planRoot"],
         "receiptDependencyRoot": descriptor["receiptDependencyRoot"],
-        "generation": descriptor["generation"],
+        "cutRoot": descriptor["cutRoot"],
+        "revision": descriptor["revision"],
         "contributions": contributions,
     }

--- a/framework/core/tests/native-kfx-registry-node-binding.test.js
+++ b/framework/core/tests/native-kfx-registry-node-binding.test.js
@@ -93,7 +93,8 @@ test(
           action: 'apply',
           request: {
             ...request,
-            expectedGeneration: plan.generation,
+            expectedCutRoot: plan.cutRoot,
+            expectedRevision: plan.revision,
             expectedRegistryRoot: plan.registryRoot,
             expectedGraphRoot: plan.graphRoot,
             expectedPlanRoot: plan.planRoot,
@@ -108,9 +109,15 @@ test(
       assert.equal(plan.registryRoot, expected.lifecycleRegistryRoot);
       assert.equal(plan.graphRoot, expected.lifecycleGraphRoot);
       assert.equal(plan.planRoot, expected.lifecyclePlanRoot);
+      assert.equal(application.revision, 1);
+      assert.match(application.cutRoot, /^sha256:[0-9a-f]{64}$/);
       assert.equal(
-        application.receipt.receiptDependencyRoot,
-        expected.lifecycleReceiptDependencyRoot,
+        application.receipt.schema,
+        'kungfu.kfx.work-settlement-receipt/v1',
+      );
+      assert.equal(
+        fs.existsSync(path.join(runtimeDir, 'kfx', 'registry-history.jsonl')),
+        false,
       );
     } finally {
       fs.rmSync(home, { recursive: true, force: true });

--- a/framework/core/tests/python/test_native_kfx_contract.py
+++ b/framework/core/tests/python/test_native_kfx_contract.py
@@ -85,9 +85,9 @@ def _expected_registry_roots():
 
 def test_native_kfx_python_binding_is_a_thin_core_edge(tmp_path):
     contract = storage_service.kfx_runtime_contract(tmp_path)
-    assert contract["schema"] == "kungfu.kfx.native-contract/v2"
-    assert contract["contractVersion"] == 2
-    assert contract["versionNegotiation"]["supported"] == [1, 2]
+    assert contract["schema"] == "kungfu.kfx.native-contract/v3"
+    assert contract["contractVersion"] == 3
+    assert contract["versionNegotiation"]["supported"] == [1, 2, 3]
     assert contract["runtimeTiers"] != contract["admissionGrades"]
     assert contract["authority"]["owner"] == "libkungfu"
     assert contract["sourceContractRoot"].startswith("sha256:")
@@ -151,6 +151,12 @@ def test_python_and_host_projections_preserve_core_semantic_roots(tmp_path):
     assert {projection["planRoot"] for projection in projections} == {plan["planRoot"]}
     assert {projection["receiptDependencyRoot"] for projection in projections} == {
         plan["hostContract"]["receiptDependencyRoot"]
+    }
+    assert {projection["cutRoot"] for projection in projections} == {
+        plan["hostContract"]["cutRoot"]
+    }
+    assert {projection["revision"] for projection in projections} == {
+        plan["hostContract"]["revision"]
     }
     tui = next(item for item in projections if item["host"] == "tui")
     assert tui["contributions"][0]["semanticState"] == "active"

--- a/framework/kfx/kungfu-kfx-domain-profile.contract.json
+++ b/framework/kfx/kungfu-kfx-domain-profile.contract.json
@@ -1,0 +1,52 @@
+{
+  "schema": "kungfu.kfx-domain-profile/v1",
+  "id": "kungfu-kfx-domain-profile",
+  "version": 1,
+  "authority": {
+    "factKernel": "yijinjing-hana-pod-journal",
+    "namedCutRef": "profiles/kfx/registry",
+    "mutation": "work-warrant-action-episode-settlement-ref-cas",
+    "projection": "pinned-fact-cut"
+  },
+  "factTypes": [
+    "kungfu.kfx.registry-projection",
+    "kungfu.kfx.package",
+    "kungfu.kfx.provider",
+    "kungfu.kfx.contribution",
+    "kungfu.kfx.dependency",
+    "kungfu.kfx.work",
+    "kungfu.kfx.warrant",
+    "kungfu.kfx.episode",
+    "kungfu.kfx.settlement"
+  ],
+  "relationTypes": [
+    "kfx-package-provides",
+    "kfx-provider-contributes",
+    "kfx-provider-depends-on",
+    "kfx-work-authorized-by",
+    "kfx-work-observed-in",
+    "kfx-work-settled-by",
+    "kfx-settlement-updates-package"
+  ],
+  "operations": [
+    "install",
+    "update",
+    "remove",
+    "enable",
+    "disable",
+    "activate",
+    "qualify"
+  ],
+  "perspectives": {
+    "desired": "accepted package Fact version at the pinned Cut",
+    "observed": "immutable KFX Episode facts",
+    "verdict": "derived from desired Facts, observed Episodes, provider graph and policy"
+  },
+  "boundaries": [
+    "packageKey is a transport and display coordinate, not Fact identity",
+    "filesystem discovery and materialization are observations and Actions, not registry authority",
+    "package.json and kungfu.kfx.json do not contain runtime lifecycle state",
+    "no KFX-specific lifecycle journal or independent generation counter is authoritative",
+    "every accepted mutation advances the named Cut through exact expected-old and revision CAS"
+  ]
+}

--- a/framework/kfx/kungfu-kfx.contract.json
+++ b/framework/kfx/kungfu-kfx.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.kfx.contract/v1",
   "id": "kungfu-kfx",
-  "version": 9,
+  "version": 10,
   "weldedSurface": "kfx-contract",
   "description": "Single source for KFX package manifests, discovery rules, trust inputs, and build detection.",
   "contractSchema": {
@@ -895,16 +895,17 @@
     }
   },
   "nativeRuntime": {
-    "schema": "kungfu.kfx.native-contract/v2",
-    "contractVersion": 2,
+    "schema": "kungfu.kfx.native-contract/v3",
+    "contractVersion": 3,
     "versionNegotiation": {
-      "current": 2,
+      "current": 3,
       "supported": [
         1,
-        2
+        2,
+        3
       ],
       "minimumReader": 1,
-      "minimumWriter": 2,
+      "minimumWriter": 3,
       "policy": "exact-supported-version-or-refuse"
     },
     "authority": {
@@ -1257,7 +1258,8 @@
       "schema": "kungfu.kfx.lifecycle/v1",
       "authority": "one-libkungfu-writer-per-runtime-directory",
       "fences": [
-        "expectedGeneration",
+        "expectedCutRoot",
+        "expectedRevision",
         "expectedRegistryRoot",
         "expectedGraphRoot",
         "expectedPlanRoot",
@@ -1270,7 +1272,8 @@
         "remove",
         "enable",
         "disable",
-        "activate"
+        "activate",
+        "qualify"
       ],
       "receiptOutcomes": [
         "applied",
@@ -1278,7 +1281,7 @@
       ],
       "payloadRetention": "content-addressed-retain-no-gc",
       "replacement": "stage-then-atomic-rename",
-      "history": "append-only-receipt-chain"
+      "history": "immutable-work-episode-settlement-facts-at-named-cut"
     },
     "experienceFlowHost": {
       "schema": "kungfu.kfx.experience-flow-host/v1",
@@ -1312,6 +1315,7 @@
       "KF_KFX_GRAPH_STALE",
       "KF_KFX_PLAN_STALE",
       "KF_KFX_WRITER_BUSY",
+      "KF_KFX_CUT_STALE",
       "KF_KFX_GENERATION_MISMATCH",
       "KF_KFX_REQUIRED_PROVIDER_MISSING",
       "KF_KFX_PROVIDER_VERSION_MISMATCH",
@@ -1328,9 +1332,9 @@
       "KF_KFX_AUTHORITY_CLAIM_FORBIDDEN"
     ],
     "compatibility": {
-      "typescriptLoader": "retained-shadow-adapter",
-      "pythonInstaller": "retained-shadow-adapter",
-      "mutationCutover": "native-service-edge-after-exact-plan-fence",
+      "typescriptLoader": "thin-native-service-adapter",
+      "pythonInstaller": "thin-native-service-adapter",
+      "mutationCutover": "named-fact-cut-after-exact-cut-and-revision-fence",
       "unknownFields": "reject",
       "migration": "validate-existing-documents-before-authority-cutover"
     },
@@ -1503,6 +1507,95 @@
             "receiptId",
             "planId",
             "generation",
+            "verified"
+          ]
+        }
+      },
+      "3": {
+        "request": {
+          "schema": "kungfu.kfx.native-request/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "operation",
+            "packagePath",
+            "requestedCapabilities"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "operation",
+            "packagePath",
+            "requestedCapabilities",
+            "actor"
+          ]
+        },
+        "inspection": {
+          "schema": "kungfu.kfx.native-inspection/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "packageKey",
+            "packageRoot",
+            "runtimeTier",
+            "admissionGrade",
+            "owners",
+            "closure",
+            "declaredCapabilities"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "packageKey",
+            "packageRoot",
+            "runtimeTier",
+            "admissionGrade",
+            "owners",
+            "closure",
+            "declaredCapabilities"
+          ]
+        },
+        "plan": {
+          "schema": "kungfu.kfx.native-plan/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "planId",
+            "basis",
+            "nextRevision",
+            "requestedCapabilities",
+            "grantedCapabilities",
+            "effects"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "planId",
+            "basis",
+            "nextRevision",
+            "requestedCapabilities",
+            "grantedCapabilities",
+            "effects"
+          ]
+        },
+        "receipt": {
+          "schema": "kungfu.kfx.native-receipt/v3",
+          "required": [
+            "schema",
+            "contractVersion",
+            "receiptId",
+            "planId",
+            "cutRoot",
+            "revision",
+            "verified"
+          ],
+          "allowed": [
+            "schema",
+            "contractVersion",
+            "receiptId",
+            "planId",
+            "cutRoot",
+            "revision",
             "verified"
           ]
         }


### PR DESCRIPTION
## Summary

Establish the Core-native Fact/Work authority for KFX registry state and lifecycle mutations while preserving the reusable parser, resolver, graph, host, and diagnostics surfaces from #1624.

This is the second ordered successor slice for Atlas Assignment `2026-07-27-kungfu-native-kfx-registry-foundation-conversion-ready`. It is intentionally stacked on #1624 and does not merge, queue, or independently settle the parent. Control Suite recursive dogfood remains the final ordered gate.

## Changes

- embed the typed KFX Domain Profile in Core and publish the named Fact Cut at `profiles/kfx/registry`
- model registry packages, providers, contributions, dependencies, Work, Warrant, Episode, and Settlement as immutable Facts and relations
- enforce exact expected-old Cut/revision CAS for every mutation
- make package metadata, scan output, and language adapters thin observations/projections rather than authority
- remove `registry-history.jsonl` and independent generation lifecycle authority
- keep desired, observed, and verdict state distinct across native, Python, and TypeScript surfaces
- preserve v1/v2 generation inputs only as frozen validate-only compatibility; v3 uses Cut/revision
- leave the protected Agent Qualification Lab boundary unchanged

## Verification

- `./shifu build:core`
- `./shifu check`
- `./shifu kfd:buildchain`
- `ctest --test-dir framework/core/build -R '^kungfu_native_kfx_contract_tests$' --output-on-failure`
- Node KFX host/native binding tests: 3/3 passed
- Python KFX contract/trust tests: 28 passed
- affected-native exact source `327b866650d647b94d84fe466274c907584eb2e1..271725d61dbc3e34474d7b832234811a79aec1d2`: 21/21 passed
- affected-native receipt verified with plan digest `sha256:bea855ba6b40c1cbb2ffda7181728ace50d2fb5cb13c9158820e7ad24b700f73`
- public leak / private Atlas path / AI-maintenance scan: no matches

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": [
    "KF-ADR-019f86da-4f90-7ef4-b28b-ee1fbaf9e62e"
  ],
  "summary": "Establish KFX Fact and Work authority without claiming the later recursive Control Suite gate or parent settlement.",
  "verification": [
    "./shifu build:core",
    "./shifu check",
    "affected-native receipt sha256:bea855ba6b40c1cbb2ffda7181728ace50d2fb5cb13c9158820e7ad24b700f73"
  ]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No package was published and no deployment occurred. The generated evidence is repository-local verification for this authority migration.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and contracts updated
- [x] Parent #1624 remains open and unqueued
