### PR TITLE
fix(product): isolate Agent Hub smoke cache

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:8f51a8ab5fe41d9f3029323809feb6e3cd52a9fd4ce80c455b61910cc2775323",
+  "sourceRoot": "sha256:f51b997efe9229d3d307dc1848e12eeef858b9e0ac1efddc15b43c0032d59c23",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -519,9 +519,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 2529,
+          "currentLines": 2528,
           "baselineLines": 2514,
-          "currentRoot": "sha256:4a64f78208b30822f011b9060ecdf5d3d4f6bd73b862eb4b708c2695ef98a1f2",
+          "currentRoot": "sha256:ed07667712d206b8425bcaa1a699467155f5df9c92fdf49f9a0af7ce7f2f401c",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:c1c1afaefefa7d17398973b6ce6ff4706aa838522c061e5dcc352c0cc6912a4f",
+  "sourceRoot": "sha256:8f51a8ab5fe41d9f3029323809feb6e3cd52a9fd4ce80c455b61910cc2775323",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -519,9 +519,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 2530,
+          "currentLines": 2529,
           "baselineLines": 2514,
-          "currentRoot": "sha256:d48088fe0951e44834cf2f07ada4459daa67ed34c85c624897f75d42f359f6d1",
+          "currentRoot": "sha256:4a64f78208b30822f011b9060ecdf5d3d4f6bd73b862eb4b708c2695ef98a1f2",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }

--- a/product/scripts/agent-hub-smoke-environment.mjs
+++ b/product/scripts/agent-hub-smoke-environment.mjs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'node:path';
+
+export function installedAgentHubSmokeEnvironment(installRoot, env) {
+  const userHome = path.join(installRoot, '.agent-hub-user-home');
+  return {
+    userHome,
+    env: {
+      ...env,
+      HOME: userHome,
+      USERPROFILE: userHome,
+      // The installed trunk owns a disposable product cache. Pin it outside
+      // HOME so the smoke continues to prove that Agent Hub qualification is
+      // stateless with respect to the operator-facing user directory.
+      KF_CACHE_HOME: path.join(installRoot, '.agent-hub-cache-home'),
+    },
+  };
+}

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Build distributable Kungfu products from source in one command:
-// dependency sync -> core rebuild -> freeze -> all declared first-party kfx ->
+// Build distributable Kungfu products: dependency sync -> core rebuild -> freeze ->
 // product assembly -> TUI bundle -> desktop installer and/or CLI archive under
 // product/release.
 // Run through the repo entrypoint so Node is pinned:

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -17,6 +17,7 @@ import {
   createBuildchainLogger,
   verifyBuildchainLogEvents,
 } from '@kungfu-tech/buildchain/logging';
+import { installedAgentHubSmokeEnvironment } from './agent-hub-smoke-environment.mjs';
 import { extractTarGz, extractZip, writeTarGz, writeZip } from './archive.mjs';
 import { cliLauncherContent } from './cli-launcher.mjs';
 import { qualifyCliSurface } from './cli-surface-qualification.mjs';
@@ -1547,12 +1548,10 @@ function runInstalledKungfuKfdSmoke({
 function runInstalledKungfuAgentHubSmoke({ installRoot, kungfuBin, env }) {
   const qualificationDir = path.join(installRoot, 'agent-hub-qualification');
   const runtimeHome = path.join(installRoot, '.agent-hub-runtime-home');
-  const userHome = path.join(installRoot, '.agent-hub-user-home');
-  const smokeEnv = {
-    ...env,
-    HOME: userHome,
-    USERPROFILE: userHome,
-  };
+  const { userHome, env: smokeEnv } = installedAgentHubSmokeEnvironment(
+    installRoot,
+    env,
+  );
   const qualification = parseJsonOutput(
     runInstalledKungfu({
       kungfuBin,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -7,6 +7,7 @@ import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
+import { installedAgentHubSmokeEnvironment } from './agent-hub-smoke-environment.mjs';
 import { cliLauncherContent } from './cli-launcher.mjs';
 import {
   cliArchiveBase,
@@ -102,6 +103,34 @@ test('CLI authoring runtime resolves the exact Agent Hub KFD package', () => {
       `missing installed KFD Agent Hub entry: ${relative}`,
     );
   }
+});
+
+test('Agent Hub installed smoke keeps disposable cache outside user HOME', (t) => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-agent-hub-smoke-environment-'),
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const installRoot = path.join(root, 'installed');
+  const operatorHome = path.join(root, 'operator-home');
+  const operatorCache = path.join(operatorHome, 'operator-cache');
+  fs.mkdirSync(installRoot, { recursive: true });
+
+  const smoke = installedAgentHubSmokeEnvironment(installRoot, {
+    HOME: operatorHome,
+    USERPROFILE: operatorHome,
+    KF_CACHE_HOME: operatorCache,
+  });
+
+  assert.equal(smoke.userHome, path.join(installRoot, '.agent-hub-user-home'));
+  assert.equal(smoke.env.HOME, smoke.userHome);
+  assert.equal(smoke.env.USERPROFILE, smoke.userHome);
+  assert.equal(
+    smoke.env.KF_CACHE_HOME,
+    path.join(installRoot, '.agent-hub-cache-home'),
+  );
+  fs.mkdirSync(smoke.env.KF_CACHE_HOME, { recursive: true });
+  assert.equal(fs.existsSync(smoke.userHome), false);
+  assert.equal(fs.existsSync(operatorHome), false);
 });
 
 test('CLI product archive name uses the Kungfu Episodes product prefix', () => {


### PR DESCRIPTION
## Summary

- isolate the installed Agent Hub smoke cache from the disposable user home
- keep the operator home untouched while allowing launcher-owned product cache writes
- add a regression test for HOME, USERPROFILE, and KF_CACHE_HOME boundaries

## Root cause

Build run 30267579084 packaged the macOS launcher successfully, then failed because the installed Agent Hub smoke expected its disposable HOME to remain absent while the launcher correctly created its default cache beneath HOME/Library/Caches. Pinning KF_CACHE_HOME under the isolated installation root preserves both contracts.

## Verification

- ./shifu exec node --test product/scripts/dist.test.mjs
- ./shifu test:kfd-agent-hub-20
- ./shifu check:source

Build evidence: https://github.com/kungfu-origin/kungfu/actions/runs/30267579084

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fix enforces the existing product cache isolation contract and does not alter an architecture contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this change repairs the installed-product smoke used by the Alpha build. Verification is bound to Build run 30267579084 and the checks listed above.