### PR TITLE
fix(build): bind updated portable cache profile digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
       # Do not project the private-LAN runner profile onto hosted legs; use the
       # checked-in explicit-off profile so cache provenance remains auditable.
       shifu-cache-profile-ref: ${{ inputs.platforms-json && 'docs/shifu/qualification-portable-off.cache-profile.json' || vars.SHIFU_CACHE_PROFILE_REF }}
-      shifu-cache-profile-digest: ${{ inputs.platforms-json && 'sha256:251ecdb33a34b770a6fbd40b0b05c5c8c0d629a06d9144e6d2d89c9c8e70258b' || vars.SHIFU_CACHE_PROFILE_DIGEST }}
+      shifu-cache-profile-digest: ${{ inputs.platforms-json && 'sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c' || vars.SHIFU_CACHE_PROFILE_DIGEST }}
       cache-dependency-lock-root: ${{ needs.preflight.outputs.dependency-lock-root }}
       cache-toolchain-root: ${{ needs.preflight.outputs.toolchain-root }}
       cache-policy-root: ${{ needs.preflight.outputs.policy-root }}
@@ -211,7 +211,7 @@ jobs:
       checkout-cache-timeout-seconds: 60
       checkout-cache-github-timeout-seconds: 1200
       shifu-cache-profile-ref: docs/shifu/qualification-portable-off.cache-profile.json
-      shifu-cache-profile-digest: sha256:251ecdb33a34b770a6fbd40b0b05c5c8c0d629a06d9144e6d2d89c9c8e70258b
+      shifu-cache-profile-digest: sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c
       buildchain-contract-lock-path: .buildchain/contract-lock.json
       buildchain-contract-compatibility-policy: major-compatible
       buildchain-contract-drift-issue-mode: compatible-and-breaking

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -770,7 +770,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:78e35dd1773156161451b5e2736410c724d8142a37e4bf378621760deba0478b",
+          "definitionDigest": "sha256:be225e4e8c4369c3c95a8148fc768916c984d08773f5226bbde9d97fe32d6155",
           "credentials": {
             "githubToken": "write",
             "oidc": true,
@@ -848,7 +848,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:ba5be3ddff4f52b785d8ffc173adb374b0db519ddb65a1ae611eea2283c461c3",
+          "definitionDigest": "sha256:e6305adae11b3207995daa414fc106118500a958dd99f2440df1ad6fe90c77c4",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -100,7 +100,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:fea587da981f39d11ff6baee9d714548d927edffa8c355371c4c99d69e78f77d"
+          "sourceRoot": "sha256:f85b0bbf56a3824ae7190bc1dd7fd0bf5a4c478fe64ba7b8439c0c41a3f2f13b"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:5e3b29cc816d8ad1777234a438e294b42c73fa2d3a21da8ed2fc9711138cc053"
+  "registryRoot": "sha256:a22b3dda63e68a8197a4f6dc1db8a684c25b23d433684d0255cfcffbe90e434e"
 }

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -142,21 +142,25 @@ test('cache contract schemas accept valid fixtures and reject unsafe policy', as
 });
 
 test('portable-off qualification profile covers every native Build lane', () => {
-  const profile = JSON.parse(
-    fs.readFileSync(
-      path.join(
-        ROOT,
-        'docs/shifu/qualification-portable-off.cache-profile.json',
-      ),
-      'utf8',
-    ),
+  const profilePath = path.join(
+    ROOT,
+    'docs/shifu/qualification-portable-off.cache-profile.json',
   );
+  const profileText = fs.readFileSync(profilePath, 'utf8');
+  const profile = JSON.parse(profileText);
   assert.deepEqual(profile.subject.platforms, [
     'darwin-arm64',
     'linux-arm64',
     'linux-x64',
     'windows-x64',
   ]);
+
+  const digest = crypto.createHash('sha256').update(profileText).digest('hex');
+  const buildWorkflow = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/build.yml'),
+    'utf8',
+  );
+  assert.equal(buildWorkflow.split(`sha256:${digest}`).length - 1, 2);
 });
 
 for (const [label, args, source] of [


### PR DESCRIPTION
## Summary

- bind both native Build lanes to the exact current portable-off cache profile digest
- refresh the generated workflow authority projection
- add a regression check that both digest bindings match the checked-in profile bytes

## Validation

- `node scripts/check-kungfu-gate-catalog.mjs`
- `node --test scripts/check-shifu-cache-contract.test.mjs scripts/check-kungfu-gate-catalog.test.mjs`
- `./shifu check:staged`

## Release boundary

- [x] No package or channel publication is performed by this PR.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Synchronize the exact Build cache profile digest with the already-reviewed profile bytes; no architecture or release authority changes"
}
-->