### PR TITLE
fix(product): isolate Agent Hub smoke cache

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:eb139392b2522f570e9d4c901b7351bfa03d36137616004e38e93f84e881aa4b",
+  "sourceRoot": "sha256:8708790065c43f2f34c0d2bd2095e877254789051eb87a6ea6fe1be97103d150",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -521,7 +521,7 @@
           "path": "product/scripts/dist.mjs",
           "currentLines": 2530,
           "baselineLines": 2514,
-          "currentRoot": "sha256:d48088fe0951e44834cf2f07ada4459daa67ed34c85c624897f75d42f359f6d1",
+          "currentRoot": "sha256:8204f9e353ca411d489077ad124955512a741cd865486e25b289b6f8455764cf",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1544,26 +1544,30 @@ function runInstalledKungfuKfdSmoke({
   }
 }
 
-function runInstalledKungfuAgentHubSmoke({ installRoot, kungfuBin, env }) {
-  const qualificationDir = path.join(installRoot, 'agent-hub-qualification');
-  const runtimeHome = path.join(installRoot, '.agent-hub-runtime-home');
+export function runInstalledKungfuAgentHubSmoke({
+  installRoot,
+  kungfuBin,
+  env,
+  run = runInstalledKungfu,
+}) {
   const userHome = path.join(installRoot, '.agent-hub-user-home');
   const smokeEnv = {
     ...env,
     HOME: userHome,
     USERPROFILE: userHome,
+    KF_CACHE_HOME: path.join(installRoot, '.agent-hub-cache-home'),
   };
   const qualification = parseJsonOutput(
-    runInstalledKungfu({
+    run({
       kungfuBin,
       installRoot,
-      home: runtimeHome,
+      home: path.join(installRoot, '.agent-hub-runtime-home'),
       args: [
         'agent',
         'hub',
         'qualify',
         '--output-dir',
-        qualificationDir,
+        path.join(installRoot, 'agent-hub-qualification'),
         '--json',
       ],
       env: smokeEnv,
@@ -1586,16 +1590,16 @@ function runInstalledKungfuAgentHubSmoke({ installRoot, kungfuBin, env }) {
     );
   }
   const verification = parseJsonOutput(
-    runInstalledKungfu({
+    run({
       kungfuBin,
       installRoot,
-      home: runtimeHome,
+      home: path.join(installRoot, '.agent-hub-runtime-home'),
       args: [
         'agent',
         'hub',
         'verify',
         '--qualification-dir',
-        qualificationDir,
+        path.join(installRoot, 'agent-hub-qualification'),
         '--json',
       ],
       env: smokeEnv,
@@ -1616,11 +1620,7 @@ function runInstalledKungfuAgentHubSmoke({ installRoot, kungfuBin, env }) {
     );
   }
   if (fs.existsSync(userHome)) {
-    // Qualification must remain stateless even when the product receives an
-    // isolated HOME instead of the operator's real user directory.
-    throw new Error(
-      'installed kungfu Agent Hub smoke modified its isolated user home',
-    );
+    throw new Error('Agent Hub smoke modified isolated HOME');
   }
 }
 

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -18,6 +18,7 @@ import {
   isShippedKfdSupport,
   kfxBundleExternalModules,
   requiresManagedEsbuildPlatform,
+  runInstalledKungfuAgentHubSmoke,
   runInstalledKungfuAssignmentAdmissionSmoke,
   runInstalledKungfuCommand,
   stageXinfaContract,
@@ -354,6 +355,61 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
     JSON.parse(fs.readFileSync(isolatedCatalog, 'utf8')).locator,
     path.join(installRoot, 'assignment-admission-workspace'),
   );
+});
+
+test('Agent Hub smoke redirects Python cache outside its isolated user home', (t) => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-agent-hub-cache-isolation-'),
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const installRoot = path.join(root, 'installed');
+  fs.mkdirSync(installRoot, { recursive: true });
+
+  const invocations = [];
+  const meaning = 'Agent Hub qualification passed';
+  const nonClaims = ['KFD certification'];
+  runInstalledKungfuAgentHubSmoke({
+    installRoot,
+    kungfuBin: path.join(installRoot, 'kungfu'),
+    env: process.env,
+    run(invocation) {
+      invocations.push(invocation);
+      fs.mkdirSync(invocation.env.KF_CACHE_HOME, { recursive: true });
+      fs.writeFileSync(
+        path.join(invocation.env.KF_CACHE_HOME, 'qualification.pyc'),
+        'cache',
+      );
+      if (invocation.args.includes('qualify')) {
+        return `${JSON.stringify({
+          valid: true,
+          coverage: { passed: 20, total: 20 },
+          isolation: { realHomeUnchanged: true },
+          meaning,
+          nonClaims,
+          next: { verify: 'kungfu agent hub verify' },
+          evidence: { reportDigest: `sha256:${'1'.repeat(64)}` },
+        })}\n`;
+      }
+      return `${JSON.stringify({
+        valid: true,
+        coverage: { passed: 20, total: 20 },
+        meaning,
+        nonClaims,
+        checks: [{ passed: true }],
+      })}\n`;
+    },
+  });
+
+  assert.equal(invocations.length, 2);
+  const expectedUserHome = path.join(installRoot, '.agent-hub-user-home');
+  const expectedCacheHome = path.join(installRoot, '.agent-hub-cache-home');
+  for (const invocation of invocations) {
+    assert.equal(invocation.env.HOME, expectedUserHome);
+    assert.equal(invocation.env.USERPROFILE, expectedUserHome);
+    assert.equal(invocation.env.KF_CACHE_HOME, expectedCacheHome);
+  }
+  assert.equal(fs.existsSync(expectedUserHome), false);
+  assert.equal(fs.existsSync(expectedCacheHome), true);
 });
 
 test('product observability ignores errors from sibling components', () => {


### PR DESCRIPTION
## Summary

- Route disposable Python bytecode and product caches from the installed Agent Hub qualification to its isolated runtime cache.
- Preserve the stronger invariant that the isolated user HOME remains entirely absent after qualification.
- Add a regression fence and refresh the semantic amplification projection without increasing the grandfathered dist.mjs line count.

## Failure evidence

- Alpha Build run 30267579084, macOS job 89983080260, failed before signing with: installed kungfu Agent Hub smoke modified its isolated user home.
- The native launcher now derives PYTHONPYCACHEPREFIX from KF_CACHE_HOME. Without an explicit smoke cache, the platform default resolves through HOME and creates the isolated user directory.

## Verification

- node --test product/scripts/dist.test.mjs: 26 passed, 0 failed.
- node scripts/source-acceptance.mjs: passed; 684 contract tests reported 674 pass, 10 skip, 0 fail, followed by 40 Agent Work, 116 runtime-upgrade, and 69 desktop-update tests passing.
- node scripts/code-complexity-budget.mjs: passed.
- Biome, TypeScript tooling check, git diff --check, and commit staged gate: passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repairs installed-product qualification after the already-implemented disposable product cache contract; it does not change public semantics or widen release claims."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; qualification wiring only)
