### PR TITLE
feat(agent): add repository work experiment

### DIFF
--- a/.github/workflows/opencode-agent-repository-work.yml
+++ b/.github/workflows/opencode-agent-repository-work.yml
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: OpenCode Agent Repository Work Experiment
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: opencode-agent-repository-work
+  cancel-in-progress: false
+
+jobs:
+  experiment:
+    name: agent-120 / two-session Qwen3-Coder
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - agent-120
+      - kungfu-build
+    timeout-minutes: 45
+    env:
+      OPENCODE_IMAGE: ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3
+      OPENCODE_MODEL: qwen3-coder:30b-opencode-64k
+      OPENCODE_BASE_URL: http://host.docker.internal:11435/v1
+      OPENCODE_HOST_PROBE_URL: http://172.17.0.1:11435/v1/models
+    steps:
+      - name: Check out exact requested source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify trusted runner and local-model runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "agent-120-kungfu-systems"
+          # shifu-entry-contract: allow trusted runner Node version probe before workspace execution
+          test "$(node --version | cut -d. -f1)" = "v24"
+          docker image inspect "$OPENCODE_IMAGE" >/dev/null
+          curl -fsS --max-time 5 "$OPENCODE_HOST_PROBE_URL" >/dev/null
+
+      - name: Install and build exact Kungfu source
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./shifu install --frozen-lockfile
+          ./shifu build:core
+          ./shifu test:agent-repository-work
+
+      - name: Run two fresh OpenCode sessions through Kungfu
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/agent-repository-work-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          printf 'AGENT_REPOSITORY_WORK_EVIDENCE=%s\n' "$evidence_dir" >>"$GITHUB_ENV"
+          ./shifu qualify:agent-repository-work -- \
+            --output "$evidence_dir" \
+            --image "$OPENCODE_IMAGE" \
+            --model "$OPENCODE_MODEL" \
+            --base-url "$OPENCODE_BASE_URL" \
+            --source-head "$GITHUB_SHA" \
+            --timeout-seconds 900
+          jq -e \
+            '.passed == true
+             and .sessions.distinct == 2
+             and .continuity.priorTranscriptBytes == 0
+             and .continuity.humanRestatementCount == 0
+             and .warrant.agentAZeroModification == true
+             and .oracle.passed == true
+             and .oracle.authoritative == true' \
+            "$evidence_dir/agent-repository-work-report.json" >/dev/null
+
+      - name: Upload bounded pass/fail evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: agent-repository-work-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.AGENT_REPOSITORY_WORK_EVIDENCE }}/agent-repository-work-report.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/document-metadata.registry.json
+++ b/docs/document-metadata.registry.json
@@ -1214,6 +1214,25 @@
         "invisible_context_boundary": "provider internals, private session stores, unobserved release artifacts, and hidden model checkpoints are not claimed"
       }
     },
+    "docs/qualification/agent-repository-work-experiment.md": {
+      "metadata_schema": "kungfu.document-metadata/v1",
+      "document_status": "draft",
+      "doc_type": "qualification-guide",
+      "review_state": "self-reviewed",
+      "sensitivity": "public",
+      "sources": ["executable-probe", "local-files", "user-consensus"],
+      "period": "2026-07-27",
+      "theme": "local-agent-repository-work",
+      "confidence": "high",
+      "evidence_grade": "B",
+      "last_reviewed": "2026-07-27",
+      "ai_provenance": {
+        "model_family": "OpenAI GPT-5",
+        "product": "Codex",
+        "generated_at": "2026-07-27",
+        "invisible_context_boundary": "provider internals, hidden model checkpoints, private session stores, and generalized product claims are not claimed"
+      }
+    },
     "docs/qualification/fact-storage-authority.md": {
       "metadata_schema": "kungfu.document-metadata/v1",
       "document_status": "active",

--- a/docs/qualification/README.md
+++ b/docs/qualification/README.md
@@ -30,6 +30,7 @@ implemented behavior, retained evidence, and released guarantees. Begin with
 - [Native Dogfood Feedback-loop Qualification](native-dogfood-feedback-loop.md)
 - [Continuity Pilot v1](continuity-pilot.md)
 - [`kungfu run agent` OpenCode Continuity](run-agent-opencode-continuity.md)
+- [Local-agent Repository-work Experiment](agent-repository-work-experiment.md)
 - [Auditable Demo Artifact Pipeline](auditable-demo-artifact-pipeline.md)
 - [Layer Gate Timing Baseline](layer-gate-timing-baseline.md)
 - [KFD-2 Trust Assessment](kfd2-trust-assessment.md)

--- a/docs/qualification/agent-repository-work-experiment.md
+++ b/docs/qualification/agent-repository-work-experiment.md
@@ -1,0 +1,89 @@
+# Local-agent repository-work experiment
+
+This independent experiment asks whether Kungfu can carry enough bounded work
+state between two fresh OpenCode processes to support a moderately complex
+repository repair. It is deliberately separate from Auditable Demo,
+Qualification Lab, release Gates, public capability claims, and model ranking.
+
+```text
+49-file / 2433-line Python fixture with a seeded defect
+-> fresh Agent A investigates under a read-only Warrant
+-> deterministic assessment accepts only a bounded partial Claim
+-> Kungfu admits a content-rooted continuation envelope
+-> fresh Agent B receives no transcript or human task restatement
+-> Agent B may change only three production modules
+-> an external visible-plus-hidden oracle decides pass or fail
+```
+
+The fixture implements an append-only incident board. Its seeded defect permits
+an expired lease to complete work and counts historical retry completions more
+than once after restart. The repository uses only the Python standard library.
+
+## Trust boundaries
+
+- Agent A runs with a read-only workspace mount. A byte-level tree comparison
+  must also prove zero production changes.
+- Agent B receives a writable disposable fixture, but its Warrant permits only
+  `incident_board/commands.py`, `incident_board/lease.py`, and
+  `incident_board/replay.py`.
+- The reference repair and hidden oracle stay on the host and are never mounted
+  into either Agent container.
+- A successful OpenCode process exit and natural-language self-report are
+  observations, not completion authority.
+- The deterministic oracle rejects protected-file changes, added files,
+  symlinks, visible-test failure, or hidden-test failure.
+- Retained evidence contains content roots and bounded outcome dimensions, not
+  provider transcripts, repository bytes, credentials, or hidden tests.
+
+The machine-readable contract is
+[`contract.json`](../../tests/qualification/agent-repository-work/contract.json).
+
+## Local deterministic checks
+
+The local test does not invoke a model:
+
+```bash
+./shifu test:agent-repository-work
+```
+
+It proves that the seeded fixture fails at the intended two tests, the
+independent reference repair passes all visible and hidden checks, and tampering
+outside the three-file Warrant fails closed.
+
+## Trusted agent-120 run
+
+The manual
+[`opencode-agent-repository-work.yml`](../../.github/workflows/opencode-agent-repository-work.yml)
+workflow is the authoritative execution path. It requires:
+
+- trusted self-hosted runner `agent-120-kungfu-systems`;
+- the digest-pinned `opencode-ci` image;
+- local model `qwen3-coder:30b-opencode-64k`;
+- the explicit OpenAI-compatible endpoint on port `11435`;
+- two fresh OpenCode processes launched through native `kungfu run agent`;
+- a disposable workspace and fresh Kungfu/XDG state;
+- read-only container roots, dropped capabilities, no-new-privileges, bounded
+  memory, CPU, PIDs, and timeout; and
+- one bounded report retained for 14 days.
+
+For a direct trusted-host invocation:
+
+```bash
+./shifu build:core
+./shifu qualify:agent-repository-work -- \
+  --output /tmp/kungfu-agent-repository-work \
+  --image ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3 \
+  --model qwen3-coder:30b-opencode-64k \
+  --base-url http://host.docker.internal:11435/v1
+```
+
+The resulting `agent-repository-work-report.json` records execution,
+correctness, scope, continuity, evidence, efficiency, and residual limitations.
+A pass is bounded to this fixture, image, model, endpoint, and runner.
+
+## Residual limitations
+
+This experiment does not establish multi-day durability, concurrent editing,
+arbitrary repository competence, provider superiority, production safety,
+GUI/TUI parity, or release readiness. A single passing run is evidence that the
+tested path bore this workload; it is not a generalized product claim.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1739,6 +1739,60 @@
       ]
     },
     {
+      "path": ".github/workflows/opencode-agent-repository-work.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:1cb29566a9b397c3028374379a1b78b1b764083045cda6ba78bf670926774d8c",
+      "jobs": [
+        {
+          "id": "experiment",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:dfaabde68ca8fbe5350128831ba91222db8b38af927f2b9af7622781ac92eaca",
+          "credentials": {
+            "githubToken": "read",
+            "oidc": false,
+            "repositorySecrets": [],
+            "inheritedSecrets": false,
+            "environment": null
+          },
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Check out exact requested source",
+              "authority": "qualification",
+              "definitionDigest": "sha256:8dadccb662572a36e399d8e49b2d322f8bfd05795c0ccfc318f9467d456738af"
+            },
+            {
+              "index": 2,
+              "label": "name:Verify trusted runner and local-model runtime",
+              "authority": "qualification",
+              "definitionDigest": "sha256:5adf31a595ebc0f5a293750189dc15ca3ab7606595a87fbb551bb67ca0358cf7"
+            },
+            {
+              "index": 3,
+              "label": "name:Install and build exact Kungfu source",
+              "authority": "qualification",
+              "definitionDigest": "sha256:815183de19d5ab01d9425cd24cb6b362832291eecd1c0332678171eb6bdbfe57"
+            },
+            {
+              "index": 4,
+              "label": "name:Run two fresh OpenCode sessions through Kungfu",
+              "authority": "qualification",
+              "definitionDigest": "sha256:c631b34757f41ccc053a34122e4fba284a0453b6f1b30e924d5e930149a9fd5a"
+            },
+            {
+              "index": 5,
+              "label": "name:Upload bounded pass/fail evidence",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:ba7814e0fe536957d76700a6c8eba798362b3ce673b565cd7d5f075d091f3ea0"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": ".github/workflows/opencode-local-model-canary.yml",
       "authority": "qualification",
       "definitionDigest": "sha256:7d70ef34c7fd9bc2fd9e42d9b9aa5e500223527e10cbaa1f6f04ed7d5aef1c85",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -78,6 +78,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/gate-measurement.yml` | `focused` | qualification | none | diagnostic | token:read | none | 7 |
 | `.github/workflows/gate-measurement.yml` | `measure` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/kfd-verifier-drift.yml` | `verify-owned-fixtures` | qualification | none | qualifying | token:read | none | 4 |
+| `.github/workflows/opencode-agent-repository-work.yml` | `experiment` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/opencode-local-model-canary.yml` | `canary` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/publish-layer-artifacts.yml` | `prepare` | qualification | none | diagnostic | token:read | none | 11 |
 | `.github/workflows/publish-layer-artifacts.yml` | `publish` | product-publication | product | none | token:write, oidc | `adr0049-production-publication` | 9 |

--- a/framework/agent-repository-work/opencode-docker-proxy.mjs
+++ b/framework/agent-repository-work/opencode-docker-proxy.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Internal least-privilege adapter for the repository-work experiment.
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+function fail(message) {
+  process.stderr.write(`opencode-docker-proxy: ${message}\n`);
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const result = {
+    image: '',
+    baseUrl: '',
+    model: '',
+    context: 65_536,
+    mode: '',
+    command: [],
+  };
+  let index = 0;
+  for (; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--') {
+      result.command = argv.slice(index + 1);
+      break;
+    }
+    if (value === '--image') result.image = argv[++index] || '';
+    else if (value === '--base-url') result.baseUrl = argv[++index] || '';
+    else if (value === '--model') result.model = argv[++index] || '';
+    else if (value === '--context')
+      result.context = Number.parseInt(argv[++index] || '', 10);
+    else if (value === '--mode') result.mode = argv[++index] || '';
+    else fail(`unknown proxy argument: ${value}`);
+  }
+  if (!result.image.includes('@sha256:'))
+    fail('--image must be pinned by digest');
+  if (!/^https?:\/\/[^/]+(?::[0-9]+)?\/v1$/u.test(result.baseUrl))
+    fail('--base-url must be an explicit HTTP(S) /v1 endpoint');
+  if (!result.model || result.model.includes('/'))
+    fail('--model must be a non-empty provider-local identifier');
+  if (!Number.isInteger(result.context) || result.context < 8_192)
+    fail('--context must be an integer of at least 8192');
+  if (!['read-only', 'bounded-write'].includes(result.mode))
+    fail('--mode must be read-only or bounded-write');
+  if (result.command[0] !== 'run')
+    fail('only the OpenCode run command is supported');
+  return result;
+}
+
+function config({ baseUrl, model, context, mode }) {
+  const writePermission = mode === 'read-only' ? 'deny' : 'allow';
+  return JSON.stringify({
+    $schema: 'https://opencode.ai/config.json',
+    autoupdate: false,
+    share: 'disabled',
+    permission: {
+      '*': 'deny',
+      read: 'allow',
+      list: 'allow',
+      glob: 'allow',
+      grep: 'allow',
+      edit: writePermission,
+      bash: 'allow',
+      external_directory: 'deny',
+    },
+    provider: {
+      local: {
+        npm: '@ai-sdk/openai-compatible',
+        name: 'Runtime supplied local provider',
+        options: { baseURL: baseUrl },
+        models: {
+          [model]: {
+            name: model,
+            limit: { context, output: 8_192 },
+          },
+        },
+      },
+    },
+  });
+}
+
+export function dockerArgs(options, cwd = process.cwd()) {
+  const uid = typeof process.getuid === 'function' ? process.getuid() : 1000;
+  const gid = typeof process.getgid === 'function' ? process.getgid() : 1000;
+  const volume =
+    options.mode === 'read-only' ? `${cwd}:/workspace:ro` : `${cwd}:/workspace`;
+  return [
+    'run',
+    '--rm',
+    '--user',
+    `${uid}:${gid}`,
+    '--read-only',
+    '--tmpfs',
+    '/tmp:rw,noexec,nosuid,nodev,size=512m',
+    '--cap-drop',
+    'ALL',
+    '--security-opt',
+    'no-new-privileges',
+    '--pids-limit',
+    '256',
+    '--memory',
+    '8g',
+    '--cpus',
+    '4',
+    '--network',
+    'bridge',
+    '--add-host',
+    'host.docker.internal:host-gateway',
+    '--volume',
+    volume,
+    '--workdir',
+    '/workspace',
+    '--env',
+    'HOME=/tmp/opencode-home',
+    '--env',
+    'XDG_CONFIG_HOME=/tmp/opencode-config',
+    '--env',
+    'XDG_DATA_HOME=/tmp/opencode-data',
+    '--env',
+    'XDG_STATE_HOME=/tmp/opencode-state',
+    '--env',
+    'XDG_CACHE_HOME=/tmp/opencode-cache',
+    '--env',
+    'PYTHONDONTWRITEBYTECODE=1',
+    '--env',
+    `OPENCODE_CONFIG_CONTENT=${config(options)}`,
+    options.image,
+    'opencode',
+    ...options.command,
+  ];
+}
+
+export function runProxy(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const result = spawnSync('docker', dockerArgs(options), {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    process.stderr.write(`${result.error.message}\n`);
+    return 127;
+  }
+  if (result.signal) {
+    process.stderr.write(`docker terminated by ${result.signal}\n`);
+    return 128;
+  }
+  return result.status ?? 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`)
+  process.exitCode = runProxy();

--- a/framework/agent-repository-work/run.mjs
+++ b/framework/agent-repository-work/run.mjs
@@ -1,0 +1,745 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  materializeIncidentBoardFixture,
+  qualifySeededIncidentBoardFixture,
+  verifyIncidentBoardWorkspace,
+} from '../../tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs';
+import { INCIDENT_BOARD_FIXTURE } from '../../tests/qualification/agent-repository-work/incident-board-replay-v1.mjs';
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+const PROXY_PATH = path.join(
+  ROOT,
+  'framework/agent-repository-work/opencode-docker-proxy.mjs',
+);
+const CONTRACT_PATH = path.join(
+  ROOT,
+  'tests/qualification/agent-repository-work/contract.json',
+);
+const REPORT_SCHEMA = 'kungfu.agent-repository-work.report/v1';
+const PROFILE_SCHEMA = 'kungfu.agent-runtime-profile/v1';
+const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const DEFAULT_IMAGE =
+  'ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3';
+const DEFAULT_MODEL = 'qwen3-coder:30b-opencode-64k';
+const DEFAULT_BASE_URL = 'http://host.docker.internal:11435/v1';
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object')
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonical(value[key])]),
+    );
+  return value;
+}
+
+export function jsonRoot(value) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(JSON.stringify(canonical(value)))
+    .digest('hex')}`;
+}
+
+function fileRoot(file) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(file))
+    .digest('hex')}`;
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const result = {
+    output: '',
+    image: DEFAULT_IMAGE,
+    model: DEFAULT_MODEL,
+    baseUrl: DEFAULT_BASE_URL,
+    opencode: '',
+    sourceHead: '',
+    timeoutSeconds: 900,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue;
+    if (arg === '--output') result.output = argv[++index] || '';
+    else if (arg === '--image') result.image = argv[++index] || '';
+    else if (arg === '--model') result.model = argv[++index] || '';
+    else if (arg === '--base-url') result.baseUrl = argv[++index] || '';
+    else if (arg === '--opencode') result.opencode = argv[++index] || '';
+    else if (arg === '--source-head') result.sourceHead = argv[++index] || '';
+    else if (arg === '--timeout-seconds')
+      result.timeoutSeconds = Number.parseInt(argv[++index] || '', 10);
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!Number.isInteger(result.timeoutSeconds) || result.timeoutSeconds < 60)
+    throw new Error('--timeout-seconds must be an integer of at least 60');
+  if (!result.opencode && !result.image.includes('@sha256:'))
+    throw new Error('--image must be pinned by digest');
+  return result;
+}
+
+function command(commandName, args, options = {}) {
+  const result = spawnSync(commandName, args, {
+    cwd: options.cwd || ROOT,
+    env: { ...process.env, ...(options.env || {}) },
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: options.timeout || 120_000,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const evidence = `${result.stdout || ''}\n${result.stderr || ''}`;
+    const error = new Error(
+      `${commandName} exited ${result.status}; output root ${jsonRoot(evidence)}`,
+    );
+    error.command = commandName;
+    error.status = result.status;
+    error.outputRoot = jsonRoot(evidence);
+    throw error;
+  }
+  return result.stdout;
+}
+
+function currentHead() {
+  return command('git', ['rev-parse', 'HEAD']).trim();
+}
+
+function pythonKungfu(args, { home, configHome, cwd, timeout }) {
+  const pythonPath = [
+    path.join(ROOT, 'framework/core/src/python'),
+    process.env.KUNGFU_NATIVE_PATH ||
+      path.join(ROOT, 'framework/core/build/Release'),
+    process.env.PYTHONPATH,
+  ]
+    .filter(Boolean)
+    .join(path.delimiter);
+  return command(
+    'uv',
+    [
+      'run',
+      '--project',
+      path.join(ROOT, 'framework/core'),
+      '--frozen',
+      'python',
+      '-m',
+      'kungfu',
+      '--home',
+      home,
+      ...args,
+    ],
+    {
+      cwd,
+      timeout,
+      env: {
+        PYTHONPATH: pythonPath,
+        KF_CONFIG_HOME: configHome,
+        KUNGFU_CONFIG_CONTRACT: path.join(
+          ROOT,
+          'framework/config/kungfu-config.contract.json',
+        ),
+      },
+    },
+  );
+}
+
+function treeRows(workspace) {
+  const rows = [];
+  function walk(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      const relative = path
+        .relative(workspace, absolute)
+        .split(path.sep)
+        .join('/');
+      const stats = fs.lstatSync(absolute);
+      if (stats.isSymbolicLink())
+        throw new Error(`workspace symlink is forbidden: ${relative}`);
+      if (stats.isDirectory()) walk(absolute);
+      else if (stats.isFile())
+        rows.push({
+          path: relative,
+          bytes: stats.size,
+          root: fileRoot(absolute),
+        });
+    }
+  }
+  walk(workspace);
+  return rows.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function runtimeProfile({
+  id,
+  mode,
+  model,
+  image,
+  baseUrl,
+  opencode,
+  agent,
+}) {
+  const nodeAdapter = opencode.endsWith('.mjs');
+  const executable = !opencode || nodeAdapter ? process.execPath : opencode;
+  const prefix = opencode
+    ? nodeAdapter
+      ? [path.resolve(opencode)]
+      : []
+    : [
+        PROXY_PATH,
+        '--image',
+        image,
+        '--base-url',
+        baseUrl,
+        '--model',
+        model,
+        '--context',
+        '65536',
+        '--mode',
+        mode,
+        '--',
+      ];
+  return {
+    schema: PROFILE_SCHEMA,
+    id,
+    label: `OpenCode repository work ${mode}`,
+    provider: 'opencode',
+    launch: {
+      executable,
+      argv: [
+        ...prefix,
+        'run',
+        '--pure',
+        '--model',
+        `local/${model}`,
+        '--agent',
+        agent,
+        '--format',
+        'json',
+      ],
+      shellMode: false,
+    },
+    cwdPolicy: 'workspace-root',
+    backendDefault: 'direct',
+    bootstrap: { adapter: 'opencode', envelope: 'required' },
+    source: 'user',
+    lastVerified: null,
+  };
+}
+
+function configureProfile(profile, context) {
+  const args = [
+    'agent',
+    'runtime',
+    'upsert',
+    '--id',
+    profile.id,
+    '--label',
+    profile.label,
+    '--provider',
+    profile.provider,
+    '--executable',
+    profile.launch.executable,
+    ...profile.launch.argv.flatMap((arg) => [`--arg=${arg}`]),
+    '--cwd-policy',
+    profile.cwdPolicy,
+    '--backend',
+    profile.backendDefault,
+    '--envelope',
+    profile.bootstrap.envelope,
+    '--execute',
+    '--json',
+  ];
+  return JSON.parse(pythonKungfu(args, context));
+}
+
+function providerSessionId(run, label) {
+  const values = run.providerObservation?.providerSessionIds || [];
+  if (values.length !== 1)
+    throw new Error(`${label} must expose exactly one provider session id`);
+  return values[0];
+}
+
+export function parseInvestigationClaim(text) {
+  if (typeof text !== 'string' || !text.trim())
+    throw new Error('Agent A returned no investigation claim');
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/iu);
+  const source =
+    fenced?.[1] || text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1);
+  const value = JSON.parse(source);
+  const expectedFailures = [
+    'test_expired_lease_cannot_complete',
+    'test_legacy_duplicate_log_has_stable_restart_summary',
+  ];
+  const expectedPaths = [
+    ...INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths,
+  ].sort();
+  if (
+    value?.schema !== 'kungfu.agent-repository-work.investigation-claim/v1' ||
+    value.investigationComplete !== true ||
+    JSON.stringify([...(value.failingTests || [])].sort()) !==
+      JSON.stringify(expectedFailures) ||
+    JSON.stringify([...(value.repairPaths || [])].sort()) !==
+      JSON.stringify(expectedPaths) ||
+    value.remainingObligation !== 'implement-and-verify-bounded-repair' ||
+    value.nextAction !== 'repair-seeded-completion-idempotency'
+  )
+    throw new Error(
+      'Agent A investigation claim failed deterministic assessment',
+    );
+  return value;
+}
+
+function classifyFailure(error) {
+  const message = String(error?.message || error);
+  if (/oracle|visible|hidden|seeded|test/iu.test(message)) return 'verifier';
+  if (/scope|symlink|writable|tree|modified/iu.test(message))
+    return 'warrant-scope';
+  if (/continuation|WorkRef|claim|assessment/iu.test(message))
+    return 'kungfu-continuity';
+  if (/timeout|timed out/iu.test(message)) return 'timeout';
+  if (/docker|opencode|provider session|profile/iu.test(message))
+    return 'model-tool-runtime';
+  return 'runner-environment';
+}
+
+export function validateExperimentReport(report) {
+  if (report?.schema !== REPORT_SCHEMA)
+    throw new Error('repository-work report schema is unsupported');
+  if (report.evidenceClass !== 'bounded-experiment')
+    throw new Error('repository-work evidence class must stay bounded');
+  if (report.nonClaims?.auditableDemo !== true)
+    throw new Error('Auditable Demo non-integration boundary is required');
+  if (report.nonClaims?.qualificationLab !== true)
+    throw new Error('Qualification Lab non-integration boundary is required');
+  if (
+    report.nonClaims?.releaseGate !== true ||
+    report.nonClaims?.publicClaim !== true
+  )
+    throw new Error('release and public-claim boundaries are required');
+  if (report.passed) {
+    if (report.sessions?.distinct !== 2)
+      throw new Error('exactly two fresh provider sessions are required');
+    if (report.continuity?.priorTranscriptBytes !== 0)
+      throw new Error('Agent B must receive zero prior transcript bytes');
+    if (report.continuity?.humanRestatementCount !== 0)
+      throw new Error('Agent B must receive no human task restatement');
+    if (report.warrant?.agentAZeroModification !== true)
+      throw new Error('Agent A modified the production fixture');
+    if (report.oracle?.passed !== true || report.oracle?.authoritative !== true)
+      throw new Error('external deterministic oracle is authoritative');
+    if (
+      report.sessions.a.providerSessionId ===
+      report.sessions.b.providerSessionId
+    )
+      throw new Error('provider sessions are not fresh and distinct');
+    for (const value of [
+      report.claim?.root,
+      report.assessment?.root,
+      report.continuity?.root,
+      report.oracle?.reportRoot,
+    ])
+      if (!ROOT_PATTERN.test(value || ''))
+        throw new Error('repository-work evidence root is invalid');
+  }
+  return true;
+}
+
+function buildBaseReport(options, sourceHead) {
+  return {
+    schema: REPORT_SCHEMA,
+    evidenceClass: 'bounded-experiment',
+    passed: false,
+    sourceHead,
+    fixture: {
+      id: INCIDENT_BOARD_FIXTURE.id,
+      fileCount: Object.keys(INCIDENT_BOARD_FIXTURE.files).length,
+      lineCount: Object.values(INCIDENT_BOARD_FIXTURE.files).reduce(
+        (count, content) => count + content.split('\n').length,
+        0,
+      ),
+    },
+    runtime: {
+      provider: 'opencode',
+      image: options.opencode ? null : options.image,
+      directExecutable: options.opencode || null,
+      model: options.model,
+      baseUrlRoot: options.opencode ? null : jsonRoot(options.baseUrl),
+      context: 65_536,
+    },
+    sessions: { distinct: 0 },
+    continuity: {
+      priorTranscriptBytes: 0,
+      humanRestatementCount: 0,
+    },
+    warrant: {
+      agentA: 'investigation-only',
+      agentB: 'bounded-repair',
+      writablePaths: [...INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths],
+      verifierOutsideAgentWorkspace: true,
+    },
+    dimensions: {
+      execution: null,
+      correctness: null,
+      scope: null,
+      continuity: null,
+      evidence: null,
+      efficiency: null,
+      residuals: null,
+    },
+    nonClaims: {
+      auditableDemo: true,
+      qualificationLab: true,
+      releaseGate: true,
+      publicClaim: true,
+      modelRanking: true,
+    },
+    failure: null,
+  };
+}
+
+export function runExperiment(options = {}) {
+  const normalized = {
+    output:
+      options.output ||
+      fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-agent-repository-work.')),
+    image: options.image || DEFAULT_IMAGE,
+    model: options.model || DEFAULT_MODEL,
+    baseUrl: options.baseUrl || DEFAULT_BASE_URL,
+    opencode: options.opencode || '',
+    sourceHead: options.sourceHead || '',
+    timeoutSeconds: options.timeoutSeconds || 900,
+  };
+  const output = path.resolve(normalized.output);
+  if (fs.existsSync(output) && fs.readdirSync(output).length > 0)
+    throw new Error('output directory must be new or empty');
+  fs.mkdirSync(output, { recursive: true });
+  const reportPath = path.join(output, 'agent-repository-work-report.json');
+  const sourceHead = normalized.sourceHead || currentHead();
+  const report = buildBaseReport(normalized, sourceHead);
+  const started = process.hrtime.bigint();
+  try {
+    if (!fs.existsSync(CONTRACT_PATH))
+      throw new Error('agent repository work contract is missing');
+    const contract = JSON.parse(fs.readFileSync(CONTRACT_PATH, 'utf8'));
+    const workspace = path.join(output, 'workspace');
+    const home = path.join(output, 'kf-home');
+    const configHome = path.join(output, 'kf-config');
+    const initialTree = materializeIncidentBoardFixture(workspace);
+    const initialTreeRoot = jsonRoot(initialTree);
+    const seeded = qualifySeededIncidentBoardFixture();
+    if (!seeded.passed)
+      throw new Error('seeded fixture did not expose the expected failures');
+    const planProfile = runtimeProfile({
+      id: 'opencode.repository-work.investigate',
+      mode: 'read-only',
+      model: normalized.model,
+      image: normalized.image,
+      baseUrl: normalized.baseUrl,
+      opencode: normalized.opencode,
+      // OpenCode's built-in plan agent disables shell execution. Use the
+      // tool-capable agent while the Docker mount and permission policy keep
+      // this runtime strictly read-only.
+      agent: 'build',
+    });
+    const buildProfile = runtimeProfile({
+      id: 'opencode.repository-work.repair',
+      mode: 'bounded-write',
+      model: normalized.model,
+      image: normalized.image,
+      baseUrl: normalized.baseUrl,
+      opencode: normalized.opencode,
+      agent: 'build',
+    });
+    const context = {
+      home,
+      configHome,
+      cwd: workspace,
+      timeout: (normalized.timeoutSeconds + 60) * 1000,
+    };
+    configureProfile(planProfile, context);
+    configureProfile(buildProfile, context);
+    for (const profile of [planProfile, buildProfile]) {
+      const verification = JSON.parse(
+        pythonKungfu(
+          ['agent', 'runtime', 'verify', profile.id, '--json'],
+          context,
+        ),
+      );
+      if (!verification.ok)
+        throw new Error(`Agent Runtime Profile failed: ${profile.id}`);
+    }
+    const contractRoot = fileRoot(CONTRACT_PATH);
+    const workEntity = {
+      schema: 'kungfu.agent-repository-work.entity/v1',
+      contractRoot,
+      fixtureId: INCIDENT_BOARD_FIXTURE.id,
+      initialTreeRoot,
+      warrantRoot: jsonRoot(INCIDENT_BOARD_FIXTURE.warrants),
+    };
+    const currentCutRoot = jsonRoot({
+      schema: 'kungfu.agent-repository-work.cut/v1',
+      sourceHead,
+      ...workEntity,
+    });
+    const workRef = {
+      schema: 'kungfu.work-ref/v1',
+      workspaceId: 'agent-repository-work-disposable',
+      profileId: 'incident-board-replay-v1',
+      profileRoot: jsonRoot(contract),
+      entityType: 'work',
+      entityId: 'incident-board-replay-v1',
+      entityRoot: jsonRoot(workEntity),
+      purpose: 'bounded-local-agent-repository-load-experiment',
+      systemTimeCut: currentCutRoot,
+    };
+    const workRefPath = path.join(output, 'inputs/work-ref.json');
+    writeJson(workRefPath, workRef);
+    const promptA = [
+      'Investigate the repository defect without modifying any file.',
+      'Run `python -m unittest discover -s tests -v`, inspect the lease, command, and replay boundaries, and identify the exact bounded repair paths.',
+      `The admitted investigation Warrant limits the candidate repair to exactly these repository-relative paths: ${INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths.join(', ')}.`,
+      'Confirm the seeded failures can be repaired within that Warrant; do not propose tests, service.py, or any other path.',
+      'Return only one JSON object, with no prose or Markdown.',
+      'The object must contain schema "kungfu.agent-repository-work.investigation-claim/v1", investigationComplete true, failingTests containing exactly the two failing unittest method names, repairPaths containing exactly three repository-relative Python paths without leading slashes, line numbers, or fragments, remainingObligation "implement-and-verify-bounded-repair", and nextAction "repair-seeded-completion-idempotency".',
+    ].join(' ');
+    const sessionA = JSON.parse(
+      pythonKungfu(
+        [
+          'run',
+          'agent',
+          '--agent',
+          planProfile.id,
+          '--prompt',
+          promptA,
+          '--workspace',
+          workspace,
+          '--work-ref',
+          workRefPath,
+          '--timeout',
+          String(normalized.timeoutSeconds),
+          '--json',
+        ],
+        context,
+      ),
+    );
+    const afterATree = treeRows(workspace);
+    const agentAZeroModification =
+      JSON.stringify(afterATree) === JSON.stringify(initialTree);
+    if (!agentAZeroModification)
+      throw new Error('Agent A modified the investigation-only workspace');
+    const investigation = parseInvestigationClaim(
+      sessionA.providerObservation?.text,
+    );
+    const claimBody = {
+      schema: 'kungfu.agent-repository-work.claim/v1',
+      currentCutRoot,
+      providerRunRoot: sessionA.reportRoot,
+      investigationRoot: jsonRoot(investigation),
+      completed: 'bounded-investigation',
+      remainingObligation: investigation.remainingObligation,
+      nextAction: investigation.nextAction,
+      selfReported: true,
+      completionAuthority: false,
+    };
+    const claim = { ...claimBody, root: jsonRoot(claimBody) };
+    const assessmentBody = {
+      schema: 'kungfu.agent-repository-work.assessment/v1',
+      assessor: 'deterministic-seeded-fixture-verifier',
+      independent: true,
+      claimRoot: claim.root,
+      currentCutRoot,
+      initialTreeRoot,
+      seededDefectRoot: jsonRoot(seeded),
+      outcome: 'partial',
+      remainingObligation:
+        'Repair expired-lease authorization, retry idempotency, and restart replay using only incident_board/commands.py, incident_board/lease.py, and incident_board/replay.py; run python -m unittest discover -s tests -v and leave the workspace for an external hidden verifier.',
+      nextAction: 'implement bounded repair and run visible tests',
+    };
+    const assessment = {
+      ...assessmentBody,
+      root: jsonRoot(assessmentBody),
+    };
+    const continuation = {
+      schema: 'kungfu.agent-continuation-envelope/v1',
+      workRef,
+      currentCutRoot,
+      priorClaimRoot: claim.root,
+      assessmentRoot: assessment.root,
+      remainingObligation: assessment.remainingObligation,
+      nextAction: assessment.nextAction,
+    };
+    const continuationPath = path.join(output, 'inputs/continuation.json');
+    writeJson(continuationPath, continuation);
+    const promptB = [
+      'Continue solely from the admitted Kungfu continuation evidence.',
+      'Do not request a transcript or a human restatement.',
+      'Before editing, report the recovered roots and obligation as required by the Kungfu bootstrap.',
+      'Complete the admitted bounded work, run the visible verification, and return a concise completion claim.',
+    ].join(' ');
+    const sessionB = JSON.parse(
+      pythonKungfu(
+        [
+          'run',
+          'agent',
+          '--agent',
+          buildProfile.id,
+          '--prompt',
+          promptB,
+          '--workspace',
+          workspace,
+          '--continuation',
+          continuationPath,
+          '--timeout',
+          String(normalized.timeoutSeconds),
+          '--json',
+        ],
+        context,
+      ),
+    );
+    const providerSessionA = providerSessionId(sessionA, 'Agent A');
+    const providerSessionB = providerSessionId(sessionB, 'Agent B');
+    if (providerSessionA === providerSessionB)
+      throw new Error('Agent A and Agent B reused one provider session');
+    const episodeVerification = {};
+    for (const [label, session] of [
+      ['a', sessionA],
+      ['b', sessionB],
+    ])
+      episodeVerification[label] = JSON.parse(
+        pythonKungfu(
+          [
+            'storage',
+            'fsck',
+            '--scope',
+            'episode',
+            '--episode-id',
+            String(session.episode.episodeId),
+            '--verify-frames',
+            '--json',
+          ],
+          context,
+        ),
+      );
+    if (!episodeVerification.a.ok || !episodeVerification.b.ok)
+      throw new Error('Kungfu Episode frame verification failed');
+    report.sessions = {
+      distinct: 2,
+      a: {
+        runId: sessionA.runId,
+        providerSessionId: providerSessionA,
+        profileId: sessionA.runtimeProfile.id,
+        reportRoot: sessionA.reportRoot,
+        processExitSettlesWork: sessionA.work.processExitSettlesWork,
+        selfReportSettlesWork: sessionA.work.selfReportSettlesWork,
+      },
+      b: {
+        runId: sessionB.runId,
+        providerSessionId: providerSessionB,
+        profileId: sessionB.runtimeProfile.id,
+        reportRoot: sessionB.reportRoot,
+        processExitSettlesWork: sessionB.work.processExitSettlesWork,
+        selfReportSettlesWork: sessionB.work.selfReportSettlesWork,
+      },
+    };
+    report.claim = claim;
+    report.assessment = assessment;
+    report.continuity = {
+      ...report.continuity,
+      root: jsonRoot(continuation),
+      currentCutRoot,
+      priorClaimRoot: claim.root,
+      assessmentRoot: assessment.root,
+      agentBReportedPriorTranscriptBytes:
+        sessionB.privacy.priorTranscriptBytesGivenToAgent,
+    };
+    report.warrant = {
+      ...report.warrant,
+      agentAZeroModification,
+    };
+    report.episodeVerification = episodeVerification;
+    const oracle = verifyIncidentBoardWorkspace(workspace, {
+      expectedInitialTree: initialTree,
+    });
+    report.oracle = oracle;
+    report.warrant = {
+      ...report.warrant,
+      changedPaths: oracle.changedPaths,
+      scopeViolations: oracle.scopeViolations,
+    };
+    report.dimensions = {
+      execution: 'two-fresh-opencode-processes-completed',
+      correctness: oracle.passed
+        ? 'visible-and-hidden-oracles-passed'
+        : 'external-oracle-rejected-repair',
+      scope:
+        oracle.scopeViolations.length === 0
+          ? 'all-changes-within-three-file-warrant'
+          : 'warrant-scope-violation',
+      continuity: 'native-workref-and-transcript-free-continuation-admitted',
+      evidence: 'content-rooted-episodes-claim-assessment-and-oracle',
+      efficiency: {
+        elapsedMilliseconds: Number(
+          (process.hrtime.bigint() - started) / 1_000_000n,
+        ),
+        sessionAUsage: sessionA.providerObservation?.usage || null,
+        sessionBUsage: sessionB.providerObservation?.usage || null,
+      },
+      residuals: [
+        'single deterministic Python fixture',
+        'single pinned local model and one trusted runner',
+        'no multi-day durability or concurrent repository-edit claim',
+      ],
+    };
+    if (!oracle.passed)
+      throw new Error(`external oracle rejected repair: ${oracle.reportRoot}`);
+    report.passed = true;
+    validateExperimentReport(report);
+  } catch (error) {
+    report.failure = {
+      category: classifyFailure(error),
+      message: String(error?.message || error).slice(0, 500),
+      outputRoot: error?.outputRoot || null,
+    };
+    report.dimensions.efficiency = {
+      elapsedMilliseconds: Number(
+        (process.hrtime.bigint() - started) / 1_000_000n,
+      ),
+    };
+  }
+  writeJson(reportPath, report);
+  return { output, reportPath, report };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const result = runExperiment(parseArgs(process.argv.slice(2)));
+    process.stdout.write(
+      `${JSON.stringify({
+        passed: result.report.passed,
+        output: result.output,
+        report: result.reportPath,
+        failure: result.report.failure,
+      })}\n`,
+    );
+    if (!result.report.passed) process.exitCode = 1;
+  } catch (error) {
+    process.stderr.write(`${error.stack || error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -195,6 +195,13 @@
           "sourceRoot": "sha256:b59d313837702193d551d655a944a74b86d6dbf91c4d99b5968cf2a6ceb08488"
         },
         {
+          "path": ".github/workflows/opencode-agent-repository-work.yml",
+          "classification": "non-publication",
+          "owner": "kungfu-ci",
+          "surfaceIds": [],
+          "sourceRoot": "sha256:f918cb568e819fdcc64b8417d8c17cab1fcba8015bcd81e287125d17275859a5"
+        },
+        {
           "path": ".github/workflows/opencode-local-model-canary.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
@@ -821,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:841a45db7b3b4240be7554bddd95c850de685955ee4ad29184ede3c7c2bbb33b"
+  "registryRoot": "sha256:7e4387658a5fdf61383618908377fed20fada312fbdaf8bf8174d6f4b363a04e"
 }

--- a/package.json
+++ b/package.json
@@ -129,6 +129,8 @@
     "qualify:continuity-pilot": "node scripts/require-shifu.mjs qualify:continuity-pilot && node scripts/run-continuity-pilot.mjs",
     "test:run-agent-opencode-continuity": "node scripts/require-shifu.mjs test:run-agent-opencode-continuity && node --test scripts/run-agent-opencode-continuity.test.mjs",
     "qualify:run-agent-opencode-continuity": "node scripts/require-shifu.mjs qualify:run-agent-opencode-continuity && node scripts/run-agent-opencode-continuity.mjs",
+    "test:agent-repository-work": "node scripts/require-shifu.mjs test:agent-repository-work && node --test scripts/run-agent-repository-work-experiment.test.mjs scripts/agent-repository-work-workflow.test.mjs",
+    "qualify:agent-repository-work": "node scripts/require-shifu.mjs qualify:agent-repository-work && node framework/agent-repository-work/run.mjs",
     "check:agent-pack": "node scripts/require-shifu.mjs check:agent-pack && node scripts/verify-agent-pack.mjs",
     "check:fact-cut-kernel-contract": "node scripts/require-shifu.mjs check:fact-cut-kernel-contract && node --test scripts/check-fact-cut-kernel-contract.test.mjs",
     "check:work-lifecycle-operation-matrix": "node scripts/require-shifu.mjs check:work-lifecycle-operation-matrix && node scripts/materialize-work-lifecycle-operation-matrix.mjs --check && node scripts/render-work-lifecycle-operation-matrix.mjs --check && node developer/sdk/src/sdk.js contract render work-lifecycle-operation-matrix --check --json && node developer/sdk/src/sdk.js contract policy --check --json && node developer/sdk/src/sdk.js contract audit --json && node --test scripts/check-work-lifecycle-operation-matrix.test.mjs scripts/check-native-authority-membrane.test.mjs",

--- a/scripts/agent-repository-work-workflow.test.mjs
+++ b/scripts/agent-repository-work-workflow.test.mjs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workflow = fs.readFileSync(
+  path.join(root, '.github/workflows/opencode-agent-repository-work.yml'),
+  'utf8',
+);
+const workflowAuthority = JSON.parse(
+  fs.readFileSync(
+    path.join(root, 'docs/qualification/gates/workflow-authority.json'),
+    'utf8',
+  ),
+);
+
+test('repository-work experiment is manual and restricted to trusted agent-120', () => {
+  assert.equal(
+    workflowAuthority.workflows.find(
+      ({ path: workflowPath }) =>
+        workflowPath === '.github/workflows/opencode-agent-repository-work.yml',
+    )?.authority,
+    'qualification',
+  );
+  assert.match(workflow, /^on:\n {2}workflow_dispatch:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s+(?:pull_request|push|schedule):/m);
+  assert.match(workflow, /permissions:\n {2}contents: read/);
+  assert.match(
+    workflow,
+    /runs-on:\n {6}- self-hosted\n {6}- Linux\n {6}- X64\n {6}- agent-120\n {6}- kungfu-build/,
+  );
+  assert.match(workflow, /test "\$RUNNER_NAME" = "agent-120-kungfu-systems"/);
+  assert.match(workflow, /timeout-minutes: 45/);
+});
+
+test('repository-work experiment pins image, model, and local endpoint', () => {
+  assert.match(
+    workflow,
+    /opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3/,
+  );
+  assert.match(workflow, /OPENCODE_MODEL: qwen3-coder:30b-opencode-64k/);
+  assert.match(
+    workflow,
+    /OPENCODE_BASE_URL: http:\/\/host\.docker\.internal:11435\/v1/,
+  );
+  assert.match(
+    workflow,
+    /OPENCODE_HOST_PROBE_URL: http:\/\/172\.17\.0\.1:11435\/v1\/models/,
+  );
+  assert.match(workflow, /docker image inspect "\$OPENCODE_IMAGE"/);
+  assert.doesNotMatch(workflow, /docker pull|:latest\b/);
+});
+
+test('workflow preserves bounded evidence and non-secret execution', () => {
+  assert.match(workflow, /\.\/shifu build:core/);
+  assert.match(workflow, /\.\/shifu qualify:agent-repository-work/);
+  assert.match(
+    workflow,
+    /actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02/,
+  );
+  assert.match(workflow, /retention-days: 14/);
+  assert.doesNotMatch(
+    workflow,
+    /secrets\.|GITHUB_TOKEN|api[_-]?key|authorization|password/iu,
+  );
+  assert.doesNotMatch(workflow, /--privileged|docker\.sock|--network host/);
+});

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -189,7 +189,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 10);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 22);
+  assert.equal(result.workflowAuthority.workflows.length, 23);
   const alphaPreflight = result.workflowAuthority.workflows.find(
     (workflow) =>
       workflow.path === '.github/workflows/alpha-promotion-preflight.yml',

--- a/scripts/run-agent-repository-work-experiment.test.mjs
+++ b/scripts/run-agent-repository-work-experiment.test.mjs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { dockerArgs } from '../framework/agent-repository-work/opencode-docker-proxy.mjs';
+import {
+  parseInvestigationClaim,
+  runExperiment,
+  runtimeProfile,
+  validateExperimentReport,
+} from '../framework/agent-repository-work/run.mjs';
+import {
+  applyIncidentBoardReferenceRepair,
+  materializeIncidentBoardFixture,
+  qualifyReferenceIncidentBoardRepair,
+  qualifySeededIncidentBoardFixture,
+  verifyIncidentBoardWorkspace,
+} from '../tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs';
+import { INCIDENT_BOARD_FIXTURE } from '../tests/qualification/agent-repository-work/incident-board-replay-v1.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const contractPath = path.join(
+  root,
+  'tests/qualification/agent-repository-work/contract.json',
+);
+const fixturePath = path.join(
+  root,
+  'tests/qualification/agent-repository-work/incident-board-replay-v1.mjs',
+);
+const oraclePath = path.join(
+  root,
+  'tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs',
+);
+const referencePath = path.join(
+  root,
+  'tests/qualification/agent-repository-work/incident-board-replay-v1-reference.mjs',
+);
+const mockOpenCodePath = path.join(
+  root,
+  'tests/qualification/agent-repository-work/mock-opencode.mjs',
+);
+
+function fileRoot(file) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(file))
+    .digest('hex')}`;
+}
+
+function withWorkspace(callback) {
+  const workspace = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-repository-work-test.'),
+  );
+  try {
+    const initial = materializeIncidentBoardFixture(workspace);
+    return callback(workspace, initial);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+test('fixture contract pins a moderate deterministic repository', () => {
+  const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+  const fileCount = Object.keys(INCIDENT_BOARD_FIXTURE.files).length;
+  const lineCount = Object.values(INCIDENT_BOARD_FIXTURE.files).reduce(
+    (count, content) => count + content.split('\n').length,
+    0,
+  );
+  assert.equal(contract.schema, 'kungfu.agent-repository-work.v1');
+  assert.equal(fileCount, contract.fixture.fileCount);
+  assert.equal(lineCount, contract.fixture.lineCount);
+  assert.ok(fileCount >= 30 && fileCount <= 50);
+  assert.ok(lineCount >= 2_000 && lineCount <= 4_000);
+  assert.equal(contract.fixture.sourceRoot, fileRoot(fixturePath));
+  assert.equal(contract.oracle.sourceRoot, fileRoot(oraclePath));
+  assert.equal(contract.oracle.referenceRoot, fileRoot(referencePath));
+  assert.equal(contract.oracle.mountedIntoAgentWorkspace, false);
+});
+
+test('seeded defect fails and independent reference repair passes', () => {
+  assert.equal(qualifySeededIncidentBoardFixture().passed, true);
+  const reference = qualifyReferenceIncidentBoardRepair();
+  assert.equal(reference.passed, true);
+  assert.deepEqual(
+    reference.changedPaths,
+    INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths.slice().sort(),
+  );
+  assert.equal(reference.checks.visible.passed, true);
+  assert.equal(reference.checks.hidden.passed, true);
+});
+
+test('external oracle fails closed on protected or added paths', () => {
+  withWorkspace((workspace, initial) => {
+    applyIncidentBoardReferenceRepair(workspace);
+    fs.appendFileSync(path.join(workspace, 'README.md'), '\ntampered\n');
+    const report = verifyIncidentBoardWorkspace(workspace, {
+      expectedInitialTree: initial,
+    });
+    assert.equal(report.passed, false);
+    assert.deepEqual(report.scopeViolations, ['README.md']);
+  });
+  withWorkspace((workspace, initial) => {
+    applyIncidentBoardReferenceRepair(workspace);
+    fs.writeFileSync(path.join(workspace, 'incident_board/shortcut.py'), '');
+    const report = verifyIncidentBoardWorkspace(workspace, {
+      expectedInitialTree: initial,
+    });
+    assert.equal(report.passed, false);
+    assert.deepEqual(report.scopeViolations, ['incident_board/shortcut.py']);
+  });
+});
+
+test('Docker profile is digest-pinned, bounded, and mode-specific', () => {
+  const input = {
+    id: 'test',
+    model: 'qwen3-coder:30b-opencode-64k',
+    image:
+      'example.invalid/opencode-ci@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    baseUrl: 'http://host.docker.internal:11435/v1',
+    opencode: '',
+    agent: 'plan',
+  };
+  const profile = runtimeProfile({ ...input, mode: 'read-only' });
+  assert.equal(profile.provider, 'opencode');
+  assert.equal(profile.launch.executable, process.execPath);
+  assert.ok(profile.launch.argv.includes('--mode'));
+  assert.ok(profile.launch.argv.includes('read-only'));
+  const args = dockerArgs(
+    {
+      image: input.image,
+      baseUrl: input.baseUrl,
+      model: input.model,
+      context: 65_536,
+      mode: 'read-only',
+      command: ['run', '--pure', 'prompt'],
+    },
+    '/tmp/disposable-workspace',
+  );
+  assert.ok(args.includes('--read-only'));
+  assert.ok(args.includes('ALL'));
+  assert.ok(args.includes('no-new-privileges'));
+  assert.ok(args.includes('PYTHONDONTWRITEBYTECODE=1'));
+  assert.ok(args.includes('/tmp/disposable-workspace:/workspace:ro'));
+  assert.ok(!args.includes('--privileged'));
+  assert.ok(!args.includes('/var/run/docker.sock'));
+  assert.ok(!args.includes('host'));
+});
+
+test('Agent A claim and final report require deterministic continuity evidence', () => {
+  const claim = {
+    schema: 'kungfu.agent-repository-work.investigation-claim/v1',
+    investigationComplete: true,
+    failingTests: [
+      'test_expired_lease_cannot_complete',
+      'test_legacy_duplicate_log_has_stable_restart_summary',
+    ],
+    repairPaths: [
+      'incident_board/commands.py',
+      'incident_board/lease.py',
+      'incident_board/replay.py',
+    ],
+    remainingObligation: 'implement-and-verify-bounded-repair',
+    nextAction: 'repair-seeded-completion-idempotency',
+  };
+  assert.deepEqual(parseInvestigationClaim(JSON.stringify(claim)), claim);
+  const report = {
+    schema: 'kungfu.agent-repository-work.report/v1',
+    evidenceClass: 'bounded-experiment',
+    passed: true,
+    sessions: {
+      distinct: 2,
+      a: { providerSessionId: 'session-a' },
+      b: { providerSessionId: 'session-b' },
+    },
+    continuity: {
+      priorTranscriptBytes: 0,
+      humanRestatementCount: 0,
+      root: `sha256:${'a'.repeat(64)}`,
+    },
+    warrant: { agentAZeroModification: true },
+    claim: { root: `sha256:${'b'.repeat(64)}` },
+    assessment: { root: `sha256:${'c'.repeat(64)}` },
+    oracle: {
+      passed: true,
+      authoritative: true,
+      reportRoot: `sha256:${'d'.repeat(64)}`,
+    },
+    nonClaims: {
+      auditableDemo: true,
+      qualificationLab: true,
+      releaseGate: true,
+      publicClaim: true,
+    },
+  };
+  assert.equal(validateExperimentReport(report), true);
+  report.sessions.b.providerSessionId = 'session-a';
+  assert.throws(
+    () => validateExperimentReport(report),
+    /not fresh and distinct/u,
+  );
+});
+
+test('native Kungfu runner carries a transcript-free continuation end to end', () => {
+  const output = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-repository-work-runner-test.'),
+  );
+  try {
+    const result = runExperiment({
+      output,
+      opencode: mockOpenCodePath,
+      model: 'mock-repository-model',
+      sourceHead: '0123456789abcdef0123456789abcdef01234567',
+      timeoutSeconds: 120,
+    });
+    assert.equal(result.report.passed, true, result.report.failure?.message);
+    assert.equal(result.report.sessions.distinct, 2);
+    assert.equal(result.report.continuity.priorTranscriptBytes, 0);
+    assert.equal(result.report.continuity.humanRestatementCount, 0);
+    assert.equal(result.report.warrant.agentAZeroModification, true);
+    assert.equal(result.report.oracle.passed, true);
+    assert.deepEqual(result.report.warrant.scopeViolations, []);
+  } finally {
+    fs.rmSync(output, { recursive: true, force: true });
+  }
+});
+
+test('failed repair retains bounded session and oracle diagnostics', () => {
+  const output = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent-repository-work-failure-test.'),
+  );
+  try {
+    const result = runExperiment({
+      output,
+      opencode: mockOpenCodePath,
+      model: 'mock-incomplete-repository-model',
+      sourceHead: '0123456789abcdef0123456789abcdef01234567',
+      timeoutSeconds: 120,
+    });
+    assert.equal(result.report.passed, false);
+    assert.equal(result.report.failure.category, 'verifier');
+    assert.equal(result.report.sessions.distinct, 2);
+    assert.equal(result.report.oracle.passed, false);
+    assert.equal(result.report.oracle.checks.visible.passed, false);
+    assert.equal(result.report.oracle.checks.hidden.passed, false);
+    assert.deepEqual(result.report.warrant.scopeViolations, []);
+    assert.ok(fs.existsSync(result.reportPath));
+  } finally {
+    fs.rmSync(output, { recursive: true, force: true });
+  }
+});

--- a/tests/qualification/agent-repository-work/contract.json
+++ b/tests/qualification/agent-repository-work/contract.json
@@ -1,0 +1,69 @@
+{
+  "schema": "kungfu.agent-repository-work.v1",
+  "id": "incident-board-replay-v1",
+  "status": "experimental",
+  "evidenceClass": "bounded-experiment",
+  "fixture": {
+    "language": "python",
+    "dependencyPolicy": "standard-library-only",
+    "fileCount": 49,
+    "lineCount": 2433,
+    "sourceRoot": "sha256:5c9498cf308e4ee7f53be1ce2a6025a8b26f3bb197322a3ebd93c5cfa4774de6",
+    "seededFailures": [
+      "test_expired_lease_cannot_complete",
+      "test_legacy_duplicate_log_has_stable_restart_summary"
+    ]
+  },
+  "sessions": {
+    "count": 2,
+    "agentA": {
+      "mode": "investigation-only",
+      "productionModifications": 0
+    },
+    "agentB": {
+      "mode": "bounded-repair",
+      "priorTranscriptBytes": 0,
+      "humanRestatementCount": 0
+    }
+  },
+  "warrant": {
+    "writablePaths": [
+      "incident_board/commands.py",
+      "incident_board/lease.py",
+      "incident_board/replay.py"
+    ],
+    "protectedRootsFailClosed": true,
+    "externalVerifierAuthoritative": true
+  },
+  "oracle": {
+    "sourceRoot": "sha256:74b1ec3cd7dcd4f27e4db981fa7d869119b6fc208fd890547576ad00f524349f",
+    "referenceRoot": "sha256:9c55e48f2d0cbcc5fe88c8a0a8e1a0f9dd242bf12f955519e5738c1b7d6fd634",
+    "mountedIntoAgentWorkspace": false,
+    "visibleAndHiddenTestsRequired": true
+  },
+  "runtime": {
+    "runner": "agent-120",
+    "image": "ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3",
+    "model": "qwen3-coder:30b-opencode-64k",
+    "context": 65536,
+    "workspace": "disposable",
+    "network": "bridge-to-explicit-local-model-endpoint",
+    "credentials": "none"
+  },
+  "evidenceDimensions": [
+    "execution",
+    "correctness",
+    "scope",
+    "continuity",
+    "evidence",
+    "efficiency",
+    "residuals"
+  ],
+  "nonClaims": {
+    "auditableDemo": true,
+    "qualificationLab": true,
+    "releaseGate": true,
+    "publicClaim": true,
+    "modelRanking": true
+  }
+}

--- a/tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs
+++ b/tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { INCIDENT_BOARD_REFERENCE_REPAIR } from './incident-board-replay-v1-reference.mjs';
+import { INCIDENT_BOARD_FIXTURE } from './incident-board-replay-v1.mjs';
+
+const REPORT_SCHEMA = 'kungfu.agent-repository-work.oracle-report/v1';
+const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
+function root(value) {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+}
+
+function normalizedRelative(value) {
+  return value.split(path.sep).join('/');
+}
+
+function walkFiles(workspace) {
+  const rows = [];
+  function walk(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolute = path.join(directory, entry.name);
+      const relative = normalizedRelative(path.relative(workspace, absolute));
+      const stats = fs.lstatSync(absolute);
+      if (stats.isSymbolicLink())
+        throw new Error(`fixture workspace contains a symlink: ${relative}`);
+      if (stats.isDirectory()) walk(absolute);
+      else if (stats.isFile())
+        rows.push({
+          path: relative,
+          bytes: stats.size,
+          root: root(fs.readFileSync(absolute)),
+        });
+      else throw new Error(`unsupported fixture entry: ${relative}`);
+    }
+  }
+  walk(workspace);
+  return rows.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function expectedTree() {
+  return Object.entries(INCIDENT_BOARD_FIXTURE.files)
+    .map(([relative, content]) => ({
+      path: relative,
+      bytes: Buffer.byteLength(content),
+      root: root(content),
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env || {}) },
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: options.timeout || 120_000,
+  });
+  return {
+    command: [command, ...args],
+    status: result.status,
+    signal: result.signal,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    error: result.error ? String(result.error.message || result.error) : null,
+  };
+}
+
+function visibleSuite(workspace) {
+  return run(
+    process.env.PYTHON || 'python3',
+    ['-m', 'unittest', 'discover', '-s', 'tests', '-v'],
+    { cwd: workspace },
+  );
+}
+
+function hiddenSuite(workspace) {
+  const oracleDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'incident-board-hidden-oracle.'),
+  );
+  const oraclePath = path.join(oracleDirectory, 'hidden_oracle.py');
+  fs.writeFileSync(
+    oraclePath,
+    `import tempfile
+import unittest
+from pathlib import Path
+
+from incident_board.errors import CompletionRejected
+from incident_board.events import Event
+from incident_board.replay import replay
+from incident_board.service import IncidentBoard
+
+
+class HiddenLeaseReplayOracle(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.board = IncidentBoard(Path(self.temporary.name) / "events.jsonl")
+        self.board.open(
+            incident_id="inc-hidden",
+            title="Hidden retry boundary",
+            severity="critical",
+            at="2026-01-01T00:00:00Z",
+            command_id="cmd-hidden-open",
+        )
+        self.board.lease(
+            incident_id="inc-hidden",
+            lease_id="lease-hidden-one",
+            worker_id="worker-hidden-one",
+            ttl_seconds=10,
+            at="2026-01-01T00:00:00Z",
+            command_id="cmd-hidden-lease-one",
+        )
+
+    def test_successor_lease_revokes_expired_predecessor(self):
+        self.board.lease(
+            incident_id="inc-hidden",
+            lease_id="lease-hidden-two",
+            worker_id="worker-hidden-two",
+            ttl_seconds=20,
+            at="2026-01-01T00:00:11Z",
+            command_id="cmd-hidden-lease-two",
+        )
+        with self.assertRaises(CompletionRejected):
+            self.board.complete(
+                incident_id="inc-hidden",
+                lease_id="lease-hidden-one",
+                completion_id="done-hidden-stale",
+                result="stale result",
+                at="2026-01-01T00:00:12Z",
+                command_id="cmd-hidden-stale",
+            )
+        self.board.complete(
+            incident_id="inc-hidden",
+            lease_id="lease-hidden-two",
+            completion_id="done-hidden-current",
+            result="current result",
+            at="2026-01-01T00:00:12Z",
+            command_id="cmd-hidden-current",
+        )
+        self.assertEqual(self.board.summary()["completed"], 1)
+
+    def test_distinct_retry_after_completion_is_idempotent(self):
+        self.board.complete(
+            incident_id="inc-hidden",
+            lease_id="lease-hidden-one",
+            completion_id="done-hidden-one",
+            result="first result",
+            at="2026-01-01T00:00:05Z",
+            command_id="cmd-hidden-complete-one",
+        )
+        self.assertIsNone(
+            self.board.complete(
+                incident_id="inc-hidden",
+                lease_id="lease-hidden-one",
+                completion_id="done-hidden-two",
+                result="retry result",
+                at="2026-01-01T00:00:06Z",
+                command_id="cmd-hidden-complete-two",
+            )
+        )
+        self.assertEqual(len(self.board.store.read()), 3)
+
+    def test_three_historical_completions_count_once(self):
+        self.board.complete(
+            incident_id="inc-hidden",
+            lease_id="lease-hidden-one",
+            completion_id="done-hidden-one",
+            result="first result",
+            at="2026-01-01T00:00:05Z",
+            command_id="cmd-hidden-complete-one",
+        )
+        source = self.board.store.read()[-1].as_dict()
+        for sequence, suffix in ((4, "two"), (5, "three")):
+            duplicate = {
+                **source,
+                "event_id": f"evt-hidden-{suffix}",
+                "sequence": sequence,
+                "data": {
+                    **source["data"],
+                    "completion_id": f"done-hidden-{suffix}",
+                    "result": f"{suffix} result",
+                },
+            }
+            self.board.store.append(Event.from_dict(duplicate))
+        live = self.board.summary()
+        restarted = self.board.summary(restarted=True)
+        self.assertEqual(live["completed"], 1)
+        self.assertEqual(restarted["completed"], 1)
+        self.assertEqual(live, restarted)
+        incident = replay(self.board.store.read()).require_incident("inc-hidden")
+        self.assertEqual(incident.result, "first result")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+`,
+  );
+  try {
+    return run(process.env.PYTHON || 'python3', [oraclePath], {
+      cwd: oracleDirectory,
+      env: {
+        PYTHONPATH: [workspace, process.env.PYTHONPATH]
+          .filter(Boolean)
+          .join(path.delimiter),
+      },
+    });
+  } finally {
+    fs.rmSync(oracleDirectory, { recursive: true, force: true });
+  }
+}
+
+function diffTrees(initial, current) {
+  const initialMap = new Map(initial.map((row) => [row.path, row.root]));
+  const currentMap = new Map(current.map((row) => [row.path, row.root]));
+  return [...new Set([...initialMap.keys(), ...currentMap.keys()])]
+    .filter((relative) => initialMap.get(relative) !== currentMap.get(relative))
+    .sort();
+}
+
+export function materializeIncidentBoardFixture(workspace) {
+  if (fs.existsSync(workspace) && fs.readdirSync(workspace).length > 0)
+    throw new Error('fixture workspace must be new or empty');
+  fs.mkdirSync(workspace, { recursive: true });
+  for (const [relative, content] of Object.entries(
+    INCIDENT_BOARD_FIXTURE.files,
+  )) {
+    const target = path.resolve(workspace, relative);
+    if (!target.startsWith(`${path.resolve(workspace)}${path.sep}`))
+      throw new Error(`fixture path escapes workspace: ${relative}`);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  return walkFiles(workspace);
+}
+
+export function applyIncidentBoardReferenceRepair(workspace) {
+  for (const [relative, content] of Object.entries(
+    INCIDENT_BOARD_REFERENCE_REPAIR,
+  ))
+    fs.writeFileSync(path.join(workspace, relative), content);
+}
+
+export function verifyIncidentBoardWorkspace(
+  workspace,
+  {
+    expectedInitialTree = expectedTree(),
+    requireModification = true,
+    runHidden = true,
+  } = {},
+) {
+  const before = expectedInitialTree;
+  const current = walkFiles(workspace);
+  const changedPaths = diffTrees(before, current);
+  const allowed = new Set(INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths);
+  const scopeViolations = changedPaths.filter(
+    (relative) => !allowed.has(relative),
+  );
+  const visible = visibleSuite(workspace);
+  const hidden = runHidden ? hiddenSuite(workspace) : null;
+  const passed =
+    scopeViolations.length === 0 &&
+    (!requireModification || changedPaths.length > 0) &&
+    visible.status === 0 &&
+    (!hidden || hidden.status === 0);
+  const report = {
+    schema: REPORT_SCHEMA,
+    fixtureId: INCIDENT_BOARD_FIXTURE.id,
+    passed,
+    authoritative: true,
+    verifierLocation: 'outside-agent-workspace',
+    workspaceTreeRoot: root(JSON.stringify(current)),
+    initialTreeRoot: root(JSON.stringify(before)),
+    changedPaths,
+    allowedWritablePaths: [...allowed].sort(),
+    scopeViolations,
+    checks: {
+      modificationRequired: !requireModification || changedPaths.length > 0,
+      scope: scopeViolations.length === 0,
+      visible: {
+        passed: visible.status === 0,
+        status: visible.status,
+        signal: visible.signal,
+        error: visible.error,
+        outputRoot: root(`${visible.stdout}\n${visible.stderr}`),
+      },
+      hidden: hidden
+        ? {
+            passed: hidden.status === 0,
+            status: hidden.status,
+            signal: hidden.signal,
+            error: hidden.error,
+            outputRoot: root(`${hidden.stdout}\n${hidden.stderr}`),
+          }
+        : null,
+    },
+  };
+  report.reportRoot = root(JSON.stringify(report));
+  if (!ROOT_PATTERN.test(report.reportRoot))
+    throw new Error('oracle report root is invalid');
+  return report;
+}
+
+export function qualifySeededIncidentBoardFixture() {
+  const workspace = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'incident-board-seeded.'),
+  );
+  try {
+    materializeIncidentBoardFixture(workspace);
+    const visible = visibleSuite(workspace);
+    const combined = `${visible.stdout}\n${visible.stderr}`;
+    const expectedFailures = [
+      'test_expired_lease_cannot_complete',
+      'test_legacy_duplicate_log_has_stable_restart_summary',
+    ];
+    return {
+      schema: 'kungfu.agent-repository-work.seeded-defect-report/v1',
+      passed:
+        visible.status !== 0 &&
+        expectedFailures.every((name) => combined.includes(name)),
+      expectedFailures,
+      status: visible.status,
+      outputRoot: root(combined),
+    };
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+}
+
+export function qualifyReferenceIncidentBoardRepair() {
+  const workspace = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'incident-board-reference.'),
+  );
+  try {
+    const initialTree = materializeIncidentBoardFixture(workspace);
+    applyIncidentBoardReferenceRepair(workspace);
+    return verifyIncidentBoardWorkspace(workspace, {
+      expectedInitialTree: initialTree,
+    });
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+}

--- a/tests/qualification/agent-repository-work/incident-board-replay-v1-reference.mjs
+++ b/tests/qualification/agent-repository-work/incident-board-replay-v1-reference.mjs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+
+function text(value) {
+  return `${value.replace(/^\n/u, '').trimEnd()}\n`;
+}
+
+export const INCIDENT_BOARD_REFERENCE_REPAIR = Object.freeze({
+  'incident_board/lease.py': text(`
+"""Lease authorization policy."""
+
+from datetime import datetime
+
+from .clock import parse_time
+from .domain import Incident
+
+
+def lease_is_expired(expires_at: str, at: str | datetime) -> bool:
+    checked = parse_time(at) if isinstance(at, str) else at
+    return checked >= parse_time(expires_at)
+
+
+def completion_is_authorized(
+    incident: Incident,
+    supplied_lease_id: str,
+    at: str,
+) -> bool:
+    """Require the current active and unexpired lease."""
+    if incident.status != "leased" or incident.lease is None:
+        return False
+    if incident.lease.lease_id != supplied_lease_id:
+        return False
+    return not lease_is_expired(incident.lease.expires_at, at)
+
+
+def next_attempt(incident: Incident) -> int:
+    if incident.lease is None:
+        return 1
+    return incident.lease.attempt + 1
+`),
+  'incident_board/commands.py': text(`
+"""Command handlers append domain events."""
+
+from datetime import timedelta
+
+from .clock import format_time, parse_time
+from .errors import CompletionRejected, LeaseConflict
+from .events import Event
+from .ids import event_id
+from .lease import completion_is_authorized, lease_is_expired, next_attempt
+from .state import BoardState
+
+
+def open_incident(
+    state: BoardState,
+    *,
+    incident_id: str,
+    title: str,
+    severity: str,
+    at: str,
+    command_id: str,
+) -> Event:
+    if incident_id in state.incidents:
+        raise ValueError("incident already exists")
+    return Event(
+        event_id=event_id("incident.opened", command_id),
+        sequence=state.last_sequence + 1,
+        event_type="incident.opened",
+        incident_id=incident_id,
+        occurred_at=at,
+        data={"title": title, "severity": severity},
+    )
+
+
+def grant_lease(
+    state: BoardState,
+    *,
+    incident_id: str,
+    lease_id: str,
+    worker_id: str,
+    ttl_seconds: int,
+    at: str,
+    command_id: str,
+) -> list[Event]:
+    incident = state.require_incident(incident_id)
+    result = []
+    sequence = state.last_sequence + 1
+    if incident.status == "completed":
+        raise LeaseConflict("completed incident cannot be leased")
+    if incident.lease and not lease_is_expired(incident.lease.expires_at, at):
+        raise LeaseConflict("incident already has an active lease")
+    if incident.lease and incident.status == "leased":
+        result.append(
+            Event(
+                event_id=event_id("lease.expired", command_id),
+                sequence=sequence,
+                event_type="lease.expired",
+                incident_id=incident_id,
+                occurred_at=at,
+                data={"lease_id": incident.lease.lease_id},
+            )
+        )
+        sequence += 1
+    expires = format_time(parse_time(at) + timedelta(seconds=ttl_seconds))
+    result.append(
+        Event(
+            event_id=event_id("lease.granted", command_id),
+            sequence=sequence,
+            event_type="lease.granted",
+            incident_id=incident_id,
+            occurred_at=at,
+            data={
+                "lease_id": lease_id,
+                "worker_id": worker_id,
+                "expires_at": expires,
+                "attempt": next_attempt(incident),
+            },
+        )
+    )
+    return result
+
+
+def complete_incident(
+    state: BoardState,
+    *,
+    incident_id: str,
+    lease_id: str,
+    completion_id: str,
+    result: str,
+    at: str,
+    command_id: str,
+) -> Event | None:
+    incident = state.require_incident(incident_id)
+    if completion_id in incident.completion_ids:
+        return None
+    if incident.status == "completed":
+        return None
+    if not completion_is_authorized(incident, lease_id, at):
+        raise CompletionRejected("lease does not authorize completion")
+    return Event(
+        event_id=event_id("incident.completed", command_id),
+        sequence=state.last_sequence + 1,
+        event_type="incident.completed",
+        incident_id=incident_id,
+        occurred_at=at,
+        data={
+            "lease_id": lease_id,
+            "completion_id": completion_id,
+            "result": result,
+        },
+    )
+`),
+  'incident_board/replay.py': text(`
+"""Event reducer and restart replay."""
+
+from collections.abc import Iterable
+
+from .domain import Incident, Lease
+from .errors import InvalidEvent
+from .events import Event
+from .state import BoardState
+
+
+def apply_event(state: BoardState, event: Event) -> BoardState:
+    if event.event_id in state.seen_event_ids:
+        return state
+    if event.sequence != state.last_sequence + 1:
+        raise InvalidEvent("event sequence is not contiguous")
+
+    if event.event_type == "incident.opened":
+        if event.incident_id in state.incidents:
+            raise InvalidEvent("incident was opened twice")
+        state.incidents[event.incident_id] = Incident(
+            incident_id=event.incident_id,
+            title=event.data["title"],
+            severity=event.data["severity"],
+        )
+        state.counters.opened += 1
+    elif event.event_type == "lease.granted":
+        incident = state.require_incident(event.incident_id)
+        incident.status = "leased"
+        incident.lease = Lease(
+            lease_id=event.data["lease_id"],
+            worker_id=event.data["worker_id"],
+            granted_at=event.occurred_at,
+            expires_at=event.data["expires_at"],
+            attempt=event.data["attempt"],
+        )
+        state.counters.leased += 1
+    elif event.event_type == "lease.expired":
+        incident = state.require_incident(event.incident_id)
+        if incident.lease and incident.lease.lease_id == event.data["lease_id"]:
+            incident.status = "open"
+        state.counters.expired += 1
+    elif event.event_type == "incident.completed":
+        incident = state.require_incident(event.incident_id)
+        first_completion = not incident.completion_ids
+        incident.status = "completed"
+        incident.completion_ids.add(event.data["completion_id"])
+        if first_completion:
+            incident.completed_at = event.occurred_at
+            incident.result = event.data["result"]
+            state.counters.completed += 1
+    else:
+        raise InvalidEvent(f"unknown event type: {event.event_type}")
+
+    state.seen_event_ids.add(event.event_id)
+    state.last_sequence = event.sequence
+    return state
+
+
+def replay(events: Iterable[Event]) -> BoardState:
+    state = BoardState()
+    for event in events:
+        apply_event(state, event)
+    return state
+`),
+});

--- a/tests/qualification/agent-repository-work/incident-board-replay-v1.mjs
+++ b/tests/qualification/agent-repository-work/incident-board-replay-v1.mjs
@@ -1,0 +1,1558 @@
+// SPDX-License-Identifier: Apache-2.0
+
+function text(value) {
+  return `${value.replace(/^\n/u, '').trimEnd()}\n`;
+}
+
+const files = {
+  'README.md': text(`
+# Incident Board Replay
+
+Incident Board is a small standard-library-only incident coordination service.
+It accepts commands through a CLI, appends immutable JSONL events, and rebuilds
+state and summaries by replaying those events after restart.
+
+## Intended behavior
+
+- One incident may have at most one active lease.
+- A completion is authorized only by the current unexpired lease.
+- Completion is idempotent across worker retry and process restart.
+- Historical duplicate completion events remain readable, but they count as one
+  completed incident and one accepted completion.
+- Live and restarted summaries must be identical for the same event log.
+
+Run the visible suite:
+
+    python -m unittest discover -s tests -v
+
+The repository intentionally contains a seeded retry/replay defect. Do not
+change tests, configuration, examples, evidence, or expected outputs to hide
+the defect.
+`),
+  'pyproject.toml': text(`
+[build-system]
+requires = []
+build-backend = "incident_board.build"
+
+[project]
+name = "incident-board-replay"
+version = "0.1.0"
+description = "Deterministic incident lease and replay fixture"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+incident-board = "incident_board.cli:main"
+`),
+  'incident_board/__init__.py': text(`
+"""Incident Board public package."""
+
+from .service import IncidentBoard
+from .version import __version__
+
+__all__ = ["IncidentBoard", "__version__"]
+`),
+  'incident_board/__main__.py': text(`
+"""Module entry point."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+`),
+  'incident_board/version.py': text(`
+"""Package version."""
+
+__version__ = "0.1.0"
+`),
+  'incident_board/errors.py': text(`
+"""Stable domain errors used by the CLI and tests."""
+
+
+class IncidentBoardError(RuntimeError):
+    """Base class for expected domain failures."""
+
+
+class IncidentNotFound(IncidentBoardError):
+    """Raised when an incident id is unknown."""
+
+
+class LeaseConflict(IncidentBoardError):
+    """Raised when a lease cannot be granted."""
+
+
+class CompletionRejected(IncidentBoardError):
+    """Raised when a completion lacks current authority."""
+
+
+class InvalidEvent(IncidentBoardError):
+    """Raised when persisted input violates the event contract."""
+`),
+  'incident_board/clock.py': text(`
+"""Clock helpers keep tests independent from wall-clock time."""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+def parse_time(value: str) -> datetime:
+    """Parse one UTC ISO-8601 timestamp."""
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def format_time(value: datetime) -> str:
+    """Render a timestamp in canonical UTC form."""
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class ManualClock:
+    """Mutable test clock."""
+
+    current: datetime
+
+    @classmethod
+    def at(cls, value: str) -> "ManualClock":
+        return cls(parse_time(value))
+
+    def now(self) -> datetime:
+        return self.current
+
+    def set(self, value: str) -> None:
+        self.current = parse_time(value)
+`),
+  'incident_board/ids.py': text(`
+"""Deterministic identifiers for event and command records."""
+
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_json(value: Any) -> str:
+    """Return compact stable JSON."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def semantic_id(prefix: str, value: Any) -> str:
+    """Create a bounded readable content identifier."""
+    digest = hashlib.sha256(canonical_json(value).encode()).hexdigest()[:20]
+    return f"{prefix}-{digest}"
+
+
+def event_id(event_type: str, command_id: str, ordinal: int = 0) -> str:
+    """Derive an event id from the command identity."""
+    return semantic_id(
+        "evt",
+        {"type": event_type, "command_id": command_id, "ordinal": ordinal},
+    )
+`),
+  'incident_board/domain.py': text(`
+"""Domain records for incidents and leases."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Lease:
+    lease_id: str
+    worker_id: str
+    granted_at: str
+    expires_at: str
+    attempt: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "lease_id": self.lease_id,
+            "worker_id": self.worker_id,
+            "granted_at": self.granted_at,
+            "expires_at": self.expires_at,
+            "attempt": self.attempt,
+        }
+
+
+@dataclass
+class Incident:
+    incident_id: str
+    title: str
+    severity: str
+    status: str = "open"
+    lease: Lease | None = None
+    completion_ids: set[str] = field(default_factory=set)
+    completed_at: str | None = None
+    result: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "incident_id": self.incident_id,
+            "title": self.title,
+            "severity": self.severity,
+            "status": self.status,
+            "lease": self.lease.as_dict() if self.lease else None,
+            "completion_ids": sorted(self.completion_ids),
+            "completed_at": self.completed_at,
+            "result": self.result,
+        }
+`),
+  'incident_board/events.py': text(`
+"""Versioned event envelope."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from .errors import InvalidEvent
+
+SUPPORTED_TYPES = {
+    "incident.opened",
+    "lease.granted",
+    "lease.expired",
+    "incident.completed",
+}
+
+
+@dataclass(frozen=True)
+class Event:
+    event_id: str
+    sequence: int
+    event_type: str
+    incident_id: str
+    occurred_at: str
+    data: dict[str, Any]
+    schema: str = "incident-board.event/v1"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "event_id": self.event_id,
+            "sequence": self.sequence,
+            "type": self.event_type,
+            "incident_id": self.incident_id,
+            "occurred_at": self.occurred_at,
+            "data": self.data,
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "Event":
+        required = {
+            "schema",
+            "event_id",
+            "sequence",
+            "type",
+            "incident_id",
+            "occurred_at",
+            "data",
+        }
+        if set(value) != required:
+            raise InvalidEvent("event fields do not match v1")
+        if value["schema"] != "incident-board.event/v1":
+            raise InvalidEvent("event schema is unsupported")
+        if value["type"] not in SUPPORTED_TYPES:
+            raise InvalidEvent("event type is unsupported")
+        if not isinstance(value["sequence"], int) or value["sequence"] < 1:
+            raise InvalidEvent("event sequence must be positive")
+        if not isinstance(value["data"], dict):
+            raise InvalidEvent("event data must be an object")
+        return cls(
+            event_id=value["event_id"],
+            sequence=value["sequence"],
+            event_type=value["type"],
+            incident_id=value["incident_id"],
+            occurred_at=value["occurred_at"],
+            data=value["data"],
+        )
+`),
+  'incident_board/serde.py': text(`
+"""Strict JSON serialization."""
+
+import json
+from typing import Any
+
+
+def dumps(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def loads(value: str) -> Any:
+    return json.loads(value)
+
+
+def pretty(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, indent=2)
+`),
+  'incident_board/event_store.py': text(`
+"""Append-only JSONL event store."""
+
+from pathlib import Path
+from typing import Iterable
+
+from .events import Event
+from .serde import dumps, loads
+
+
+class JsonlEventStore:
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+
+    def read(self) -> list[Event]:
+        if not self.path.exists():
+            return []
+        events = []
+        for line_number, line in enumerate(
+            self.path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            if not line.strip():
+                continue
+            try:
+                events.append(Event.from_dict(loads(line)))
+            except Exception as error:
+                raise ValueError(
+                    f"invalid event at line {line_number}: {error}"
+                ) from error
+        self._validate_sequences(events)
+        return events
+
+    def append(self, event: Event) -> None:
+        events = self.read()
+        expected = len(events) + 1
+        if event.sequence != expected:
+            raise ValueError(
+                f"event sequence {event.sequence} does not match {expected}"
+            )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(dumps(event.as_dict()))
+            handle.write("\\n")
+
+    def extend(self, events: Iterable[Event]) -> None:
+        for event in events:
+            self.append(event)
+
+    @staticmethod
+    def _validate_sequences(events: list[Event]) -> None:
+        expected = list(range(1, len(events) + 1))
+        actual = [event.sequence for event in events]
+        if actual != expected:
+            raise ValueError("event sequence is not contiguous")
+`),
+  'incident_board/state.py': text(`
+"""Replay state and counters."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .domain import Incident
+
+
+@dataclass
+class ReplayCounters:
+    opened: int = 0
+    leased: int = 0
+    expired: int = 0
+    completed: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "opened": self.opened,
+            "leased": self.leased,
+            "expired": self.expired,
+            "completed": self.completed,
+        }
+
+
+@dataclass
+class BoardState:
+    incidents: dict[str, Incident] = field(default_factory=dict)
+    counters: ReplayCounters = field(default_factory=ReplayCounters)
+    seen_event_ids: set[str] = field(default_factory=set)
+    last_sequence: int = 0
+
+    def require_incident(self, incident_id: str) -> Incident:
+        try:
+            return self.incidents[incident_id]
+        except KeyError as error:
+            from .errors import IncidentNotFound
+
+            raise IncidentNotFound(incident_id) from error
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "incidents": {
+                key: value.as_dict()
+                for key, value in sorted(self.incidents.items())
+            },
+            "counters": self.counters.as_dict(),
+            "last_sequence": self.last_sequence,
+        }
+`),
+  'incident_board/lease.py': text(`
+"""Lease policy.
+
+The completion authorization below contains the seeded defect. It compares the
+identifier but does not prove that the lease is still current and unexpired.
+"""
+
+from datetime import datetime
+
+from .clock import parse_time
+from .domain import Incident
+
+
+def lease_is_expired(expires_at: str, at: str | datetime) -> bool:
+    checked = parse_time(at) if isinstance(at, str) else at
+    return checked >= parse_time(expires_at)
+
+
+def completion_is_authorized(
+    incident: Incident,
+    supplied_lease_id: str,
+    at: str,
+) -> bool:
+    """Return whether one lease authorizes completion."""
+    if incident.lease is None:
+        return False
+    return incident.lease.lease_id == supplied_lease_id
+
+
+def next_attempt(incident: Incident) -> int:
+    if incident.lease is None:
+        return 1
+    return incident.lease.attempt + 1
+`),
+  'incident_board/replay.py': text(`
+"""Event reducer and restart replay.
+
+The completion reducer intentionally increments the replay counter for every
+historical completion event. That makes a restarted summary diverge when an old
+retry log contains duplicate completions.
+"""
+
+from collections.abc import Iterable
+
+from .domain import Incident, Lease
+from .errors import InvalidEvent
+from .events import Event
+from .state import BoardState
+
+
+def apply_event(state: BoardState, event: Event) -> BoardState:
+    if event.event_id in state.seen_event_ids:
+        return state
+    if event.sequence != state.last_sequence + 1:
+        raise InvalidEvent("event sequence is not contiguous")
+
+    if event.event_type == "incident.opened":
+        if event.incident_id in state.incidents:
+            raise InvalidEvent("incident was opened twice")
+        state.incidents[event.incident_id] = Incident(
+            incident_id=event.incident_id,
+            title=event.data["title"],
+            severity=event.data["severity"],
+        )
+        state.counters.opened += 1
+    elif event.event_type == "lease.granted":
+        incident = state.require_incident(event.incident_id)
+        incident.status = "leased"
+        incident.lease = Lease(
+            lease_id=event.data["lease_id"],
+            worker_id=event.data["worker_id"],
+            granted_at=event.occurred_at,
+            expires_at=event.data["expires_at"],
+            attempt=event.data["attempt"],
+        )
+        state.counters.leased += 1
+    elif event.event_type == "lease.expired":
+        incident = state.require_incident(event.incident_id)
+        if incident.lease and incident.lease.lease_id == event.data["lease_id"]:
+            incident.status = "open"
+        state.counters.expired += 1
+    elif event.event_type == "incident.completed":
+        incident = state.require_incident(event.incident_id)
+        incident.status = "completed"
+        incident.completion_ids.add(event.data["completion_id"])
+        incident.completed_at = event.occurred_at
+        incident.result = event.data["result"]
+        state.counters.completed += 1
+    else:
+        raise InvalidEvent(f"unknown event type: {event.event_type}")
+
+    state.seen_event_ids.add(event.event_id)
+    state.last_sequence = event.sequence
+    return state
+
+
+def replay(events: Iterable[Event]) -> BoardState:
+    state = BoardState()
+    for event in events:
+        apply_event(state, event)
+    return state
+`),
+  'incident_board/commands.py': text(`
+"""Command handlers append domain events."""
+
+from datetime import timedelta
+
+from .clock import format_time, parse_time
+from .errors import CompletionRejected, LeaseConflict
+from .events import Event
+from .ids import event_id
+from .lease import completion_is_authorized, lease_is_expired, next_attempt
+from .state import BoardState
+
+
+def open_incident(
+    state: BoardState,
+    *,
+    incident_id: str,
+    title: str,
+    severity: str,
+    at: str,
+    command_id: str,
+) -> Event:
+    if incident_id in state.incidents:
+        raise ValueError("incident already exists")
+    return Event(
+        event_id=event_id("incident.opened", command_id),
+        sequence=state.last_sequence + 1,
+        event_type="incident.opened",
+        incident_id=incident_id,
+        occurred_at=at,
+        data={"title": title, "severity": severity},
+    )
+
+
+def grant_lease(
+    state: BoardState,
+    *,
+    incident_id: str,
+    lease_id: str,
+    worker_id: str,
+    ttl_seconds: int,
+    at: str,
+    command_id: str,
+) -> list[Event]:
+    incident = state.require_incident(incident_id)
+    result = []
+    sequence = state.last_sequence + 1
+    if incident.status == "completed":
+        raise LeaseConflict("completed incident cannot be leased")
+    if incident.lease and not lease_is_expired(incident.lease.expires_at, at):
+        raise LeaseConflict("incident already has an active lease")
+    if incident.lease and incident.status == "leased":
+        result.append(
+            Event(
+                event_id=event_id("lease.expired", command_id),
+                sequence=sequence,
+                event_type="lease.expired",
+                incident_id=incident_id,
+                occurred_at=at,
+                data={"lease_id": incident.lease.lease_id},
+            )
+        )
+        sequence += 1
+    expires = format_time(parse_time(at) + timedelta(seconds=ttl_seconds))
+    result.append(
+        Event(
+            event_id=event_id("lease.granted", command_id),
+            sequence=sequence,
+            event_type="lease.granted",
+            incident_id=incident_id,
+            occurred_at=at,
+            data={
+                "lease_id": lease_id,
+                "worker_id": worker_id,
+                "expires_at": expires,
+                "attempt": next_attempt(incident),
+            },
+        )
+    )
+    return result
+
+
+def complete_incident(
+    state: BoardState,
+    *,
+    incident_id: str,
+    lease_id: str,
+    completion_id: str,
+    result: str,
+    at: str,
+    command_id: str,
+) -> Event | None:
+    incident = state.require_incident(incident_id)
+    if completion_id in incident.completion_ids:
+        return None
+    if not completion_is_authorized(incident, lease_id, at):
+        raise CompletionRejected("lease does not authorize completion")
+    return Event(
+        event_id=event_id("incident.completed", command_id),
+        sequence=state.last_sequence + 1,
+        event_type="incident.completed",
+        incident_id=incident_id,
+        occurred_at=at,
+        data={
+            "lease_id": lease_id,
+            "completion_id": completion_id,
+            "result": result,
+        },
+    )
+`),
+  'incident_board/summary.py': text(`
+"""Summary projections."""
+
+from typing import Any
+
+from .state import BoardState
+
+
+def live_summary(state: BoardState) -> dict[str, Any]:
+    """Compute current state without trusting replay counters."""
+    incidents = list(state.incidents.values())
+    return {
+        "opened": len(incidents),
+        "open": sum(item.status == "open" for item in incidents),
+        "leased": sum(item.status == "leased" for item in incidents),
+        "completed": sum(item.status == "completed" for item in incidents),
+        "completion_records": sum(
+            len(item.completion_ids) for item in incidents
+        ),
+    }
+
+
+def replay_summary(state: BoardState) -> dict[str, Any]:
+    """Project persisted replay counters after restart."""
+    current = live_summary(state)
+    return {
+        **current,
+        "completed": state.counters.completed,
+        "completion_records": state.counters.completed,
+    }
+`),
+  'incident_board/service.py': text(`
+"""Application service joining commands, storage, and replay."""
+
+from pathlib import Path
+from typing import Any
+
+from . import commands
+from .event_store import JsonlEventStore
+from .replay import apply_event, replay
+from .summary import live_summary, replay_summary
+
+
+class IncidentBoard:
+    def __init__(self, store_path: str | Path):
+        self.store = JsonlEventStore(store_path)
+        self.state = replay(self.store.read())
+
+    def _append(self, event):
+        if event is None:
+            return None
+        self.store.append(event)
+        apply_event(self.state, event)
+        return event
+
+    def open(self, **values):
+        return self._append(commands.open_incident(self.state, **values))
+
+    def lease(self, **values):
+        events = commands.grant_lease(self.state, **values)
+        for event in events:
+            self._append(event)
+        return events[-1]
+
+    def complete(self, **values):
+        return self._append(commands.complete_incident(self.state, **values))
+
+    def summary(self, *, restarted: bool = False) -> dict[str, Any]:
+        if restarted:
+            restarted_state = replay(self.store.read())
+            return replay_summary(restarted_state)
+        return live_summary(self.state)
+`),
+  'incident_board/config.py': text(`
+"""Configuration loader with strict supported fields."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Config:
+    default_ttl_seconds: int = 30
+    severity_levels: tuple[str, ...] = ("low", "medium", "high", "critical")
+
+
+def load_config(path: str | Path | None = None) -> Config:
+    if path is None:
+        return Config()
+    value = json.loads(Path(path).read_text(encoding="utf-8"))
+    allowed = {"default_ttl_seconds", "severity_levels"}
+    unknown = set(value) - allowed
+    if unknown:
+        raise ValueError(f"unknown configuration fields: {sorted(unknown)}")
+    ttl = int(value.get("default_ttl_seconds", 30))
+    if ttl < 1:
+        raise ValueError("default_ttl_seconds must be positive")
+    levels = tuple(value.get("severity_levels", Config.severity_levels))
+    if not levels:
+        raise ValueError("severity_levels cannot be empty")
+    return Config(default_ttl_seconds=ttl, severity_levels=levels)
+`),
+  'incident_board/validation.py': text(`
+"""Input validation kept separate from command policy."""
+
+import re
+
+IDENTIFIER = re.compile(r"^[a-z][a-z0-9-]{2,63}$")
+
+
+def require_identifier(value: str, label: str) -> str:
+    if not IDENTIFIER.fullmatch(value):
+        raise ValueError(f"{label} is invalid")
+    return value
+
+
+def require_non_empty(value: str, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{label} cannot be empty")
+    return normalized
+
+
+def require_severity(value: str, allowed: tuple[str, ...]) -> str:
+    if value not in allowed:
+        raise ValueError(f"severity must be one of {allowed}")
+    return value
+`),
+  'incident_board/cli.py': text(`
+"""Command line interface."""
+
+import argparse
+import json
+import sys
+
+from .config import load_config
+from .errors import IncidentBoardError
+from .service import IncidentBoard
+from .validation import require_identifier, require_non_empty, require_severity
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(prog="incident-board")
+    root.add_argument("--store", required=True)
+    root.add_argument("--config")
+    commands = root.add_subparsers(dest="command", required=True)
+
+    opened = commands.add_parser("open")
+    opened.add_argument("incident_id")
+    opened.add_argument("--title", required=True)
+    opened.add_argument("--severity", required=True)
+    opened.add_argument("--at", required=True)
+    opened.add_argument("--command-id", required=True)
+
+    lease = commands.add_parser("lease")
+    lease.add_argument("incident_id")
+    lease.add_argument("--lease-id", required=True)
+    lease.add_argument("--worker-id", required=True)
+    lease.add_argument("--ttl", type=int)
+    lease.add_argument("--at", required=True)
+    lease.add_argument("--command-id", required=True)
+
+    completed = commands.add_parser("complete")
+    completed.add_argument("incident_id")
+    completed.add_argument("--lease-id", required=True)
+    completed.add_argument("--completion-id", required=True)
+    completed.add_argument("--result", required=True)
+    completed.add_argument("--at", required=True)
+    completed.add_argument("--command-id", required=True)
+
+    summary = commands.add_parser("summary")
+    summary.add_argument("--restarted", action="store_true")
+    return root
+
+
+def execute(argv: list[str]) -> dict:
+    args = parser().parse_args(argv)
+    config = load_config(args.config)
+    board = IncidentBoard(args.store)
+    if args.command == "open":
+        event = board.open(
+            incident_id=require_identifier(args.incident_id, "incident_id"),
+            title=require_non_empty(args.title, "title"),
+            severity=require_severity(args.severity, config.severity_levels),
+            at=args.at,
+            command_id=require_identifier(args.command_id, "command_id"),
+        )
+        return event.as_dict()
+    if args.command == "lease":
+        event = board.lease(
+            incident_id=require_identifier(args.incident_id, "incident_id"),
+            lease_id=require_identifier(args.lease_id, "lease_id"),
+            worker_id=require_identifier(args.worker_id, "worker_id"),
+            ttl_seconds=args.ttl or config.default_ttl_seconds,
+            at=args.at,
+            command_id=require_identifier(args.command_id, "command_id"),
+        )
+        return event.as_dict()
+    if args.command == "complete":
+        event = board.complete(
+            incident_id=require_identifier(args.incident_id, "incident_id"),
+            lease_id=require_identifier(args.lease_id, "lease_id"),
+            completion_id=require_identifier(
+                args.completion_id, "completion_id"
+            ),
+            result=require_non_empty(args.result, "result"),
+            at=args.at,
+            command_id=require_identifier(args.command_id, "command_id"),
+        )
+        return {"idempotent": event is None, "event": event.as_dict() if event else None}
+    return board.summary(restarted=args.restarted)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        output = execute(list(sys.argv[1:] if argv is None else argv))
+    except (IncidentBoardError, ValueError) as error:
+        print(json.dumps({"ok": False, "error": str(error)}, sort_keys=True))
+        return 2
+    print(json.dumps({"ok": True, "result": output}, sort_keys=True))
+    return 0
+`),
+  'incident_board/projections.py': text(`
+"""Read-only projections used by operators."""
+
+from collections import Counter
+from typing import Any
+
+from .state import BoardState
+
+
+def by_severity(state: BoardState) -> dict[str, int]:
+    return dict(
+        sorted(Counter(item.severity for item in state.incidents.values()).items())
+    )
+
+
+def worker_load(state: BoardState) -> dict[str, int]:
+    counter = Counter()
+    for incident in state.incidents.values():
+        if incident.status == "leased" and incident.lease:
+            counter[incident.lease.worker_id] += 1
+    return dict(sorted(counter.items()))
+
+
+def incident_view(state: BoardState, incident_id: str) -> dict[str, Any]:
+    return state.require_incident(incident_id).as_dict()
+`),
+};
+
+const supportModules = {
+  query: {
+    title: 'Bounded incident query',
+    functionName: 'select_status',
+    body: 'return [item.as_dict() for item in state.incidents.values() if item.status == status]',
+    args: 'state, status: str',
+  },
+  repository: {
+    title: 'Repository coordinates',
+    functionName: 'repository_identity',
+    body: 'return {"kind": "jsonl", "path": str(path)}',
+    args: 'path',
+  },
+  retry: {
+    title: 'Retry classification',
+    functionName: 'is_retryable',
+    body: 'return code in {"lease-conflict", "timeout", "worker-lost"}',
+    args: 'code: str',
+  },
+  snapshots: {
+    title: 'Stable state snapshots',
+    functionName: 'snapshot',
+    body: 'return state.as_dict()',
+  },
+  telemetry: {
+    title: 'Bounded telemetry dimensions',
+    functionName: 'dimensions',
+    body: 'return {"status": incident.status, "severity": incident.severity, "leased": incident.lease is not None}',
+    args: 'incident',
+  },
+};
+
+for (const [name, spec] of Object.entries(supportModules)) {
+  const args = spec.args || 'state';
+  files[`incident_board/${name}.py`] = text(`
+"""${spec.title}.
+
+This module is deliberately read-only. It keeps operational projections out of
+the command and replay policy so recovery behavior remains testable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def ${spec.functionName}(${args}) -> Any:
+    """Return one deterministic projection."""
+    ${spec.body}
+
+
+def contract() -> dict[str, Any]:
+    """Describe this small projection for diagnostics."""
+    return {
+        "schema": "incident-board.support-contract/v1",
+        "module": "${name}",
+        "mutation": False,
+        "deterministic": True,
+    }
+`);
+}
+
+const architectureComponents = [
+  [
+    'Command boundary',
+    'validated command dictionaries',
+    'domain events',
+    'reject malformed user input',
+    'retry with corrected arguments',
+  ],
+  [
+    'CLI adapter',
+    'process arguments and JSON config',
+    'JSON result envelopes',
+    'return a stable nonzero status',
+    'inspect the structured error',
+  ],
+  [
+    'Service facade',
+    'validated domain values',
+    'events and projections',
+    'preserve the domain exception',
+    'retry only idempotent calls',
+  ],
+  [
+    'Command handler',
+    'current state and one command',
+    'zero or one new event',
+    'reject stale authority',
+    'obtain a successor lease',
+  ],
+  [
+    'Lease policy',
+    'lease identity and clock time',
+    'authorization decision',
+    'deny expired or replaced leases',
+    'request a fresh lease',
+  ],
+  [
+    'Replay reducer',
+    'ordered immutable events',
+    'rebuilt board state',
+    'reject invalid sequence order',
+    'restore from a verified copy',
+  ],
+  [
+    'Event store',
+    'versioned event envelopes',
+    'durable JSONL records',
+    'stop on malformed JSON',
+    'quarantine the damaged copy',
+  ],
+  [
+    'Event envelope',
+    'domain payload and sequence',
+    'canonical event dictionary',
+    'reject unsupported event types',
+    'upgrade through an explicit migration',
+  ],
+  [
+    'Board state',
+    'accepted domain events',
+    'incident and counter projections',
+    'reject unknown incidents',
+    'replay from the first event',
+  ],
+  [
+    'Incident model',
+    'title severity and lifecycle data',
+    'stable incident dictionary',
+    'retain completion identity',
+    'compare with the event log',
+  ],
+  [
+    'Lease model',
+    'worker identity and expiry',
+    'stable lease dictionary',
+    'retain attempt ordering',
+    'grant a successor explicitly',
+  ],
+  [
+    'Summary projection',
+    'board state or replay result',
+    'bounded counters',
+    'never inspect wall clock time',
+    'recompute from stored events',
+  ],
+  [
+    'Severity projection',
+    'current incidents',
+    'sorted severity counters',
+    'avoid mutating the board',
+    'discard and recompute',
+  ],
+  [
+    'Worker projection',
+    'active leased incidents',
+    'sorted worker counters',
+    'exclude completed incidents',
+    'discard and recompute',
+  ],
+  [
+    'Configuration loader',
+    'optional JSON document',
+    'validated immutable config',
+    'reject unknown severity values',
+    'fall back only when absent',
+  ],
+  [
+    'Validation layer',
+    'external identifiers and text',
+    'normalized domain values',
+    'reject empty or malformed values',
+    'correct the caller input',
+  ],
+  [
+    'Clock adapter',
+    'timezone-aware ISO timestamps',
+    'canonical UTC values',
+    'reject naive timestamps',
+    'provide an explicit timezone',
+  ],
+  [
+    'Identifier helper',
+    'canonical command content',
+    'bounded content identifiers',
+    'avoid random process state',
+    'recompute from the same input',
+  ],
+  [
+    'Repository facade',
+    'event-store path',
+    'repository coordinates',
+    'make storage kind explicit',
+    'open a new bounded repository',
+  ],
+  [
+    'Query helper',
+    'board state and status filter',
+    'incident dictionaries',
+    'remain read-only',
+    'repeat against rebuilt state',
+  ],
+  [
+    'Retry classifier',
+    'stable error code',
+    'retryability boolean',
+    'default unknown codes to false',
+    'escalate non-retryable failures',
+  ],
+  [
+    'Snapshot helper',
+    'current board state',
+    'stable state dictionary',
+    'do not write snapshots automatically',
+    'regenerate from replay',
+  ],
+  [
+    'Telemetry helper',
+    'one incident projection',
+    'bounded low-cardinality dimensions',
+    'exclude titles and results',
+    'drop unsafe dimensions',
+  ],
+  [
+    'Recovery procedure',
+    'copied immutable event log',
+    'verified replay projection',
+    'keep admission stopped on mismatch',
+    'compare live and replay summaries',
+  ],
+];
+
+files['docs/architecture.md'] = text(`
+# Architecture and recovery contract
+
+This document is intentionally detailed because the repository-load task asks
+an agent to navigate a realistic service rather than a toy function. The event
+log is authoritative. Every other view is disposable and reproducible.
+
+${architectureComponents
+  .map(
+    ([title, input, output, failure, recovery], index) => `
+## ${index + 1}. ${title}
+
+- Responsibility: keep this boundary deterministic and independently testable.
+- Input: ${input}.
+- Output: ${output}.
+- Failure rule: ${failure}.
+- Recovery rule: ${recovery}.
+- Mutation boundary: only command admission may append an event.
+- Replay boundary: rebuilding state must not append or rewrite any event.
+- Time boundary: timestamps enter as explicit command values.
+- Identity boundary: content identifiers never depend on process randomness.
+- Evidence boundary: errors remain structured and safe to retain.
+- Compatibility boundary: historical bytes stay readable without silent edits.
+- Review question: can this component alter completion cardinality?
+- Review question: does restart reproduce the same observable summary?
+- Review question: is a stale worker prevented from extending its authority?
+`,
+  )
+  .join('\n')}
+
+## End-to-end invariant
+
+For one immutable event log, live state and restarted state must report the same
+incident cardinality, completion cardinality, and completion identity set. A
+successor lease may authorize new work, but it cannot make an expired lease
+valid again. Repeated transport delivery may be idempotent; two distinct domain
+completions for one incident are not.
+`);
+
+const operationalScenarios = Array.from({ length: 34 }, (_, index) => ({
+  number: index + 1,
+  severity: ['low', 'medium', 'high', 'critical'][index % 4],
+  status: index % 2 === 0 ? 'open' : 'leased',
+}));
+
+files['tests/test_operational_matrix.py'] = text(`
+import unittest
+
+from incident_board.projections import by_severity, worker_load
+from tests.helpers import board
+
+
+class OperationalMatrixTests(unittest.TestCase):
+${operationalScenarios
+  .map(
+    ({ number, severity, status }) => `
+    def test_scenario_${String(number).padStart(2, '0')}_${status}_${severity}(self):
+        temporary, value = board()
+        self.addCleanup(temporary.cleanup)
+        incident_id = "inc-scenario-${String(number).padStart(2, '0')}"
+        value.open(
+            incident_id=incident_id,
+            title="Operational scenario ${number}",
+            severity="${severity}",
+            at="2026-01-01T00:00:00Z",
+            command_id="cmd-open-${String(number).padStart(2, '0')}",
+        )
+${
+  status === 'leased'
+    ? `        value.lease(
+            incident_id=incident_id,
+            lease_id="lease-scenario-${String(number).padStart(2, '0')}",
+            worker_id="worker-${(number % 3) + 1}",
+            ttl_seconds=120,
+            at="2026-01-01T00:00:01Z",
+            command_id="cmd-lease-${String(number).padStart(2, '0')}",
+        )
+        self.assertEqual(sum(worker_load(value.state).values()), 1)`
+    : '        self.assertEqual(worker_load(value.state), {})'
+}
+        self.assertEqual(by_severity(value.state), {"${severity}": 1})
+        self.assertEqual(value.summary()["opened"], 1)
+        self.assertEqual(value.summary(restarted=True)["opened"], 1)
+`,
+  )
+  .join('\n')}
+`);
+
+Object.assign(files, {
+  'tests/__init__.py': '',
+  'tests/helpers.py': text(`
+"""Shared visible test helpers."""
+
+import tempfile
+from pathlib import Path
+
+from incident_board.service import IncidentBoard
+
+T0 = "2026-01-01T00:00:00Z"
+
+
+def board():
+    temporary = tempfile.TemporaryDirectory()
+    path = Path(temporary.name) / "events.jsonl"
+    return temporary, IncidentBoard(path)
+
+
+def opened_and_leased():
+    temporary, value = board()
+    value.open(
+        incident_id="inc-one",
+        title="Database unavailable",
+        severity="critical",
+        at=T0,
+        command_id="cmd-open",
+    )
+    value.lease(
+        incident_id="inc-one",
+        lease_id="lease-one",
+        worker_id="worker-one",
+        ttl_seconds=30,
+        at=T0,
+        command_id="cmd-lease",
+    )
+    return temporary, value
+`),
+  'tests/test_commands.py': text(`
+import unittest
+
+from tests.helpers import opened_and_leased
+
+
+class CommandTests(unittest.TestCase):
+    def test_open_lease_and_complete(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        event = board.complete(
+            incident_id="inc-one",
+            lease_id="lease-one",
+            completion_id="done-one",
+            result="recovered",
+            at="2026-01-01T00:00:10Z",
+            command_id="cmd-complete",
+        )
+        self.assertEqual(event.event_type, "incident.completed")
+        self.assertEqual(board.summary()["completed"], 1)
+
+    def test_same_completion_is_idempotent(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        values = dict(
+            incident_id="inc-one",
+            lease_id="lease-one",
+            completion_id="done-one",
+            result="recovered",
+            at="2026-01-01T00:00:10Z",
+        )
+        board.complete(command_id="cmd-complete", **values)
+        self.assertIsNone(
+            board.complete(command_id="cmd-complete-retry", **values)
+        )
+`),
+  'tests/test_retry_regression.py': text(`
+import unittest
+
+from incident_board.errors import CompletionRejected
+from tests.helpers import opened_and_leased
+
+
+class RetryRegressionTests(unittest.TestCase):
+    def test_expired_lease_cannot_complete(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        with self.assertRaises(CompletionRejected):
+            board.complete(
+                incident_id="inc-one",
+                lease_id="lease-one",
+                completion_id="done-stale",
+                result="stale worker result",
+                at="2026-01-01T00:00:31Z",
+                command_id="cmd-stale",
+            )
+
+    def test_legacy_duplicate_log_has_stable_restart_summary(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        board.complete(
+            incident_id="inc-one",
+            lease_id="lease-one",
+            completion_id="done-one",
+            result="recovered",
+            at="2026-01-01T00:00:10Z",
+            command_id="cmd-complete",
+        )
+        duplicate = board.store.read()[-1]
+        value = duplicate.as_dict()
+        value["event_id"] = "evt-legacy-duplicate"
+        value["sequence"] += 1
+        value["data"] = {**value["data"], "completion_id": "done-retry"}
+        from incident_board.events import Event
+
+        board.store.append(Event.from_dict(value))
+        self.assertEqual(board.summary()["completed"], 1)
+        self.assertEqual(board.summary(restarted=True)["completed"], 1)
+`),
+  'tests/test_replay.py': text(`
+import unittest
+
+from incident_board.replay import replay
+from tests.helpers import opened_and_leased
+
+
+class ReplayTests(unittest.TestCase):
+    def test_normal_replay_matches_live_state(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        restored = replay(board.store.read())
+        self.assertEqual(restored.as_dict(), board.state.as_dict())
+
+    def test_replay_is_deterministic(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        events = board.store.read()
+        self.assertEqual(replay(events).as_dict(), replay(events).as_dict())
+`),
+  'tests/test_store.py': text(`
+import unittest
+
+from incident_board.event_store import JsonlEventStore
+from tests.helpers import opened_and_leased
+
+
+class StoreTests(unittest.TestCase):
+    def test_round_trip(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        reopened = JsonlEventStore(board.store.path)
+        self.assertEqual(
+            [event.as_dict() for event in reopened.read()],
+            [event.as_dict() for event in board.store.read()],
+        )
+
+    def test_missing_store_is_empty(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        missing = JsonlEventStore(board.store.path.parent / "missing.jsonl")
+        self.assertEqual(missing.read(), [])
+`),
+  'tests/test_config.py': text(`
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from incident_board.config import Config, load_config
+
+
+class ConfigTests(unittest.TestCase):
+    def test_default(self):
+        self.assertEqual(load_config(), Config())
+
+    def test_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "config.json"
+            path.write_text(
+                json.dumps({"default_ttl_seconds": 45}),
+                encoding="utf-8",
+            )
+            self.assertEqual(load_config(path).default_ttl_seconds, 45)
+`),
+  'tests/test_cli.py': text(`
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from incident_board.cli import execute
+
+
+class CliTests(unittest.TestCase):
+    def test_open_and_summary(self):
+        with tempfile.TemporaryDirectory() as directory:
+            store = str(Path(directory) / "events.jsonl")
+            execute(
+                [
+                    "--store", store, "open", "inc-one",
+                    "--title", "API unavailable",
+                    "--severity", "high",
+                    "--at", "2026-01-01T00:00:00Z",
+                    "--command-id", "cmd-open",
+                ]
+            )
+            summary = execute(["--store", store, "summary"])
+            self.assertEqual(summary["opened"], 1)
+            self.assertEqual(summary["completed"], 0)
+`),
+  'tests/test_domain.py': text(`
+import unittest
+
+from incident_board.domain import Incident, Lease
+
+
+class DomainTests(unittest.TestCase):
+    def test_incident_projection_is_sorted(self):
+        incident = Incident("inc-one", "Example", "low")
+        incident.completion_ids.update({"done-two", "done-one"})
+        self.assertEqual(
+            incident.as_dict()["completion_ids"],
+            ["done-one", "done-two"],
+        )
+
+    def test_lease_projection(self):
+        lease = Lease(
+            "lease-one", "worker-one",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:30Z",
+            1,
+        )
+        self.assertEqual(lease.as_dict()["attempt"], 1)
+`),
+  'tests/test_validation.py': text(`
+import unittest
+
+from incident_board.validation import (
+    require_identifier,
+    require_non_empty,
+    require_severity,
+)
+
+
+class ValidationTests(unittest.TestCase):
+    def test_identifier(self):
+        self.assertEqual(require_identifier("inc-one", "id"), "inc-one")
+        with self.assertRaises(ValueError):
+            require_identifier("../escape", "id")
+
+    def test_text_and_severity(self):
+        self.assertEqual(require_non_empty(" value ", "value"), "value")
+        self.assertEqual(
+            require_severity("high", ("low", "high")),
+            "high",
+        )
+`),
+  'tests/test_projections.py': text(`
+import unittest
+
+from incident_board.projections import by_severity, worker_load
+from tests.helpers import opened_and_leased
+
+
+class ProjectionTests(unittest.TestCase):
+    def test_severity_and_worker_views(self):
+        temporary, board = opened_and_leased()
+        self.addCleanup(temporary.cleanup)
+        self.assertEqual(by_severity(board.state), {"critical": 1})
+        self.assertEqual(worker_load(board.state), {"worker-one": 1})
+`),
+  'config/default.json': text(`
+{
+  "default_ttl_seconds": 30,
+  "severity_levels": ["low", "medium", "high", "critical"]
+}
+`),
+  'config/retry-fast.json': text(`
+{
+  "default_ttl_seconds": 5,
+  "severity_levels": ["low", "medium", "high", "critical"]
+}
+`),
+  'config/retry-slow.json': text(`
+{
+  "default_ttl_seconds": 120,
+  "severity_levels": ["low", "medium", "high", "critical"]
+}
+`),
+  'docs/domain.md': text(`
+# Domain model
+
+An Incident begins open, may become leased, and ends completed. A Lease is a
+bounded authority record, not merely a worker label. A retry grants a successor
+lease only after the prior lease expires. The successor does not retroactively
+authorize the prior worker.
+
+Completion identity and event identity are different. Repeated delivery of one
+completion is idempotent. Legacy logs may contain two completion events from a
+past bug; replay must preserve the bytes while folding them into one incident
+completion.
+`),
+  'docs/event-log.md': text(`
+# Event log
+
+The JSONL store is append-only and sequence ordered. Event ids make transport
+retry idempotent, while domain identity prevents two distinct event ids from
+representing two completions of the same incident.
+
+Restart replay must be deterministic. It may diagnose historical anomalies but
+cannot silently discard or rewrite stored lines. Summary counters are derived
+state and must agree with the incident projection.
+`),
+  'docs/recovery.md': text(`
+# Recovery procedure
+
+1. Stop command admission.
+2. Copy the JSONL file without editing it.
+3. Replay into a fresh in-memory state.
+4. Compare live incident counts with replay counters.
+5. Resume admission only when the projections agree.
+
+This fixture does not implement destructive repair. Historical duplicates are
+handled by a backward-compatible reducer rule.
+`),
+  'examples/normal-events.jsonl': '',
+  'examples/README.md': text(`
+# Examples
+
+The empty JSONL file is intentional. Visible tests create deterministic examples
+with fixed timestamps so repository bytes remain stable.
+`),
+  LICENSE: text(`
+Apache License 2.0
+
+This qualification fixture is distributed under the repository license.
+`),
+});
+
+export const INCIDENT_BOARD_FIXTURE = Object.freeze({
+  schema: 'kungfu.agent-repository-work.fixture/v1',
+  id: 'incident-board-replay-v1',
+  language: 'python',
+  runtime: 'python-standard-library-only',
+  defect: {
+    id: 'expired-lease-duplicate-completion-replay-divergence',
+    seeded: true,
+    requiredBoundaries: ['lease', 'command', 'replay', 'summary', 'cli'],
+  },
+  task: {
+    title:
+      'Repair completion idempotency across lease retry and restart replay',
+    visibleTestCommand: 'python -m unittest discover -s tests -v',
+    expectedBehavior: [
+      'expired leases cannot authorize completion',
+      'completion retry is idempotent',
+      'legacy duplicate completion events replay as one completed incident',
+      'live and restarted summaries agree',
+    ],
+  },
+  warrants: {
+    agentA: {
+      mode: 'investigation-only',
+      writablePaths: [],
+    },
+    agentB: {
+      mode: 'bounded-repair',
+      writablePaths: [
+        'incident_board/commands.py',
+        'incident_board/lease.py',
+        'incident_board/replay.py',
+      ],
+    },
+  },
+  protectedPaths: [
+    'README.md',
+    'pyproject.toml',
+    'tests',
+    'config',
+    'docs',
+    'examples',
+  ],
+  files: Object.freeze(files),
+});

--- a/tests/qualification/agent-repository-work/mock-opencode.mjs
+++ b/tests/qualification/agent-repository-work/mock-opencode.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { INCIDENT_BOARD_REFERENCE_REPAIR } from './incident-board-replay-v1-reference.mjs';
+
+const args = process.argv.slice(2);
+const agentIndex = args.indexOf('--agent');
+const agent = agentIndex >= 0 ? args[agentIndex + 1] : '';
+const prompt = args.at(-1) || '';
+
+if (agent === 'build' && prompt.includes('Investigate the repository defect')) {
+  const claim = {
+    schema: 'kungfu.agent-repository-work.investigation-claim/v1',
+    investigationComplete: true,
+    failingTests: [
+      'test_expired_lease_cannot_complete',
+      'test_legacy_duplicate_log_has_stable_restart_summary',
+    ],
+    repairPaths: [
+      'incident_board/commands.py',
+      'incident_board/lease.py',
+      'incident_board/replay.py',
+    ],
+    remainingObligation: 'implement-and-verify-bounded-repair',
+    nextAction: 'repair-seeded-completion-idempotency',
+  };
+  process.stdout.write(
+    `${JSON.stringify({
+      type: 'text',
+      sessionID: 'mock-investigation-session',
+      part: { text: JSON.stringify(claim) },
+    })}\n`,
+  );
+} else if (agent === 'build') {
+  const repair = args.some((arg) => arg.includes('mock-incomplete'))
+    ? {
+        'incident_board/lease.py':
+          INCIDENT_BOARD_REFERENCE_REPAIR['incident_board/lease.py'],
+      }
+    : INCIDENT_BOARD_REFERENCE_REPAIR;
+  for (const [relative, content] of Object.entries(repair))
+    fs.writeFileSync(path.join(process.cwd(), relative), content);
+  process.stdout.write(
+    `${JSON.stringify({
+      type: 'text',
+      sessionID: 'mock-repair-session',
+      part: {
+        text: 'Recovered the admitted continuation and completed the bounded repair.',
+      },
+    })}\n`,
+  );
+} else {
+  process.stderr.write(`unsupported mock agent: ${agent}\n`);
+  process.exitCode = 2;
+}


### PR DESCRIPTION
## Summary

Add an independently owned, manual repository-work experiment for two fresh OpenCode sessions backed by the local Qwen3-Coder model. Kungfu carries a content-rooted, transcript-free continuation from an investigation-only Agent A to a bounded-repair Agent B, while an external deterministic oracle remains authoritative.

The final agent-120 observation is intentionally reported as a fail-closed experimental result: Kungfu completed the two-session continuity and evidence path, but the model repair did not pass the visible or hidden oracle.

## Related issue

Dedicated Kungfu Assignment `2026-07-27-kungfu-local-agent-repository-load-experiment`.

## Delivery topology

This is the final protected-queue linear delivery following source review PR #1627 and prior delivery replays #1645 and #1652. Commit `849381ae32b192e9cc8ee143d7e0fd257cf3b06b` has current protected base `f2c7df9000f340ab62f008888245bd558ec41b23` as its single parent and combines the reviewed experiment with the protected ARM64 and Auditable Demo base changes. The original implementation commit `9bd83f8d6e017cc030522605b5f3cbfb854dddac`, source-review history, and portable seal remain preserved on #1627; no history was force-pushed or deleted.

## Changes

- add the fixed `incident-board-replay-v1` repository fixture, contract, hidden oracle, and reference repair
- add a native Kungfu runner for two fresh OpenCode processes with zero transcript handoff
- enforce a read-only Agent A Warrant and a three-file Agent B Warrant in a least-privilege container
- retain bounded session, Episode, Warrant, visible, hidden, and failure diagnostics
- add a manual agent-120 workflow pinned to the released OpenCode image and local model endpoint
- register the workflow as qualification-only, non-publication authority
- document explicit non-integration boundaries for Auditable Demo, Qualification Lab, release gates, model ranking, and public claims

## Verification

- `./shifu test:agent-repository-work` (10/10)
- `./shifu check:release-publication-control-plane`
- `node scripts/check-kungfu-gate-catalog.test.mjs` (23/23)
- `./shifu maintainability:complexity -- --json`
- full staged source/documentation/invariant gate on every commit
- protected PR checks: DCO, governance, source acceptance, and affected-native
- latest complete agent-120 run before the final queue replay, at tree-equivalent predecessor `188e6c309fcf4a1ac423593aff29c5e06bd45733` with `qwen3-coder:30b-opencode-64k` (exact-head replay is in progress):
  - two distinct provider sessions completed
  - Agent A made zero workspace changes
  - Agent B received zero prior transcript bytes and no human restatement
  - both Kungfu Episodes passed frame fsck
  - Agent B changed only allowlisted `incident_board/lease.py`; no scope violation occurred
  - the independent verifier rejected the incomplete repair and both visible and hidden oracle checks failed, so the experiment failed closed
  - elapsed model experiment time: `381836 ms`
  - bounded report file root: `sha256:7d02dc0ad2a7dd49d077abe4b09d1060fc7eb88419a17ed71f603a38500c0dd2`
  - oracle report root: `sha256:0d16974f3a266c96a27c1a3f3fe300d595558704251581afc4d58f7792ed2c01`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This independent bounded qualification experiment does not alter a product architecture contract, release gate, publication surface, Auditable Demo, or Qualification Lab"
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow invokes only the pinned OpenCode CLI image and host-bound local OpenAI-compatible endpoint without credentials. It uploads one bounded diagnostic report and is registered as non-publication.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
