### PR TITLE
feat(kfx): bind host admission identities

### DIFF
--- a/framework/api/src/capability/kfx-host.ts
+++ b/framework/api/src/capability/kfx-host.ts
@@ -3,6 +3,22 @@ export type KfxNodeState = 'active' | 'dormant' | 'degraded';
 
 export type KfxHostContribution = {
   state: KfxNodeState;
+  contributionRoot: string;
+  ownerProviderRoot: string;
+  ownerTrustRoot: string;
+  capabilityRoot: string;
+  facetRoot: string;
+  capabilities: string[];
+  authorization: {
+    schema: 'kungfu.kfx.host-authorization/v1';
+    ownerProviderRoot: string;
+    trustRoot: string;
+    capabilityRoot: string;
+    requiredCapabilities: string[];
+    cutRoot: string | null;
+    revision: number;
+    authorizationRoot: string;
+  };
   presentation?: {
     optional?: boolean;
     hosts?: KfxHost[];
@@ -11,13 +27,37 @@ export type KfxHostContribution = {
 };
 
 export type KfxExperienceFlowDescriptor = {
-  schema: 'kungfu.kfx.experience-flow-host/v1';
+  schema: 'kungfu.kfx.experience-flow-host/v2';
   descriptorRoot: string;
+  registryRoot: string;
   graphRoot: string;
   planRoot: string;
   receiptDependencyRoot: string;
   cutRoot: string | null;
   revision: number;
+  generation: {
+    schema: 'kungfu.kfx.host-generation/v1';
+    registryRoot: string;
+    graphRoot: string;
+    cutRoot: string | null;
+    revision: number;
+  };
+  generationRoot: string;
+  admission: {
+    schema: 'kungfu.kfx.host-admission/v1';
+    state: 'admitted' | 'preview-only';
+    exactRootRequired: true;
+    registryRoot: string;
+    graphRoot: string;
+    planRoot: string;
+    cutRoot: string | null;
+    revision: number;
+    generationRoot: string;
+    contributionRoots: string[];
+    facetRoots: string[];
+    capabilityRoots: string[];
+    authorizationRoots: string[];
+  };
   contributions: KfxHostContribution[];
 };
 
@@ -30,6 +70,13 @@ export type KfxHostProjection = {
   receiptDependencyRoot: string;
   cutRoot: string | null;
   revision: number;
+  generationRoot: string;
+  admissionState: 'admitted' | 'preview-only';
+  diagnostics: Array<{
+    code: 'KF_KFX_HOST_NOT_ADMITTED' | 'KF_KFX_PRESENTATION_DORMANT';
+    contributionRoot?: string;
+    recoveryGuidance: string[];
+  }>;
   contributions: Array<
     KfxHostContribution & {
       semanticState: KfxNodeState;
@@ -45,8 +92,33 @@ export function projectKfxExperienceFlowHost(
   descriptor: KfxExperienceFlowDescriptor,
   host: KfxHost,
 ): KfxHostProjection {
-  if (descriptor.schema !== 'kungfu.kfx.experience-flow-host/v1') {
+  if (descriptor.schema !== 'kungfu.kfx.experience-flow-host/v2') {
     throw new Error('unsupported KFX Experience/Flow host descriptor');
+  }
+  const exact = descriptor.admission;
+  if (
+    exact.schema !== 'kungfu.kfx.host-admission/v1' ||
+    exact.exactRootRequired !== true ||
+    exact.registryRoot !== descriptor.registryRoot ||
+    exact.graphRoot !== descriptor.graphRoot ||
+    exact.planRoot !== descriptor.planRoot ||
+    exact.cutRoot !== descriptor.cutRoot ||
+    exact.revision !== descriptor.revision ||
+    exact.generationRoot !== descriptor.generationRoot ||
+    descriptor.generation.registryRoot !== descriptor.registryRoot ||
+    descriptor.generation.graphRoot !== descriptor.graphRoot ||
+    descriptor.generation.cutRoot !== descriptor.cutRoot ||
+    descriptor.generation.revision !== descriptor.revision ||
+    (exact.state === 'admitted') !== (descriptor.cutRoot !== null)
+  ) {
+    throw new Error('KFX host descriptor admission identity does not match');
+  }
+  const diagnostics: KfxHostProjection['diagnostics'] = [];
+  if (exact.state !== 'admitted') {
+    diagnostics.push({
+      code: 'KF_KFX_HOST_NOT_ADMITTED',
+      recoveryGuidance: ['settle-exact-kfx-fact-cut'],
+    });
   }
   return {
     schema: 'kungfu.kfx.host-projection/v1',
@@ -57,7 +129,31 @@ export function projectKfxExperienceFlowHost(
     receiptDependencyRoot: descriptor.receiptDependencyRoot,
     cutRoot: descriptor.cutRoot,
     revision: descriptor.revision,
+    generationRoot: descriptor.generationRoot,
+    admissionState: exact.state,
+    diagnostics,
     contributions: descriptor.contributions.map((contribution) => {
+      const index = exact.contributionRoots.indexOf(
+        contribution.contributionRoot,
+      );
+      if (
+        index < 0 ||
+        exact.facetRoots[index] !== contribution.facetRoot ||
+        exact.capabilityRoots[index] !== contribution.capabilityRoot ||
+        exact.authorizationRoots[index] !==
+          contribution.authorization.authorizationRoot ||
+        contribution.authorization.ownerProviderRoot !==
+          contribution.ownerProviderRoot ||
+        contribution.authorization.trustRoot !== contribution.ownerTrustRoot ||
+        contribution.authorization.capabilityRoot !==
+          contribution.capabilityRoot ||
+        contribution.authorization.cutRoot !== descriptor.cutRoot ||
+        contribution.authorization.revision !== descriptor.revision
+      ) {
+        throw new Error(
+          'KFX host contribution admission identity does not match',
+        );
+      }
       const supported =
         contribution.presentation?.hosts?.includes(host) === true;
       const optional = contribution.presentation?.optional === true;
@@ -66,12 +162,21 @@ export function projectKfxExperienceFlowHost(
         : optional
           ? 'dormant'
           : 'degraded';
+      if (presentationState === 'dormant') {
+        diagnostics.push({
+          code: 'KF_KFX_PRESENTATION_DORMANT',
+          contributionRoot: contribution.contributionRoot,
+          recoveryGuidance: [`install-optional-${host}-presentation`],
+        });
+      }
       return {
         ...contribution,
         semanticState: contribution.state,
         presentationState,
         executionEligible:
-          contribution.state === 'active' && presentationState !== 'degraded',
+          exact.state === 'admitted' &&
+          contribution.state === 'active' &&
+          presentationState === 'active',
       };
     }),
   };

--- a/framework/api/tests/kfx-host.test.ts
+++ b/framework/api/tests/kfx-host.test.ts
@@ -1,21 +1,63 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { projectGuiKfxExperienceFlow } from '../../gui/src/main/kfx-host.ts';
+import { projectTuiKfxExperienceFlow } from '../../tui/src/kfx-host.ts';
 import {
   type KfxExperienceFlowDescriptor,
   projectKfxExperienceFlowHost,
 } from '../src/capability/kfx-host.ts';
 
 const descriptor: KfxExperienceFlowDescriptor = {
-  schema: 'kungfu.kfx.experience-flow-host/v1',
+  schema: 'kungfu.kfx.experience-flow-host/v2',
   descriptorRoot: `sha256:${'1'.repeat(64)}`,
+  registryRoot: `sha256:${'0'.repeat(64)}`,
   graphRoot: `sha256:${'2'.repeat(64)}`,
   planRoot: `sha256:${'3'.repeat(64)}`,
   receiptDependencyRoot: `sha256:${'4'.repeat(64)}`,
   cutRoot: `sha256:${'5'.repeat(64)}`,
   revision: 7,
+  generation: {
+    schema: 'kungfu.kfx.host-generation/v1',
+    registryRoot: `sha256:${'0'.repeat(64)}`,
+    graphRoot: `sha256:${'2'.repeat(64)}`,
+    cutRoot: `sha256:${'5'.repeat(64)}`,
+    revision: 7,
+  },
+  generationRoot: `sha256:${'6'.repeat(64)}`,
+  admission: {
+    schema: 'kungfu.kfx.host-admission/v1',
+    state: 'admitted',
+    exactRootRequired: true,
+    registryRoot: `sha256:${'0'.repeat(64)}`,
+    graphRoot: `sha256:${'2'.repeat(64)}`,
+    planRoot: `sha256:${'3'.repeat(64)}`,
+    cutRoot: `sha256:${'5'.repeat(64)}`,
+    revision: 7,
+    generationRoot: `sha256:${'6'.repeat(64)}`,
+    contributionRoots: [`sha256:${'7'.repeat(64)}`],
+    facetRoots: [`sha256:${'8'.repeat(64)}`],
+    capabilityRoots: [`sha256:${'9'.repeat(64)}`],
+    authorizationRoots: [`sha256:${'a'.repeat(64)}`],
+  },
   contributions: [
     {
       contributionId: 'workbench',
+      contributionRoot: `sha256:${'7'.repeat(64)}`,
+      ownerProviderRoot: `sha256:${'b'.repeat(64)}`,
+      ownerTrustRoot: `sha256:${'c'.repeat(64)}`,
+      capabilityRoot: `sha256:${'9'.repeat(64)}`,
+      facetRoot: `sha256:${'8'.repeat(64)}`,
+      capabilities: ['domain'],
+      authorization: {
+        schema: 'kungfu.kfx.host-authorization/v1',
+        ownerProviderRoot: `sha256:${'b'.repeat(64)}`,
+        trustRoot: `sha256:${'c'.repeat(64)}`,
+        capabilityRoot: `sha256:${'9'.repeat(64)}`,
+        requiredCapabilities: ['domain'],
+        cutRoot: `sha256:${'5'.repeat(64)}`,
+        revision: 7,
+        authorizationRoot: `sha256:${'a'.repeat(64)}`,
+      },
       state: 'active',
       presentation: { optional: true, hosts: ['gui', 'cli'] },
     },
@@ -23,9 +65,12 @@ const descriptor: KfxExperienceFlowDescriptor = {
 };
 
 test('GUI, TUI, CLI, and Agent adapters retain the same Core identities', () => {
-  const projections = (['gui', 'tui', 'cli', 'agent'] as const).map((host) =>
-    projectKfxExperienceFlowHost(descriptor, host),
-  );
+  const projections = [
+    projectGuiKfxExperienceFlow(descriptor),
+    projectTuiKfxExperienceFlow(descriptor),
+    projectKfxExperienceFlowHost(descriptor, 'cli'),
+    projectKfxExperienceFlowHost(descriptor, 'agent'),
+  ];
   for (const projection of projections) {
     assert.equal(projection.descriptorRoot, descriptor.descriptorRoot);
     assert.equal(projection.graphRoot, descriptor.graphRoot);
@@ -36,9 +81,37 @@ test('GUI, TUI, CLI, and Agent adapters retain the same Core identities', () => 
     );
     assert.equal(projection.cutRoot, descriptor.cutRoot);
     assert.equal(projection.revision, descriptor.revision);
+    assert.equal(projection.generationRoot, descriptor.generationRoot);
+    assert.equal(projection.admissionState, 'admitted');
     assert.equal(projection.contributions[0]?.semanticState, 'active');
   }
   assert.equal(projections[0]?.contributions[0]?.presentationState, 'active');
   assert.equal(projections[1]?.contributions[0]?.presentationState, 'dormant');
-  assert.equal(projections[1]?.contributions[0]?.executionEligible, true);
+  assert.equal(projections[1]?.contributions[0]?.executionEligible, false);
+  assert.equal(
+    projections[1]?.diagnostics[0]?.code,
+    'KF_KFX_PRESENTATION_DORMANT',
+  );
+});
+
+test('preview and mismatched admissions fail closed before host execution', () => {
+  const preview: KfxExperienceFlowDescriptor = structuredClone(descriptor);
+  preview.cutRoot = null;
+  preview.generation.cutRoot = null;
+  preview.admission.cutRoot = null;
+  preview.admission.state = 'preview-only';
+  const previewContribution = preview.contributions[0];
+  assert.ok(previewContribution);
+  previewContribution.authorization.cutRoot = null;
+  const projected = projectKfxExperienceFlowHost(preview, 'gui');
+  assert.equal(projected.admissionState, 'preview-only');
+  assert.equal(projected.contributions[0]?.executionEligible, false);
+  assert.equal(projected.diagnostics[0]?.code, 'KF_KFX_HOST_NOT_ADMITTED');
+
+  const mismatched: KfxExperienceFlowDescriptor = structuredClone(descriptor);
+  mismatched.admission.capabilityRoots[0] = `sha256:${'f'.repeat(64)}`;
+  assert.throws(
+    () => projectKfxExperienceFlowHost(mismatched, 'gui'),
+    /contribution admission identity does not match/,
+  );
 });

--- a/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
@@ -1315,18 +1315,71 @@ json experience_flow_descriptor(const snapshot &value, const lifecycle_view &lif
     const auto observed =
         lifecycle.observed_states.contains(provider_id) ? lifecycle.observed_states.at(provider_id) : "unknown";
     projected["providerState"] = derived_verdict(provider_for(value, provider_id), desired, observed);
+    const auto &provider = provider_for(value, provider_id);
+    const json facet_identity = {{"schema", "kungfu.kfx.presentation-facet/v1"},
+                                 {"contributionRoot", contribution.at("contributionRoot")},
+                                 {"presentation", contribution.value("presentation", json::object())}};
+    const json authorization_identity = {{"schema", "kungfu.kfx.host-authorization/v1"},
+                                         {"ownerProviderRoot", provider.at("providerRoot")},
+                                         {"trustRoot", provider.at("trustRoot")},
+                                         {"capabilityRoot", contribution.at("capabilityRoot")},
+                                         {"requiredCapabilities", contribution.at("capabilities")},
+                                         {"cutRoot", lifecycle.present ? json(lifecycle.cut_root) : json(nullptr)},
+                                         {"revision", lifecycle.revision}};
+    projected["ownerProviderRoot"] = provider.at("providerRoot");
+    projected["ownerTrustRoot"] = provider.at("trustRoot");
+    projected["facetRoot"] = root_of(facet_identity);
+    projected["authorization"] = authorization_identity;
+    projected["authorization"]["authorizationRoot"] = root_of(authorization_identity);
     contributions.push_back(projected);
   }
   const json cut_root = lifecycle.present ? json(lifecycle.cut_root) : json(nullptr);
-  const json receipt_dependency = {{"graphRoot", value.graph_root},
+  const json generation = {{"schema", "kungfu.kfx.host-generation/v1"},
+                           {"registryRoot", value.registry_root},
+                           {"graphRoot", value.graph_root},
+                           {"cutRoot", cut_root},
+                           {"revision", lifecycle.revision}};
+  const auto generation_root = root_of(generation);
+  json contribution_roots = json::array();
+  json facet_roots = json::array();
+  json capability_roots = json::array();
+  json authorization_roots = json::array();
+  for (const auto &contribution : contributions) {
+    contribution_roots.push_back(contribution.at("contributionRoot"));
+    facet_roots.push_back(contribution.at("facetRoot"));
+    capability_roots.push_back(contribution.at("capabilityRoot"));
+    authorization_roots.push_back(contribution.at("authorization").at("authorizationRoot"));
+  }
+  const json admission = {{"schema", "kungfu.kfx.host-admission/v1"},
+                          {"state", lifecycle.present ? "admitted" : "preview-only"},
+                          {"exactRootRequired", true},
+                          {"registryRoot", value.registry_root},
+                          {"graphRoot", value.graph_root},
+                          {"planRoot", plan_root},
+                          {"cutRoot", cut_root},
+                          {"revision", lifecycle.revision},
+                          {"generationRoot", generation_root},
+                          {"contributionRoots", contribution_roots},
+                          {"facetRoots", facet_roots},
+                          {"capabilityRoots", capability_roots},
+                          {"authorizationRoots", authorization_roots}};
+  const json receipt_dependency = {{"registryRoot", value.registry_root},
+                                   {"graphRoot", value.graph_root},
                                    {"planRoot", plan_root},
                                    {"cutRoot", cut_root},
-                                   {"revision", lifecycle.revision}};
-  const json identity = {{"schema", "kungfu.kfx.experience-flow-host/v1"},
+                                   {"revision", lifecycle.revision},
+                                   {"generationRoot", generation_root},
+                                   {"authorizationRoots", authorization_roots}};
+  const json identity = {{"schema", "kungfu.kfx.experience-flow-host/v2"},
+                         {"registryRoot", value.registry_root},
                          {"graphRoot", value.graph_root},
                          {"planRoot", plan_root},
                          {"cutRoot", cut_root},
                          {"revision", lifecycle.revision},
+                         {"generation", generation},
+                         {"generationRoot", generation_root},
+                         {"admission", admission},
+                         {"receiptDependencies", receipt_dependency},
                          {"receiptDependencyRoot", root_of(receipt_dependency)},
                          {"hosts", json::array({"gui", "tui", "cli", "agent"})},
                          {"contributions", contributions}};

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
@@ -4,6 +4,6 @@
   "lifecycleReceiptDependencyRoot": "sha256:683bbc2f5d8d6bbbaa6acefba35681b0999c7b80b1d83a9e6d7d633863dfc33f",
   "lifecycleRegistryRoot": "sha256:7be373f60bbad5fc9dea25623e5d94ffbddc7cf426bcce0682c3f91e8b27cfd2",
   "semanticGraphRoot": "sha256:18955819ef0c42e541666d88f5f6f951485f47034f5d137f34cd2bb5be21e6fd",
-  "semanticHostReceiptDependencyRoot": "sha256:fb309c54e9faae8d7297f294539d46773be89368273b7c5a4fdeec5d10ac36e1",
+  "semanticHostReceiptDependencyRoot": "sha256:a7d75ec5b794070541dd41069a26e032b8ef347e3a8f5a7cde0aa49e8e296bec",
   "semanticPlanRoot": "sha256:23abcb9530839f169f7ea757c1f055a91d2ea5e13be5b6b8f611e9f907c1c708"
 }

--- a/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
@@ -525,9 +525,13 @@ void test_semantic_graph_and_host_contract_are_canonical() {
           "contributes-to composition transferred extension-point ownership");
   require(contribution.at("state") == "active", "optional provider loss hid an active semantic contribution");
   const auto &host = first.at("hostContract");
-  require(host.at("schema") == "kungfu.kfx.experience-flow-host/v1" && host.at("planRoot") == first.at("planRoot") &&
+  require(host.at("schema") == "kungfu.kfx.experience-flow-host/v2" && host.at("planRoot") == first.at("planRoot") &&
               host.at("graphRoot") == first.at("graphRoot"),
           "Experience/Flow descriptor did not bind the exact graph and plan");
+  require(host.at("admission").at("state") == "preview-only" && host.at("cutRoot").is_null() &&
+              host.at("generation").at("revision") == 0 &&
+              host.at("contributions").front().at("authorization").at("cutRoot").is_null(),
+          "observation-only host descriptor claimed executable admission");
   require(host.at("contributions").front().at("surface") == "experience",
           "host descriptor lost the surface-neutral Experience contribution");
 
@@ -660,6 +664,11 @@ void test_native_lifecycle_uses_fact_work_and_named_cut_authority() {
           "native lifecycle did not atomically materialize the package");
   require(!fs::exists(runtime_dir / "kfx" / "registry-history.jsonl"),
           "native lifecycle recreated a KFX-specific authority journal");
+  const auto admitted_plan = kfx::query_native_kfx_registry("plan", nlohmann::json::object(), runtime_dir.string());
+  require(admitted_plan.at("hostContract").at("admission").at("state") == "admitted" &&
+              admitted_plan.at("hostContract").at("cutRoot") == install.at("cutRoot") &&
+              admitted_plan.at("hostContract").at("generation").at("revision") == 1,
+          "settled Fact Cut did not produce one exact admitted host generation");
 
   require_refusal("KF_KFX_CUT_STALE", [&] {
     (void)kfx::query_native_kfx_registry(

--- a/framework/core/src/python/kungfu/kfx_host.py
+++ b/framework/core/src/python/kungfu/kfx_host.py
@@ -13,24 +13,77 @@ def project_experience_flow_host(
 ) -> dict[str, Any]:
     """Retain Core identities while adding only host-native availability."""
 
-    if descriptor.get("schema") != "kungfu.kfx.experience-flow-host/v1":
+    if descriptor.get("schema") != "kungfu.kfx.experience-flow-host/v2":
         raise ValueError("unsupported KFX Experience/Flow host descriptor")
     if host not in HOSTS:
         raise ValueError(f"unsupported KFX host: {host}")
     for field in (
         "descriptorRoot",
+        "registryRoot",
         "graphRoot",
         "planRoot",
         "receiptDependencyRoot",
         "cutRoot",
         "revision",
+        "generation",
+        "generationRoot",
+        "admission",
         "contributions",
     ):
         if field not in descriptor:
             raise ValueError(f"KFX host descriptor is missing {field}")
 
+    admission = descriptor["admission"]
+    generation = descriptor["generation"]
+    if (
+        admission.get("schema") != "kungfu.kfx.host-admission/v1"
+        or admission.get("exactRootRequired") is not True
+        or admission.get("registryRoot") != descriptor["registryRoot"]
+        or admission.get("graphRoot") != descriptor["graphRoot"]
+        or admission.get("planRoot") != descriptor["planRoot"]
+        or admission.get("cutRoot") != descriptor["cutRoot"]
+        or admission.get("revision") != descriptor["revision"]
+        or admission.get("generationRoot") != descriptor["generationRoot"]
+        or generation.get("registryRoot") != descriptor["registryRoot"]
+        or generation.get("graphRoot") != descriptor["graphRoot"]
+        or generation.get("cutRoot") != descriptor["cutRoot"]
+        or generation.get("revision") != descriptor["revision"]
+        or (admission.get("state") == "admitted") != (descriptor["cutRoot"] is not None)
+    ):
+        raise ValueError("KFX host descriptor admission identity does not match")
+
+    diagnostics = []
+    if admission["state"] != "admitted":
+        diagnostics.append(
+            {
+                "code": "KF_KFX_HOST_NOT_ADMITTED",
+                "recoveryGuidance": ["settle-exact-kfx-fact-cut"],
+            }
+        )
     contributions = []
     for contribution in descriptor["contributions"]:
+        try:
+            index = admission["contributionRoots"].index(
+                contribution["contributionRoot"]
+            )
+        except (KeyError, ValueError) as error:
+            raise ValueError(
+                "KFX host contribution admission identity does not match"
+            ) from error
+        authorization = contribution.get("authorization") or {}
+        if (
+            admission["facetRoots"][index] != contribution.get("facetRoot")
+            or admission["capabilityRoots"][index] != contribution.get("capabilityRoot")
+            or admission["authorizationRoots"][index]
+            != authorization.get("authorizationRoot")
+            or authorization.get("ownerProviderRoot")
+            != contribution.get("ownerProviderRoot")
+            or authorization.get("trustRoot") != contribution.get("ownerTrustRoot")
+            or authorization.get("capabilityRoot") != contribution.get("capabilityRoot")
+            or authorization.get("cutRoot") != descriptor["cutRoot"]
+            or authorization.get("revision") != descriptor["revision"]
+        ):
+            raise ValueError("KFX host contribution admission identity does not match")
         projection = dict(contribution)
         presentation = contribution.get("presentation") or {}
         supported = host in presentation.get("hosts", [])
@@ -40,9 +93,18 @@ def project_experience_flow_host(
             "active" if supported else "dormant" if optional else "degraded"
         )
         projection["executionEligible"] = (
-            contribution["state"] == "active"
-            and projection["presentationState"] != "degraded"
+            admission["state"] == "admitted"
+            and contribution["state"] == "active"
+            and projection["presentationState"] == "active"
         )
+        if projection["presentationState"] == "dormant":
+            diagnostics.append(
+                {
+                    "code": "KF_KFX_PRESENTATION_DORMANT",
+                    "contributionRoot": contribution["contributionRoot"],
+                    "recoveryGuidance": [f"install-optional-{host}-presentation"],
+                }
+            )
         contributions.append(projection)
 
     return {
@@ -54,5 +116,20 @@ def project_experience_flow_host(
         "receiptDependencyRoot": descriptor["receiptDependencyRoot"],
         "cutRoot": descriptor["cutRoot"],
         "revision": descriptor["revision"],
+        "generationRoot": descriptor["generationRoot"],
+        "admissionState": admission["state"],
+        "diagnostics": diagnostics,
         "contributions": contributions,
     }
+
+
+def project_cli_experience_flow_host(
+    descriptor: dict[str, Any],
+) -> dict[str, Any]:
+    return project_experience_flow_host(descriptor, "cli")
+
+
+def project_agent_experience_flow_host(
+    descriptor: dict[str, Any],
+) -> dict[str, Any]:
+    return project_experience_flow_host(descriptor, "agent")

--- a/framework/core/tests/python/test_native_kfx_contract.py
+++ b/framework/core/tests/python/test_native_kfx_contract.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from kungfu import kfx_contract, kfx_host
@@ -158,9 +159,35 @@ def test_python_and_host_projections_preserve_core_semantic_roots(tmp_path):
     assert {projection["revision"] for projection in projections} == {
         plan["hostContract"]["revision"]
     }
+    assert {projection["generationRoot"] for projection in projections} == {
+        plan["hostContract"]["generationRoot"]
+    }
+    assert {projection["admissionState"] for projection in projections} == {
+        "preview-only"
+    }
+    assert all(
+        not projection["contributions"][0]["executionEligible"]
+        for projection in projections
+    )
     tui = next(item for item in projections if item["host"] == "tui")
     assert tui["contributions"][0]["semanticState"] == "active"
     assert tui["contributions"][0]["presentationState"] == "dormant"
+    assert tui["diagnostics"][0]["code"] == "KF_KFX_HOST_NOT_ADMITTED"
+    assert (
+        kfx_host.project_cli_experience_flow_host(plan["hostContract"])["planRoot"]
+        == plan["planRoot"]
+    )
+    assert (
+        kfx_host.project_agent_experience_flow_host(plan["hostContract"])["planRoot"]
+        == plan["planRoot"]
+    )
+
+    mismatched = json.loads(json.dumps(plan["hostContract"]))
+    mismatched["admission"]["capabilityRoots"][0] = "sha256:" + "f" * 64
+    with pytest.raises(
+        ValueError, match="contribution admission identity does not match"
+    ):
+        kfx_host.project_experience_flow_host(mismatched, "gui")
 
 
 def test_native_kfx_cli_projects_the_same_plan_root(tmp_path):

--- a/framework/gui/src/main/kfx-host.ts
+++ b/framework/gui/src/main/kfx-host.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type KfxExperienceFlowDescriptor,
+  projectKfxExperienceFlowHost,
+} from '@kungfu-tech/api/capability';
+
+// Electron remains a renderer/transport host. Core supplies every semantic,
+// admission, capability, authorization, generation, and receipt identity.
+export function projectGuiKfxExperienceFlow(
+  descriptor: KfxExperienceFlowDescriptor,
+) {
+  return projectKfxExperienceFlowHost(descriptor, 'gui');
+}

--- a/framework/tui/src/kfx-host.ts
+++ b/framework/tui/src/kfx-host.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  type KfxExperienceFlowDescriptor,
+  projectKfxExperienceFlowHost,
+} from '@kungfu-tech/api/capability';
+
+// Ink owns presentation only; it cannot reinterpret Core admission.
+export function projectTuiKfxExperienceFlow(
+  descriptor: KfxExperienceFlowDescriptor,
+) {
+  return projectKfxExperienceFlowHost(descriptor, 'tui');
+}


### PR DESCRIPTION
## Summary

Publish one Core-owned Experience/Flow host descriptor that binds contribution, owner, graph, plan, generation, capability, authorization and receipt identities for GUI, TUI, CLI and Agent consumers.

This is the host-contract prerequisite inside the third ordered successor slice for Atlas Assignment `2026-07-27-kungfu-native-kfx-registry-foundation-conversion-ready`. It is intentionally stacked on #1624. It does not merge, queue, or independently settle the parent; the Control Suite recursive-dogfood gate remains next.

## Changes

- upgrade the Core host descriptor to `kungfu.kfx.experience-flow-host/v2`
- bind the exact registry, graph, plan, Cut/revision, generation, contribution, facet, capability, trust and authorization roots
- fail closed before execution for preview-only or mismatched exact admissions
- expose thin TypeScript and Python projections without semantic or mutation authority
- add representative GUI, TUI, CLI and Agent adapters that preserve the same Core identities
- keep missing optional presentation typed as dormant while the semantic contribution remains active
- update the one expected host receipt-dependency root
- leave protected Agent Qualification Lab files and PR #1585 unchanged

## Verification

- `./shifu build:core`
- `./shifu test:native-kfx-admission`
- `./shifu check` (after `./shifu pack:spec` materialized the ignored Spec test prerequisite)
- native KFX CTest: 2/2 passed
- Python native KFX + ActionEnvelope: 13/13 passed
- public API host/storage projection: 6/6 passed
- Node native binding root parity: 2/2 passed
- GUI/TUI/CLI/Agent exact-root adapter test: 2/2 passed
- Qualification Lab / PR #1585 isolation: passed with 0 protected changes

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": [
    "KF-ADR-019f86da-4f90-72df-add3-948f3ae38c3a"
  ],
  "summary": "Bind one surface-neutral KFX host descriptor without claiming the later recursive Control Suite gate or parent settlement.",
  "verification": [
    "./shifu build:core",
    "./shifu test:native-kfx-admission",
    "./shifu check"
  ]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No package was published and no deployment occurred. The generated Spec artifact was ignored local verification input only.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Exact-root host and cross-language tests pass
- [x] Parent #1624 remains open and unqueued
