### PR TITLE
fix(shifu): admit Linux ARM64 portable cache profile

### DIFF
--- a/docs/shifu/qualification-portable-off.cache-profile.json
+++ b/docs/shifu/qualification-portable-off.cache-profile.json
@@ -11,7 +11,7 @@
   },
   "subject": {
     "principal": "runner:qualification",
-    "platforms": ["darwin-arm64", "linux-x64", "windows-x64"],
+    "platforms": ["darwin-arm64", "linux-arm64", "linux-x64", "windows-x64"],
     "scopes": ["ci", "self-hosted-runner"]
   },
   "policy": {

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -141,6 +141,24 @@ test('cache contract schemas accept valid fixtures and reject unsafe policy', as
   });
 });
 
+test('portable-off qualification profile covers every native Build lane', () => {
+  const profile = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        ROOT,
+        'docs/shifu/qualification-portable-off.cache-profile.json',
+      ),
+      'utf8',
+    ),
+  );
+  assert.deepEqual(profile.subject.platforms, [
+    'darwin-arm64',
+    'linux-arm64',
+    'linux-x64',
+    'windows-x64',
+  ]);
+});
+
 for (const [label, args, source] of [
   ['contract', ['cache', 'contract'], 'docs/shifu/cache-contract.json'],
   [


### PR DESCRIPTION
## Summary

- admit `linux-arm64` in the explicit-off qualification cache profile used by the native Hub CLI Build lane
- lock the complete native Build platform set with a focused regression test

## Verification

- `node --test scripts/check-shifu-cache-contract.test.mjs` (28/28)
- `./shifu check:staged`
- observed failure repaired: Build run 30272373738 rejected `linux-arm64` before install because the profile platform set was incomplete

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Complete the existing explicit-off qualification profile platform set; no architecture, release authority, or cache mode changes"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This repairs the fail-closed platform admission boundary without adding publication authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed