### PR TITLE
fix(shifu): admit Linux ARM64 portable cache profile

### DIFF
--- a/docs/shifu/qualification-portable-off.cache-profile.json
+++ b/docs/shifu/qualification-portable-off.cache-profile.json
@@ -11,7 +11,7 @@
   },
   "subject": {
     "principal": "runner:qualification",
-    "platforms": ["darwin-arm64", "linux-x64", "windows-x64"],
+    "platforms": ["darwin-arm64", "linux-arm64", "linux-x64", "windows-x64"],
     "scopes": ["ci", "self-hosted-runner"]
   },
   "policy": {

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -141,6 +141,24 @@ test('cache contract schemas accept valid fixtures and reject unsafe policy', as
   });
 });
 
+test('portable-off qualification profile covers every native Build lane', () => {
+  const profile = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        ROOT,
+        'docs/shifu/qualification-portable-off.cache-profile.json',
+      ),
+      'utf8',
+    ),
+  );
+  assert.deepEqual(profile.subject.platforms, [
+    'darwin-arm64',
+    'linux-arm64',
+    'linux-x64',
+    'windows-x64',
+  ]);
+});
+
 for (const [label, args, source] of [
   ['contract', ['cache', 'contract'], 'docs/shifu/cache-contract.json'],
   [


### PR DESCRIPTION
## Summary
- admit `linux-arm64` in the explicit-off qualification cache profile used by the native Hub CLI Build lane
- lock the complete native Build platform set with a focused regression test

## Evidence
- `node --test scripts/check-shifu-cache-contract.test.mjs` (28/28)
- `./shifu check:staged`
- observed failure repaired: Build run 30272373738 rejected `linux-arm64` before install because the profile platform set was incomplete

## Scope
ADR-neutral bug fix; no release or publication authority is added.