### PR TITLE
feat: add Agent Work Lab product experience

### DIFF
--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -176,15 +176,19 @@ fn build_relation(entry: &BuildEntry, installed: &str, entry_count: usize) -> Gi
 }
 
 fn build_valid(entry: &BuildEntry) -> bool {
+    build_previewable(entry)
+        && entry.integrated
+        && entry.qualified
+        && entry.sha == entry.mainline_sha
+}
+
+fn build_previewable(entry: &BuildEntry) -> bool {
     !entry.sha.is_empty()
         && entry.sha != "unknown"
         && !entry.sha.ends_with("-dirty")
         && matches!(entry.kind.as_str(), "app" | "installer" | "appimage")
         && entry.slot.join(&entry.artifact).exists()
-        && entry.integrated
-        && entry.qualified
         && entry.mainline_ref == "origin/dev/v4/v4.0"
-        && entry.sha == entry.mainline_sha
         && product_manifests_valid(entry)
 }
 
@@ -266,17 +270,7 @@ fn select_product_build<'a>(
     allow_nonlinear: bool,
 ) -> &'a BuildEntry {
     if let Some(id) = selected {
-        let matches: Vec<_> = entries
-            .iter()
-            .filter(|entry| entry.name == id || entry.name.starts_with(id))
-            .collect();
-        if matches.len() != 1 {
-            util::die(&format!(
-                "--build {id} matched {} builds; use the exact id from shifu builds",
-                matches.len()
-            ));
-        }
-        let entry = matches[0];
+        let entry = select_named_build(entries, id);
         if !build_valid(entry) {
             util::die(&format!(
                 "build {} is invalid and cannot be promoted even with an override",
@@ -316,6 +310,47 @@ fn select_product_build<'a>(
              one explicitly with --build <id>",
         ),
     }
+}
+
+fn select_named_build<'a>(entries: &'a [BuildEntry], id: &str) -> &'a BuildEntry {
+    let matches: Vec<_> = entries
+        .iter()
+        .filter(|entry| entry.name == id || entry.name.starts_with(id))
+        .collect();
+    if matches.len() != 1 {
+        util::die(&format!(
+            "--build {id} matched {} builds; use the exact id from shifu builds",
+            matches.len()
+        ));
+    }
+    matches[0]
+}
+
+fn select_preview_build<'a>(
+    entries: &'a [BuildEntry],
+    installed: &str,
+    selected: Option<&str>,
+    allow_nonlinear: bool,
+) -> &'a BuildEntry {
+    let Some(id) = selected else {
+        util::die("--preview requires an explicit --build <id>");
+    };
+    let entry = select_named_build(entries, id);
+    if !build_previewable(entry) {
+        util::die(&format!(
+            "build {} lacks exact clean product provenance and cannot be previewed",
+            entry.name
+        ));
+    }
+    let relation = build_relation(entry, installed, entries.len());
+    if !matches!(relation, GitRelation::Same | GitRelation::Descendant) && !allow_nonlinear {
+        util::die(&format!(
+            "preview build {} is {} and requires --allow-nonlinear after review",
+            entry.name,
+            relation.as_str()
+        ));
+    }
+    entry
 }
 
 fn print_builds_json(entries: &[BuildEntry]) {
@@ -365,6 +400,7 @@ fn write_installed_receipt(
     installed: &Path,
     rollback_build_id: &str,
     rollback_sha: &str,
+    mode: &str,
 ) {
     let text = format!(
         "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n\
@@ -379,6 +415,7 @@ fn write_installed_receipt(
          KUNGFU_INSTALLED_MAINLINE_SHA='{}'\n\
          KUNGFU_INSTALLED_INTEGRATED='{}'\n\
          KUNGFU_INSTALLED_QUALIFIED='{}'\n\
+         KUNGFU_INSTALLED_MODE='{}'\n\
          KUNGFU_ROLLBACK_BUILD_ID='{}'\n\
          KUNGFU_ROLLBACK_SHA='{}'\n",
         entry.sha,
@@ -392,6 +429,7 @@ fn write_installed_receipt(
         entry.mainline_sha,
         entry.integrated,
         entry.qualified,
+        mode,
         rollback_build_id,
         rollback_sha,
     );
@@ -484,6 +522,7 @@ pub fn run_promote(args: &[String]) -> ! {
     let mut force = false;
     let mut check = false;
     let mut rollback = false;
+    let mut preview = false;
     let mut allow_nonlinear = false;
     let mut build_arg: Option<String> = None;
     let mut iter = args.iter();
@@ -493,6 +532,7 @@ pub fn run_promote(args: &[String]) -> ! {
             "--force" => force = true,
             "--check" => check = true,
             "--rollback" => rollback = true,
+            "--preview" => preview = true,
             "--allow-nonlinear" => allow_nonlinear = true,
             "--build" => match iter.next() {
                 Some(value) => build_arg = Some(value.clone()),
@@ -510,10 +550,10 @@ pub fn run_promote(args: &[String]) -> ! {
     let previous_build_id = installed_value("KUNGFU_INSTALLED_BUILD_ID");
     let rollback_build_id = installed_value("KUNGFU_ROLLBACK_BUILD_ID");
     let rollback_sha = installed_value("KUNGFU_ROLLBACK_SHA");
-    if rollback && (build_arg.is_some() || allow_nonlinear) {
+    if rollback && (build_arg.is_some() || allow_nonlinear || preview) {
         util::die(
             "--rollback identifies the exact retained Product; do not combine it with \
-             --build or --allow-nonlinear",
+             --build, --preview, or --allow-nonlinear",
         );
     }
     let entry = if rollback {
@@ -523,6 +563,13 @@ pub fn run_promote(args: &[String]) -> ! {
         rollback_build(&entries, &rollback_build_id, &rollback_sha).unwrap_or_else(|| {
             util::die("verified rollback Product is absent from the local registry")
         })
+    } else if preview {
+        if !rollback_entry_valid(&registry_dir(), &previous_build_id, &installed) {
+            util::die(
+                "installed Product has no verified rollback coordinate; refusing dogfood promotion",
+            );
+        }
+        select_preview_build(&entries, &installed, build_arg.as_deref(), allow_nonlinear)
     } else {
         if !rollback_entry_valid(&registry_dir(), &previous_build_id, &installed) {
             util::die(
@@ -531,7 +578,13 @@ pub fn run_promote(args: &[String]) -> ! {
         }
         select_product_build(&entries, &installed, build_arg.as_deref(), allow_nonlinear)
     };
-    let action = if rollback { "rollback" } else { "promote" };
+    let action = if rollback {
+        "rollback"
+    } else if preview {
+        "preview"
+    } else {
+        "promote"
+    };
     if check {
         println!(
             "{{\"schema\":\"shifu.local-promotion-plan/v1\",\"ok\":true,\
@@ -556,6 +609,8 @@ pub fn run_promote(args: &[String]) -> ! {
             "{} dev build {} ({} @ {})",
             if rollback {
                 "rolling back to"
+            } else if preview {
+                "previewing"
             } else {
                 "promoting"
             },
@@ -574,12 +629,29 @@ pub fn run_promote(args: &[String]) -> ! {
 
     eprintln!(
         "\u{2705} {} {}",
-        style::green(if rollback { "rolled back" } else { "promoted" }),
+        style::green(if rollback {
+            "rolled back"
+        } else if preview {
+            "previewed"
+        } else {
+            "promoted"
+        }),
         style::bold(&installed.display().to_string())
     );
     let previous_sha = installed_sha();
     let relation = build_relation(entry, &previous_sha, entries.len());
-    write_installed_receipt(entry, &installed, &previous_build_id, &previous_sha);
+    let installed_mode = if build_valid(entry) {
+        "qualified"
+    } else {
+        "preview"
+    };
+    write_installed_receipt(
+        entry,
+        &installed,
+        &previous_build_id,
+        &previous_sha,
+        installed_mode,
+    );
     if let Err(error) = write_promotion_receipt(
         &registry_dir(),
         "kungfu",
@@ -604,7 +676,7 @@ pub fn run_promote(args: &[String]) -> ! {
 }
 
 const PROMOTE_USAGE: &str =
-    "usage: shifu promote [--build <id> [--allow-nonlinear] | --rollback] [--check] [--launch] [--force]";
+    "usage: shifu promote [--build <id> [--preview] [--allow-nonlinear] | --rollback] [--check] [--launch] [--force]";
 
 /// Install target: KUNGFU_PRODUCT_INSTALL_DIR > platform default (falling
 /// back to a per-user location when the default is not writable).
@@ -841,6 +913,22 @@ mod tests {
             r#"{"sourceCommit":"2222222222222222222222222222222222222222"}"#,
         )
         .unwrap();
+        assert!(!build_valid(&entry));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn preview_keeps_mainline_qualification_separate_from_exact_product_provenance() {
+        let root = shifu_core::host::unique_temp_dir("promote-preview").unwrap();
+        let mut entry = qualified_app(&root);
+        entry.branch = "feature/local-review".into();
+        entry.integrated = false;
+        entry.qualified = false;
+        entry.mainline_sha = "2222222222222222222222222222222222222222".into();
+        fs::create_dir_all(entry.slot.join(&entry.artifact)).unwrap();
+        write_app_manifests(&entry);
+
+        assert!(build_previewable(&entry));
         assert!(!build_valid(&entry));
         let _ = fs::remove_dir_all(root);
     }

--- a/docs/adr/SHIFU-ADR-019f86da-4f90-7885-9597-bfdcb4fd4453.md
+++ b/docs/adr/SHIFU-ADR-019f86da-4f90-7885-9597-bfdcb4fd4453.md
@@ -58,6 +58,14 @@ Candidate resolution compares the candidate commit with the installed commit:
 - an explicit override names the artifact and acknowledges non-linear history;
 - rollback-only generations never re-enter automatic candidate selection.
 
+Local product review is a separate, explicitly unqualified path. A developer
+may name one exact clean build with `shifu promote --preview --build <id>`.
+Preview admission still verifies the artifact kind, source commit, product
+manifests, Git relation, and retained rollback coordinate, but it does not
+claim that the source is integrated into or qualified by the development
+mainline. The installed receipt records `KUNGFU_INSTALLED_MODE='preview'`;
+normal `promote` continues to require exact qualified mainline provenance.
+
 After a successful descendant promotion, strict ancestor build slots become
 `superseded` and leave the automatic candidate pool. Implementations may remove
 superseded build slots under their bounded retention policy. Rollback

--- a/docs/shifu/artifact-contract.json
+++ b/docs/shifu/artifact-contract.json
@@ -17,6 +17,14 @@
     "productQualificationRequired": true,
     "productMainlineRef": "origin/dev/v4/v4.0",
     "productSourceMustEqualMainline": true,
+    "localPreview": {
+      "explicitBuildIdRequired": true,
+      "cleanSourceRequired": true,
+      "productManifestSourceMustEqualArtifactCommit": true,
+      "mainlineQualificationClaimed": false,
+      "rollbackCoordinateRequired": true,
+      "installedMode": "preview"
+    },
     "priorInstalledSlotRetainedForRollback": true,
     "priorInstalledSlotRequiredBeforePromotion": true,
     "macProductManifestsRequired": [

--- a/docs/shifu/schema/local-promotion-receipt-v1.schema.json
+++ b/docs/shifu/schema/local-promotion-receipt-v1.schema.json
@@ -11,7 +11,7 @@
   "properties": {
     "schema": { "const": "shifu.local-promotion-receipt/v1" },
     "product": { "type": "string", "minLength": 1 },
-    "action": { "enum": ["promote", "self-update", "rollback"] },
+    "action": { "enum": ["promote", "preview", "self-update", "rollback"] },
     "artifactId": { "type": "string" },
     "fromCommit": { "type": "string" },
     "toCommit": { "type": "string" },

--- a/extensions/system/kfx-manager/src/view/index.tsx
+++ b/extensions/system/kfx-manager/src/view/index.tsx
@@ -232,6 +232,7 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     Record<string, string>
   >({});
   const [loading, setLoading] = React.useState(true);
+  const initialLoad = React.useRef(true);
   const [pending, setPending] = React.useState<{
     plan: ProfileLifecyclePlan;
     action: 'qualify' | 'activate' | 'upgrade';
@@ -255,10 +256,11 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
 
   const refresh = React.useCallback(async () => {
     if (!caps.profile) return;
-    setLoading(true);
+    if (initialLoad.current) setLoading(true);
     try {
       const next = await caps.profile.managerAsync();
       setManager(next);
+      initialLoad.current = false;
       const rows = await Promise.all(
         next.profiles
           .filter((managed) => managed.source)

--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -134,7 +134,9 @@ function GlobalWorkView({
   const [snapshot, setSnapshot] = React.useState<GlobalWorkSnapshot | null>(
     null,
   );
-  const [selected, setSelected] = React.useState<string | null>(null);
+  const [selected, setSelected] = React.useState<string | null>(
+    () => shell.params.workId?.trim() || null,
+  );
   const [search, setSearch] = React.useState('');
   const [status, setStatus] = React.useState('connecting live Portfolio…');
   const [error, setError] = React.useState('');
@@ -150,6 +152,13 @@ function GlobalWorkView({
       ).ipcRenderer,
     [host],
   );
+
+  React.useEffect(() => {
+    const requestedWorkId = shell.params.workId?.trim();
+    if (!requestedWorkId) return;
+    setSelected(requestedWorkId);
+    setSearch('');
+  }, [shell.params.workId]);
 
   React.useEffect(() => {
     let dispose: (() => Promise<void>) | undefined;

--- a/framework/api/package.json
+++ b/framework/api/package.json
@@ -19,7 +19,7 @@
   "main": "./src/capability/index.ts",
   "scripts": {
     "build": "tsc --noEmit",
-    "test:query": "node --test tests/query.test.ts tests/ledger.test.ts tests/profile.test.ts tests/storage.test.ts tests/exit.test.ts tests/agent-console.test.ts tests/work-loop.test.ts tests/qualification-lab.test.ts",
+    "test:query": "node --test tests/query.test.ts tests/ledger.test.ts tests/profile.test.ts tests/storage.test.ts tests/exit.test.ts tests/agent-console.test.ts tests/work-loop.test.ts tests/qualification-lab.test.ts tests/product-search.test.ts",
     "clean": "rimraf build dist"
   },
   "dependencies": {

--- a/framework/api/src/capability/global-work.ts
+++ b/framework/api/src/capability/global-work.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ProductSearchDocument } from './product-search.js';
+
+export type GlobalWorkRow = {
+  canonical_root: string;
+  object_kind: string;
+  subject: string;
+  display: {
+    title?: string;
+    status?: string;
+    portfolio_state?: string;
+    next_actions?: string[];
+  };
+  observations: Array<{
+    workspace_id?: string;
+    availability?: string;
+  }>;
+  conflict?: boolean;
+};
+
+export type GlobalWorkSnapshot = {
+  schema: 'kungfu.workspace-federation.query/v1';
+  observed_at?: string;
+  aggregate: {
+    state?: string;
+    component_count?: number;
+    available_component_count?: number;
+    unknown_component_count?: number;
+    conflict_count?: number;
+  };
+  verification?: { ok?: boolean };
+  proof?: { proof_root?: string };
+  global_work: {
+    projection_root?: string;
+    visible_work: GlobalWorkRow[];
+    visible_work_count?: number;
+    canonical_work_count?: number;
+    conflict_count?: number;
+    label_collision_count?: number;
+  };
+};
+
+function object(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function parseGlobalWorkSnapshot(value: unknown): GlobalWorkSnapshot {
+  const root = object(value);
+  const candidate =
+    root?.schema === 'kungfu.gui.global-work-observer/v2'
+      ? object(root.query)
+      : root?.schema === 'kungfu.gui.global-work-observer-event/v1'
+        ? object(root.snapshot)
+        : root;
+  const globalWork = object(candidate?.global_work);
+  if (
+    candidate?.schema !== 'kungfu.workspace-federation.query/v1' ||
+    !globalWork ||
+    !Array.isArray(globalWork.visible_work)
+  ) {
+    throw new Error('Kungfu returned an invalid global Work snapshot');
+  }
+  return candidate as unknown as GlobalWorkSnapshot;
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+}
+
+export function globalWorkSearchDocuments(
+  snapshot: GlobalWorkSnapshot,
+): ProductSearchDocument[] {
+  return snapshot.global_work.visible_work.map((row, index) => {
+    const status =
+      clean(row.display.status) || clean(row.display.portfolio_state) || 'open';
+    const workspaces = row.observations
+      .map((observation) => clean(observation.workspace_id))
+      .filter(Boolean);
+    const nextActions = (row.display.next_actions ?? [])
+      .map(clean)
+      .filter(Boolean);
+    const kind = clean(row.object_kind) || 'work';
+    return {
+      id: `work.global.${row.canonical_root}`,
+      kind: 'work',
+      title:
+        clean(row.display.title) || clean(row.subject) || row.canonical_root,
+      summary: [
+        `${kind} · ${status}`,
+        workspaces.length > 0 ? workspaces.join(' · ') : '',
+        nextActions.length > 0 ? `Next: ${nextActions.join(' · ')}` : '',
+        row.conflict ? 'Conflicting observations require attention.' : '',
+      ]
+        .filter(Boolean)
+        .join(' · '),
+      section: 'Global Work',
+      keywords: [
+        kind,
+        clean(row.subject),
+        status,
+        clean(row.display.portfolio_state),
+        ...workspaces,
+      ].filter(Boolean),
+      priority: index,
+      action: { kind: 'open-work', workId: row.canonical_root },
+    };
+  });
+}

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -20,6 +20,7 @@ export * from './agent-runtime.js';
 export * from './agent-console.js';
 export * from './agent-session.js';
 export * from './qualification-lab.js';
+export * from './product-search.js';
 export * from './runtime.js';
 
 // The runtime-plane trust boundary (KF-ADR-019f86da-4f90-79f1-8716-aca36b142847 / KF-ADR-019f86da-4f90-7789-8b48-620aa694acf9): the OS-sandbox

--- a/framework/api/src/capability/index.ts
+++ b/framework/api/src/capability/index.ts
@@ -21,6 +21,7 @@ export * from './agent-console.js';
 export * from './agent-session.js';
 export * from './qualification-lab.js';
 export * from './product-search.js';
+export * from './global-work.js';
 export * from './runtime.js';
 
 // The runtime-plane trust boundary (KF-ADR-019f86da-4f90-79f1-8716-aca36b142847 / KF-ADR-019f86da-4f90-7789-8b48-620aa694acf9): the OS-sandbox

--- a/framework/api/src/capability/product-search.ts
+++ b/framework/api/src/capability/product-search.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type ProductSearchKind = 'help' | 'command' | 'work' | 'view';
+
+export type ProductSearchAction =
+  | { kind: 'show-help'; topicId: string }
+  | { kind: 'describe-command'; command: string }
+  | { kind: 'open-work'; workId: string }
+  | { kind: 'open-view'; viewId: string };
+
+export type ProductSearchDocument = {
+  id: string;
+  kind: ProductSearchKind;
+  title: string;
+  summary: string;
+  section?: string;
+  keywords?: string[];
+  priority?: number;
+  action: ProductSearchAction;
+};
+
+export type ProductSearchResult = ProductSearchDocument & {
+  score: number;
+};
+
+export type CliHelpProjection = {
+  schema: 'kungfu.cli-help-projection/v1';
+  sections: Array<{ id: string; title: string; summary?: string }>;
+  commands: Array<{
+    id: string;
+    name: string;
+    path: string;
+    summary?: string;
+    section: string;
+    priority?: number;
+    availability?: { state?: string; reason?: string };
+  }>;
+};
+
+export type ProductSearchExecFile = (
+  file: string,
+  args: string[],
+  options: {
+    encoding: 'utf8';
+    env: Record<string, string | undefined>;
+    maxBuffer: number;
+  },
+) => Promise<string>;
+
+export type OpenProductSearchOptions = {
+  bin: string;
+  env: Record<string, string | undefined>;
+  execFile: ProductSearchExecFile;
+};
+
+export const SYSTEM_HELP_DOCUMENTS: ProductSearchDocument[] = [
+  {
+    id: 'help.keyboard',
+    kind: 'help',
+    title: 'Keyboard shortcuts',
+    summary:
+      '? opens Help. Use Ctrl+K in the terminal or Cmd/Ctrl+K in the desktop app to search Kungfu.',
+    keywords: ['keys', 'shortcut', 'help', 'search'],
+    priority: 0,
+    action: { kind: 'show-help', topicId: 'keyboard' },
+  },
+  {
+    id: 'help.quick-commands',
+    kind: 'help',
+    title: 'Quick commands',
+    summary:
+      'Type / in the terminal input bar to list bounded product actions. Kungfu does not run arbitrary shell text.',
+    keywords: ['slash', 'command', 'input', 'terminal'],
+    priority: 1,
+    action: { kind: 'show-help', topicId: 'quick-commands' },
+  },
+  {
+    id: 'help.product-search',
+    kind: 'help',
+    title: 'Search Kungfu',
+    summary:
+      'One read-only search surface finds product help, available commands, views, and current Work information.',
+    keywords: ['find', 'command palette', 'work', 'view'],
+    priority: 2,
+    action: { kind: 'show-help', topicId: 'product-search' },
+  },
+  {
+    id: 'help.work',
+    kind: 'help',
+    title: 'Work information',
+    summary:
+      'Work results come from the current read-only Work or Profile projection. Search never creates or changes Work.',
+    keywords: ['assignment', 'initiative', 'task', 'read-only'],
+    priority: 3,
+    action: { kind: 'show-help', topicId: 'work' },
+  },
+];
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+}
+
+export function parseCliHelpProjection(raw: string): CliHelpProjection {
+  const parsed = JSON.parse(raw) as Partial<CliHelpProjection>;
+  if (
+    parsed.schema !== 'kungfu.cli-help-projection/v1' ||
+    !Array.isArray(parsed.sections) ||
+    !Array.isArray(parsed.commands)
+  ) {
+    throw new Error('Kungfu CLI returned an invalid help projection');
+  }
+  return parsed as CliHelpProjection;
+}
+
+export function cliHelpSearchDocuments(
+  projection: CliHelpProjection,
+): ProductSearchDocument[] {
+  const sections = new Map(
+    projection.sections.map((section) => [section.id, section]),
+  );
+  const help = projection.sections.map<ProductSearchDocument>(
+    (section, index) => ({
+      id: `help.section.${section.id}`,
+      kind: 'help',
+      title: clean(section.title),
+      summary: clean(section.summary) || 'Kungfu command help section.',
+      section: section.id,
+      keywords: ['help', 'commands', section.id],
+      priority: 20 + index,
+      action: { kind: 'show-help', topicId: section.id },
+    }),
+  );
+  const commands = projection.commands.map<ProductSearchDocument>((command) => {
+    const availability = command.availability?.state ?? 'available';
+    const reason = clean(command.availability?.reason);
+    const availabilitySummary =
+      availability === 'available'
+        ? ''
+        : ` [${availability}${reason ? `: ${reason}` : ''}]`;
+    return {
+      id: `command.${command.id}`,
+      kind: 'command',
+      title: clean(command.path),
+      summary: `${clean(command.summary)}${availabilitySummary}`.trim(),
+      section: sections.get(command.section)?.title ?? command.section,
+      keywords: [command.name, command.section, availability],
+      priority: command.priority ?? 100,
+      action: { kind: 'describe-command', command: clean(command.path) },
+    };
+  });
+  return [...help, ...commands];
+}
+
+export async function loadCliHelpSearchDocuments(
+  options: OpenProductSearchOptions,
+): Promise<ProductSearchDocument[]> {
+  const raw = await options.execFile(options.bin, ['--help-json'], {
+    encoding: 'utf8',
+    env: options.env,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  return cliHelpSearchDocuments(parseCliHelpProjection(raw));
+}
+
+function normalized(value: string): string {
+  return value.toLocaleLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function kindOrder(kind: ProductSearchKind): number {
+  if (kind === 'work') return 0;
+  if (kind === 'command') return 1;
+  if (kind === 'help') return 2;
+  return 3;
+}
+
+function scoreDocument(
+  document: ProductSearchDocument,
+  query: string,
+): number | null {
+  const title = normalized(document.title);
+  const summary = normalized(document.summary);
+  const section = normalized(document.section ?? '');
+  const keywords = normalized((document.keywords ?? []).join(' '));
+  const haystack = `${title} ${summary} ${section} ${keywords}`;
+  const tokens = normalized(query).split(' ').filter(Boolean);
+  if (tokens.length === 0) return 1_000 - (document.priority ?? 100);
+  if (!tokens.every((token) => haystack.includes(token))) return null;
+  let score = 0;
+  const complete = tokens.join(' ');
+  if (title === complete) score += 1_000;
+  else if (title.startsWith(complete)) score += 700;
+  else if (title.includes(complete)) score += 500;
+  for (const token of tokens) {
+    if (title.startsWith(token)) score += 160;
+    else if (title.includes(token)) score += 100;
+    if (keywords.includes(token)) score += 50;
+    if (section.includes(token)) score += 30;
+    if (summary.includes(token)) score += 15;
+  }
+  return score - (document.priority ?? 100) / 100;
+}
+
+export function searchProductDocuments(
+  documents: ProductSearchDocument[],
+  query: string,
+  limit = 12,
+): ProductSearchResult[] {
+  const unique = new Map<string, ProductSearchDocument>();
+  for (const document of documents) {
+    if (!unique.has(document.id)) unique.set(document.id, document);
+  }
+  return [...unique.values()]
+    .map((document) => {
+      const score = scoreDocument(document, query);
+      return score === null ? null : { ...document, score };
+    })
+    .filter((row): row is ProductSearchResult => row !== null)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        kindOrder(left.kind) - kindOrder(right.kind) ||
+        left.title.localeCompare(right.title),
+    )
+    .slice(0, Math.max(0, limit));
+}

--- a/framework/api/src/capability/qualification-lab.ts
+++ b/framework/api/src/capability/qualification-lab.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Shared adapter over the Core Agent Qualification Lab. Hosts inject process
+// Shared adapter over the Core Agent Work Lab. Hosts inject process
 // execution; GUI and TUI receive the same startup route, plans, receipts,
 // assessments and reports and own no private semantic state.
 import type { AgentRuntimeCatalog } from './agent-runtime.js';

--- a/framework/api/tests/product-search.test.ts
+++ b/framework/api/tests/product-search.test.ts
@@ -4,6 +4,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  type GlobalWorkSnapshot,
+  globalWorkSearchDocuments,
+  parseGlobalWorkSnapshot,
+} from '../src/capability/global-work.ts';
+import {
   type ProductSearchDocument,
   SYSTEM_HELP_DOCUMENTS,
   cliHelpSearchDocuments,
@@ -116,5 +121,63 @@ test('searches help, commands, Work, and views with deterministic ranking', () =
   assert.deepEqual(
     searchProductDocuments([work, work], 'improve').map((row) => row.id),
     [work.id],
+  );
+});
+
+test('projects the same global Work snapshot into searchable Initiative and Assignment rows', () => {
+  const snapshot: GlobalWorkSnapshot = {
+    schema: 'kungfu.workspace-federation.query/v1',
+    aggregate: { state: 'complete', component_count: 2 },
+    verification: { ok: true },
+    proof: { proof_root: 'sha256:proof' },
+    global_work: {
+      projection_root: 'sha256:projection',
+      visible_work: [
+        {
+          canonical_root: 'sha256:initiative',
+          object_kind: 'initiative',
+          subject: 'initiative-a',
+          display: { title: 'Improve Work', status: 'active' },
+          observations: [{ workspace_id: 'home' }],
+        },
+        {
+          canonical_root: 'sha256:assignment',
+          object_kind: 'assignment',
+          subject: 'initiative-a:assignment-a',
+          display: {
+            title: 'Unify product search',
+            portfolio_state: 'open',
+            next_actions: ['ship one shared projection'],
+          },
+          observations: [{ workspace_id: 'project:one' }],
+        },
+      ],
+    },
+  };
+  const cached = {
+    schema: 'kungfu.gui.global-work-observer/v2',
+    query: snapshot,
+  };
+  assert.equal(parseGlobalWorkSnapshot(cached), snapshot);
+  const documents = globalWorkSearchDocuments(snapshot);
+  assert.equal(
+    searchProductDocuments(documents, 'initiative')[0]?.title,
+    'Improve Work',
+  );
+  assert.deepEqual(
+    searchProductDocuments(documents, 'assignment').map((row) => row.title),
+    ['Unify product search'],
+  );
+  assert.equal(documents[1]?.action.kind, 'open-work');
+});
+
+test('rejects observer state without a global Work projection', () => {
+  assert.throws(
+    () =>
+      parseGlobalWorkSnapshot({
+        schema: 'kungfu.gui.global-work-observer/v2',
+        query: {},
+      }),
+    /invalid global Work snapshot/,
   );
 });

--- a/framework/api/tests/product-search.test.ts
+++ b/framework/api/tests/product-search.test.ts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  type ProductSearchDocument,
+  SYSTEM_HELP_DOCUMENTS,
+  cliHelpSearchDocuments,
+  loadCliHelpSearchDocuments,
+  parseCliHelpProjection,
+  searchProductDocuments,
+} from '../src/capability/product-search.ts';
+
+const projection = {
+  schema: 'kungfu.cli-help-projection/v1' as const,
+  sections: [
+    {
+      id: 'start-here',
+      title: 'START HERE',
+      summary: 'Open the product and inspect readiness.',
+    },
+  ],
+  commands: [
+    {
+      id: 'kungfu.agent',
+      name: 'agent',
+      path: 'kungfu agent',
+      summary: 'Agent-facing local discovery entrypoint.',
+      section: 'start-here',
+      priority: 2,
+      availability: { state: 'available' },
+    },
+  ],
+};
+
+test('parses the governed CLI help projection and rejects another schema', () => {
+  assert.deepEqual(
+    parseCliHelpProjection(JSON.stringify(projection)),
+    projection,
+  );
+  assert.throws(
+    () =>
+      parseCliHelpProjection('{"schema":"other","sections":[],"commands":[]}'),
+    /invalid help projection/,
+  );
+});
+
+test('projects help sections and commands without inventing execution authority', () => {
+  const documents = cliHelpSearchDocuments(projection);
+  assert.deepEqual(
+    documents.map((row) => [row.kind, row.title, row.action.kind]),
+    [
+      ['help', 'START HERE', 'show-help'],
+      ['command', 'kungfu agent', 'describe-command'],
+    ],
+  );
+});
+
+test('loads CLI help through the injected read-only process boundary', async () => {
+  const calls: unknown[] = [];
+  const documents = await loadCliHelpSearchDocuments({
+    bin: '/opt/kungfu',
+    env: { KF_HOME: '/tmp/home' },
+    execFile: async (...args) => {
+      calls.push(args);
+      return JSON.stringify(projection);
+    },
+  });
+  assert.equal(documents[1]?.title, 'kungfu agent');
+  assert.deepEqual(calls[0], [
+    '/opt/kungfu',
+    ['--help-json'],
+    {
+      encoding: 'utf8',
+      env: { KF_HOME: '/tmp/home' },
+      maxBuffer: 4 * 1024 * 1024,
+    },
+  ]);
+});
+
+test('searches help, commands, Work, and views with deterministic ranking', () => {
+  const work: ProductSearchDocument = {
+    id: 'work.assignment-7',
+    kind: 'work',
+    title: 'Improve terminal search',
+    summary: 'Assignment stage is executing.',
+    keywords: ['assignment-7'],
+    action: { kind: 'open-work', workId: 'assignment-7' },
+  };
+  const view: ProductSearchDocument = {
+    id: 'view.work-dashboard',
+    kind: 'view',
+    title: 'Work Dashboard',
+    summary: 'Open the Work view.',
+    action: { kind: 'open-view', viewId: 'work-dashboard' },
+  };
+  const documents = [
+    ...SYSTEM_HELP_DOCUMENTS,
+    ...cliHelpSearchDocuments(projection),
+    work,
+    view,
+  ];
+  assert.equal(
+    searchProductDocuments(documents, 'terminal search')[0]?.id,
+    work.id,
+  );
+  assert.equal(
+    searchProductDocuments(documents, 'agent discovery')[0]?.title,
+    'kungfu agent',
+  );
+  assert.equal(
+    searchProductDocuments(documents, 'keyboard shortcut')[0]?.id,
+    'help.keyboard',
+  );
+  assert.deepEqual(
+    searchProductDocuments([work, work], 'improve').map((row) => row.id),
+    [work.id],
+  );
+});

--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -270,7 +270,7 @@ def _progressive_help(ctx, param, value):
 @click.option(
     "--qualification-lab-demo",
     is_flag=True,
-    help="run the deterministic Agent Qualification Lab demo in the TUI",
+    help="run the deterministic Agent Work Lab demo in the TUI",
 )
 @click.help_option("-h", "--help")
 @click.version_option(

--- a/framework/core/src/python/kungfu/cli/commands/qualification_lab.py
+++ b/framework/core/src/python/kungfu/cli/commands/qualification_lab.py
@@ -31,7 +31,7 @@ def _event_json(value):
 @kfd3_api("kungfu.qualification-lab")
 @kfc.pass_context()
 def qualification_lab(ctx):
-    """The shared, boot-safe Agent Qualification Lab authority."""
+    """The shared, boot-safe Agent Work Lab authority."""
 
 
 @qualification_lab.command(help="resolve the boot route without writing state")
@@ -55,7 +55,7 @@ def catalog(ctx, as_json):
     if as_json:
         _json(payload)
         return
-    click.echo("Agent Qualification Lab")
+    click.echo("Agent Work Lab")
     click.echo(f"  startup: {payload['startup']['route']}")
     for action in payload["actions"]:
         click.echo(f"  {action['id']} ({action['mutation']})")
@@ -116,9 +116,7 @@ def demo(output, events_json, as_json):
     if as_json:
         _json(payload)
         return
-    click.echo(
-        f"Agent Qualification Lab demo: {payload['status']} ({payload['reportRoot']})"
-    )
+    click.echo(f"Agent Work Lab demo: {payload['status']} ({payload['reportRoot']})")
 
 
 @qualification_lab.command(name="agent-plan", help="preview one exact local agent run")

--- a/framework/core/src/python/kungfu/qualification_lab.py
+++ b/framework/core/src/python/kungfu/qualification_lab.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared Agent Qualification Lab authority.
+"""Shared Agent Work Lab authority.
 
 The GUI and TUI consume this module through the public CLI. Startup inspection
 reads the verified global Work projection without materializing runtime state.
@@ -655,7 +655,7 @@ def _agent_prompt(state_path: Path, attempt_index: int) -> str:
         attempt_index
     ]
     return (
-        "Kungfu Agent Qualification Lab. Work only inside the current isolated "
+        "Kungfu Agent Work Lab. Work only inside the current isolated "
         "temporary directory. Do not inspect credentials, user chats, or any "
         "path outside this directory. "
         "Make your work observable with concise public status updates, never "

--- a/framework/gui/src/main/global-work-observer-host.test.ts
+++ b/framework/gui/src/main/global-work-observer-host.test.ts
@@ -124,3 +124,49 @@ test('late renderer immediately receives the retained snapshot', () => {
   assert.equal(received.length, 1);
   host.dispose();
 });
+
+test('first renderer receives the last verified observer cache before a live scan', () => {
+  const child = fakeChild();
+  const host = createGlobalWorkObserverHost({
+    bin: '/kungfu',
+    env: {},
+    statePath: '/state',
+    readState: () =>
+      JSON.stringify({
+        schema: 'kungfu.gui.global-work-observer/v2',
+        query: {
+          schema: 'kungfu.workspace-federation.query/v1',
+          observed_at: '2026-07-27T14:29:26Z',
+          aggregate: { state: 'partial' },
+          global_work: {
+            visible_work: [
+              {
+                canonical_root: 'sha256:initiative',
+                object_kind: 'initiative',
+              },
+              {
+                canonical_root: 'sha256:assignment',
+                object_kind: 'assignment',
+              },
+            ],
+          },
+        },
+      }),
+    spawn: () => child as never,
+    restart: () => ({}) as NodeJS.Timeout,
+    cancelRestart: () => {},
+  });
+  const received: unknown[] = [];
+  host.subscribe('renderer', (event) => received.push(event));
+  assert.equal(received.length, 1);
+  assert.equal((received[0] as { mode: string }).mode, 'resume');
+  assert.equal(
+    (
+      received[0] as {
+        snapshot: { global_work: { visible_work: unknown[] } };
+      }
+    ).snapshot.global_work.visible_work.length,
+    2,
+  );
+  host.dispose();
+});

--- a/framework/gui/src/main/global-work-observer-host.ts
+++ b/framework/gui/src/main/global-work-observer-host.ts
@@ -29,6 +29,7 @@ export type GlobalWorkObserverHostDeps = {
   bin: string;
   env: NodeJS.ProcessEnv;
   statePath: string;
+  readState?: (path: string) => string;
   spawn: (
     file: string,
     args: string[],
@@ -63,6 +64,38 @@ function snapshotRevision(event: GlobalWorkObserverEvent): string {
     aggregate: event.snapshot.aggregate,
     verification: event.snapshot.verification,
   });
+}
+
+function cachedObserverSnapshot(value: string): GlobalWorkObserverEvent | null {
+  try {
+    const state = JSON.parse(value) as {
+      schema?: string;
+      query?: Record<string, unknown>;
+    };
+    const query = state.query;
+    const globalWork = query?.global_work as
+      | { visible_work?: unknown }
+      | undefined;
+    if (
+      state.schema !== 'kungfu.gui.global-work-observer/v2' ||
+      query?.schema !== 'kungfu.workspace-federation.query/v1' ||
+      !Array.isArray(globalWork?.visible_work)
+    ) {
+      return null;
+    }
+    return {
+      schema: 'kungfu.gui.global-work-observer-event/v1',
+      kind: 'snapshot',
+      mode: 'resume',
+      observed_at:
+        typeof query.observed_at === 'string' ? query.observed_at : '',
+      latency_ms: 0,
+      changed_workspace_ids: [],
+      snapshot: query,
+    };
+  } catch {
+    return null;
+  }
 }
 
 export function createGlobalWorkObserverHost(deps: GlobalWorkObserverHostDeps) {
@@ -159,6 +192,17 @@ export function createGlobalWorkObserverHost(deps: GlobalWorkObserverHostDeps) {
       subscriber: (event: GlobalWorkObserverEvent) => void,
     ) {
       subscribers.set(clientKey, subscriber);
+      if (!latestSnapshot && deps.readState) {
+        try {
+          const cached = cachedObserverSnapshot(deps.readState(deps.statePath));
+          if (cached) {
+            latestSnapshot = cached;
+            latestRevision = snapshotRevision(cached);
+          }
+        } catch {
+          // A missing or partial cache never blocks the live observer.
+        }
+      }
       if (latestSnapshot) subscriber(latestSnapshot);
       start();
     },

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -765,6 +765,7 @@ const globalWorkObserverBinding = bindElectronGlobalWorkObserver(
       'gui',
       'global-work-observer.json',
     ),
+    readState: (file) => readFileSync(file, 'utf8'),
     spawn: (file, args, options) => spawn(file, args, options),
     restart: (fn, delayMs) => setTimeout(fn, delayMs),
     cancelRestart: (timer) => clearTimeout(timer),

--- a/framework/gui/src/product-search.test.ts
+++ b/framework/gui/src/product-search.test.ts
@@ -8,6 +8,20 @@ const source = readFileSync(
   new URL('./renderer/src/main.tsx', import.meta.url),
   'utf8',
 );
+const workViewSource = readFileSync(
+  new URL(
+    '../../../extensions/work-dashboard/src/view/index.tsx',
+    import.meta.url,
+  ),
+  'utf8',
+);
+const profileManagerSource = readFileSync(
+  new URL(
+    '../../../extensions/system/kfx-manager/src/view/index.tsx',
+    import.meta.url,
+  ),
+  'utf8',
+);
 
 test('the title-bar search shares Help, Command, Work, and view sources', () => {
   assert.match(source, /SYSTEM_HELP_DOCUMENTS/);
@@ -30,5 +44,30 @@ test('Cmd or Ctrl K focuses the same search plane without executing CLI results'
   assert.match(source, /searchInput\.current\?\.focus\(\)/);
   assert.match(source, /result\.action\.kind === 'open-view'/);
   assert.match(source, /result\.action\.kind === 'open-work'/);
+  assert.match(source, /productRoleEntry\(enabled, 'profile-view'\)/);
+  assert.doesNotMatch(
+    source,
+    /openKfx\(profileHomeId\(profile, enabled\), \{\s*workId:/,
+  );
   assert.doesNotMatch(source, /execFile\(result\.action/);
+});
+
+test('Work activation reaches the declared Work view and selects the exact result', () => {
+  assert.match(source, /productRoleEntry\(enabled, 'profile-view'\)/);
+  assert.match(source, /openKfx\(workView\.id, \{ workId:/);
+  assert.match(workViewSource, /shell\.params\.workId\?\.trim\(\)/);
+  assert.match(workViewSource, /\[shell\.params\.workId\]/);
+});
+
+test('Profile lifecycle refresh preserves the last visible projection', () => {
+  assert.match(
+    profileManagerSource,
+    /const initialLoad = React\.useRef\(true\)/,
+  );
+  assert.match(
+    profileManagerSource,
+    /if \(initialLoad\.current\) setLoading\(true\)/,
+  );
+  assert.match(profileManagerSource, /initialLoad\.current = false/);
+  assert.doesNotMatch(profileManagerSource, /\n {4}setLoading\(true\);\n/);
 });

--- a/framework/gui/src/product-search.test.ts
+++ b/framework/gui/src/product-search.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(
+  new URL('./renderer/src/main.tsx', import.meta.url),
+  'utf8',
+);
+
+test('the title-bar search shares Help, Command, Work, and view sources', () => {
+  assert.match(source, /SYSTEM_HELP_DOCUMENTS/);
+  assert.match(source, /loadCliHelpSearchDocuments/);
+  assert.match(source, /workSearchDocuments/);
+  assert.match(source, /viewSearchDocuments/);
+  assert.match(source, /searchProductDocuments\(searchDocuments, searchText\)/);
+  assert.match(source, /Search Help, Commands, Work/);
+  assert.doesNotMatch(source, /Search views/);
+  assert.doesNotMatch(source, /<datalist/);
+});
+
+test('Cmd or Ctrl K focuses the same search plane without executing CLI results', () => {
+  assert.match(
+    source,
+    /event\.metaKey \|\| event\.ctrlKey[\s\S]*event\.key\.toLowerCase\(\) === 'k'/,
+  );
+  assert.match(source, /searchInput\.current\?\.focus\(\)/);
+  assert.match(source, /result\.action\.kind === 'open-view'/);
+  assert.match(source, /result\.action\.kind === 'open-work'/);
+  assert.doesNotMatch(source, /execFile\(result\.action/);
+});

--- a/framework/gui/src/product-search.test.ts
+++ b/framework/gui/src/product-search.test.ts
@@ -12,6 +12,8 @@ const source = readFileSync(
 test('the title-bar search shares Help, Command, Work, and view sources', () => {
   assert.match(source, /SYSTEM_HELP_DOCUMENTS/);
   assert.match(source, /loadCliHelpSearchDocuments/);
+  assert.match(source, /GLOBAL_WORK_OBSERVER_SUBSCRIBE_CHANNEL/);
+  assert.match(source, /globalWorkSearchDocuments/);
   assert.match(source, /workSearchDocuments/);
   assert.match(source, /viewSearchDocuments/);
   assert.match(source, /searchProductDocuments\(searchDocuments, searchText\)/);

--- a/framework/gui/src/qualification-lab.test.ts
+++ b/framework/gui/src/qualification-lab.test.ts
@@ -8,6 +8,10 @@ import type {
   QualificationLabReport,
 } from '@kungfu-tech/api/capability';
 import {
+  AGENT_WORK_LAB_SUITE,
+  agentWorkLabRecommendation,
+} from '@kungfu-tech/kfx';
+import {
   QUALIFICATION_MODES,
   QUALIFICATION_PLAYBACK_TIMING,
   qualificationBehaviorFindings,
@@ -50,6 +54,19 @@ test('the Lab exposes one explicit selector for all three experiment modes', () 
     source: true,
     target: true,
   });
+  assert.equal(AGENT_WORK_LAB_SUITE.title, 'Agent Work Lab');
+  assert.equal(AGENT_WORK_LAB_SUITE.collection.title, 'Work Continuity');
+  assert.deepEqual(
+    QUALIFICATION_MODES.map(({ id, label }) => ({ id, label })),
+    AGENT_WORK_LAB_SUITE.cases.map(({ id, title }) => ({
+      id,
+      label: title,
+    })),
+  );
+  assert.equal(
+    agentWorkLabRecommendation('offline-demo').nextCase,
+    'same-agent',
+  );
 });
 
 test('the two session stories distinguish bounded progress from continuation', () => {
@@ -136,6 +153,10 @@ test('canonical runtime events expand into public terminal activity', () => {
   );
   assert.equal(QUALIFICATION_PLAYBACK_TIMING.eventDelayMs, 1000);
   assert.equal(QUALIFICATION_PLAYBACK_TIMING.verdictDelayMs, 520);
+  assert.equal(
+    QUALIFICATION_PLAYBACK_TIMING.eventDelayMs,
+    AGENT_WORK_LAB_SUITE.timing.eventIntervalMs,
+  );
 });
 
 test('live provider activity becomes safe agent and tool narration', () => {
@@ -242,6 +263,8 @@ test('the visual contract keeps a fixed frame with independently scrolling sessi
   );
   assert.match(source, /kf-lab-report-dock/);
   assert.match(source, /role="tooltip"/);
+  assert.match(source, /WHAT TO TRY NEXT/);
+  assert.match(source, /recommendationDurationMs/);
   assert.match(source, /createPortal/);
   assert.match(source, /position: fixed/);
   assert.match(source, /window\.innerWidth/);

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -1765,9 +1765,17 @@ function App() {
       if (result.action.kind === 'open-view') {
         openKfx(result.action.viewId);
       } else if (result.action.kind === 'open-work') {
-        openKfx(profileHomeId(profile, enabled), {
-          workId: result.action.workId,
-        });
+        const workView = productRoleEntry(enabled, 'profile-view');
+        if (workView) {
+          openKfx(workView.id, { workId: result.action.workId });
+        } else {
+          showNotification({
+            level: 'warning',
+            title: 'Work view unavailable',
+            message:
+              'The Work result remains read-only, but no enabled Profile view can open its details.',
+          });
+        }
       } else {
         showNotification({
           level: 'info',
@@ -1777,7 +1785,7 @@ function App() {
       }
       setSearchText('');
     },
-    [enabled, openKfx, profile, showNotification],
+    [enabled, openKfx, showNotification],
   );
 
   const workspaceRuntime = deriveWorkspaceRuntimePresentation(runtimeStatus);

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -1368,8 +1368,8 @@ function App() {
     <button
       type="button"
       onClick={() => setLabOpen(true)}
-      title="Agent Qualification Lab"
-      aria-label="Agent Qualification Lab"
+      title="Agent Work Lab"
+      aria-label="Agent Work Lab"
       aria-current={labOpen ? 'page' : undefined}
       style={{
         ...mono,
@@ -1390,7 +1390,7 @@ function App() {
       <span aria-hidden="true" style={{ fontSize: 16 }}>
         🧪
       </span>
-      {!sidebarCollapsed && <span>Agent Lab</span>}
+      {!sidebarCollapsed && <span>Agent Work Lab</span>}
     </button>
   );
 
@@ -1857,9 +1857,7 @@ function App() {
       <ShellTitleBar
         chrome={windowChrome}
         activeTitle={
-          labOpen
-            ? 'Agent Qualification Lab'
-            : (activeKfx?.title ?? 'Kungfu Episodes')
+          labOpen ? 'Agent Work Lab' : (activeKfx?.title ?? 'Kungfu Episodes')
         }
         commandText={commandText}
         commandOptions={commandOptions}

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -48,6 +48,9 @@ import {
   deriveWorkspaceRuntimePresentation,
 } from '../../runtime-status';
 import {
+  GLOBAL_WORK_OBSERVER_EVENT_CHANNEL,
+  GLOBAL_WORK_OBSERVER_SUBSCRIBE_CHANNEL,
+  GLOBAL_WORK_OBSERVER_UNSUBSCRIBE_CHANNEL,
   RUNTIME_BACKUP_RESET_CHANNEL,
   RUNTIME_STATUS_GET_CHANNEL,
   SESSION_WINDOW_OPEN_CHANNEL,
@@ -1076,6 +1079,8 @@ function App() {
   const [workSearchDocuments, setWorkSearchDocuments] = React.useState<
     ProductSearchDocument[]
   >([]);
+  const [globalWorkSearchDocuments, setGlobalWorkSearchDocuments] =
+    React.useState<ProductSearchDocument[]>([]);
   const [searchCatalogStatus, setSearchCatalogStatus] = React.useState(
     'Loading governed command catalog',
   );
@@ -1163,6 +1168,62 @@ function App() {
       });
     return () => {
       active = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    type GlobalWorkObserverEvent =
+      | {
+          schema: 'kungfu.gui.global-work-observer-event/v1';
+          kind: 'snapshot';
+          snapshot: Record<string, unknown>;
+        }
+      | {
+          schema: 'kungfu.gui.global-work-observer-event/v1';
+          kind: 'error';
+          error: string;
+        };
+    type GlobalWorkIpc = {
+      invoke: (channel: string) => Promise<unknown>;
+      on: (
+        channel: string,
+        listener: (event: unknown, payload: GlobalWorkObserverEvent) => void,
+      ) => void;
+      removeListener: (
+        channel: string,
+        listener: (event: unknown, payload: GlobalWorkObserverEvent) => void,
+      ) => void;
+    };
+    let ipc: GlobalWorkIpc | null = null;
+    try {
+      ipc = (window.require('electron') as { ipcRenderer: GlobalWorkIpc })
+        .ipcRenderer;
+    } catch {
+      ipc = null;
+    }
+    if (!ipc) return;
+    const receive = (_event: unknown, payload: GlobalWorkObserverEvent) => {
+      if (
+        payload?.schema !== 'kungfu.gui.global-work-observer-event/v1' ||
+        payload.kind !== 'snapshot'
+      ) {
+        return;
+      }
+      try {
+        setGlobalWorkSearchDocuments(
+          capability.globalWorkSearchDocuments(
+            capability.parseGlobalWorkSnapshot(payload.snapshot),
+          ),
+        );
+      } catch {
+        // Keep the last verified search projection during observer recovery.
+      }
+    };
+    ipc.on(GLOBAL_WORK_OBSERVER_EVENT_CHANNEL, receive);
+    void ipc.invoke(GLOBAL_WORK_OBSERVER_SUBSCRIBE_CHANNEL);
+    return () => {
+      ipc?.removeListener(GLOBAL_WORK_OBSERVER_EVENT_CHANNEL, receive);
+      void ipc?.invoke(GLOBAL_WORK_OBSERVER_UNSUBSCRIBE_CHANNEL);
     };
   }, []);
 
@@ -1684,10 +1745,16 @@ function App() {
     () => [
       ...capability.SYSTEM_HELP_DOCUMENTS,
       ...cliSearchDocuments,
+      ...globalWorkSearchDocuments,
       ...workSearchDocuments,
       ...viewSearchDocuments,
     ],
-    [cliSearchDocuments, viewSearchDocuments, workSearchDocuments],
+    [
+      cliSearchDocuments,
+      globalWorkSearchDocuments,
+      viewSearchDocuments,
+      workSearchDocuments,
+    ],
   );
   const searchResults = React.useMemo(
     () => capability.searchProductDocuments(searchDocuments, searchText),

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -1,5 +1,9 @@
 import * as capability from '@kungfu-tech/api/capability';
-import type { QualificationLabStartupRoute } from '@kungfu-tech/api/capability';
+import type {
+  ProductSearchDocument,
+  ProductSearchResult,
+  QualificationLabStartupRoute,
+} from '@kungfu-tech/api/capability';
 import * as query from '@kungfu-tech/api/query';
 // Reference app shell: boots the in-process runtime and mounts kfx loaded
 // from extension packages. The shell owns system concerns only — extension
@@ -389,28 +393,66 @@ function useWindowChrome(): [
 function ShellTitleBar({
   chrome,
   activeTitle,
-  commandText,
-  commandOptions,
+  searchText,
+  searchResults,
+  searchStatus,
   settingsOpen,
   workspaceLabel,
-  onCommandChange,
-  onCommandSubmit,
+  onSearchChange,
+  onSearchActivate,
   onOpenSettings,
   onOpenWorkspace,
   onWindowControl,
 }: {
   chrome: WindowChromeConfig;
   activeTitle: string;
-  commandText: string;
-  commandOptions: { id: string; title: string }[];
+  searchText: string;
+  searchResults: ProductSearchResult[];
+  searchStatus: string;
   settingsOpen: boolean;
   workspaceLabel: string;
-  onCommandChange: (value: string) => void;
-  onCommandSubmit: () => void;
+  onSearchChange: (value: string) => void;
+  onSearchActivate: (result: ProductSearchResult) => void;
   onOpenSettings: () => void;
   onOpenWorkspace: () => void;
   onWindowControl: (control: WindowChromeControl) => void;
 }) {
+  const searchRoot = React.useRef<HTMLFormElement>(null);
+  const searchInput = React.useRef<HTMLInputElement>(null);
+  const [searchOpen, setSearchOpen] = React.useState(false);
+  const [selectedSearchResult, setSelectedSearchResult] = React.useState(0);
+  React.useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setSearchOpen(true);
+        searchInput.current?.focus();
+        searchInput.current?.select();
+      }
+    };
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        searchRoot.current &&
+        !searchRoot.current.contains(target)
+      ) {
+        setSearchOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('mousedown', onPointerDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('mousedown', onPointerDown);
+    };
+  }, []);
+  const activateSearchResult = (index = selectedSearchResult) => {
+    const result = searchResults[index];
+    if (!result) return;
+    onSearchActivate(result);
+    setSearchOpen(false);
+  };
   const dragRegion: ElectronChromeStyle = {
     WebkitAppRegion: chrome.draggable ? 'drag' : undefined,
   };
@@ -458,6 +500,8 @@ function ShellTitleBar({
     <header
       style={{
         ...dragRegion,
+        position: 'relative',
+        zIndex: 100,
         height: 42,
         flexShrink: 0,
         display: 'grid',
@@ -492,23 +536,50 @@ function ShellTitleBar({
           Kungfu Episodes
         </div>
         <form
+          ref={searchRoot}
           onSubmit={(event) => {
             event.preventDefault();
-            onCommandSubmit();
+            activateSearchResult();
           }}
           style={{
             ...interactiveRegion,
+            position: 'relative',
             minWidth: 0,
             display: 'flex',
             alignItems: 'center',
+            zIndex: 50,
           }}
         >
           <input
-            aria-label="Search views"
-            list="kf-shell-command-options"
-            value={commandText}
-            onChange={(event) => onCommandChange(event.target.value)}
-            placeholder="Search"
+            ref={searchInput}
+            aria-label="Search Kungfu"
+            value={searchText}
+            onFocus={() => setSearchOpen(true)}
+            onChange={(event) => {
+              setSelectedSearchResult(0);
+              onSearchChange(event.target.value);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setSelectedSearchResult(
+                  (current) =>
+                    (current + 1) % Math.max(1, searchResults.length),
+                );
+              } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setSelectedSearchResult(
+                  (current) =>
+                    (current - 1 + Math.max(1, searchResults.length)) %
+                    Math.max(1, searchResults.length),
+                );
+              } else if (event.key === 'Escape') {
+                event.preventDefault();
+                setSearchOpen(false);
+                searchInput.current?.blur();
+              }
+            }}
+            placeholder="Search Help, Commands, Work"
             style={{
               width: '100%',
               height: 26,
@@ -522,11 +593,108 @@ function ShellTitleBar({
               fontSize: 12,
             }}
           />
-          <datalist id="kf-shell-command-options">
-            {commandOptions.map((option) => (
-              <option key={option.id} value={option.title} />
-            ))}
-          </datalist>
+          {searchOpen ? (
+            <section
+              aria-label="Kungfu search results"
+              style={{
+                position: 'absolute',
+                top: 30,
+                left: 0,
+                width: '100%',
+                maxHeight: 360,
+                overflow: 'auto',
+                boxSizing: 'border-box',
+                border: '1px solid #454545',
+                borderRadius: 6,
+                background: '#181818',
+                boxShadow: '0 12px 28px rgba(0, 0, 0, 0.55)',
+                padding: 5,
+              }}
+            >
+              <div
+                style={{
+                  ...mono,
+                  color: '#858585',
+                  padding: '3px 7px 6px',
+                  fontSize: 11,
+                }}
+              >
+                {searchStatus} · ↑↓ choose · Enter open
+              </div>
+              {searchResults.length === 0 ? (
+                <div style={{ ...mono, color: '#dcdcaa', padding: 8 }}>
+                  No matching Help, Command, Work, or view.
+                </div>
+              ) : null}
+              {searchResults.map((result, index) => (
+                <button
+                  key={result.id}
+                  type="button"
+                  aria-pressed={index === selectedSearchResult}
+                  onMouseEnter={() => setSelectedSearchResult(index)}
+                  onClick={() => activateSearchResult(index)}
+                  style={{
+                    ...mono,
+                    width: '100%',
+                    display: 'grid',
+                    gridTemplateColumns: '68px minmax(0, 1fr)',
+                    gap: 7,
+                    padding: '6px 7px',
+                    border: 'none',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    color: '#cccccc',
+                    background:
+                      index === selectedSearchResult
+                        ? '#04395e'
+                        : 'transparent',
+                  }}
+                >
+                  <span
+                    style={{
+                      color:
+                        result.kind === 'work'
+                          ? '#4ec9b0'
+                          : result.kind === 'command'
+                            ? '#dcdcaa'
+                            : result.kind === 'view'
+                              ? '#c586c0'
+                              : '#9cdcfe',
+                      fontSize: 10,
+                      textTransform: 'uppercase',
+                    }}
+                  >
+                    {result.kind}
+                  </span>
+                  <span style={{ minWidth: 0 }}>
+                    <span
+                      style={{
+                        display: 'block',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {result.title}
+                    </span>
+                    <span
+                      style={{
+                        display: 'block',
+                        color: '#858585',
+                        fontSize: 11,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {result.summary}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </section>
+          ) : null}
         </form>
       </div>
       <div
@@ -901,7 +1069,16 @@ function App() {
   const [params, setParams] = React.useState<Record<string, string>>({});
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [workspaceOpen, setWorkspaceOpen] = React.useState(false);
-  const [commandText, setCommandText] = React.useState('');
+  const [searchText, setSearchText] = React.useState('');
+  const [cliSearchDocuments, setCliSearchDocuments] = React.useState<
+    ProductSearchDocument[]
+  >([]);
+  const [workSearchDocuments, setWorkSearchDocuments] = React.useState<
+    ProductSearchDocument[]
+  >([]);
+  const [searchCatalogStatus, setSearchCatalogStatus] = React.useState(
+    'Loading governed command catalog',
+  );
   const [windowChrome, controlWindow] = useWindowChrome();
   const [config, setConfig] = React.useState<KungfuResolvedConfig | null>(null);
   const [configError, setConfigError] = React.useState('');
@@ -931,6 +1108,63 @@ function App() {
       setActive(consoleEntry.id);
     }
   }, [config, enabled]);
+
+  React.useEffect(() => {
+    type ExecFile = (
+      file: string,
+      args: string[],
+      options: {
+        encoding: 'utf8';
+        env: Record<string, string | undefined>;
+        maxBuffer: number;
+      },
+      callback: (error: Error | null, stdout: string, stderr: string) => void,
+    ) => void;
+    const { execFile } = window.require('node:child_process') as {
+      execFile: ExecFile;
+    };
+    const env: Record<string, string | undefined> = {
+      ...window.process.env,
+      KUNGFU_AS_VARIANT: undefined,
+    };
+    let active = true;
+    void capability
+      .loadCliHelpSearchDocuments({
+        bin:
+          env.KUNGFU_CLI_BIN ||
+          env.KUNGFU_BIN ||
+          (window.process.platform === 'win32' ? 'kungfu.exe' : 'kungfu'),
+        env,
+        execFile: (file, args, options) =>
+          new Promise<string>((resolve, reject) => {
+            execFile(file, args, options, (error, stdout, stderr) => {
+              if (error) {
+                reject(new Error(stderr.trim() || error.message));
+              } else {
+                resolve(stdout);
+              }
+            });
+          }),
+      })
+      .then((documents) => {
+        if (!active) return;
+        setCliSearchDocuments(documents);
+        setSearchCatalogStatus(
+          `${documents.length} governed Help and Command entries`,
+        );
+      })
+      .catch((error) => {
+        if (!active) return;
+        setSearchCatalogStatus(
+          `Command catalog unavailable: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // shared refresh bus: one shell-owned timer, kfx subscribe
   const subscribers = React.useRef(new Set<() => void>());
@@ -998,6 +1232,39 @@ function App() {
       window.clearInterval(timer);
     };
   }, [runtime.ok]);
+
+  React.useEffect(() => {
+    if (!runtime.work) {
+      setWorkSearchDocuments([]);
+      return;
+    }
+    const refresh = () => {
+      try {
+        runtime.work?.refresh();
+        setWorkSearchDocuments(
+          (runtime.work?.items() ?? []).map((item, index) => ({
+            id: `work.${item.workId}`,
+            kind: 'work',
+            title: item.title || item.workId,
+            summary:
+              [item.summary, item.nextAction && `Next: ${item.nextAction}`]
+                .filter(Boolean)
+                .join(' · ') || 'Current Work information.',
+            keywords: [item.workId, item.kind || '', item.nextAction || ''],
+            priority: index,
+            action: { kind: 'open-work', workId: item.workId },
+          })),
+        );
+      } catch {
+        setWorkSearchDocuments([]);
+      }
+    };
+    refresh();
+    subscribers.current.add(refresh);
+    return () => {
+      subscribers.current.delete(refresh);
+    };
+  }, [runtime.work]);
 
   React.useEffect(
     () => () => {
@@ -1400,29 +1667,51 @@ function App() {
     loaded.entries.find((k) => k.id === 'settings') ??
     null;
   const settingsCaps = settingsKfx ? subsetCaps(runtime, settingsKfx) : null;
-  const commandOptions = enabled.map((entry) => ({
-    id: entry.id,
-    title: entry.title,
-  }));
-  const submitCommand = React.useCallback(() => {
-    const query = commandText.trim().toLowerCase();
-    if (!query) return;
-    const match =
-      enabled.find((entry) => entry.title.toLowerCase() === query) ??
-      enabled.find((entry) => entry.id.toLowerCase() === query) ??
-      enabled.find((entry) => entry.title.toLowerCase().includes(query)) ??
-      enabled.find((entry) => entry.id.toLowerCase().includes(query));
-    if (!match) {
-      showNotification({
-        level: 'info',
-        title: 'No matching view',
-        message: commandText,
-      });
-      return;
-    }
-    openKfx(match.id);
-    setCommandText('');
-  }, [commandText, enabled, openKfx, showNotification]);
+  const viewSearchDocuments = React.useMemo<ProductSearchDocument[]>(
+    () =>
+      enabled.map((entry, index) => ({
+        id: `view.${entry.id}`,
+        kind: 'view',
+        title: entry.title,
+        summary: `Open the ${entry.title} product view.`,
+        keywords: [entry.id, ...(entry.product.roles ?? [])],
+        priority: index,
+        action: { kind: 'open-view', viewId: entry.id },
+      })),
+    [enabled],
+  );
+  const searchDocuments = React.useMemo(
+    () => [
+      ...capability.SYSTEM_HELP_DOCUMENTS,
+      ...cliSearchDocuments,
+      ...workSearchDocuments,
+      ...viewSearchDocuments,
+    ],
+    [cliSearchDocuments, viewSearchDocuments, workSearchDocuments],
+  );
+  const searchResults = React.useMemo(
+    () => capability.searchProductDocuments(searchDocuments, searchText),
+    [searchDocuments, searchText],
+  );
+  const activateSearchResult = React.useCallback(
+    (result: ProductSearchResult) => {
+      if (result.action.kind === 'open-view') {
+        openKfx(result.action.viewId);
+      } else if (result.action.kind === 'open-work') {
+        openKfx(profileHomeId(profile, enabled), {
+          workId: result.action.workId,
+        });
+      } else {
+        showNotification({
+          level: 'info',
+          title: result.title,
+          message: result.summary,
+        });
+      }
+      setSearchText('');
+    },
+    [enabled, openKfx, profile, showNotification],
+  );
 
   const workspaceRuntime = deriveWorkspaceRuntimePresentation(runtimeStatus);
   const trustCounts = runtimeStatus?.payload?.assessments?.counts ?? {};
@@ -1859,14 +2148,15 @@ function App() {
         activeTitle={
           labOpen ? 'Agent Work Lab' : (activeKfx?.title ?? 'Kungfu Episodes')
         }
-        commandText={commandText}
-        commandOptions={commandOptions}
+        searchText={searchText}
+        searchResults={searchResults}
+        searchStatus={searchCatalogStatus}
         settingsOpen={settingsOpen}
         workspaceLabel={
           window.process.env.KF_WORKSPACE_DISPLAY_PATH || 'Home Workspace'
         }
-        onCommandChange={setCommandText}
-        onCommandSubmit={submitCommand}
+        onSearchChange={setSearchText}
+        onSearchActivate={activateSearchResult}
         onOpenSettings={() => setSettingsOpen(true)}
         onOpenWorkspace={() => setWorkspaceOpen(true)}
         onWindowControl={controlWindow}

--- a/framework/gui/src/renderer/src/qualification-lab.tsx
+++ b/framework/gui/src/renderer/src/qualification-lab.tsx
@@ -10,10 +10,16 @@ import type {
 } from '@kungfu-tech/api/capability';
 import { qualificationRunProgressLabel } from '@kungfu-tech/api/capability';
 import { mono, panelStyle } from '@kungfu-tech/kfx';
+import {
+  AGENT_WORK_LAB_CHECKS,
+  AGENT_WORK_LAB_SUITE,
+  type AgentWorkLabCaseId,
+  agentWorkLabRecommendation,
+} from '@kungfu-tech/kfx';
 import React from 'react';
 import { createPortal } from 'react-dom';
 
-export type QualificationMode = 'offline-demo' | 'same-agent' | 'cross-agent';
+export type QualificationMode = AgentWorkLabCaseId;
 
 type VisualStatus =
   | 'ready'
@@ -51,35 +57,20 @@ type PlaybackLine = {
 };
 
 export const QUALIFICATION_PLAYBACK_TIMING = {
-  eventDelayMs: 1000,
-  verdictDelayMs: 520,
-  reducedMotionDelayMs: 24,
+  eventDelayMs: AGENT_WORK_LAB_SUITE.timing.eventIntervalMs,
+  verdictDelayMs: AGENT_WORK_LAB_SUITE.timing.verdictIntervalMs,
+  reducedMotionDelayMs: AGENT_WORK_LAB_SUITE.timing.reducedMotionIntervalMs,
 } as const;
 
 export const QUALIFICATION_MODES: Array<{
   id: QualificationMode;
   label: string;
   description: string;
-}> = [
-  {
-    id: 'offline-demo',
-    label: 'Offline demo',
-    description:
-      'Start here. A bundled deterministic agent proves the continuity mechanism without accounts or configuration.',
-  },
-  {
-    id: 'same-agent',
-    label: 'Same-agent continuity',
-    description:
-      'Run one selected local agent in two fresh processes and check whether the second process continues the first.',
-  },
-  {
-    id: 'cross-agent',
-    label: 'Cross-agent handoff',
-    description:
-      'Let one local agent begin the task and a different local agent continue from the same governed evidence.',
-  },
-];
+}> = AGENT_WORK_LAB_SUITE.cases.map((entry) => ({
+  id: entry.id,
+  label: entry.title,
+  description: entry.description,
+}));
 
 const STATUS_META: Record<
   VisualStatus,
@@ -147,38 +138,13 @@ function playbackSourceLabel(line: PlaybackLine): string {
   }[line.kind];
 }
 
-const CHECK_COPY: Record<string, { title: string; detail: string }> = {
-  'two-distinct-fresh-processes': {
-    title: 'The two sessions were genuinely fresh',
-    detail:
-      'Kungfu observed two different process identities instead of reusing one hidden session.',
-  },
-  'second-attempt-no-transcript-or-explanation': {
-    title: 'No transcript or human re-explanation was injected',
-    detail:
-      'Session 2 had to recover the work from governed state, not from copied conversation context.',
-  },
-  'second-attempt-recognized-partial-state': {
-    title: 'Session 2 recognized the partial result',
-    detail:
-      'The continuation found the exact state left by Session 1 before deciding what to do next.',
-  },
-  'fixture-completed': {
-    title: 'The task reached the expected final state',
-    detail:
-      'The deterministic oracle found both the first claim and the continuation result.',
-  },
-  'both-processes-exited-cleanly': {
-    title: 'Both agent processes exited cleanly',
-    detail:
-      'Process completion was observed for both sessions without treating exit alone as task proof.',
-  },
-  'fresh-session-completed-exact-state': {
-    title: 'The fresh session completed the exact governed task',
-    detail:
-      'The final state retained the same Work identity and the expected ordered steps.',
-  },
-};
+const CHECK_COPY: Record<string, { title: string; detail: string }> =
+  Object.fromEntries(
+    Object.entries(AGENT_WORK_LAB_CHECKS).map(([id, copy]) => [
+      id,
+      { title: copy.title, detail: copy.meaning },
+    ]),
+  );
 
 function shortRoot(value: string): string {
   return value.length > 28 ? `${value.slice(0, 16)}…${value.slice(-8)}` : value;
@@ -823,7 +789,7 @@ function SessionColumn({
           <span style={{ color: '#d7ba7d' }}>●</span>
           <span style={{ color: '#4ec9b0' }}>●</span>
           <span style={{ marginLeft: 5 }}>
-            agent@qualification-lab · session-{session}
+            agent@work-lab · session-{session}
           </span>
           {running ? (
             <span className="kf-lab-live-dots" style={{ marginLeft: 'auto' }}>
@@ -1166,6 +1132,8 @@ export function QualificationLabPanel({
   >([]);
   const [visibleFindingCount, setVisibleFindingCount] = React.useState(0);
   const [activeFindingIndex, setActiveFindingIndex] = React.useState(-1);
+  const [showNextRecommendation, setShowNextRecommendation] =
+    React.useState(false);
   const [busy, setBusy] = React.useState('');
   const [error, setError] = React.useState('');
   const [runProgress, setRunProgress] = React.useState<{
@@ -1180,9 +1148,20 @@ export function QualificationLabPanel({
   React.useEffect(() => {
     if (!runProgress) return undefined;
     setProgressNow(Date.now());
-    const timer = window.setInterval(() => setProgressNow(Date.now()), 1000);
+    const timer = window.setInterval(
+      () => setProgressNow(Date.now()),
+      AGENT_WORK_LAB_SUITE.timing.quietProgressIntervalMs,
+    );
     return () => window.clearInterval(timer);
   }, [runProgress]);
+  React.useEffect(() => {
+    if (!showNextRecommendation) return undefined;
+    const timer = window.setTimeout(
+      () => setShowNextRecommendation(false),
+      AGENT_WORK_LAB_SUITE.timing.recommendationDurationMs,
+    );
+    return () => window.clearTimeout(timer);
+  }, [showNextRecommendation]);
 
   const discover = React.useCallback(async () => {
     setBusy('discover');
@@ -1223,6 +1202,7 @@ export function QualificationLabPanel({
     setVisiblePlaybackLines([]);
     setVisibleFindingCount(0);
     setActiveFindingIndex(-1);
+    setShowNextRecommendation(false);
     setRunProgress(null);
     setError('');
   };
@@ -1255,6 +1235,7 @@ export function QualificationLabPanel({
     setVisiblePlaybackLines([]);
     setVisibleFindingCount(0);
     setActiveFindingIndex(-1);
+    setShowNextRecommendation(false);
     const startedAt = Date.now();
     setProgressNow(startedAt);
     setRunProgress({
@@ -1317,6 +1298,7 @@ export function QualificationLabPanel({
       }
       if (playbackRunRef.current !== runId) return;
       setActiveFindingIndex(-1);
+      setShowNextRecommendation(true);
       setError('');
     } catch (reason) {
       if (playbackRunRef.current === runId) {
@@ -1359,6 +1341,7 @@ export function QualificationLabPanel({
     label: 'Unknown test mode',
     description: 'Choose a supported qualification mode.',
   };
+  const nextRecommendation = agentWorkLabRecommendation(mode);
   const progress = runProgress
     ? qualificationRunProgressLabel({
         elapsedMs: progressNow - runProgress.startedAt,
@@ -1393,7 +1376,8 @@ export function QualificationLabPanel({
       >
         <div style={{ minWidth: 0 }}>
           <div style={{ ...mono, color: '#9cdcfe', fontSize: 11 }}>
-            AGENT QUALIFICATION LAB
+            AGENT WORK LAB ·{' '}
+            {AGENT_WORK_LAB_SUITE.collection.title.toUpperCase()}
           </div>
           <h1
             style={{
@@ -1603,6 +1587,71 @@ export function QualificationLabPanel({
         targetPlan={targetPlan}
         error={error}
       />
+      {showNextRecommendation && typeof document !== 'undefined'
+        ? createPortal(
+            <output
+              aria-live="polite"
+              style={{
+                position: 'fixed',
+                inset: 0,
+                zIndex: 10000,
+                display: 'grid',
+                placeItems: 'center',
+                background: 'rgba(6, 8, 10, 0.78)',
+              }}
+            >
+              <div
+                style={{
+                  ...panelStyle,
+                  width: 'min(520px, calc(100vw - 48px))',
+                  padding: 20,
+                  border: '2px solid #d7ba7d',
+                  background: '#101820',
+                  boxShadow: '0 18px 64px rgba(0, 0, 0, 0.72)',
+                }}
+              >
+                <div style={{ ...mono, color: '#d7ba7d', fontSize: 11 }}>
+                  WHAT TO TRY NEXT
+                </div>
+                <h2 style={{ margin: '8px 0', fontSize: 19 }}>
+                  {nextRecommendation.title}
+                </h2>
+                <p style={{ margin: 0, color: '#d4d4d4', lineHeight: 1.5 }}>
+                  {nextRecommendation.instruction}
+                </p>
+                <div
+                  style={{
+                    marginTop: 14,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    gap: 12,
+                  }}
+                >
+                  <span style={{ ...mono, color: '#858585', fontSize: 11 }}>
+                    Closes automatically in 5 seconds
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setShowNextRecommendation(false)}
+                    style={{
+                      ...mono,
+                      border: '1px solid #666',
+                      borderRadius: 4,
+                      padding: '5px 9px',
+                      color: '#f3f3f3',
+                      background: '#292929',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+            </output>,
+            document.body,
+          )
+        : null}
       <style>{`
         .kf-lab-tip {
           position: relative;
@@ -1671,7 +1720,7 @@ export function QualificationLabPanel({
         }
         .kf-lab-verdict-focus {
           border-color: #4ec9b0 !important;
-          animation: kf-lab-verdict-emphasis 520ms ease-out both;
+          animation: kf-lab-verdict-emphasis ${AGENT_WORK_LAB_SUITE.timing.verdictIntervalMs}ms ease-out both;
         }
         @media (prefers-reduced-motion: reduce) {
           .kf-lab-event-line,

--- a/framework/kfx/src/agent-work-lab.ts
+++ b/framework/kfx/src/agent-work-lab.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export type AgentWorkLabCaseId = 'offline-demo' | 'same-agent' | 'cross-agent';
+
+export type AgentWorkLabCheckMeaning = {
+  title: string;
+  meaning: string;
+};
+
+export type AgentWorkLabCase = {
+  id: AgentWorkLabCaseId;
+  title: string;
+  shortTitle: string;
+  description: string;
+  sourceRequirement: 'bundled' | 'configured';
+  targetRequirement: 'fresh-demo' | 'same' | 'different';
+  runLabel: string;
+};
+
+export type AgentWorkLabRecommendation = {
+  title: string;
+  instruction: string;
+  nextCase?: AgentWorkLabCaseId;
+};
+
+export const AGENT_WORK_LAB_SUITE = {
+  id: 'kungfu.agent-work-lab',
+  title: 'Agent Work Lab',
+  collection: {
+    id: 'work-continuity',
+    title: 'Work Continuity',
+    description:
+      'See whether fresh agent sessions can continue the same governed Work without copied chat.',
+  },
+  cases: [
+    {
+      id: 'offline-demo',
+      title: 'Offline demo',
+      shortTitle: 'Demo',
+      description:
+        'Watch two bundled fresh processes demonstrate a bounded stop and governed continuation.',
+      sourceRequirement: 'bundled',
+      targetRequirement: 'fresh-demo',
+      runLabel: 'running two fresh demo sessions',
+    },
+    {
+      id: 'same-agent',
+      title: 'Same agent',
+      shortTitle: 'Same',
+      description:
+        'Run the selected agent twice and verify that a fresh process recovers the same Work.',
+      sourceRequirement: 'configured',
+      targetRequirement: 'same',
+      runLabel: 'running selected agent twice',
+    },
+    {
+      id: 'cross-agent',
+      title: 'Agent handoff',
+      shortTitle: 'Handoff',
+      description:
+        'Start with one agent and ask a different agent to continue from governed evidence.',
+      sourceRequirement: 'configured',
+      targetRequirement: 'different',
+      runLabel: 'running cross-provider handoff',
+    },
+  ] satisfies AgentWorkLabCase[],
+  timing: {
+    eventIntervalMs: 1000,
+    verdictIntervalMs: 520,
+    recommendationDurationMs: 5000,
+    quietProgressIntervalMs: 1000,
+    reducedMotionIntervalMs: 24,
+  },
+} as const;
+
+export const AGENT_WORK_LAB_KFX_SUITE = {
+  title: AGENT_WORK_LAB_SUITE.title,
+  members: [
+    'agent-work-lab-catalog',
+    'agent-work-lab-gui',
+    'agent-work-lab-tui',
+  ],
+} as const;
+
+export const AGENT_WORK_LAB_CHECKS: Record<string, AgentWorkLabCheckMeaning> = {
+  'two-distinct-fresh-processes': {
+    title: 'Two genuinely fresh processes',
+    meaning:
+      'Kungfu observed two different process identities instead of reusing one hidden session.',
+  },
+  'distinct-fresh-processes': {
+    title: 'Two genuinely fresh processes',
+    meaning: 'Session 2 did not reuse the Session 1 provider process.',
+  },
+  'first-attempt-ended-partial': {
+    title: 'Session 1 stopped at a bounded partial result',
+    meaning:
+      'The first process left durable evidence instead of pretending to finish.',
+  },
+  'second-attempt-no-transcript-or-explanation': {
+    title: 'Session 2 received no copied chat',
+    meaning:
+      'Continuation came from governed Work, not hidden transcript transfer.',
+  },
+  'second-attempt-recognized-partial-state': {
+    title: 'Session 2 recovered the partial state',
+    meaning: 'The fresh process found what was done and what remained.',
+  },
+  'fixture-completed': {
+    title: 'The original Work was completed',
+    meaning:
+      'The second process continued the same identity to its expected result.',
+  },
+  'both-processes-exited-cleanly': {
+    title: 'Both agent processes exited cleanly',
+    meaning:
+      'Process completion was observed for both sessions without treating exit alone as task proof.',
+  },
+  'fresh-session-completed-exact-state': {
+    title: 'The fresh session completed the exact governed task',
+    meaning:
+      'The final state retained the same Work identity and the expected ordered steps.',
+  },
+};
+
+export const AGENT_WORK_LAB_RECOMMENDATIONS: Record<
+  AgentWorkLabCaseId,
+  AgentWorkLabRecommendation
+> = {
+  'offline-demo': {
+    title: 'Offline complete · now test your real agent',
+    instruction:
+      'Run Same agent to verify continuity with your selected provider.',
+    nextCase: 'same-agent',
+  },
+  'same-agent': {
+    title: 'Same-agent complete · now test a handoff',
+    instruction: 'Choose a different target, then run Agent handoff.',
+    nextCase: 'cross-agent',
+  },
+  'cross-agent': {
+    title: 'Handoff complete · inspect the evidence',
+    instruction:
+      'Open Correct or Failed to see every continuity check and its meaning.',
+  },
+};
+
+export function agentWorkLabCase(id: AgentWorkLabCaseId): AgentWorkLabCase {
+  const found = AGENT_WORK_LAB_SUITE.cases.find((entry) => entry.id === id);
+  if (!found) throw new Error(`unknown Agent Work Lab case: ${id}`);
+  return found;
+}
+
+export function agentWorkLabRecommendation(
+  id: AgentWorkLabCaseId,
+): AgentWorkLabRecommendation {
+  return AGENT_WORK_LAB_RECOMMENDATIONS[id];
+}

--- a/framework/kfx/src/index.ts
+++ b/framework/kfx/src/index.ts
@@ -27,6 +27,22 @@ import type {
 } from '@kungfu-tech/api/capability';
 import Ajv2020 from 'ajv/dist/2020.js';
 import type React from 'react';
+import { AGENT_WORK_LAB_KFX_SUITE } from './agent-work-lab.js';
+
+export {
+  AGENT_WORK_LAB_CHECKS,
+  AGENT_WORK_LAB_KFX_SUITE,
+  AGENT_WORK_LAB_RECOMMENDATIONS,
+  AGENT_WORK_LAB_SUITE,
+  agentWorkLabCase,
+  agentWorkLabRecommendation,
+} from './agent-work-lab.js';
+export type {
+  AgentWorkLabCase,
+  AgentWorkLabCaseId,
+  AgentWorkLabCheckMeaning,
+  AgentWorkLabRecommendation,
+} from './agent-work-lab.js';
 
 // Re-export the terminal session types a view needs to build its own UI (pane
 // snapshots, discovery, spawn options). The view contract package is the one
@@ -1174,7 +1190,12 @@ export function planKfx(
   const { fs, path } = deps;
   const entries: KfxPlanEntry[] = [];
   const services: KfxServicePlanEntry[] = [];
-  const suites: Record<string, KfxSuiteDecl> = {};
+  const suites: Record<string, KfxSuiteDecl> = {
+    'kungfu.agent-work-lab': {
+      title: AGENT_WORK_LAB_KFX_SUITE.title,
+      members: [...AGENT_WORK_LAB_KFX_SUITE.members],
+    },
+  };
   const profiles: ProfileManifest[] = [];
   const failures: KfxPlanFailure[] = [];
   const seen = new Set<string>();

--- a/framework/kfx/src/profile-suite.test.ts
+++ b/framework/kfx/src/profile-suite.test.ts
@@ -188,6 +188,33 @@ test('KFX plan projects the declared Work Control GUI experience', () => {
   );
 });
 
+test('KFX plan discovers the stable Agent Work Lab Suite membership', () => {
+  const plan = planKfx(
+    {
+      KUNGFU_KFX_CONTRACT: path.join(
+        root,
+        'framework/kfx/kungfu-kfx.contract.json',
+      ),
+      KF_EXTENSION_PATH: path.join(root, 'extensions'),
+    },
+    planDeps,
+  );
+  assert.deepEqual(plan.suites['kungfu.agent-work-lab'], {
+    title: 'Agent Work Lab',
+    members: [
+      'agent-work-lab-catalog',
+      'agent-work-lab-gui',
+      'agent-work-lab-tui',
+    ],
+  });
+  assert.equal(
+    plan.failures.some((failure) =>
+      failure.dir.includes(path.join('extensions', 'agent-work-lab')),
+    ),
+    false,
+  );
+});
+
 test('KFX package contract rejects unknown or duplicate product roles', () => {
   const manifest = {
     name: '@example/view',

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:85829360a77ec44639ba99defd7692d96844002e554e115b72a34d0bd5cacf47",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:365cb652a2eda128837b3ec491849a54d49a25e0509be93f913b6bfe48e41a98",
+  "sourceRoot": "sha256:4396f3efa173709112ec6b6d56cd3525338a5acdf556cac883a38a5f34582788",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -25,7 +25,7 @@
     "families": 6,
     "authorities": 6,
     "mappedSurfaces": 72,
-    "changedMappedSurfaces": 24,
+    "changedMappedSurfaces": 29,
     "blockingIssues": 0
   },
   "families": [
@@ -378,9 +378,9 @@
         },
         {
           "path": "scripts/check-work-lifecycle-operation-matrix.test.mjs",
-          "currentLines": 355,
+          "currentLines": 360,
           "baselineLines": 355,
-          "currentRoot": "sha256:7591d5eec7a656ffcb287609c0f50f4a6e0eca802a0b0209d902c05b1b5217c4",
+          "currentRoot": "sha256:1f887e173d05398824fbc4a073f158a7323c48c1a8e5e8220e661dc7fabbf6fe",
           "baselineRoot": "sha256:7fb9d01feb8ef08e8af4a2d7d7691551923a8fc2714a0e967e332d0057131283",
           "changedSinceBaseline": true
         },
@@ -421,10 +421,11 @@
       "amplification": {
         "mappedSurfaces": 11,
         "nonAuthoritySurfaces": 8,
-        "changedSurfaces": 4,
+        "changedSurfaces": 5,
         "changedPaths": [
           "framework/kfx/src/index.ts",
           "framework/kfx/src/agent-work-lab.ts",
+          "framework/core/src/python/kungfu/cli/commands/kfx.py",
           "scripts/run-kfx-profile-suite-tests.mjs",
           "product/scripts/dist.mjs"
         ]
@@ -514,11 +515,11 @@
         },
         {
           "path": "framework/core/src/python/kungfu/cli/commands/kfx.py",
-          "currentLines": 787,
+          "currentLines": 775,
           "baselineLines": 787,
-          "currentRoot": "sha256:1395a3bf28f16d5fca7f38042345c2ef3001ee863b766bc6273d1900a6b47721",
+          "currentRoot": "sha256:4a07c46beb13588d6437a2d0b761dca41361f542d27e39eac5281217c126b755",
           "baselineRoot": "sha256:1395a3bf28f16d5fca7f38042345c2ef3001ee863b766bc6273d1900a6b47721",
-          "changedSinceBaseline": false
+          "changedSinceBaseline": true
         },
         {
           "path": "scripts/run-native-kfx-admission-tests.mjs",
@@ -548,7 +549,7 @@
           "path": "product/scripts/dist.mjs",
           "currentLines": 2530,
           "baselineLines": 2514,
-          "currentRoot": "sha256:0113c4e9a766be1ab1debf27c3be1286d13e9f62880b25ca39ceff23efa5223a",
+          "currentRoot": "sha256:8204f9e353ca411d489077ad124955512a741cd865486e25b289b6f8455764cf",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }
@@ -584,8 +585,10 @@
       "amplification": {
         "mappedSurfaces": 11,
         "nonAuthoritySurfaces": 7,
-        "changedSurfaces": 0,
-        "changedPaths": []
+        "changedSurfaces": 1,
+        "changedPaths": [
+          "scripts/check-fact-cut-kernel-contract.test.mjs"
+        ]
       },
       "surfaces": [
         {
@@ -676,11 +679,11 @@
         },
         {
           "path": "scripts/check-fact-cut-kernel-contract.test.mjs",
-          "currentLines": 322,
+          "currentLines": 327,
           "baselineLines": 322,
-          "currentRoot": "sha256:682ff55fcad16b6e0df68704d73a9a6b3708ba916a323c0a7cf448a2d01efe05",
+          "currentRoot": "sha256:69617cd8d4a9ddd5d000d58c00b867af9b8938927a646ca96991ac1ed3cfae87",
           "baselineRoot": "sha256:682ff55fcad16b6e0df68704d73a9a6b3708ba916a323c0a7cf448a2d01efe05",
-          "changedSinceBaseline": false
+          "changedSinceBaseline": true
         },
         {
           "path": "framework/core/tests/python/test_episode_control.py",
@@ -863,9 +866,9 @@
         },
         {
           "path": "scripts/check-work-lifecycle-operation-matrix.test.mjs",
-          "currentLines": 355,
+          "currentLines": 360,
           "baselineLines": 355,
-          "currentRoot": "sha256:7591d5eec7a656ffcb287609c0f50f4a6e0eca802a0b0209d902c05b1b5217c4",
+          "currentRoot": "sha256:1f887e173d05398824fbc4a073f158a7323c48c1a8e5e8220e661dc7fabbf6fe",
           "baselineRoot": "sha256:7fb9d01feb8ef08e8af4a2d7d7691551923a8fc2714a0e967e332d0057131283",
           "changedSinceBaseline": true
         },
@@ -924,9 +927,10 @@
       "amplification": {
         "mappedSurfaces": 12,
         "nonAuthoritySurfaces": 8,
-        "changedSurfaces": 5,
+        "changedSurfaces": 6,
         "changedPaths": [
           "docs/qualification/gates/release-admission-policy.json",
+          "scripts/verify-kungfu-release-admission.mjs",
           "scripts/release-promotion-rehearsal.mjs",
           "docs/qualification/gates/workflow-bindings.json",
           ".github/workflows/release-new-version.yml",
@@ -994,19 +998,19 @@
         },
         {
           "path": "docs/qualification/gates/release-admission-policy.json",
-          "currentLines": 41,
+          "currentLines": 49,
           "baselineLines": 41,
-          "currentRoot": "sha256:32b8d5be971bb3d4e24ca89ae14f1e2f646cecd79dacbdfaa2b7a07202209986",
+          "currentRoot": "sha256:b700161aa02b53026eb97e653e49939680623fc098c13129f79dd854454130c4",
           "baselineRoot": "sha256:e8a0f7037f2331610f3b9c07e7cdf5e47ea701045c73d0f67bf909372e77e0ac",
           "changedSinceBaseline": true
         },
         {
           "path": "scripts/verify-kungfu-release-admission.mjs",
-          "currentLines": 325,
+          "currentLines": 377,
           "baselineLines": 325,
-          "currentRoot": "sha256:e77a02ecf79651ef1dbfbbf57d494a334fd863ae81de5d7ccd8264922a216403",
+          "currentRoot": "sha256:b63705eb9575f2faf34c5c9b31b07cbb3375ba69f17d19730a77d04225ee79e0",
           "baselineRoot": "sha256:e77a02ecf79651ef1dbfbbf57d494a334fd863ae81de5d7ccd8264922a216403",
-          "changedSinceBaseline": false
+          "changedSinceBaseline": true
         },
         {
           "path": "scripts/prepare-ungfu-release-evidence.mjs",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:85829360a77ec44639ba99defd7692d96844002e554e115b72a34d0bd5cacf47",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:4396f3efa173709112ec6b6d56cd3525338a5acdf556cac883a38a5f34582788",
+  "sourceRoot": "sha256:865abb51683e09a8fec069a0e16f3541759607778133c5f6beb7578fa00390f1",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1038,9 +1038,9 @@
         },
         {
           "path": ".github/workflows/release-new-version.yml",
-          "currentLines": 384,
+          "currentLines": 386,
           "baselineLines": 362,
-          "currentRoot": "sha256:40b02a006d82a6b1bab1ec08d1ef15139a6c96659fc94b6443da49c158e6c806",
+          "currentRoot": "sha256:92b331d7748c6ffa1cbac43020b794acd790a88dfbc8ace99592b6d062ab11cc",
           "baselineRoot": "sha256:3bdd847c80a05030de1d826282cef2e76a85e31dc0904df02c7f0cdda7a5eb74",
           "changedSinceBaseline": true
         },

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -3,9 +3,9 @@
   "verdict": "pass",
   "authoritySemantics": "navigation-only-projection-over-existing-authorities",
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
-  "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
+  "manifestRoot": "sha256:85829360a77ec44639ba99defd7692d96844002e554e115b72a34d0bd5cacf47",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:b781cc85ea58882668857201b28819d0935cc0b151dfe4dca3c1a866f7a67d72",
+  "sourceRoot": "sha256:8cb3e0a9aa947f8a473e6a3beb5b1944f2fd2fdef00a42386b10e49f508c9082",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -24,8 +24,8 @@
   "summary": {
     "families": 6,
     "authorities": 6,
-    "mappedSurfaces": 70,
-    "changedMappedSurfaces": 26,
+    "mappedSurfaces": 72,
+    "changedMappedSurfaces": 24,
     "blockingIssues": 0
   },
   "families": [
@@ -378,9 +378,9 @@
         },
         {
           "path": "scripts/check-work-lifecycle-operation-matrix.test.mjs",
-          "currentLines": 360,
+          "currentLines": 355,
           "baselineLines": 355,
-          "currentRoot": "sha256:1f887e173d05398824fbc4a073f158a7323c48c1a8e5e8220e661dc7fabbf6fe",
+          "currentRoot": "sha256:7591d5eec7a656ffcb287609c0f50f4a6e0eca802a0b0209d902c05b1b5217c4",
           "baselineRoot": "sha256:7fb9d01feb8ef08e8af4a2d7d7691551923a8fc2714a0e967e332d0057131283",
           "changedSinceBaseline": true
         },
@@ -412,22 +412,32 @@
       "authorityCount": 1,
       "roles": {
         "authority": 3,
-        "thin-binding": 2,
+        "thin-binding": 4,
         "conformance-oracle": 1,
         "test": 1,
         "documentation": 1,
         "package-release": 1
       },
       "amplification": {
-        "mappedSurfaces": 9,
-        "nonAuthoritySurfaces": 6,
-        "changedSurfaces": 2,
+        "mappedSurfaces": 11,
+        "nonAuthoritySurfaces": 8,
+        "changedSurfaces": 4,
         "changedPaths": [
-          "framework/core/src/python/kungfu/cli/commands/kfx.py",
+          "framework/kfx/src/index.ts",
+          "framework/kfx/src/agent-work-lab.ts",
+          "scripts/run-kfx-profile-suite-tests.mjs",
           "product/scripts/dist.mjs"
         ]
       },
       "surfaces": [
+        {
+          "path": "framework/kfx/src/index.ts",
+          "role": "thin-binding"
+        },
+        {
+          "path": "framework/kfx/src/agent-work-lab.ts",
+          "role": "thin-binding"
+        },
         {
           "path": "framework/core/src/python/kungfu/kfx_contract.py",
           "role": "thin-binding"
@@ -479,6 +489,22 @@
           "changedSinceBaseline": false
         },
         {
+          "path": "framework/kfx/src/index.ts",
+          "currentLines": 1643,
+          "baselineLines": 1622,
+          "currentRoot": "sha256:b002d1c496fec0e6c988a7ca25b30b84f28977dcf6ae2059a49e049d851f4786",
+          "baselineRoot": "sha256:c27078f816d82f9d6aceb9d681f387ab1ee5ccdb806f0570e1b8959f8f2fadf8",
+          "changedSinceBaseline": true
+        },
+        {
+          "path": "framework/kfx/src/agent-work-lab.ts",
+          "currentLines": 158,
+          "baselineLines": null,
+          "currentRoot": "sha256:52ce6b086a910c2184d6223750d26c566fb4fb6574c8c80a36c25b7ea9874a27",
+          "baselineRoot": null,
+          "changedSinceBaseline": true
+        },
+        {
           "path": "framework/core/src/python/kungfu/kfx_contract.py",
           "currentLines": 311,
           "baselineLines": 311,
@@ -488,11 +514,11 @@
         },
         {
           "path": "framework/core/src/python/kungfu/cli/commands/kfx.py",
-          "currentLines": 775,
+          "currentLines": 787,
           "baselineLines": 787,
-          "currentRoot": "sha256:4a07c46beb13588d6437a2d0b761dca41361f542d27e39eac5281217c126b755",
+          "currentRoot": "sha256:1395a3bf28f16d5fca7f38042345c2ef3001ee863b766bc6273d1900a6b47721",
           "baselineRoot": "sha256:1395a3bf28f16d5fca7f38042345c2ef3001ee863b766bc6273d1900a6b47721",
-          "changedSinceBaseline": true
+          "changedSinceBaseline": false
         },
         {
           "path": "scripts/run-native-kfx-admission-tests.mjs",
@@ -506,9 +532,9 @@
           "path": "scripts/run-kfx-profile-suite-tests.mjs",
           "currentLines": 89,
           "baselineLines": 89,
-          "currentRoot": "sha256:d7d0cd90cf794bd7f9240f0f9a2a8ed1757eb42e20179396f6268bee7c1bc035",
+          "currentRoot": "sha256:3d7024ffde6aed01312c0635edb3d9fee671f26c1cbc33a68ffd2811203616ac",
           "baselineRoot": "sha256:d7d0cd90cf794bd7f9240f0f9a2a8ed1757eb42e20179396f6268bee7c1bc035",
-          "changedSinceBaseline": false
+          "changedSinceBaseline": true
         },
         {
           "path": "docs/qualification/kfd-native-sdk-release-gates.md",
@@ -522,7 +548,7 @@
           "path": "product/scripts/dist.mjs",
           "currentLines": 2530,
           "baselineLines": 2514,
-          "currentRoot": "sha256:8204f9e353ca411d489077ad124955512a741cd865486e25b289b6f8455764cf",
+          "currentRoot": "sha256:0113c4e9a766be1ab1debf27c3be1286d13e9f62880b25ca39ceff23efa5223a",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }
@@ -558,10 +584,8 @@
       "amplification": {
         "mappedSurfaces": 11,
         "nonAuthoritySurfaces": 7,
-        "changedSurfaces": 1,
-        "changedPaths": [
-          "scripts/check-fact-cut-kernel-contract.test.mjs"
-        ]
+        "changedSurfaces": 0,
+        "changedPaths": []
       },
       "surfaces": [
         {
@@ -652,11 +676,11 @@
         },
         {
           "path": "scripts/check-fact-cut-kernel-contract.test.mjs",
-          "currentLines": 327,
+          "currentLines": 322,
           "baselineLines": 322,
-          "currentRoot": "sha256:69617cd8d4a9ddd5d000d58c00b867af9b8938927a646ca96991ac1ed3cfae87",
+          "currentRoot": "sha256:682ff55fcad16b6e0df68704d73a9a6b3708ba916a323c0a7cf448a2d01efe05",
           "baselineRoot": "sha256:682ff55fcad16b6e0df68704d73a9a6b3708ba916a323c0a7cf448a2d01efe05",
-          "changedSinceBaseline": true
+          "changedSinceBaseline": false
         },
         {
           "path": "framework/core/tests/python/test_episode_control.py",
@@ -839,9 +863,9 @@
         },
         {
           "path": "scripts/check-work-lifecycle-operation-matrix.test.mjs",
-          "currentLines": 360,
+          "currentLines": 355,
           "baselineLines": 355,
-          "currentRoot": "sha256:1f887e173d05398824fbc4a073f158a7323c48c1a8e5e8220e661dc7fabbf6fe",
+          "currentRoot": "sha256:7591d5eec7a656ffcb287609c0f50f4a6e0eca802a0b0209d902c05b1b5217c4",
           "baselineRoot": "sha256:7fb9d01feb8ef08e8af4a2d7d7691551923a8fc2714a0e967e332d0057131283",
           "changedSinceBaseline": true
         },
@@ -900,10 +924,9 @@
       "amplification": {
         "mappedSurfaces": 12,
         "nonAuthoritySurfaces": 8,
-        "changedSurfaces": 6,
+        "changedSurfaces": 5,
         "changedPaths": [
           "docs/qualification/gates/release-admission-policy.json",
-          "scripts/verify-kungfu-release-admission.mjs",
           "scripts/release-promotion-rehearsal.mjs",
           "docs/qualification/gates/workflow-bindings.json",
           ".github/workflows/release-new-version.yml",
@@ -971,19 +994,19 @@
         },
         {
           "path": "docs/qualification/gates/release-admission-policy.json",
-          "currentLines": 49,
+          "currentLines": 41,
           "baselineLines": 41,
-          "currentRoot": "sha256:b700161aa02b53026eb97e653e49939680623fc098c13129f79dd854454130c4",
+          "currentRoot": "sha256:32b8d5be971bb3d4e24ca89ae14f1e2f646cecd79dacbdfaa2b7a07202209986",
           "baselineRoot": "sha256:e8a0f7037f2331610f3b9c07e7cdf5e47ea701045c73d0f67bf909372e77e0ac",
           "changedSinceBaseline": true
         },
         {
           "path": "scripts/verify-kungfu-release-admission.mjs",
-          "currentLines": 377,
+          "currentLines": 325,
           "baselineLines": 325,
-          "currentRoot": "sha256:b63705eb9575f2faf34c5c9b31b07cbb3375ba69f17d19730a77d04225ee79e0",
+          "currentRoot": "sha256:e77a02ecf79651ef1dbfbbf57d494a334fd863ae81de5d7ccd8264922a216403",
           "baselineRoot": "sha256:e77a02ecf79651ef1dbfbbf57d494a334fd863ae81de5d7ccd8264922a216403",
-          "changedSinceBaseline": true
+          "changedSinceBaseline": false
         },
         {
           "path": "scripts/prepare-ungfu-release-evidence.mjs",
@@ -1011,9 +1034,9 @@
         },
         {
           "path": ".github/workflows/release-new-version.yml",
-          "currentLines": 386,
+          "currentLines": 384,
           "baselineLines": 362,
-          "currentRoot": "sha256:92b331d7748c6ffa1cbac43020b794acd790a88dfbc8ace99592b6d062ab11cc",
+          "currentRoot": "sha256:40b02a006d82a6b1bab1ec08d1ef15139a6c96659fc94b6443da49c158e6c806",
           "baselineRoot": "sha256:3bdd847c80a05030de1d826282cef2e76a85e31dc0904df02c7f0cdda7a5eb74",
           "changedSinceBaseline": true
         },

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:85829360a77ec44639ba99defd7692d96844002e554e115b72a34d0bd5cacf47",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:8cb3e0a9aa947f8a473e6a3beb5b1944f2fd2fdef00a42386b10e49f508c9082",
+  "sourceRoot": "sha256:365cb652a2eda128837b3ec491849a54d49a25e0509be93f913b6bfe48e41a98",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -530,9 +530,9 @@
         },
         {
           "path": "scripts/run-kfx-profile-suite-tests.mjs",
-          "currentLines": 89,
+          "currentLines": 98,
           "baselineLines": 89,
-          "currentRoot": "sha256:3d7024ffde6aed01312c0635edb3d9fee671f26c1cbc33a68ffd2811203616ac",
+          "currentRoot": "sha256:39ad307e3879616e5d712bafa586d87f6d34366f8d3265fe7304bd8fac0a3dba",
           "baselineRoot": "sha256:d7d0cd90cf794bd7f9240f0f9a2a8ed1757eb42e20179396f6268bee7c1bc035",
           "changedSinceBaseline": true
         },

--- a/framework/maintainability/semantic-amplification.manifest.json
+++ b/framework/maintainability/semantic-amplification.manifest.json
@@ -183,6 +183,14 @@
       },
       "surfaces": [
         {
+          "path": "framework/kfx/src/index.ts",
+          "role": "thin-binding"
+        },
+        {
+          "path": "framework/kfx/src/agent-work-lab.ts",
+          "role": "thin-binding"
+        },
+        {
           "path": "framework/core/src/python/kungfu/kfx_contract.py",
           "role": "thin-binding"
         },

--- a/framework/maintainability/semantic-amplification.test.mjs
+++ b/framework/maintainability/semantic-amplification.test.mjs
@@ -30,7 +30,7 @@ test('current semantic amplification projection has one route per family', () =>
   assert.equal(report.verdict, 'pass');
   assert.equal(report.summary.families, 6);
   assert.equal(report.summary.authorities, 6);
-  assert.equal(report.summary.mappedSurfaces, 70);
+  assert.equal(report.summary.mappedSurfaces, 72);
   assert.deepEqual(report.issues, []);
 });
 

--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { Writable } from 'node:stream';
+import test from 'node:test';
+import { Box, Text, render } from 'ink';
+import React from 'react';
+
+import {
+  CLOSED_CONTROL_PLANE,
+  ControlPlaneBar,
+  ControlPlaneOverlay,
+  type ControlPlaneState,
+  QUICK_COMMANDS,
+  createControlPlaneInputFence,
+  quickCommandMatches,
+  reduceControlPlaneInput,
+} from './profile-shell.js';
+
+class CaptureOutput extends Writable {
+  readonly isTTY = false;
+  readonly columns = 80;
+  readonly rows = 24;
+  readonly chunks: string[] = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ) {
+    this.chunks.push(String(chunk));
+    callback();
+  }
+}
+
+test('opens Help, slash commands, and product search from the idle input bar', () => {
+  assert.equal(
+    reduceControlPlaneInput(CLOSED_CONTROL_PLANE, '?', 0).state.mode,
+    'help',
+  );
+  assert.deepEqual(
+    reduceControlPlaneInput(CLOSED_CONTROL_PLANE, '/', QUICK_COMMANDS.length)
+      .state,
+    { mode: 'commands', query: '/', selected: 0 },
+  );
+  assert.equal(
+    reduceControlPlaneInput(CLOSED_CONTROL_PLANE, '\u000b', 0).state.mode,
+    'search',
+  );
+  assert.equal(
+    reduceControlPlaneInput(CLOSED_CONTROL_PLANE, 'j', 0).handled,
+    false,
+  );
+});
+
+test('edits input, selects results, activates, and returns without leaking keys', () => {
+  const opened = reduceControlPlaneInput(
+    CLOSED_CONTROL_PLANE,
+    '/',
+    QUICK_COMMANDS.length,
+  ).state;
+  const typed = reduceControlPlaneInput(
+    opened,
+    'wo',
+    QUICK_COMMANDS.length,
+  ).state;
+  assert.equal(typed.query, '/wo');
+  assert.deepEqual(
+    quickCommandMatches(typed.query).map((row) => row.command),
+    ['/work'],
+  );
+  assert.equal(reduceControlPlaneInput(typed, '\r', 1).activate, true);
+  assert.equal(
+    reduceControlPlaneInput(typed, '\u001b', 1).state.mode,
+    'closed',
+  );
+});
+
+test('keeps a closing key captured for the rest of its synchronous input emission', async () => {
+  const input = new EventEmitter();
+  let state: ControlPlaneState = {
+    mode: 'help',
+    query: '',
+    selected: 0,
+  };
+  const fence = createControlPlaneInputFence(() => state.mode !== 'closed');
+  let leaked = false;
+  input.prependListener('data', (chunk: string) => {
+    const update = reduceControlPlaneInput(state, chunk, 0);
+    if (!update.handled) return;
+    fence.captureCurrentEmission();
+    state = update.state;
+  });
+  input.on('data', () => {
+    leaked = !fence.isCaptured();
+  });
+
+  input.emit('data', '\u001b');
+  assert.equal(state.mode, 'closed');
+  assert.equal(leaked, false);
+  await Promise.resolve();
+  assert.equal(fence.isCaptured(), false);
+});
+
+test('keeps quick commands bounded to declared product actions', () => {
+  assert.deepEqual(
+    QUICK_COMMANDS.map((row) => row.action),
+    ['help', 'search', 'work', 'lab', 'home', 'quit'],
+  );
+  assert.equal(quickCommandMatches('/rm -rf').length, 0);
+});
+
+test('the real Ink control plane covers the product canvas and keeps a fixed input bar', async () => {
+  const output = new CaptureOutput();
+  const dimensions = { columns: 80, rows: 24 };
+  const instance = render(
+    React.createElement(
+      Box,
+      { width: 80, height: 23, flexDirection: 'column' },
+      React.createElement(Text, null, 'UNDERLYING PRODUCT CONTENT'),
+      React.createElement(ControlPlaneOverlay, {
+        dimensions: { columns: 80, rows: 22 },
+        state: { mode: 'help', query: '', selected: 0 },
+        searchResults: [],
+        quickCommands: QUICK_COMMANDS,
+        catalogStatus: 'catalog ready',
+      }),
+      React.createElement(ControlPlaneBar, {
+        dimensions,
+        state: { mode: 'help', query: '', selected: 0 },
+        resultCount: 0,
+      }),
+    ),
+    {
+      stdout: output as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      debug: true,
+    },
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 80));
+  const frame = output.chunks.join('');
+  instance.unmount();
+  instance.cleanup();
+  assert.match(frame, /KUNGFU · HELP/);
+  assert.match(frame, /The input bar runs bounded product actions/);
+  assert.match(frame, /Help open · Esc return/);
+  assert.doesNotMatch(frame, /UNDERLYING PRODUCT CONTENT/);
+});
+
+test('search keeps the selected result visible beyond the first viewport', async () => {
+  const output = new CaptureOutput();
+  const searchResults = Array.from({ length: 12 }, (_, index) => ({
+    id: `help.${index}`,
+    kind: 'help' as const,
+    title: `Help topic ${index}`,
+    summary: `Summary ${index}`,
+    action: { kind: 'show-help' as const, topicId: String(index) },
+    score: 100 - index,
+  }));
+  const instance = render(
+    React.createElement(
+      Box,
+      { width: 80, height: 11, flexDirection: 'column' },
+      React.createElement(ControlPlaneOverlay, {
+        dimensions: { columns: 80, rows: 12 },
+        state: { mode: 'search', query: 'help', selected: 11 },
+        searchResults,
+        quickCommands: QUICK_COMMANDS,
+        catalogStatus: 'catalog ready',
+      }),
+    ),
+    {
+      stdout: output as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      debug: true,
+    },
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 80));
+  const frame = output.chunks.join('');
+  instance.unmount();
+  instance.cleanup();
+  assert.match(frame, /Help topic 11/);
+  assert.doesNotMatch(frame, /Help topic 0/);
+});

--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -17,6 +17,7 @@ import {
   quickCommandMatches,
   reduceControlPlaneInput,
 } from './profile-shell.js';
+import { AGENT_WORK_LAB_QUICK_COMMANDS } from './qualification-lab-view.js';
 
 class CaptureOutput extends Writable {
   readonly isTTY = false;
@@ -68,6 +69,17 @@ test('Esc hands focus to workspace shortcuts and i returns to input', () => {
   const focused = reduceControlPlaneInput(workspace, 'i', 0);
   assert.equal(focused.handled, true);
   assert.equal(focused.state.focus, 'input');
+});
+
+test('Tab enters controls and requests one bounded focus move', () => {
+  const update = reduceControlPlaneInput(CLOSED_CONTROL_PLANE, '\t', 0);
+  assert.equal(update.handled, true);
+  assert.equal(update.state.focus, 'workspace');
+  assert.equal(update.workspaceNavigation, 'next-focus');
+
+  const typed = reduceControlPlaneInput(CLOSED_CONTROL_PLANE, 'd', 0);
+  assert.equal(typed.state.query, 'd');
+  assert.equal(typed.workspaceNavigation, undefined);
 });
 
 test('edits input, selects results, activates, and returns without leaking keys', () => {
@@ -130,6 +142,19 @@ test('keeps quick commands bounded to declared product actions', () => {
     ['help', 'search', 'work', 'lab', 'home', 'quit'],
   );
   assert.equal(quickCommandMatches('/rm -rf').length, 0);
+});
+
+test('adds Suite actions only to the active Lab command catalog', () => {
+  const labCommands = [...AGENT_WORK_LAB_QUICK_COMMANDS, ...QUICK_COMMANDS];
+  assert.deepEqual(
+    quickCommandMatches('/same', labCommands).map((row) => row.action),
+    ['lab-same'],
+  );
+  assert.equal(quickCommandMatches('/same').length, 0);
+  assert.deepEqual(
+    AGENT_WORK_LAB_QUICK_COMMANDS.map((row) => row.command),
+    ['/demo', '/same', '/handoff', '/report', '/focus'],
+  );
 });
 
 test('the real Ink control plane covers the product canvas and keeps a fixed input bar', async () => {
@@ -201,9 +226,42 @@ test('the idle input is a focused full panel and renders typed text', async () =
   instance.unmount();
   instance.cleanup();
   assert.match(frame, /continue work/);
-  assert.match(frame, /Focused · Enter is bounded for now/);
+  assert.match(frame, /INPUT · Kungfu/);
+  assert.match(frame, /Text entry is active · Esc Controls/);
   assert.match(frame, /╭/);
   assert.match(frame, /╰/);
+});
+
+test('the idle bar makes Lab controls visually explicit', async () => {
+  const output = new CaptureOutput();
+  const instance = render(
+    React.createElement(
+      Box,
+      { width: 80, height: 23, flexDirection: 'column' },
+      React.createElement(ControlPlaneBar, {
+        dimensions: { columns: 80, rows: 24 },
+        state: { ...CLOSED_CONTROL_PLANE, focus: 'workspace' },
+        resultCount: 0,
+        surfaceLabel: 'Agent Work Lab',
+        controlsLabel: 'LAB CONTROLS',
+        controlsHint: 'd Demo · x Same · m Handoff · Tab Focus',
+      }),
+    ),
+    {
+      stdout: output as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      debug: true,
+    },
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 80));
+  const frame = output.chunks.join('');
+  instance.unmount();
+  instance.cleanup();
+
+  assert.match(frame, /LAB CONTROLS · Agent Work Lab/);
+  assert.match(frame, /d Demo · x Same · m Handoff · Tab Focus/);
+  assert.match(frame, /i Input/);
 });
 
 test('search keeps the selected result visible beyond the first viewport', async () => {

--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -34,7 +34,7 @@ class CaptureOutput extends Writable {
   }
 }
 
-test('opens Help, slash commands, and product search from the idle input bar', () => {
+test('opens Help, slash commands, and product search from the focused input', () => {
   assert.equal(
     reduceControlPlaneInput(CLOSED_CONTROL_PLANE, '?', 0).state.mode,
     'help',
@@ -42,16 +42,32 @@ test('opens Help, slash commands, and product search from the idle input bar', (
   assert.deepEqual(
     reduceControlPlaneInput(CLOSED_CONTROL_PLANE, '/', QUICK_COMMANDS.length)
       .state,
-    { mode: 'commands', query: '/', selected: 0 },
+    { mode: 'commands', focus: 'input', query: '/', selected: 0 },
   );
   assert.equal(
     reduceControlPlaneInput(CLOSED_CONTROL_PLANE, '\u000b', 0).state.mode,
     'search',
   );
-  assert.equal(
-    reduceControlPlaneInput(CLOSED_CONTROL_PLANE, 'j', 0).handled,
-    false,
+  const typed = reduceControlPlaneInput(CLOSED_CONTROL_PLANE, 'hello', 0);
+  assert.equal(typed.handled, true);
+  assert.equal(typed.state.query, 'hello');
+  assert.match(
+    reduceControlPlaneInput(typed.state, '\r', 0).state.notice ?? '',
+    /Free-form Agent conversation is coming soon/,
   );
+});
+
+test('Esc hands focus to workspace shortcuts and i returns to input', () => {
+  const workspace = reduceControlPlaneInput(
+    CLOSED_CONTROL_PLANE,
+    '\u001b',
+    0,
+  ).state;
+  assert.equal(workspace.focus, 'workspace');
+  assert.equal(reduceControlPlaneInput(workspace, 'j', 0).handled, false);
+  const focused = reduceControlPlaneInput(workspace, 'i', 0);
+  assert.equal(focused.handled, true);
+  assert.equal(focused.state.focus, 'input');
 });
 
 test('edits input, selects results, activates, and returns without leaking keys', () => {
@@ -81,10 +97,13 @@ test('keeps a closing key captured for the rest of its synchronous input emissio
   const input = new EventEmitter();
   let state: ControlPlaneState = {
     mode: 'help',
+    focus: 'input',
     query: '',
     selected: 0,
   };
-  const fence = createControlPlaneInputFence(() => state.mode !== 'closed');
+  const fence = createControlPlaneInputFence(
+    () => state.mode !== 'closed' || state.focus === 'input',
+  );
   let leaked = false;
   input.prependListener('data', (chunk: string) => {
     const update = reduceControlPlaneInput(state, chunk, 0);
@@ -100,6 +119,8 @@ test('keeps a closing key captured for the rest of its synchronous input emissio
   assert.equal(state.mode, 'closed');
   assert.equal(leaked, false);
   await Promise.resolve();
+  assert.equal(fence.isCaptured(), true);
+  state = reduceControlPlaneInput(state, '\u001b', 0).state;
   assert.equal(fence.isCaptured(), false);
 });
 
@@ -121,14 +142,14 @@ test('the real Ink control plane covers the product canvas and keeps a fixed inp
       React.createElement(Text, null, 'UNDERLYING PRODUCT CONTENT'),
       React.createElement(ControlPlaneOverlay, {
         dimensions: { columns: 80, rows: 22 },
-        state: { mode: 'help', query: '', selected: 0 },
+        state: { mode: 'help', focus: 'input', query: '', selected: 0 },
         searchResults: [],
         quickCommands: QUICK_COMMANDS,
         catalogStatus: 'catalog ready',
       }),
       React.createElement(ControlPlaneBar, {
         dimensions,
-        state: { mode: 'help', query: '', selected: 0 },
+        state: { mode: 'help', focus: 'input', query: '', selected: 0 },
         resultCount: 0,
       }),
     ),
@@ -144,9 +165,45 @@ test('the real Ink control plane covers the product canvas and keeps a fixed inp
   instance.unmount();
   instance.cleanup();
   assert.match(frame, /KUNGFU · HELP/);
-  assert.match(frame, /The input bar runs bounded product actions/);
-  assert.match(frame, /Help open · Esc return/);
+  assert.match(frame, /focused input accepts text/);
+  assert.match(frame, /Help is open/);
+  assert.match(frame, /╭/);
+  assert.match(frame, /╰/);
   assert.doesNotMatch(frame, /UNDERLYING PRODUCT CONTENT/);
+});
+
+test('the idle input is a focused full panel and renders typed text', async () => {
+  const output = new CaptureOutput();
+  const typed = reduceControlPlaneInput(
+    CLOSED_CONTROL_PLANE,
+    'continue work',
+    0,
+  ).state;
+  const instance = render(
+    React.createElement(
+      Box,
+      { width: 80, height: 23, flexDirection: 'column' },
+      React.createElement(ControlPlaneBar, {
+        dimensions: { columns: 80, rows: 24 },
+        state: typed,
+        resultCount: 0,
+      }),
+    ),
+    {
+      stdout: output as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      debug: true,
+    },
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 80));
+  const frame = output.chunks.join('');
+  instance.unmount();
+  instance.cleanup();
+  assert.match(frame, /continue work/);
+  assert.match(frame, /Focused · Enter is bounded for now/);
+  assert.match(frame, /╭/);
+  assert.match(frame, /╰/);
 });
 
 test('search keeps the selected result visible beyond the first viewport', async () => {
@@ -165,7 +222,12 @@ test('search keeps the selected result visible beyond the first viewport', async
       { width: 80, height: 11, flexDirection: 'column' },
       React.createElement(ControlPlaneOverlay, {
         dimensions: { columns: 80, rows: 12 },
-        state: { mode: 'search', query: 'help', selected: 11 },
+        state: {
+          mode: 'search',
+          focus: 'input',
+          query: 'help',
+          selected: 11,
+        },
         searchResults,
         quickCommands: QUICK_COMMANDS,
         catalogStatus: 'catalog ready',

--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -18,6 +18,48 @@ import {
   reduceControlPlaneInput,
 } from './profile-shell.js';
 import { AGENT_WORK_LAB_QUICK_COMMANDS } from './qualification-lab-view.js';
+import {
+  degradedGlobalWorkModel,
+  globalWorkContribution,
+  loadLatestGlobalWorkCache,
+  parseGlobalWorkObserverLine,
+} from './work-control-contribution.js';
+
+const globalWorkSnapshot = {
+  schema: 'kungfu.workspace-federation.query/v1' as const,
+  observed_at: '2026-07-27T12:00:00Z',
+  aggregate: {
+    state: 'partial',
+    component_count: 3,
+    available_component_count: 2,
+    unknown_component_count: 1,
+  },
+  verification: { ok: true },
+  proof: { proof_root: 'sha256:proof' },
+  global_work: {
+    projection_root: 'sha256:projection',
+    visible_work: [
+      {
+        canonical_root: 'sha256:initiative',
+        object_kind: 'initiative',
+        subject: 'initiative-a',
+        display: { title: 'Initiative A', status: 'active' },
+        observations: [{ workspace_id: 'home' }],
+      },
+      {
+        canonical_root: 'sha256:assignment',
+        object_kind: 'assignment',
+        subject: 'initiative-a:assignment-a',
+        display: {
+          title: 'Assignment A',
+          status: 'executing',
+          next_actions: ['continue'],
+        },
+        observations: [{ workspace_id: 'project:a' }],
+      },
+    ],
+  },
+};
 
 class CaptureOutput extends Writable {
   readonly isTTY = false;
@@ -139,9 +181,78 @@ test('keeps a closing key captured for the rest of its synchronous input emissio
 test('keeps quick commands bounded to declared product actions', () => {
   assert.deepEqual(
     QUICK_COMMANDS.map((row) => row.action),
-    ['help', 'search', 'work', 'lab', 'home', 'quit'],
+    ['help', 'search', 'health', 'work', 'lab', 'home', 'quit'],
   );
   assert.equal(quickCommandMatches('/rm -rf').length, 0);
+});
+
+test('projects the global Portfolio and indexes every visible Work row', () => {
+  const contribution = globalWorkContribution(globalWorkSnapshot);
+  assert.equal(contribution.model.profile.title, 'Work');
+  assert.equal(contribution.model.profile.qualificationLabel, 'Global proof');
+  assert.equal(
+    contribution.model.subject.title,
+    'Portfolio · 2 current work items',
+  );
+  assert.match(
+    contribution.model.subject.subtitle,
+    /1 Initiatives · 1 Assignments/,
+  );
+  assert.deepEqual(
+    contribution.searchDocuments.map((row) => row.title),
+    ['Initiative A', 'Assignment A'],
+  );
+  assert.match(
+    degradedGlobalWorkModel(new Error('observer unavailable')).notice ?? '',
+    /observer unavailable/,
+  );
+});
+
+test('reads and parses the shared GUI or TUI global Work observer state', () => {
+  const files: Record<string, string> = {
+    gui: JSON.stringify({
+      schema: 'kungfu.gui.global-work-observer/v2',
+      query: globalWorkSnapshot,
+    }),
+    tui: JSON.stringify({
+      schema: 'kungfu.gui.global-work-observer/v2',
+      query: {
+        ...globalWorkSnapshot,
+        observed_at: '2026-07-27T13:00:00Z',
+      },
+    }),
+  };
+  assert.equal(
+    loadLatestGlobalWorkCache(
+      (candidate) => files[candidate] ?? '',
+      ['gui', 'tui'],
+    )?.observed_at,
+    '2026-07-27T13:00:00Z',
+  );
+  const parsed = parseGlobalWorkObserverLine(
+    JSON.stringify({
+      schema: 'kungfu.gui.global-work-observer-event/v1',
+      kind: 'snapshot',
+      snapshot: globalWorkSnapshot,
+    }),
+  );
+  assert.equal(
+    parsed instanceof Error ? '' : parsed?.schema,
+    globalWorkSnapshot.schema,
+  );
+  assert.match(
+    (
+      parseGlobalWorkObserverLine(
+        JSON.stringify({
+          schema: 'kungfu.gui.global-work-observer-event/v1',
+          kind: 'error',
+          error: 'observer stopped',
+        }),
+      ) as Error
+    ).message,
+    /observer stopped/,
+  );
+  assert.equal(parseGlobalWorkObserverLine('not json'), null);
 });
 
 test('adds Suite actions only to the active Lab command catalog', () => {

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -8,15 +8,12 @@ import path from 'node:path';
 import {
   type Profile,
   type QualificationLab,
-  type QualificationLabEvent,
-  type QualificationLabReport,
   type QualificationLabStartupRoute,
   type WorkLoop,
   openProfile,
   openQualificationLab,
   openWorkLoop,
   qualificationLabStartupSurface,
-  qualificationRunProgressLabel,
 } from '@kungfu-tech/api/capability';
 import { Box, Text, render, useApp } from 'ink';
 import React from 'react';
@@ -28,18 +25,7 @@ import {
   type ProfileShellModel,
   type TerminalDimensions,
 } from './profile-shell.js';
-import {
-  QualificationLabView,
-  type TuiQualificationFocus,
-  type TuiQualificationMode,
-  type TuiQualificationNextPrompt,
-  type TuiQualificationReportDetail,
-  isQualificationReportReturnInput,
-  nextQualificationFocus,
-  qualificationEventLines,
-  qualificationEventRunningSession,
-  qualificationNextModePrompt,
-} from './qualification-lab-view.js';
+import { AgentWorkLabHost } from './qualification-lab-view.js';
 import {
   IncrementalTerminalOutput,
   terminalCanvasRows,
@@ -352,326 +338,6 @@ function WorkControlHost({
   );
 }
 
-function QualificationLabHost({
-  lab,
-  startup,
-  dimensions,
-  onOpenWork,
-}: {
-  lab: QualificationLab;
-  startup: QualificationLabStartupRoute;
-  dimensions: DimensionStore;
-  onOpenWork?: () => void;
-}) {
-  const { exit } = useApp();
-  const [size, setSize] = React.useState(dimensions.get());
-  const [agents, setAgents] = React.useState<
-    Awaited<ReturnType<QualificationLab['discoverAgents']>> | undefined
-  >();
-  const [mode, setMode] = React.useState<TuiQualificationMode>('offline-demo');
-  const [selected, setSelected] = React.useState(0);
-  const [target, setTarget] = React.useState(0);
-  const [report, setReport] = React.useState<QualificationLabReport>();
-  const [lines, setLines] = React.useState<
-    ReturnType<typeof qualificationEventLines>
-  >([]);
-  const [activeFocus, setActiveFocus] =
-    React.useState<TuiQualificationFocus>('session-1');
-  const [reportDetail, setReportDetail] =
-    React.useState<TuiQualificationReportDetail>();
-  const [nextPrompt, setNextPrompt] =
-    React.useState<TuiQualificationNextPrompt>();
-  const [scrollBack, setScrollBack] = React.useState<Record<1 | 2, number>>({
-    1: 0,
-    2: 0,
-  });
-  const [showHelp, setShowHelp] = React.useState(false);
-  const [busy, setBusy] = React.useState('');
-  const [error, setError] = React.useState('');
-  const [runProgress, setRunProgress] = React.useState<{
-    startedAt: number;
-    lastEventAt: number;
-    eventCount: number;
-    phase: 'running' | 'assessing';
-  }>();
-  const [runningSession, setRunningSession] = React.useState<1 | 2>();
-  const [progressNow, setProgressNow] = React.useState(() => Date.now());
-  const playbackGeneration = React.useRef(0);
-  const profiles = React.useMemo(
-    () =>
-      Array.from(
-        new Map(
-          [
-            ...(agents?.configured ?? []),
-            ...(agents?.discovered.map((row) => row.profile) ?? []),
-          ].map((profile) => [profile.id, profile]),
-        ).values(),
-      ),
-    [agents],
-  );
-  const discover = React.useCallback(async () => {
-    setBusy('discovering agents');
-    try {
-      setAgents(await lab.discoverAgents());
-      setError('');
-    } catch (reason) {
-      setError(reason instanceof Error ? reason.message : String(reason));
-    } finally {
-      setBusy('');
-    }
-  }, [lab]);
-  React.useEffect(() => {
-    void discover();
-  }, [discover]);
-  React.useEffect(
-    () => dimensions.subscribe((next) => setSize(next)),
-    [dimensions],
-  );
-  React.useEffect(() => {
-    if (!runProgress) return undefined;
-    setProgressNow(Date.now());
-    const timer = setInterval(() => setProgressNow(Date.now()), 1000);
-    return () => clearInterval(timer);
-  }, [runProgress]);
-  React.useEffect(() => {
-    if (!nextPrompt) return undefined;
-    const timer = setTimeout(() => setNextPrompt(undefined), 5000);
-    return () => clearTimeout(timer);
-  }, [nextPrompt]);
-  const runQualification = React.useCallback(
-    (
-      nextMode: TuiQualificationMode,
-      label: string,
-      execute: (
-        onEvent: Parameters<QualificationLab['runDemo']>[0],
-      ) => Promise<QualificationLabReport>,
-    ) => {
-      const generation = playbackGeneration.current + 1;
-      playbackGeneration.current = generation;
-      setMode(nextMode);
-      setBusy(label);
-      setReport(undefined);
-      setLines([]);
-      setActiveFocus('session-1');
-      setReportDetail(undefined);
-      setNextPrompt(undefined);
-      setScrollBack({ 1: 0, 2: 0 });
-      setError('');
-      const startedAt = Date.now();
-      setProgressNow(startedAt);
-      setRunProgress({
-        startedAt,
-        lastEventAt: startedAt,
-        eventCount: 0,
-        phase: 'running',
-      });
-      setRunningSession(1);
-      let queue = Promise.resolve();
-      const receiveEvent = (event: QualificationLabEvent) => {
-        queue = queue.then(
-          () =>
-            new Promise<void>((resolve) => {
-              setTimeout(resolve, 1000);
-            }),
-        );
-        queue = queue.then(() => {
-          if (playbackGeneration.current !== generation) return;
-          const eventSession = qualificationEventRunningSession(event);
-          if (eventSession) setRunningSession(eventSession);
-          setLines((current) => [
-            ...current,
-            ...qualificationEventLines(event),
-          ]);
-          setRunProgress((current) =>
-            current
-              ? {
-                  ...current,
-                  lastEventAt: Date.now(),
-                  eventCount: current.eventCount + 1,
-                }
-              : current,
-          );
-        });
-      };
-      void execute(receiveEvent)
-        .then(async (value) => {
-          await queue;
-          setRunProgress((current) =>
-            current ? { ...current, phase: 'assessing' } : current,
-          );
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 520);
-          });
-          if (playbackGeneration.current !== generation) return;
-          setReport(value);
-          setActiveFocus('correct');
-          setNextPrompt(qualificationNextModePrompt(nextMode));
-          setError('');
-        })
-        .catch((reason) => {
-          if (playbackGeneration.current !== generation) return;
-          setError(reason instanceof Error ? reason.message : String(reason));
-        })
-        .finally(() => {
-          if (playbackGeneration.current === generation) {
-            setBusy('');
-            setRunProgress(undefined);
-            setRunningSession(undefined);
-          }
-        });
-    },
-    [],
-  );
-  React.useEffect(() => {
-    const onData = (chunk: Buffer | string) => {
-      const input = String(chunk);
-      if (reportDetail && isQualificationReportReturnInput(input)) {
-        return setReportDetail(undefined);
-      }
-      const key = decodeShellKey(input);
-      if (key === 'quit') return exit();
-      if (input === '\t')
-        return setActiveFocus((current) =>
-          nextQualificationFocus(current, Boolean(report)),
-        );
-      if (
-        report &&
-        (input === '\r' || input === '\n') &&
-        (activeFocus === 'correct' || activeFocus === 'failed')
-      ) {
-        return setReportDetail(activeFocus);
-      }
-      const focusedSession =
-        activeFocus === 'session-1'
-          ? 1
-          : activeFocus === 'session-2'
-            ? 2
-            : undefined;
-      if (input === '\u001b[A' && focusedSession)
-        return setScrollBack((current) => ({
-          ...current,
-          [focusedSession]: current[focusedSession] + 1,
-        }));
-      if (input === '\u001b[B' && focusedSession)
-        return setScrollBack((current) => ({
-          ...current,
-          [focusedSession]: Math.max(0, current[focusedSession] - 1),
-        }));
-      if (input === '?') return setShowHelp((current) => !current);
-      if (key === 'next-card')
-        return setSelected((current) =>
-          boundedIndex(current, 1, profiles.length),
-        );
-      if (key === 'previous-card')
-        return setSelected((current) =>
-          boundedIndex(current, -1, profiles.length),
-        );
-      if (input === ']')
-        return setTarget((current) =>
-          boundedIndex(current, 1, profiles.length),
-        );
-      if (input === '[')
-        return setTarget((current) =>
-          boundedIndex(current, -1, profiles.length),
-        );
-      if (input === 'w' && onOpenWork) return onOpenWork();
-      if (input === 'd' && !busy) {
-        return runQualification(
-          'offline-demo',
-          'running two fresh demo sessions',
-          (onEvent) => lab.runDemo(onEvent),
-        );
-      }
-      if (input === 'x' && !busy && profiles[selected]) {
-        return runQualification(
-          'same-agent',
-          'running selected agent twice',
-          (onEvent) => lab.runAgent(profiles[selected].id, onEvent),
-        );
-      }
-      if (
-        input === 'm' &&
-        !busy &&
-        profiles[selected] &&
-        profiles[target] &&
-        selected !== target
-      ) {
-        return runQualification(
-          'cross-agent',
-          'running cross-provider handoff',
-          (onEvent) =>
-            lab.runMigration(
-              profiles[selected].id,
-              profiles[target].id,
-              onEvent,
-            ),
-        );
-      }
-    };
-    process.stdin.on('data', onData);
-    return () => {
-      process.stdin.off('data', onData);
-    };
-  }, [
-    busy,
-    activeFocus,
-    exit,
-    lab,
-    onOpenWork,
-    profiles,
-    report,
-    reportDetail,
-    selected,
-    target,
-    runQualification,
-  ]);
-  const sourceLabel =
-    mode === 'offline-demo' ? '' : profiles[selected]?.label || '';
-  const targetLabel =
-    mode === 'offline-demo'
-      ? ''
-      : mode === 'same-agent'
-        ? sourceLabel
-        : profiles[target]?.label || '';
-  const progress = runProgress
-    ? qualificationRunProgressLabel({
-        elapsedMs: progressNow - runProgress.startedAt,
-        quietMs: progressNow - runProgress.lastEventAt,
-        eventCount: runProgress.eventCount,
-        phase: runProgress.phase,
-      })
-    : '';
-  return (
-    <QualificationLabView
-      dimensions={size}
-      mode={mode}
-      sourceLabel={sourceLabel}
-      targetLabel={targetLabel}
-      lines={lines}
-      report={report}
-      busy={busy}
-      progress={progress}
-      error={
-        error ||
-        (startup.route === 'diagnostic'
-          ? `${startup.state} · ${startup.reasonCode}`
-          : '')
-      }
-      activeFocus={activeFocus}
-      scrollBack={scrollBack}
-      showHelp={showHelp}
-      activityFrame={
-        runProgress
-          ? Math.floor((progressNow - runProgress.startedAt) / 1000)
-          : 0
-      }
-      runningSession={runningSession}
-      nextPrompt={nextPrompt}
-      reportDetail={reportDetail}
-    />
-  );
-}
-
 const PENDING_STARTUP: QualificationLabStartupRoute = {
   schema: 'kungfu.qualification-lab.startup-route/v1',
   state: 'verified-empty',
@@ -719,7 +385,7 @@ function StartingHost({
       <Text dimColor>
         Reading local Work and exact Profile evidence in the background…
       </Text>
-      <Text dimColor>a qualification lab · q quit</Text>
+      <Text dimColor>[a] Agent Work Lab · q quit</Text>
     </Box>
   );
 }
@@ -775,7 +441,7 @@ function ProductHost({
     (surface === 'auto' && startupSurface === 'qualification-lab');
   if (labOpen) {
     return (
-      <QualificationLabHost
+      <AgentWorkLabHost
         lab={lab}
         startup={resolvedStartup}
         dimensions={dimensions}

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -4,25 +4,22 @@ import { execFile, execFileSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { constants as osConstants } from 'node:os';
+import { homedir } from 'node:os';
 import path from 'node:path';
 import {
+  type GlobalWorkSnapshot,
   type ProductSearchDocument,
-  type Profile,
   type QualificationLab,
   type QualificationLabStartupRoute,
   SYSTEM_HELP_DOCUMENTS,
-  type WorkLoop,
   loadCliHelpSearchDocuments,
-  openProfile,
   openQualificationLab,
-  openWorkLoop,
   qualificationLabStartupSurface,
   searchProductDocuments,
 } from '@kungfu-tech/api/capability';
 import { Box, Text, render, useApp } from 'ink';
 import React from 'react';
 
-import { loadTuiKfxPlan } from './kfx-plan.js';
 import { boundedIndex, decodeShellKey } from './navigation.js';
 import {
   CLOSED_CONTROL_PLANE,
@@ -54,10 +51,11 @@ import {
   resolveTuiRuntimeDir,
 } from './terminal-lifecycle.js';
 import {
-  degradedWorkControlModel,
-  loadWorkControlContribution,
+  degradedGlobalWorkModel,
+  globalWorkContribution,
+  loadLatestGlobalWorkCache,
+  startGlobalWorkObserver,
 } from './work-control-contribution.js';
-import { workLoopShellModel } from './work-loop-contribution.js';
 
 const nodeRequire = createRequire(import.meta.url);
 
@@ -91,30 +89,13 @@ function runtimePaths() {
         'kungfu-config.contract.json',
       ),
     }),
+    configHome:
+      process.env.KF_CONFIG_HOME || path.join(homedir(), '.kungfu-config'),
     bin:
       process.env.KUNGFU_CLI_BIN ||
       process.env.KUNGFU_BIN ||
       (fs.existsSync(packagedBin) ? packagedBin : 'kungfu'),
-    repoRoot: process.env.KF_WORKSPACE_ROOT || process.cwd(),
   };
-}
-
-function openTuiProfile(): Profile {
-  const paths = runtimePaths();
-  return openProfile({
-    runtimeDir: paths.runtimeDir,
-    bin: paths.bin,
-    env: cliEnvironment(),
-    execFileSync: (file, args, options) => execFileSync(file, args, options),
-    execFile: (file, args, options) =>
-      new Promise<string>((resolve, reject) => {
-        execFile(file, args, options, (error, stdout, stderr) => {
-          if (error)
-            reject(new Error(describeCliFailure(error, stdout, stderr)));
-          else resolve(stdout);
-        });
-      }),
-  });
 }
 
 function openTuiQualificationLab(): QualificationLab {
@@ -199,24 +180,6 @@ function openTuiQualificationLab(): QualificationLab {
   });
 }
 
-function openTuiWorkLoop(): WorkLoop {
-  const paths = runtimePaths();
-  return openWorkLoop({
-    runtimeDir: paths.runtimeDir,
-    repoRoot: paths.repoRoot,
-    bin: paths.bin,
-    env: cliEnvironment(),
-    execFile: (file, args, options) =>
-      new Promise<string>((resolve, reject) => {
-        execFile(file, args, options, (error, stdout, stderr) => {
-          if (error)
-            reject(new Error(describeCliFailure(error, stdout, stderr)));
-          else resolve(stdout);
-        });
-      }),
-  });
-}
-
 class DimensionStore {
   private listeners = new Set<(dimensions: TerminalDimensions) => void>();
   constructor(private current: TerminalDimensions) {}
@@ -257,120 +220,105 @@ class InsetDimensionSource {
 }
 
 function WorkControlHost({
-  profile,
-  workLoop,
   dimensions,
   onOpenLab,
   onSearchDocuments,
   isInputCaptured,
 }: {
-  profile: Profile;
-  workLoop: WorkLoop;
   dimensions: InsetDimensionSource;
   onOpenLab: () => void;
   onSearchDocuments: (documents: ProductSearchDocument[]) => void;
   isInputCaptured: () => boolean;
 }) {
   const { exit } = useApp();
-  const kfxPlan = React.useMemo(() => loadTuiKfxPlan(process.env), []);
+  const paths = React.useMemo(() => runtimePaths(), []);
+  const observerStatePath = React.useMemo(
+    () => path.join(paths.configHome, 'tui', 'global-work-observer.json'),
+    [paths.configHome],
+  );
+  const initialSnapshot = React.useMemo(
+    () =>
+      loadLatestGlobalWorkCache(
+        (candidate) => fs.readFileSync(candidate, 'utf8'),
+        [
+          observerStatePath,
+          path.join(paths.configHome, 'gui', 'global-work-observer.json'),
+        ],
+      ),
+    [observerStatePath, paths.configHome],
+  );
   const [size, setSize] = React.useState(dimensions.get());
   const [model, setModel] = React.useState<ProfileShellModel>(() =>
-    degradedWorkControlModel('loading public Profile projection'),
+    initialSnapshot
+      ? globalWorkContribution(initialSnapshot).model
+      : degradedGlobalWorkModel('loading global Portfolio'),
   );
-  const [busy, setBusy] = React.useState(true);
+  const [busy, setBusy] = React.useState(initialSnapshot === null);
+  const [observerError, setObserverError] = React.useState('');
   const [selectedCard, setSelectedCard] = React.useState(0);
   const [activeRegion, setActiveRegion] = React.useState(1);
-  const refreshGeneration = React.useRef(0);
+  const latestRevision = React.useRef('');
 
-  const refresh = React.useCallback(
-    async (initiativeId = '') => {
-      const generation = ++refreshGeneration.current;
-      setBusy(true);
-      try {
-        const next = await loadWorkControlContribution(
-          profile,
-          kfxPlan,
-          initiativeId,
-        );
-        let loopProjection: ProfileShellModel['workLoop'];
-        let loopError = '';
-        if (next.profile.qualified) {
-          try {
-            const [inspection, recovery] = await Promise.all([
-              workLoop.inspect(),
-              workLoop.recover(),
-            ]);
-            loopProjection = workLoopShellModel(inspection, recovery);
-          } catch (error) {
-            loopError = error instanceof Error ? error.message : String(error);
-          }
-        }
-        if (generation === refreshGeneration.current) {
-          setModel({
-            ...next,
-            workLoop: loopProjection,
-            workLoopError: loopError || undefined,
-          });
-          setSelectedCard(0);
-        }
-      } catch (error) {
-        if (generation === refreshGeneration.current) {
-          setModel(degradedWorkControlModel(error));
-        }
-      } finally {
-        if (generation === refreshGeneration.current) setBusy(false);
+  const applySnapshot = React.useCallback(
+    (snapshot: GlobalWorkSnapshot) => {
+      const revision = JSON.stringify({
+        projection: snapshot.global_work.projection_root,
+        observedAt: snapshot.observed_at,
+        visible: snapshot.global_work.visible_work_count,
+        state: snapshot.aggregate.state,
+      });
+      if (revision === latestRevision.current) {
+        setBusy(false);
+        return;
       }
+      latestRevision.current = revision;
+      const contribution = globalWorkContribution(snapshot);
+      setModel(contribution.model);
+      onSearchDocuments(contribution.searchDocuments);
+      setSelectedCard((current) =>
+        Math.min(current, Math.max(0, contribution.model.cards.length - 1)),
+      );
+      setObserverError('');
+      setBusy(false);
     },
-    [profile, workLoop, kfxPlan],
+    [onSearchDocuments],
   );
 
   React.useEffect(() => dimensions.subscribe(setSize), [dimensions]);
-  React.useEffect(
-    () => () => {
-      refreshGeneration.current += 1;
-    },
-    [],
-  );
   React.useEffect(() => {
-    void refresh(process.env.KF_INITIATIVE_ID || '');
-  }, [refresh]);
-  React.useEffect(() => {
-    const documents: ProductSearchDocument[] = [
-      ...(model.subject.id
-        ? [
-            {
-              id: `work.initiative.${model.subject.id}`,
-              kind: 'work' as const,
-              title: model.subject.title,
-              summary: model.subject.subtitle,
-              keywords: ['initiative', model.subject.id],
-              priority: 0,
-              action: {
-                kind: 'open-work' as const,
-                workId: model.subject.id,
-              },
-            },
-          ]
-        : []),
-      ...model.cards.map((card, index) => ({
-        id: `work.assignment.${card.id}`,
-        kind: 'work' as const,
-        title: card.title,
-        summary: `${card.summary} · ${card.status}`,
-        keywords: ['assignment', card.id, card.status],
-        priority: index + 1,
-        action: { kind: 'open-work' as const, workId: card.id },
-      })),
-    ];
-    onSearchDocuments(documents);
-  }, [model, onSearchDocuments]);
+    if (initialSnapshot) applySnapshot(initialSnapshot);
+    fs.mkdirSync(path.dirname(observerStatePath), { recursive: true });
+    return startGlobalWorkObserver({
+      bin: paths.bin,
+      env: cliEnvironment(),
+      statePath: observerStatePath,
+      spawn: (file, args, options) => spawn(file, args, options),
+      onSnapshot: applySnapshot,
+      onError: (error) => {
+        setObserverError(error.message);
+        setBusy(false);
+      },
+    });
+  }, [applySnapshot, initialSnapshot, observerStatePath, paths.bin]);
   React.useEffect(() => {
     const onData = (chunk: Buffer | string) => {
       if (isInputCaptured()) return;
       const key = decodeShellKey(String(chunk));
       if (key === 'quit') return exit();
       if (key === 'qualification-lab') return onOpenLab();
-      if (key === 'refresh') return void refresh(model.subject.id);
+      if (key === 'refresh') {
+        setBusy(true);
+        const cached = loadLatestGlobalWorkCache(
+          (candidate) => fs.readFileSync(candidate, 'utf8'),
+          [
+            observerStatePath,
+            path.join(paths.configHome, 'gui', 'global-work-observer.json'),
+          ],
+        );
+        if (cached) applySnapshot(cached);
+        else setBusy(false);
+        return;
+      }
       if (key === 'next-card') {
         setSelectedCard((current) =>
           boundedIndex(current, 1, model.cards.length),
@@ -383,27 +331,34 @@ function WorkControlHost({
         setActiveRegion((current) => boundedIndex(current, 1, 3));
       } else if (key === 'previous-region') {
         setActiveRegion((current) => boundedIndex(current, -1, 3));
-      } else if (key === 'next-subject' || key === 'previous-subject') {
-        const current = model.navigation.findIndex(
-          (row) => row.id === model.subject.id,
-        );
-        const delta = key === 'next-subject' ? 1 : -1;
-        const next =
-          model.navigation[
-            boundedIndex(current, delta, model.navigation.length)
-          ];
-        if (next) void refresh(next.id);
       }
     };
     process.stdin.on('data', onData);
     return () => {
       process.stdin.off('data', onData);
     };
-  }, [exit, isInputCaptured, model, onOpenLab, refresh]);
+  }, [
+    applySnapshot,
+    exit,
+    isInputCaptured,
+    model.cards.length,
+    observerStatePath,
+    onOpenLab,
+    paths.configHome,
+  ]);
+
+  const displayedModel = observerError
+    ? {
+        ...model,
+        notice: [model.notice, `live observer: ${observerError}`]
+          .filter(Boolean)
+          .join(' · '),
+      }
+    : model;
 
   return (
     <ProfileShell
-      model={model}
+      model={displayedModel}
       dimensions={size}
       selectedCard={selectedCard}
       activeRegion={activeRegion}
@@ -502,8 +457,6 @@ function ProductHost({
   const [catalogStatus, setCatalogStatus] = React.useState(
     'Loading governed command catalog',
   );
-  const profile = React.useMemo(() => openTuiProfile(), []);
-  const workLoop = React.useMemo(() => openTuiWorkLoop(), []);
   const contentDimensions = React.useMemo(
     () => new InsetDimensionSource(dimensions, 4),
     [dimensions],
@@ -571,9 +524,23 @@ function ProductHost({
 
   const resolvedStartup = startup ?? PENDING_STARTUP;
   const startupSurface = qualificationLabStartupSurface(resolvedStartup);
+  const cachedGlobalWorkPresent = React.useMemo(() => {
+    const paths = runtimePaths();
+    return (
+      (loadLatestGlobalWorkCache(
+        (candidate) => fs.readFileSync(candidate, 'utf8'),
+        [
+          path.join(paths.configHome, 'tui', 'global-work-observer.json'),
+          path.join(paths.configHome, 'gui', 'global-work-observer.json'),
+        ],
+      )?.global_work.visible_work.length ?? 0) > 0
+    );
+  }, []);
   const labOpen =
     surface === 'lab' ||
-    (surface === 'auto' && startupSurface === 'qualification-lab');
+    (surface === 'auto' &&
+      startupSurface === 'qualification-lab' &&
+      !cachedGlobalWorkPresent);
   const availableQuickCommands = React.useMemo(
     () =>
       labOpen
@@ -609,7 +576,7 @@ function ProductHost({
         kind: 'command',
         title: command.command,
         summary: command.summary,
-        section: 'Quick commands',
+        section: 'Quick actions',
         keywords: [command.title],
         priority: index,
         action: {
@@ -681,6 +648,34 @@ function ProductHost({
           query: '',
           selected: 0,
         });
+      } else if (command.action === 'health') {
+        const health =
+          cliDocuments.find(
+            (document) =>
+              document.action.kind === 'describe-command' &&
+              document.action.command === 'kungfu health',
+          ) ??
+          ({
+            id: 'command.health',
+            kind: 'command',
+            title: 'kungfu health',
+            summary:
+              'Inspect read-only runtime, Peer, storage, and Episode health.',
+            section: 'Governed Commands',
+            keywords: ['health', 'runtime', 'peer', 'storage', 'episode'],
+            priority: 0,
+            action: {
+              kind: 'describe-command',
+              command: 'kungfu health',
+            },
+          } satisfies ProductSearchDocument);
+        setControlNow({
+          mode: 'detail',
+          focus: 'input',
+          query: 'health',
+          selected: 0,
+          detail: health,
+        });
       } else if (command.action === 'work') {
         setSurface('work');
         closeControl();
@@ -727,7 +722,7 @@ function ProductHost({
         detail: result,
       });
     }
-  }, [closeControl, dispatchLabAction, exit, setControlNow]);
+  }, [cliDocuments, closeControl, dispatchLabAction, exit, setControlNow]);
   const activateControlRef = React.useRef(activateControl);
   activateControlRef.current = activateControl;
   const isInputCaptured = React.useCallback(
@@ -760,7 +755,7 @@ function ProductHost({
   }, [dispatchLabAction, exit, inputFence, labOpen, setControlNow]);
 
   let content: React.ReactNode;
-  if (!startup && surface !== 'lab') {
+  if (!startup && surface !== 'lab' && !cachedGlobalWorkPresent) {
     content = (
       <StartingHost
         dimensions={contentDimensions}
@@ -785,8 +780,6 @@ function ProductHost({
   } else {
     content = (
       <WorkControlHost
-        profile={profile}
-        workLoop={workLoop}
         dimensions={contentDimensions}
         onOpenLab={() => setSurface('lab')}
         onSearchDocuments={setWorkDocuments}

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -37,7 +37,13 @@ import {
   quickCommandMatches,
   reduceControlPlaneInput,
 } from './profile-shell.js';
-import { AgentWorkLabHost } from './qualification-lab-view.js';
+import {
+  AGENT_WORK_LAB_QUICK_COMMANDS,
+  type AgentWorkLabActionRequest,
+  AgentWorkLabHost,
+  type AgentWorkLabSuiteAction,
+  agentWorkLabActionReturnsToControls,
+} from './qualification-lab-view.js';
 import {
   IncrementalTerminalOutput,
   terminalCanvasRows,
@@ -472,6 +478,9 @@ function ProductHost({
   const [size, setSize] = React.useState(dimensions.get());
   const [startup, setStartup] = React.useState<QualificationLabStartupRoute>();
   const [surface, setSurface] = React.useState<'auto' | 'lab' | 'work'>('auto');
+  const [labActionRequest, setLabActionRequest] =
+    React.useState<AgentWorkLabActionRequest>();
+  const nextLabActionId = React.useRef(0);
   const [control, setControl] =
     React.useState<ControlPlaneState>(CLOSED_CONTROL_PLANE);
   const controlRef = React.useRef(control);
@@ -565,6 +574,13 @@ function ProductHost({
   const labOpen =
     surface === 'lab' ||
     (surface === 'auto' && startupSurface === 'qualification-lab');
+  const availableQuickCommands = React.useMemo(
+    () =>
+      labOpen
+        ? [...AGENT_WORK_LAB_QUICK_COMMANDS, ...QUICK_COMMANDS]
+        : QUICK_COMMANDS,
+    [labOpen],
+  );
   const viewDocuments = React.useMemo<ProductSearchDocument[]>(
     () => [
       {
@@ -588,7 +604,7 @@ function ProductHost({
   );
   const quickSearchDocuments = React.useMemo<ProductSearchDocument[]>(
     () =>
-      QUICK_COMMANDS.map((command, index) => ({
+      availableQuickCommands.map((command, index) => ({
         id: `command.quick.${command.id}`,
         kind: 'command',
         title: command.command,
@@ -601,7 +617,7 @@ function ProductHost({
           command: command.command,
         },
       })),
-    [],
+    [availableQuickCommands],
   );
   const documents = React.useMemo(
     () => [
@@ -618,8 +634,8 @@ function ProductHost({
     [control.query, documents],
   );
   const quickCommands = React.useMemo(
-    () => quickCommandMatches(control.query),
-    [control.query],
+    () => quickCommandMatches(control.query, availableQuickCommands),
+    [availableQuickCommands, control.query],
   );
   const searchResultsRef = React.useRef(searchResults);
   const quickCommandsRef = React.useRef(quickCommands);
@@ -634,6 +650,18 @@ function ProductHost({
     () => setControlNow(CLOSED_CONTROL_PLANE),
     [setControlNow],
   );
+  const dispatchLabAction = React.useCallback(
+    (action: AgentWorkLabSuiteAction) => {
+      nextLabActionId.current += 1;
+      setLabActionRequest({ id: nextLabActionId.current, action });
+    },
+    [],
+  );
+  const acknowledgeLabAction = React.useCallback((id: number) => {
+    setLabActionRequest((current) =>
+      current?.id === id ? undefined : current,
+    );
+  }, []);
   const activateControl = React.useCallback(() => {
     const current = controlRef.current;
     if (current.mode === 'commands') {
@@ -662,8 +690,22 @@ function ProductHost({
       } else if (command.action === 'home') {
         setSurface('auto');
         closeControl();
-      } else {
+      } else if (command.action === 'quit') {
         exit();
+      } else if (
+        AGENT_WORK_LAB_QUICK_COMMANDS.some(
+          (candidate) => candidate.action === command.action,
+        )
+      ) {
+        setSurface('lab');
+        dispatchLabAction(command.action as AgentWorkLabSuiteAction);
+        setControlNow(
+          agentWorkLabActionReturnsToControls(
+            command.action as AgentWorkLabSuiteAction,
+          )
+            ? { ...CLOSED_CONTROL_PLANE, focus: 'workspace' }
+            : CLOSED_CONTROL_PLANE,
+        );
       }
       return;
     }
@@ -685,7 +727,7 @@ function ProductHost({
         detail: result,
       });
     }
-  }, [closeControl, exit, setControlNow]);
+  }, [closeControl, dispatchLabAction, exit, setControlNow]);
   const activateControlRef = React.useRef(activateControl);
   activateControlRef.current = activateControl;
   const isInputCaptured = React.useCallback(
@@ -706,13 +748,16 @@ function ProductHost({
       inputFence.captureCurrentEmission();
       setControlNow(update.state);
       if (update.quit) return exit();
+      if (update.workspaceNavigation && labOpen) {
+        dispatchLabAction('lab-focus-next');
+      }
       if (update.activate) activateControlRef.current();
     };
     process.stdin.prependListener('data', onData);
     return () => {
       process.stdin.off('data', onData);
     };
-  }, [exit, inputFence, setControlNow]);
+  }, [dispatchLabAction, exit, inputFence, labOpen, setControlNow]);
 
   let content: React.ReactNode;
   if (!startup && surface !== 'lab') {
@@ -730,6 +775,8 @@ function ProductHost({
         startup={resolvedStartup}
         dimensions={contentDimensions}
         isInputCaptured={isInputCaptured}
+        actionRequest={labActionRequest}
+        onActionHandled={acknowledgeLabAction}
         onOpenWork={
           startupSurface === 'work-graph' ? () => setSurface('work') : undefined
         }
@@ -773,6 +820,13 @@ function ProductHost({
         dimensions={size}
         state={control}
         resultCount={resultCount}
+        surfaceLabel={labOpen ? 'Agent Work Lab' : 'Work Control'}
+        controlsLabel={labOpen ? 'LAB CONTROLS' : 'WORK CONTROLS'}
+        controlsHint={
+          labOpen
+            ? 'd Demo · x Same · m Handoff · Tab Focus'
+            : 'Work navigation is active'
+        }
       />
     </Box>
   );

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -477,7 +477,11 @@ function ProductHost({
   const controlRef = React.useRef(control);
   const inputFence = React.useMemo(
     () =>
-      createControlPlaneInputFence(() => controlRef.current.mode !== 'closed'),
+      createControlPlaneInputFence(
+        () =>
+          controlRef.current.mode !== 'closed' ||
+          controlRef.current.focus === 'input',
+      ),
     [],
   );
   const [cliDocuments, setCliDocuments] = React.useState<
@@ -492,7 +496,7 @@ function ProductHost({
   const profile = React.useMemo(() => openTuiProfile(), []);
   const workLoop = React.useMemo(() => openTuiWorkLoop(), []);
   const contentDimensions = React.useMemo(
-    () => new InsetDimensionSource(dimensions, 2),
+    () => new InsetDimensionSource(dimensions, 4),
     [dimensions],
   );
   React.useEffect(() => dimensions.subscribe(setSize), [dimensions]);
@@ -636,9 +640,19 @@ function ProductHost({
       const command = quickCommandsRef.current[current.selected];
       if (!command) return;
       if (command.action === 'help') {
-        setControlNow({ mode: 'help', query: '', selected: 0 });
+        setControlNow({
+          mode: 'help',
+          focus: 'input',
+          query: '',
+          selected: 0,
+        });
       } else if (command.action === 'search') {
-        setControlNow({ mode: 'search', query: '', selected: 0 });
+        setControlNow({
+          mode: 'search',
+          focus: 'input',
+          query: '',
+          selected: 0,
+        });
       } else if (command.action === 'work') {
         setSurface('work');
         closeControl();
@@ -665,6 +679,7 @@ function ProductHost({
     } else {
       setControlNow({
         mode: 'detail',
+        focus: 'input',
         query: current.query,
         selected: current.selected,
         detail: result,

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -850,7 +850,14 @@ async function main(): Promise<void> {
   );
 }
 
-void main().catch((error) => {
-  process.stderr.write(`Kungfu TUI failed: ${(error as Error).message}\n`);
-  process.exitCode = 1;
-});
+void main()
+  .then(() => {
+    // Ink has released the terminal at this point. Exit explicitly so an
+    // in-flight discovery child cannot keep the user's shell in the foreground
+    // after the visible TUI has already closed.
+    process.exit(process.exitCode ?? 0);
+  })
+  .catch((error) => {
+    process.stderr.write(`Kungfu TUI failed: ${(error as Error).message}\n`);
+    process.exitCode = 1;
+  });

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -6,14 +6,18 @@ import { createRequire } from 'node:module';
 import { constants as osConstants } from 'node:os';
 import path from 'node:path';
 import {
+  type ProductSearchDocument,
   type Profile,
   type QualificationLab,
   type QualificationLabStartupRoute,
+  SYSTEM_HELP_DOCUMENTS,
   type WorkLoop,
+  loadCliHelpSearchDocuments,
   openProfile,
   openQualificationLab,
   openWorkLoop,
   qualificationLabStartupSurface,
+  searchProductDocuments,
 } from '@kungfu-tech/api/capability';
 import { Box, Text, render, useApp } from 'ink';
 import React from 'react';
@@ -21,9 +25,17 @@ import React from 'react';
 import { loadTuiKfxPlan } from './kfx-plan.js';
 import { boundedIndex, decodeShellKey } from './navigation.js';
 import {
+  CLOSED_CONTROL_PLANE,
+  ControlPlaneBar,
+  ControlPlaneOverlay,
+  type ControlPlaneState,
   ProfileShell,
   type ProfileShellModel,
+  QUICK_COMMANDS,
   type TerminalDimensions,
+  createControlPlaneInputFence,
+  quickCommandMatches,
+  reduceControlPlaneInput,
 } from './profile-shell.js';
 import { AgentWorkLabHost } from './qualification-lab-view.js';
 import {
@@ -217,16 +229,41 @@ class DimensionStore {
   }
 }
 
+class InsetDimensionSource {
+  constructor(
+    private readonly source: DimensionStore,
+    private readonly bottomRows: number,
+  ) {}
+  private map(dimensions: TerminalDimensions): TerminalDimensions {
+    return {
+      ...dimensions,
+      rows: Math.max(8, dimensions.rows - this.bottomRows),
+    };
+  }
+  get() {
+    return this.map(this.source.get());
+  }
+  subscribe(listener: (dimensions: TerminalDimensions) => void) {
+    return this.source.subscribe((dimensions) =>
+      listener(this.map(dimensions)),
+    );
+  }
+}
+
 function WorkControlHost({
   profile,
   workLoop,
   dimensions,
   onOpenLab,
+  onSearchDocuments,
+  isInputCaptured,
 }: {
   profile: Profile;
   workLoop: WorkLoop;
-  dimensions: DimensionStore;
+  dimensions: InsetDimensionSource;
   onOpenLab: () => void;
+  onSearchDocuments: (documents: ProductSearchDocument[]) => void;
+  isInputCaptured: () => boolean;
 }) {
   const { exit } = useApp();
   const kfxPlan = React.useMemo(() => loadTuiKfxPlan(process.env), []);
@@ -292,7 +329,38 @@ function WorkControlHost({
     void refresh(process.env.KF_INITIATIVE_ID || '');
   }, [refresh]);
   React.useEffect(() => {
+    const documents: ProductSearchDocument[] = [
+      ...(model.subject.id
+        ? [
+            {
+              id: `work.initiative.${model.subject.id}`,
+              kind: 'work' as const,
+              title: model.subject.title,
+              summary: model.subject.subtitle,
+              keywords: ['initiative', model.subject.id],
+              priority: 0,
+              action: {
+                kind: 'open-work' as const,
+                workId: model.subject.id,
+              },
+            },
+          ]
+        : []),
+      ...model.cards.map((card, index) => ({
+        id: `work.assignment.${card.id}`,
+        kind: 'work' as const,
+        title: card.title,
+        summary: `${card.summary} · ${card.status}`,
+        keywords: ['assignment', card.id, card.status],
+        priority: index + 1,
+        action: { kind: 'open-work' as const, workId: card.id },
+      })),
+    ];
+    onSearchDocuments(documents);
+  }, [model, onSearchDocuments]);
+  React.useEffect(() => {
     const onData = (chunk: Buffer | string) => {
+      if (isInputCaptured()) return;
       const key = decodeShellKey(String(chunk));
       if (key === 'quit') return exit();
       if (key === 'qualification-lab') return onOpenLab();
@@ -325,7 +393,7 @@ function WorkControlHost({
     return () => {
       process.stdin.off('data', onData);
     };
-  }, [exit, model, onOpenLab, refresh]);
+  }, [exit, isInputCaptured, model, onOpenLab, refresh]);
 
   return (
     <ProfileShell
@@ -353,15 +421,18 @@ const PENDING_STARTUP: QualificationLabStartupRoute = {
 function StartingHost({
   dimensions,
   onOpenLab,
+  isInputCaptured,
 }: {
-  dimensions: DimensionStore;
+  dimensions: InsetDimensionSource;
   onOpenLab: () => void;
+  isInputCaptured: () => boolean;
 }) {
   const { exit } = useApp();
   const [size, setSize] = React.useState(dimensions.get());
   React.useEffect(() => dimensions.subscribe(setSize), [dimensions]);
   React.useEffect(() => {
     const onData = (chunk: Buffer | string) => {
+      if (isInputCaptured()) return;
       const key = decodeShellKey(String(chunk));
       if (key === 'quit') exit();
       if (key === 'qualification-lab') onOpenLab();
@@ -370,7 +441,7 @@ function StartingHost({
     return () => {
       process.stdin.off('data', onData);
     };
-  }, [exit, onOpenLab]);
+  }, [exit, isInputCaptured, onOpenLab]);
   return (
     <Box
       width={size.columns}
@@ -397,10 +468,68 @@ function ProductHost({
   lab: QualificationLab;
   dimensions: DimensionStore;
 }) {
+  const { exit } = useApp();
+  const [size, setSize] = React.useState(dimensions.get());
   const [startup, setStartup] = React.useState<QualificationLabStartupRoute>();
   const [surface, setSurface] = React.useState<'auto' | 'lab' | 'work'>('auto');
+  const [control, setControl] =
+    React.useState<ControlPlaneState>(CLOSED_CONTROL_PLANE);
+  const controlRef = React.useRef(control);
+  const inputFence = React.useMemo(
+    () =>
+      createControlPlaneInputFence(() => controlRef.current.mode !== 'closed'),
+    [],
+  );
+  const [cliDocuments, setCliDocuments] = React.useState<
+    ProductSearchDocument[]
+  >([]);
+  const [workDocuments, setWorkDocuments] = React.useState<
+    ProductSearchDocument[]
+  >([]);
+  const [catalogStatus, setCatalogStatus] = React.useState(
+    'Loading governed command catalog',
+  );
   const profile = React.useMemo(() => openTuiProfile(), []);
   const workLoop = React.useMemo(() => openTuiWorkLoop(), []);
+  const contentDimensions = React.useMemo(
+    () => new InsetDimensionSource(dimensions, 2),
+    [dimensions],
+  );
+  React.useEffect(() => dimensions.subscribe(setSize), [dimensions]);
+  React.useEffect(() => {
+    let active = true;
+    const paths = runtimePaths();
+    void loadCliHelpSearchDocuments({
+      bin: paths.bin,
+      env: cliEnvironment() as Record<string, string | undefined>,
+      execFile: (file, args, options) =>
+        new Promise<string>((resolve, reject) => {
+          execFile(file, args, options, (error, stdout, stderr) => {
+            if (error)
+              reject(new Error(describeCliFailure(error, stdout, stderr)));
+            else resolve(stdout);
+          });
+        }),
+    })
+      .then((documents) => {
+        if (!active) return;
+        setCliDocuments(documents);
+        setCatalogStatus(
+          `${documents.length} governed Help and Command entries`,
+        );
+      })
+      .catch((error) => {
+        if (!active) return;
+        setCatalogStatus(
+          `Command catalog unavailable: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
   React.useEffect(() => {
     let active = true;
     void lab
@@ -426,38 +555,211 @@ function ProductHost({
       active = false;
     };
   }, [lab]);
-  if (!startup && surface !== 'lab') {
-    return (
-      <StartingHost
-        dimensions={dimensions}
-        onOpenLab={() => setSurface('lab')}
-      />
-    );
-  }
+
   const resolvedStartup = startup ?? PENDING_STARTUP;
   const startupSurface = qualificationLabStartupSurface(resolvedStartup);
   const labOpen =
     surface === 'lab' ||
     (surface === 'auto' && startupSurface === 'qualification-lab');
-  if (labOpen) {
-    return (
+  const viewDocuments = React.useMemo<ProductSearchDocument[]>(
+    () => [
+      {
+        id: 'view.work-control',
+        kind: 'view',
+        title: 'Work Control',
+        summary: 'Open the read-only Work and Profile projection.',
+        keywords: ['home', 'assignments', 'initiatives'],
+        action: { kind: 'open-view', viewId: 'work' },
+      },
+      {
+        id: 'view.agent-work-lab',
+        kind: 'view',
+        title: 'Agent Work Lab',
+        summary: 'Compare bounded Agent Work behavior across two Sessions.',
+        keywords: ['qualification', 'handoff', 'session'],
+        action: { kind: 'open-view', viewId: 'lab' },
+      },
+    ],
+    [],
+  );
+  const quickSearchDocuments = React.useMemo<ProductSearchDocument[]>(
+    () =>
+      QUICK_COMMANDS.map((command, index) => ({
+        id: `command.quick.${command.id}`,
+        kind: 'command',
+        title: command.command,
+        summary: command.summary,
+        section: 'Quick commands',
+        keywords: [command.title],
+        priority: index,
+        action: {
+          kind: 'describe-command',
+          command: command.command,
+        },
+      })),
+    [],
+  );
+  const documents = React.useMemo(
+    () => [
+      ...SYSTEM_HELP_DOCUMENTS,
+      ...quickSearchDocuments,
+      ...cliDocuments,
+      ...workDocuments,
+      ...viewDocuments,
+    ],
+    [cliDocuments, quickSearchDocuments, viewDocuments, workDocuments],
+  );
+  const searchResults = React.useMemo(
+    () => searchProductDocuments(documents, control.query),
+    [control.query, documents],
+  );
+  const quickCommands = React.useMemo(
+    () => quickCommandMatches(control.query),
+    [control.query],
+  );
+  const searchResultsRef = React.useRef(searchResults);
+  const quickCommandsRef = React.useRef(quickCommands);
+  searchResultsRef.current = searchResults;
+  quickCommandsRef.current = quickCommands;
+
+  const setControlNow = React.useCallback((next: ControlPlaneState) => {
+    controlRef.current = next;
+    setControl(next);
+  }, []);
+  const closeControl = React.useCallback(
+    () => setControlNow(CLOSED_CONTROL_PLANE),
+    [setControlNow],
+  );
+  const activateControl = React.useCallback(() => {
+    const current = controlRef.current;
+    if (current.mode === 'commands') {
+      const command = quickCommandsRef.current[current.selected];
+      if (!command) return;
+      if (command.action === 'help') {
+        setControlNow({ mode: 'help', query: '', selected: 0 });
+      } else if (command.action === 'search') {
+        setControlNow({ mode: 'search', query: '', selected: 0 });
+      } else if (command.action === 'work') {
+        setSurface('work');
+        closeControl();
+      } else if (command.action === 'lab') {
+        setSurface('lab');
+        closeControl();
+      } else if (command.action === 'home') {
+        setSurface('auto');
+        closeControl();
+      } else {
+        exit();
+      }
+      return;
+    }
+    if (current.mode !== 'search') return;
+    const result = searchResultsRef.current[current.selected];
+    if (!result) return;
+    if (result.action.kind === 'open-work') {
+      setSurface('work');
+      closeControl();
+    } else if (result.action.kind === 'open-view') {
+      setSurface(result.action.viewId === 'lab' ? 'lab' : 'work');
+      closeControl();
+    } else {
+      setControlNow({
+        mode: 'detail',
+        query: current.query,
+        selected: current.selected,
+        detail: result,
+      });
+    }
+  }, [closeControl, exit, setControlNow]);
+  const activateControlRef = React.useRef(activateControl);
+  activateControlRef.current = activateControl;
+  const isInputCaptured = React.useCallback(
+    () => inputFence.isCaptured(),
+    [inputFence],
+  );
+  React.useEffect(() => {
+    const onData = (chunk: Buffer | string) => {
+      const current = controlRef.current;
+      const itemCount =
+        current.mode === 'commands'
+          ? quickCommandsRef.current.length
+          : current.mode === 'search'
+            ? searchResultsRef.current.length
+            : 0;
+      const update = reduceControlPlaneInput(current, String(chunk), itemCount);
+      if (!update.handled) return;
+      inputFence.captureCurrentEmission();
+      setControlNow(update.state);
+      if (update.quit) return exit();
+      if (update.activate) activateControlRef.current();
+    };
+    process.stdin.prependListener('data', onData);
+    return () => {
+      process.stdin.off('data', onData);
+    };
+  }, [exit, inputFence, setControlNow]);
+
+  let content: React.ReactNode;
+  if (!startup && surface !== 'lab') {
+    content = (
+      <StartingHost
+        dimensions={contentDimensions}
+        onOpenLab={() => setSurface('lab')}
+        isInputCaptured={isInputCaptured}
+      />
+    );
+  } else if (labOpen) {
+    content = (
       <AgentWorkLabHost
         lab={lab}
         startup={resolvedStartup}
-        dimensions={dimensions}
+        dimensions={contentDimensions}
+        isInputCaptured={isInputCaptured}
         onOpenWork={
           startupSurface === 'work-graph' ? () => setSurface('work') : undefined
         }
       />
     );
+  } else {
+    content = (
+      <WorkControlHost
+        profile={profile}
+        workLoop={workLoop}
+        dimensions={contentDimensions}
+        onOpenLab={() => setSurface('lab')}
+        onSearchDocuments={setWorkDocuments}
+        isInputCaptured={isInputCaptured}
+      />
+    );
   }
+
+  const resultCount =
+    control.mode === 'commands'
+      ? quickCommands.length
+      : control.mode === 'search'
+        ? searchResults.length
+        : 0;
   return (
-    <WorkControlHost
-      profile={profile}
-      workLoop={workLoop}
-      dimensions={dimensions}
-      onOpenLab={() => setSurface('lab')}
-    />
+    <Box
+      width={size.columns}
+      height={terminalCanvasRows(size.rows)}
+      flexDirection="column"
+      overflow="hidden"
+    >
+      {content}
+      <ControlPlaneOverlay
+        dimensions={contentDimensions.get()}
+        state={control}
+        searchResults={searchResults}
+        quickCommands={quickCommands}
+        catalogStatus={catalogStatus}
+      />
+      <ControlPlaneBar
+        dimensions={size}
+        state={control}
+        resultCount={resultCount}
+      />
+    </Box>
   );
 }
 

--- a/framework/tui/src/mission-control-contribution.ts
+++ b/framework/tui/src/mission-control-contribution.ts
@@ -154,7 +154,7 @@ export async function loadMissionControlContribution(
           title: 'What you can do now',
           status: 'degraded',
           summary:
-            'Press a to open Agent Qualification Lab. Profile activation remains an explicit reviewed action.',
+            'Press a to open Agent Work Lab. Profile activation remains an explicit reviewed action.',
         },
       ],
       evidence: [

--- a/framework/tui/src/profile-shell.test.ts
+++ b/framework/tui/src/profile-shell.test.ts
@@ -98,19 +98,19 @@ for (const qualification of [
     columns: 80,
     rows: 24,
     mode: 'one-column',
-    digest: 'd32f4a02bf7badced4261cc06aca4ffc567e1f8bc9412d802e5652f5f3e522fe',
+    digest: '0f5fca0d6800b6fe1298b22dc484227b4c786ed4e5af8930ec006a452702ad8e',
   },
   {
     columns: 120,
     rows: 36,
     mode: 'two-column',
-    digest: '690700c2cb0eb8849ac890c67a3486fe2e283a02db86fed0af122428a5f00f15',
+    digest: '40b746256cc4623a1507d33b8896624e321ced7da98a4b32c133a37f0c0d87a2',
   },
   {
     columns: 160,
     rows: 48,
     mode: 'three-column',
-    digest: '393d419269b2df5b89d54538e91d3d20a61c6706c80387afc04f287ca574c96b',
+    digest: 'd08bfff06683732a89735f3162a05566dbe07ee90d08906ad63b25f09dd80cb2',
   },
 ] as const) {
   test(`qualifies the ${qualification.columns}x${qualification.rows} renderer snapshot`, () => {

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -945,6 +945,7 @@ export type ControlPlaneUpdate = {
   state: ControlPlaneState;
   activate?: boolean;
   quit?: boolean;
+  workspaceNavigation?: 'next-focus';
 };
 
 export type ControlPlaneInputFence = {
@@ -967,15 +968,23 @@ export function createControlPlaneInputFence(
   };
 }
 
-export type QuickCommand = {
+export type QuickCommand<Action extends string = string> = {
   id: string;
   command: `/${string}`;
   title: string;
   summary: string;
-  action: 'help' | 'search' | 'work' | 'lab' | 'home' | 'quit';
+  action: Action;
 };
 
-export const QUICK_COMMANDS: QuickCommand[] = [
+export type ProductQuickCommandAction =
+  | 'help'
+  | 'search'
+  | 'work'
+  | 'lab'
+  | 'home'
+  | 'quit';
+
+export const QUICK_COMMANDS: QuickCommand<ProductQuickCommandAction>[] = [
   {
     id: 'help',
     command: '/help',
@@ -1028,16 +1037,19 @@ export const CLOSED_CONTROL_PLANE: ControlPlaneState = {
   selected: 0,
 };
 
-export function quickCommandMatches(query: string): QuickCommand[] {
+export function quickCommandMatches(
+  query: string,
+  commands: QuickCommand[] = QUICK_COMMANDS,
+): QuickCommand[] {
   const needle = query.replace(/^\//, '').trim().toLocaleLowerCase();
-  if (!needle) return QUICK_COMMANDS;
-  const prefixMatches = QUICK_COMMANDS.filter(
+  if (!needle) return commands;
+  const prefixMatches = commands.filter(
     (command) =>
       command.command.slice(1).startsWith(needle) ||
       command.title.toLocaleLowerCase().startsWith(needle),
   );
   if (prefixMatches.length > 0) return prefixMatches;
-  return QUICK_COMMANDS.filter((command) =>
+  return commands.filter((command) =>
     `${command.command} ${command.title} ${command.summary}`
       .toLocaleLowerCase()
       .includes(needle),
@@ -1099,6 +1111,13 @@ export function reduceControlPlaneInput(
       return {
         handled: true,
         state: { ...current, focus: 'workspace', notice: undefined },
+      };
+    }
+    if (input === '\t' && !current.query) {
+      return {
+        handled: true,
+        state: { ...current, focus: 'workspace', notice: undefined },
+        workspaceNavigation: 'next-focus',
       };
     }
     if (input === '\u007f' || input === '\b') {
@@ -1375,11 +1394,11 @@ export function ControlPlaneOverlay({
               and available product views.
             </Text>
             <Box marginTop={1} flexDirection="column">
-              <Text color="yellow">/work</Text>
-              <Text color="yellow">/lab</Text>
-              <Text color="yellow">/home</Text>
-              <Text color="yellow">/search</Text>
-              <Text color="yellow">/quit</Text>
+              {quickCommands.slice(0, Math.max(1, rowBudget)).map((command) => (
+                <Text key={command.id} color="yellow" wrap="truncate-end">
+                  {command.command.padEnd(10)} {command.title}
+                </Text>
+              ))}
             </Box>
           </>
         ) : null}
@@ -1442,10 +1461,16 @@ export function ControlPlaneBar({
   dimensions,
   state,
   resultCount,
+  surfaceLabel = 'Kungfu',
+  controlsLabel = 'VIEW CONTROLS',
+  controlsHint = 'Workspace shortcuts active',
 }: {
   dimensions: TerminalDimensions;
   state: ControlPlaneState;
   resultCount: number;
+  surfaceLabel?: string;
+  controlsLabel?: string;
+  controlsHint?: string;
 }) {
   const modalOpen = state.mode !== 'closed';
   const inputFocused = modalOpen || state.focus === 'input';
@@ -1458,7 +1483,17 @@ export function ControlPlaneBar({
       ? 'Help is open'
       : state.mode === 'detail'
         ? 'Result details are open'
-        : value || (!modalOpen ? 'Type a message…' : '');
+        : value ||
+          (!modalOpen
+            ? inputFocused
+              ? 'Type a message…'
+              : 'Keyboard shortcuts are active'
+            : '');
+  const modeLabel = modalOpen
+    ? 'KUNGFU'
+    : inputFocused
+      ? 'INPUT'
+      : controlsLabel;
   const hint =
     state.notice ??
     (state.mode === 'commands'
@@ -1468,8 +1503,8 @@ export function ControlPlaneBar({
         : state.mode === 'help' || state.mode === 'detail'
           ? 'Esc returns to the input'
           : state.focus === 'workspace'
-            ? 'Workspace shortcuts active · i focus input · ? Help · / Commands · Ctrl+K Search'
-            : 'Focused · Enter is bounded for now · ? Help · / Commands · Ctrl+K Search · Esc workspace');
+            ? `${controlsHint} · i Input · ? Help · / Commands · Ctrl+K Search`
+            : 'Text entry is active · Esc Controls · Tab next focus · ? Help · / Commands · Ctrl+K Search');
   const tone = inputFocused ? 'cyan' : 'gray';
   return (
     <Box
@@ -1484,7 +1519,15 @@ export function ControlPlaneBar({
       overflow="hidden"
     >
       <Text color={tone} wrap="truncate-end">
-        <Text bold>{modalOpen ? 'KUNGFU' : '›'}</Text> {prompt}
+        <Text
+          bold
+          color={inputFocused ? 'black' : 'white'}
+          backgroundColor={inputFocused ? 'cyan' : 'gray'}
+        >
+          {' '}
+          {modeLabel} · {surfaceLabel}{' '}
+        </Text>{' '}
+        <Text bold>{modalOpen ? '›' : inputFocused ? '›' : '◆'}</Text> {prompt}
         {!modalOpen ? inputCursor(inputFocused) : null}
       </Text>
       <Text

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import type {
+  ProductSearchDocument,
+  ProductSearchResult,
+} from '@kungfu-tech/api/capability';
 import { Box, Text } from 'ink';
 import React from 'react';
+import { boundedIndex } from './navigation.js';
 import { terminalCanvasRows } from './terminal-canvas.js';
 import type { WorkLoopShellModel } from './work-loop-contribution.js';
 
@@ -915,6 +920,465 @@ export function SessionWorkbench(props: SessionWorkbenchProps) {
           </Text>
         </Box>
       ) : null}
+    </Box>
+  );
+}
+
+export type ControlPlaneMode =
+  | 'closed'
+  | 'help'
+  | 'commands'
+  | 'search'
+  | 'detail';
+
+export type ControlPlaneState = {
+  mode: ControlPlaneMode;
+  query: string;
+  selected: number;
+  detail?: ProductSearchDocument;
+};
+
+export type ControlPlaneUpdate = {
+  handled: boolean;
+  state: ControlPlaneState;
+  activate?: boolean;
+  quit?: boolean;
+};
+
+export type ControlPlaneInputFence = {
+  captureCurrentEmission: () => void;
+  isCaptured: () => boolean;
+};
+
+export function createControlPlaneInputFence(
+  isOpen: () => boolean,
+): ControlPlaneInputFence {
+  let capturedCurrentEmission = false;
+  return {
+    captureCurrentEmission: () => {
+      capturedCurrentEmission = true;
+      queueMicrotask(() => {
+        capturedCurrentEmission = false;
+      });
+    },
+    isCaptured: () => capturedCurrentEmission || isOpen(),
+  };
+}
+
+export type QuickCommand = {
+  id: string;
+  command: `/${string}`;
+  title: string;
+  summary: string;
+  action: 'help' | 'search' | 'work' | 'lab' | 'home' | 'quit';
+};
+
+export const QUICK_COMMANDS: QuickCommand[] = [
+  {
+    id: 'help',
+    command: '/help',
+    title: 'Open Help',
+    summary:
+      'Explain the input bar, shortcuts, search sources, and safety boundary.',
+    action: 'help',
+  },
+  {
+    id: 'search',
+    command: '/search',
+    title: 'Search Kungfu',
+    summary: 'Find Help, Commands, Work, and product views.',
+    action: 'search',
+  },
+  {
+    id: 'work',
+    command: '/work',
+    title: 'Open Work',
+    summary: 'Open the current read-only Work Control projection.',
+    action: 'work',
+  },
+  {
+    id: 'lab',
+    command: '/lab',
+    title: 'Open Lab',
+    summary: 'Open the installed first-party work experiment suite.',
+    action: 'lab',
+  },
+  {
+    id: 'home',
+    command: '/home',
+    title: 'Open startup home',
+    summary: 'Return to the surface selected from current Work evidence.',
+    action: 'home',
+  },
+  {
+    id: 'quit',
+    command: '/quit',
+    title: 'Quit Kungfu',
+    summary: 'Leave the TUI and restore the terminal.',
+    action: 'quit',
+  },
+];
+
+export const CLOSED_CONTROL_PLANE: ControlPlaneState = {
+  mode: 'closed',
+  query: '',
+  selected: 0,
+};
+
+export function quickCommandMatches(query: string): QuickCommand[] {
+  const needle = query.replace(/^\//, '').trim().toLocaleLowerCase();
+  if (!needle) return QUICK_COMMANDS;
+  const prefixMatches = QUICK_COMMANDS.filter(
+    (command) =>
+      command.command.slice(1).startsWith(needle) ||
+      command.title.toLocaleLowerCase().startsWith(needle),
+  );
+  if (prefixMatches.length > 0) return prefixMatches;
+  return QUICK_COMMANDS.filter((command) =>
+    `${command.command} ${command.title} ${command.summary}`
+      .toLocaleLowerCase()
+      .includes(needle),
+  );
+}
+
+function openedControlPlane(
+  mode: Exclude<ControlPlaneMode, 'closed' | 'detail'>,
+  query = '',
+): ControlPlaneState {
+  return { mode, query, selected: 0 };
+}
+
+export function reduceControlPlaneInput(
+  current: ControlPlaneState,
+  input: string,
+  itemCount: number,
+): ControlPlaneUpdate {
+  if (input === '\u0003') {
+    return { handled: true, state: current, quit: true };
+  }
+  if (input === '\u000b') {
+    return { handled: true, state: openedControlPlane('search') };
+  }
+  if (current.mode === 'closed') {
+    if (input === '?') {
+      return { handled: true, state: openedControlPlane('help') };
+    }
+    if (input === '/') {
+      return {
+        handled: true,
+        state: openedControlPlane('commands', '/'),
+      };
+    }
+    return { handled: false, state: current };
+  }
+  if (input === '\u001b') {
+    return { handled: true, state: CLOSED_CONTROL_PLANE };
+  }
+  if (current.mode === 'help' || current.mode === 'detail') {
+    if (
+      input === '?' ||
+      input === '\r' ||
+      input === '\n' ||
+      input === '\u007f'
+    ) {
+      return { handled: true, state: CLOSED_CONTROL_PLANE };
+    }
+    if (input === '/') {
+      return {
+        handled: true,
+        state: openedControlPlane('commands', '/'),
+      };
+    }
+    return { handled: true, state: current };
+  }
+  if (input === '\u001b[A') {
+    return {
+      handled: true,
+      state: {
+        ...current,
+        selected: boundedIndex(current.selected, -1, itemCount),
+      },
+    };
+  }
+  if (input === '\u001b[B' || input === '\t') {
+    return {
+      handled: true,
+      state: {
+        ...current,
+        selected: boundedIndex(current.selected, 1, itemCount),
+      },
+    };
+  }
+  if (input === '\r' || input === '\n') {
+    return { handled: true, state: current, activate: itemCount > 0 };
+  }
+  if (input === '\u007f' || input === '\b') {
+    const next = [...current.query].slice(0, -1).join('');
+    if (current.mode === 'commands' && next === '') {
+      return { handled: true, state: CLOSED_CONTROL_PLANE };
+    }
+    return {
+      handled: true,
+      state: { ...current, query: next, selected: 0 },
+    };
+  }
+  if (/^[\x20-\x7e]+$/.test(input)) {
+    return {
+      handled: true,
+      state: {
+        ...current,
+        query: `${current.query}${input}`,
+        selected: 0,
+      },
+    };
+  }
+  return { handled: true, state: current };
+}
+
+function controlPlaneKindColor(kind: ProductSearchDocument['kind']): string {
+  if (kind === 'work') return 'green';
+  if (kind === 'command') return 'yellow';
+  if (kind === 'view') return 'magenta';
+  return 'cyan';
+}
+
+function ControlPlaneResultRows({
+  rows,
+  selected,
+  height,
+}: {
+  rows: Array<ProductSearchDocument | ProductSearchResult>;
+  selected: number;
+  height: number;
+}) {
+  const visibleCount = Math.max(1, height);
+  const start = Math.min(
+    Math.max(0, selected - visibleCount + 1),
+    Math.max(0, rows.length - visibleCount),
+  );
+  const visible = rows.slice(start, start + visibleCount);
+  return (
+    <Box flexDirection="column" flexGrow={1} minHeight={0}>
+      {visible.length === 0 ? (
+        <Text color="yellow">No matching results.</Text>
+      ) : null}
+      {visible.map((row, index) => {
+        const absoluteIndex = start + index;
+        return (
+          <Box key={row.id} flexDirection="column">
+            <Text
+              bold={absoluteIndex === selected}
+              color={
+                absoluteIndex === selected
+                  ? 'black'
+                  : controlPlaneKindColor(row.kind)
+              }
+              backgroundColor={absoluteIndex === selected ? 'cyan' : undefined}
+              wrap="truncate-end"
+            >
+              {absoluteIndex === selected ? '›' : ' '}{' '}
+              {row.kind.toUpperCase().padEnd(7)} {row.title}
+            </Text>
+            <Text dimColor wrap="truncate-end">
+              {'  '}
+              {row.summary}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+function QuickCommandRows({
+  rows,
+  selected,
+  height,
+}: {
+  rows: QuickCommand[];
+  selected: number;
+  height: number;
+}) {
+  const visibleCount = Math.max(1, height);
+  const start = Math.min(
+    Math.max(0, selected - visibleCount + 1),
+    Math.max(0, rows.length - visibleCount),
+  );
+  return (
+    <Box flexDirection="column" flexGrow={1} minHeight={0}>
+      {rows.length === 0 ? (
+        <Text color="yellow">No matching quick command.</Text>
+      ) : null}
+      {rows.slice(start, start + visibleCount).map((row, index) => {
+        const absoluteIndex = start + index;
+        return (
+          <Box key={row.id} flexDirection="column">
+            <Text
+              bold={absoluteIndex === selected}
+              color={absoluteIndex === selected ? 'black' : 'yellow'}
+              backgroundColor={absoluteIndex === selected ? 'cyan' : undefined}
+            >
+              {absoluteIndex === selected ? '›' : ' '} {row.command.padEnd(10)}{' '}
+              {row.title}
+            </Text>
+            <Text dimColor wrap="truncate-end">
+              {'  '}
+              {row.summary}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function ControlPlaneOverlay({
+  dimensions,
+  state,
+  searchResults,
+  quickCommands,
+  catalogStatus,
+}: {
+  dimensions: TerminalDimensions;
+  state: ControlPlaneState;
+  searchResults: ProductSearchResult[];
+  quickCommands: QuickCommand[];
+  catalogStatus: string;
+}) {
+  if (state.mode === 'closed') return null;
+  const height = terminalCanvasRows(dimensions.rows);
+  const rowBudget = Math.max(1, Math.floor((height - 7) / 2));
+  const title =
+    state.mode === 'help'
+      ? 'HELP'
+      : state.mode === 'commands'
+        ? 'QUICK COMMANDS'
+        : state.mode === 'detail'
+          ? 'RESULT DETAILS'
+          : 'SEARCH KUNGFU';
+  return (
+    <Box
+      position="absolute"
+      width={dimensions.columns}
+      height={height}
+      flexDirection="column"
+      borderStyle="double"
+      borderColor="cyan"
+      paddingX={1}
+      overflow="hidden"
+    >
+      <Text bold color="cyan">
+        KUNGFU · {title}
+      </Text>
+      {state.mode === 'help' ? (
+        <>
+          <Text>? Help · / Quick commands · Ctrl+K Search · Esc return</Text>
+          <Text dimColor>
+            The input bar runs bounded product actions. It is not a shell and
+            does not execute arbitrary text.
+          </Text>
+          <Text dimColor>
+            Search covers system Help, governed Kungfu Commands, current Work,
+            and available product views.
+          </Text>
+          <Box marginTop={1} flexDirection="column">
+            <Text color="yellow">/work</Text>
+            <Text color="yellow">/lab</Text>
+            <Text color="yellow">/home</Text>
+            <Text color="yellow">/search</Text>
+            <Text color="yellow">/quit</Text>
+          </Box>
+        </>
+      ) : null}
+      {state.mode === 'commands' ? (
+        <>
+          <Text dimColor>
+            Enter runs the selected bounded action · ↑↓ choose · Esc cancel
+          </Text>
+          <QuickCommandRows
+            rows={quickCommands}
+            selected={state.selected}
+            height={rowBudget}
+          />
+        </>
+      ) : null}
+      {state.mode === 'search' ? (
+        <>
+          <Text dimColor>
+            {catalogStatus} · Enter opens or explains · ↑↓ choose · Esc cancel
+          </Text>
+          <ControlPlaneResultRows
+            rows={searchResults}
+            selected={state.selected}
+            height={rowBudget}
+          />
+        </>
+      ) : null}
+      {state.mode === 'detail' && state.detail ? (
+        <Box flexDirection="column" marginTop={1}>
+          <Text bold color={controlPlaneKindColor(state.detail.kind)}>
+            {state.detail.kind.toUpperCase()} · {state.detail.title}
+          </Text>
+          <Text>{state.detail.summary}</Text>
+          {state.detail.section ? (
+            <Text dimColor>Section · {state.detail.section}</Text>
+          ) : null}
+          {state.detail.action.kind === 'describe-command' ? (
+            <Text color="yellow">
+              Inspect only · run `{state.detail.action.command} --help` in a
+              shell. Search did not execute it.
+            </Text>
+          ) : null}
+          <Text dimColor>Enter / Esc / Backspace returns.</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+export function ControlPlaneBar({
+  dimensions,
+  state,
+  resultCount,
+}: {
+  dimensions: TerminalDimensions;
+  state: ControlPlaneState;
+  resultCount: number;
+}) {
+  const value =
+    state.mode === 'commands'
+      ? state.query
+      : state.mode === 'search'
+        ? state.query
+        : '';
+  const label =
+    state.mode === 'closed'
+      ? '›  ? Help   / Commands   Ctrl+K Search'
+      : state.mode === 'help'
+        ? '›  Help open · Esc return · / commands · Ctrl+K search'
+        : state.mode === 'detail'
+          ? '›  Result details · Enter or Esc to return'
+          : `› ${value}${value ? '' : ' '}  · ${resultCount} result${resultCount === 1 ? '' : 's'}`;
+  return (
+    <Box
+      position="absolute"
+      marginTop={Math.max(0, terminalCanvasRows(dimensions.rows) - 2)}
+      width={dimensions.columns}
+      height={2}
+      borderStyle="single"
+      borderLeft={false}
+      borderRight={false}
+      borderBottom={false}
+      borderColor={state.mode === 'closed' ? 'gray' : 'cyan'}
+      paddingX={1}
+      overflow="hidden"
+    >
+      <Text
+        color={state.mode === 'closed' ? 'gray' : 'cyan'}
+        wrap="truncate-end"
+      >
+        {label}
+      </Text>
     </Box>
   );
 }

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -933,8 +933,10 @@ export type ControlPlaneMode =
 
 export type ControlPlaneState = {
   mode: ControlPlaneMode;
+  focus: 'input' | 'workspace';
   query: string;
   selected: number;
+  notice?: string;
   detail?: ProductSearchDocument;
 };
 
@@ -1021,6 +1023,7 @@ export const QUICK_COMMANDS: QuickCommand[] = [
 
 export const CLOSED_CONTROL_PLANE: ControlPlaneState = {
   mode: 'closed',
+  focus: 'input',
   query: '',
   selected: 0,
 };
@@ -1045,7 +1048,7 @@ function openedControlPlane(
   mode: Exclude<ControlPlaneMode, 'closed' | 'detail'>,
   query = '',
 ): ControlPlaneState {
-  return { mode, query, selected: 0 };
+  return { mode, focus: 'input', query, selected: 0 };
 }
 
 export function reduceControlPlaneInput(
@@ -1057,19 +1060,87 @@ export function reduceControlPlaneInput(
     return { handled: true, state: current, quit: true };
   }
   if (input === '\u000b') {
-    return { handled: true, state: openedControlPlane('search') };
+    return {
+      handled: true,
+      state: openedControlPlane(
+        'search',
+        current.mode === 'closed' && current.focus === 'input'
+          ? current.query
+          : '',
+      ),
+    };
   }
   if (current.mode === 'closed') {
-    if (input === '?') {
+    if (current.focus === 'workspace') {
+      if (input === 'i') {
+        return {
+          handled: true,
+          state: { ...current, focus: 'input', notice: undefined },
+        };
+      }
+      if (input === '?') {
+        return { handled: true, state: openedControlPlane('help') };
+      }
+      if (input === '/') {
+        return {
+          handled: true,
+          state: openedControlPlane('commands', '/'),
+        };
+      }
+      return { handled: false, state: current };
+    }
+    if (input === '\u001b') {
+      if (current.query) {
+        return {
+          handled: true,
+          state: { ...current, query: '', notice: undefined },
+        };
+      }
+      return {
+        handled: true,
+        state: { ...current, focus: 'workspace', notice: undefined },
+      };
+    }
+    if (input === '\u007f' || input === '\b') {
+      return {
+        handled: true,
+        state: {
+          ...current,
+          query: [...current.query].slice(0, -1).join(''),
+          notice: undefined,
+        },
+      };
+    }
+    if ((input === '\r' || input === '\n') && current.query) {
+      return {
+        handled: true,
+        state: {
+          ...current,
+          notice:
+            'Free-form Agent conversation is coming soon. Use / commands or Ctrl+K search.',
+        },
+      };
+    }
+    if (input === '?' && !current.query) {
       return { handled: true, state: openedControlPlane('help') };
     }
-    if (input === '/') {
+    if (input === '/' && !current.query) {
       return {
         handled: true,
         state: openedControlPlane('commands', '/'),
       };
     }
-    return { handled: false, state: current };
+    if (/^[\x20-\x7e]+$/.test(input)) {
+      return {
+        handled: true,
+        state: {
+          ...current,
+          query: `${current.query}${input}`.slice(0, 160),
+          notice: undefined,
+        },
+      };
+    }
+    return { handled: true, state: current };
   }
   if (input === '\u001b') {
     return { handled: true, state: CLOSED_CONTROL_PLANE };
@@ -1247,7 +1318,10 @@ export function ControlPlaneOverlay({
 }) {
   if (state.mode === 'closed') return null;
   const height = terminalCanvasRows(dimensions.rows);
-  const rowBudget = Math.max(1, Math.floor((height - 7) / 2));
+  const width = Math.max(24, dimensions.columns);
+  const panelWidth = Math.max(20, width - 4);
+  const panelHeight = Math.max(8, height - 2);
+  const rowBudget = Math.max(1, Math.floor((panelHeight - 7) / 2));
   const title =
     state.mode === 'help'
       ? 'HELP'
@@ -1259,81 +1333,109 @@ export function ControlPlaneOverlay({
   return (
     <Box
       position="absolute"
-      width={dimensions.columns}
+      width={width}
       height={height}
       flexDirection="column"
-      borderStyle="double"
-      borderColor="cyan"
-      paddingX={1}
       overflow="hidden"
     >
-      <Text bold color="cyan">
-        KUNGFU · {title}
-      </Text>
-      {state.mode === 'help' ? (
-        <>
-          <Text>? Help · / Quick commands · Ctrl+K Search · Esc return</Text>
-          <Text dimColor>
-            The input bar runs bounded product actions. It is not a shell and
-            does not execute arbitrary text.
+      <Box width={width} height={height} flexDirection="column">
+        {Array.from(
+          { length: height },
+          (_, index) => `backdrop-row-${index + 1}`,
+        ).map((rowId) => (
+          <Text key={rowId} backgroundColor="black">
+            {' '.repeat(width)}
           </Text>
-          <Text dimColor>
-            Search covers system Help, governed Kungfu Commands, current Work,
-            and available product views.
-          </Text>
-          <Box marginTop={1} flexDirection="column">
-            <Text color="yellow">/work</Text>
-            <Text color="yellow">/lab</Text>
-            <Text color="yellow">/home</Text>
-            <Text color="yellow">/search</Text>
-            <Text color="yellow">/quit</Text>
-          </Box>
-        </>
-      ) : null}
-      {state.mode === 'commands' ? (
-        <>
-          <Text dimColor>
-            Enter runs the selected bounded action · ↑↓ choose · Esc cancel
-          </Text>
-          <QuickCommandRows
-            rows={quickCommands}
-            selected={state.selected}
-            height={rowBudget}
-          />
-        </>
-      ) : null}
-      {state.mode === 'search' ? (
-        <>
-          <Text dimColor>
-            {catalogStatus} · Enter opens or explains · ↑↓ choose · Esc cancel
-          </Text>
-          <ControlPlaneResultRows
-            rows={searchResults}
-            selected={state.selected}
-            height={rowBudget}
-          />
-        </>
-      ) : null}
-      {state.mode === 'detail' && state.detail ? (
-        <Box flexDirection="column" marginTop={1}>
-          <Text bold color={controlPlaneKindColor(state.detail.kind)}>
-            {state.detail.kind.toUpperCase()} · {state.detail.title}
-          </Text>
-          <Text>{state.detail.summary}</Text>
-          {state.detail.section ? (
-            <Text dimColor>Section · {state.detail.section}</Text>
-          ) : null}
-          {state.detail.action.kind === 'describe-command' ? (
-            <Text color="yellow">
-              Inspect only · run `{state.detail.action.command} --help` in a
-              shell. Search did not execute it.
+        ))}
+      </Box>
+      <Box
+        position="absolute"
+        marginLeft={2}
+        marginTop={1}
+        width={panelWidth}
+        height={panelHeight}
+        flexDirection="column"
+        borderStyle="double"
+        borderColor="cyan"
+        paddingX={1}
+        overflow="hidden"
+      >
+        <Text bold color="cyan">
+          KUNGFU · {title}
+        </Text>
+        {state.mode === 'help' ? (
+          <>
+            <Text>? Help · / Quick commands · Ctrl+K Search · Esc return</Text>
+            <Text dimColor>
+              The focused input accepts text, but free-form Agent conversation
+              is not available yet.
             </Text>
-          ) : null}
-          <Text dimColor>Enter / Esc / Backspace returns.</Text>
-        </Box>
-      ) : null}
+            <Text dimColor>
+              Search covers system Help, governed Kungfu Commands, current Work,
+              and available product views.
+            </Text>
+            <Box marginTop={1} flexDirection="column">
+              <Text color="yellow">/work</Text>
+              <Text color="yellow">/lab</Text>
+              <Text color="yellow">/home</Text>
+              <Text color="yellow">/search</Text>
+              <Text color="yellow">/quit</Text>
+            </Box>
+          </>
+        ) : null}
+        {state.mode === 'commands' ? (
+          <>
+            <Text dimColor>
+              Enter runs the selected bounded action · ↑↓ choose · Esc cancel
+            </Text>
+            <QuickCommandRows
+              rows={quickCommands}
+              selected={state.selected}
+              height={rowBudget}
+            />
+          </>
+        ) : null}
+        {state.mode === 'search' ? (
+          <>
+            <Text dimColor>
+              {catalogStatus} · Enter opens or explains · ↑↓ choose · Esc cancel
+            </Text>
+            <ControlPlaneResultRows
+              rows={searchResults}
+              selected={state.selected}
+              height={rowBudget}
+            />
+          </>
+        ) : null}
+        {state.mode === 'detail' && state.detail ? (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold color={controlPlaneKindColor(state.detail.kind)}>
+              {state.detail.kind.toUpperCase()} · {state.detail.title}
+            </Text>
+            <Text>{state.detail.summary}</Text>
+            {state.detail.section ? (
+              <Text dimColor>Section · {state.detail.section}</Text>
+            ) : null}
+            {state.detail.action.kind === 'describe-command' ? (
+              <Text color="yellow">
+                Inspect only · run `{state.detail.action.command} --help` in a
+                shell. Search did not execute it.
+              </Text>
+            ) : null}
+            <Text dimColor>Enter / Esc / Backspace returns.</Text>
+          </Box>
+        ) : null}
+      </Box>
     </Box>
   );
+}
+
+function inputCursor(active: boolean) {
+  return active ? (
+    <Text inverse color="cyan">
+      {' '}
+    </Text>
+  ) : null;
 }
 
 export function ControlPlaneBar({
@@ -1345,39 +1447,52 @@ export function ControlPlaneBar({
   state: ControlPlaneState;
   resultCount: number;
 }) {
+  const modalOpen = state.mode !== 'closed';
+  const inputFocused = modalOpen || state.focus === 'input';
   const value =
-    state.mode === 'commands'
+    state.mode === 'commands' || state.mode === 'search' || !modalOpen
       ? state.query
+      : '';
+  const prompt =
+    state.mode === 'help'
+      ? 'Help is open'
+      : state.mode === 'detail'
+        ? 'Result details are open'
+        : value || (!modalOpen ? 'Type a message…' : '');
+  const hint =
+    state.notice ??
+    (state.mode === 'commands'
+      ? `${resultCount} bounded command${resultCount === 1 ? '' : 's'} · Enter run · Esc cancel`
       : state.mode === 'search'
-        ? state.query
-        : '';
-  const label =
-    state.mode === 'closed'
-      ? '›  ? Help   / Commands   Ctrl+K Search'
-      : state.mode === 'help'
-        ? '›  Help open · Esc return · / commands · Ctrl+K search'
-        : state.mode === 'detail'
-          ? '›  Result details · Enter or Esc to return'
-          : `› ${value}${value ? '' : ' '}  · ${resultCount} result${resultCount === 1 ? '' : 's'}`;
+        ? `${resultCount} result${resultCount === 1 ? '' : 's'} · Enter open · Esc cancel`
+        : state.mode === 'help' || state.mode === 'detail'
+          ? 'Esc returns to the input'
+          : state.focus === 'workspace'
+            ? 'Workspace shortcuts active · i focus input · ? Help · / Commands · Ctrl+K Search'
+            : 'Focused · Enter is bounded for now · ? Help · / Commands · Ctrl+K Search · Esc workspace');
+  const tone = inputFocused ? 'cyan' : 'gray';
   return (
     <Box
       position="absolute"
-      marginTop={Math.max(0, terminalCanvasRows(dimensions.rows) - 2)}
+      marginTop={Math.max(0, terminalCanvasRows(dimensions.rows) - 4)}
       width={dimensions.columns}
-      height={2}
-      borderStyle="single"
-      borderLeft={false}
-      borderRight={false}
-      borderBottom={false}
-      borderColor={state.mode === 'closed' ? 'gray' : 'cyan'}
+      height={4}
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={tone}
       paddingX={1}
       overflow="hidden"
     >
+      <Text color={tone} wrap="truncate-end">
+        <Text bold>{modalOpen ? 'KUNGFU' : '›'}</Text> {prompt}
+        {!modalOpen ? inputCursor(inputFocused) : null}
+      </Text>
       <Text
-        color={state.mode === 'closed' ? 'gray' : 'cyan'}
+        color={state.notice ? 'yellow' : inputFocused ? 'white' : 'gray'}
+        dimColor={!state.notice}
         wrap="truncate-end"
       >
-        {label}
+        {hint}
       </Text>
     </Box>
   );

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -26,6 +26,7 @@ export type ProfileShellModel = {
     version: string;
     suiteRoot: string;
     qualified: boolean;
+    qualificationLabel?: string;
   };
   subject: { id: string; title: string; subtitle: string };
   navigation: Array<{ id: string; label: string; status: string }>;
@@ -57,6 +58,13 @@ export function resolveProfileShellLayout(
 function shortRoot(value: string): string {
   if (value.length <= 18) return value;
   return `${value.slice(0, 7)}…${value.slice(-10)}`;
+}
+
+function qualificationState(model: ProfileShellModel): string {
+  if ((model.profile.qualificationLabel ?? 'KFD-3') === 'KFD-3') {
+    return model.profile.qualified ? 'qualified' : 'not qualified';
+  }
+  return model.profile.qualified ? 'verified' : 'not verified';
 }
 
 function NavigationPanel({
@@ -92,11 +100,19 @@ function CardPanel({
   model,
   selectedCard,
   active,
+  maxRows,
 }: {
   model: ProfileShellModel;
   selectedCard: number;
   active: boolean;
+  maxRows: number;
 }) {
+  const visibleCount = Math.max(1, Math.floor((maxRows - 8) / 2));
+  const start = Math.min(
+    Math.max(0, selectedCard - visibleCount + 1),
+    Math.max(0, model.cards.length - visibleCount),
+  );
+  const visibleCards = model.cards.slice(start, start + visibleCount);
   return (
     <Box
       flexDirection="column"
@@ -112,22 +128,34 @@ function CardPanel({
           No Profile answers are available at this cut.
         </Text>
       ) : null}
-      {model.cards.map((card, index) => (
-        <Box
-          key={card.id}
-          flexDirection="column"
-          marginTop={index === 0 ? 1 : 0}
-        >
-          <Text color={index === selectedCard ? 'cyan' : undefined} bold>
-            {index === selectedCard ? '› ' : '  '}
-            {index + 1}. {card.title}{' '}
-            <Text color={card.status === 'degraded' ? 'yellow' : 'green'}>
-              [{card.status}]
-            </Text>
-          </Text>
-          <Text wrap="truncate-end"> {card.summary}</Text>
-        </Box>
-      ))}
+      {model.cards.length > visibleCards.length ? (
+        <Text dimColor>
+          showing {start + 1}–{start + visibleCards.length} of{' '}
+          {model.cards.length}
+        </Text>
+      ) : null}
+      {visibleCards.map((card, offset) => {
+        const index = start + offset;
+        return (
+          <Box
+            key={card.id}
+            flexDirection="column"
+            marginTop={offset === 0 ? 1 : 0}
+          >
+            <Box>
+              <Text color={index === selectedCard ? 'cyan' : undefined} bold>
+                {index === selectedCard ? '› ' : '  '}
+                {index + 1}. {card.title}
+              </Text>
+              <Text color={card.status === 'degraded' ? 'yellow' : 'green'}>
+                {' '}
+                [{card.status}]
+              </Text>
+            </Box>
+            <Text wrap="truncate-end"> {card.summary}</Text>
+          </Box>
+        );
+      })}
     </Box>
   );
 }
@@ -136,6 +164,7 @@ function EvidencePanel({
   model,
   active,
 }: { model: ProfileShellModel; active: boolean }) {
+  const qualificationLabel = model.profile.qualificationLabel ?? 'KFD-3';
   return (
     <Box
       flexDirection="column"
@@ -152,7 +181,7 @@ function EvidencePanel({
         </Box>
       ))}
       <Text color={model.profile.qualified ? 'green' : 'yellow'}>
-        KFD-3 {model.profile.qualified ? 'qualified' : 'not qualified'}
+        {qualificationLabel} {qualificationState(model)}
       </Text>
       {model.notice ? <Text color="yellow">{model.notice}</Text> : null}
     </Box>
@@ -165,6 +194,7 @@ function CompactContext({ model }: { model: ProfileShellModel }) {
   );
   const subjectPosition = activeIndex < 0 ? 'none' : `${activeIndex + 1}`;
   const proof = model.evidence.find((row) => row.label === 'query proof');
+  const qualificationLabel = model.profile.qualificationLabel ?? 'KFD-3';
   return (
     <>
       <Text wrap="truncate-end">
@@ -175,7 +205,7 @@ function CompactContext({ model }: { model: ProfileShellModel }) {
         color={model.profile.qualified ? 'green' : 'yellow'}
         wrap="truncate-end"
       >
-        KFD-3 {model.profile.qualified ? 'qualified' : 'not qualified'} · proof{' '}
+        {qualificationLabel} {qualificationState(model)} · proof{' '}
         {shortRoot(proof?.value ?? '—')}
         {model.notice ? ` · ${model.notice}` : ''}
       </Text>
@@ -239,6 +269,7 @@ export function ProfileShell({
       model={model}
       selectedCard={selectedCard}
       active={activeRegion === 1}
+      maxRows={bodyHeight}
     />
   );
 
@@ -303,6 +334,7 @@ export function renderProfileShellSnapshot(
   dimensions: TerminalDimensions,
 ): string {
   const layout = resolveProfileShellLayout(dimensions);
+  const qualificationLabel = model.profile.qualificationLabel ?? 'KFD-3';
   const lines = [
     clipped(
       `${model.profile.title} · ${model.profile.version} · ${layout.mode} · read-only`,
@@ -352,7 +384,7 @@ export function renderProfileShellSnapshot(
       dimensions.columns,
     ),
     clipped(
-      `KFD-3 ${model.profile.qualified ? 'qualified' : 'not qualified'}${model.notice ? ` · ${model.notice}` : ''}`,
+      `${qualificationLabel} ${qualificationState(model)}${model.notice ? ` · ${model.notice}` : ''}`,
       dimensions.columns,
     ),
     clipped(
@@ -979,6 +1011,7 @@ export type QuickCommand<Action extends string = string> = {
 export type ProductQuickCommandAction =
   | 'help'
   | 'search'
+  | 'health'
   | 'work'
   | 'lab'
   | 'home'
@@ -999,6 +1032,14 @@ export const QUICK_COMMANDS: QuickCommand<ProductQuickCommandAction>[] = [
     title: 'Search Kungfu',
     summary: 'Find Help, Commands, Work, and product views.',
     action: 'search',
+  },
+  {
+    id: 'health',
+    command: '/health',
+    title: 'Inspect Health',
+    summary:
+      'Describe the read-only runtime, Peer, storage, and Episode health command.',
+    action: 'health',
   },
   {
     id: 'work',
@@ -1297,7 +1338,7 @@ function QuickCommandRows({
   return (
     <Box flexDirection="column" flexGrow={1} minHeight={0}>
       {rows.length === 0 ? (
-        <Text color="yellow">No matching quick command.</Text>
+        <Text color="yellow">No matching quick action.</Text>
       ) : null}
       {rows.slice(start, start + visibleCount).map((row, index) => {
         const absoluteIndex = start + index;
@@ -1345,7 +1386,7 @@ export function ControlPlaneOverlay({
     state.mode === 'help'
       ? 'HELP'
       : state.mode === 'commands'
-        ? 'QUICK COMMANDS'
+        ? 'QUICK ACTIONS'
         : state.mode === 'detail'
           ? 'RESULT DETAILS'
           : 'SEARCH KUNGFU';
@@ -1384,14 +1425,14 @@ export function ControlPlaneOverlay({
         </Text>
         {state.mode === 'help' ? (
           <>
-            <Text>? Help · / Quick commands · Ctrl+K Search · Esc return</Text>
+            <Text>? Help · / Quick actions · Ctrl+K Search · Esc return</Text>
             <Text dimColor>
               The focused input accepts text, but free-form Agent conversation
               is not available yet.
             </Text>
             <Text dimColor>
-              Search covers system Help, governed Kungfu Commands, current Work,
-              and available product views.
+              Search covers system Help, the full governed Kungfu Command
+              catalog, global Work, and available product views.
             </Text>
             <Box marginTop={1} flexDirection="column">
               {quickCommands.slice(0, Math.max(1, rowBudget)).map((command) => (
@@ -1497,14 +1538,14 @@ export function ControlPlaneBar({
   const hint =
     state.notice ??
     (state.mode === 'commands'
-      ? `${resultCount} bounded command${resultCount === 1 ? '' : 's'} · Enter run · Esc cancel`
+      ? `${resultCount} bounded action${resultCount === 1 ? '' : 's'} · Enter run · Esc cancel`
       : state.mode === 'search'
         ? `${resultCount} result${resultCount === 1 ? '' : 's'} · Enter open · Esc cancel`
         : state.mode === 'help' || state.mode === 'detail'
           ? 'Esc returns to the input'
           : state.focus === 'workspace'
-            ? `${controlsHint} · i Input · ? Help · / Commands · Ctrl+K Search`
-            : 'Text entry is active · Esc Controls · Tab next focus · ? Help · / Commands · Ctrl+K Search');
+            ? `${controlsHint} · i Input · ? Help · / Actions · Ctrl+K Search`
+            : 'Text entry is active · Esc Controls · Tab next focus · ? Help · / Actions · Ctrl+K Search');
   const tone = inputFocused ? 'cyan' : 'gray';
   return (
     <Box

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -278,7 +278,7 @@ export function ProfileShell({
       ) : null}
       <Box paddingX={1}>
         <Text dimColor>
-          ↑↓/jk answer · ←→/hl subject · tab region · a qualification lab · r
+          ↑↓/jk answer · ←→/hl subject · tab region · [a] Agent Work Lab · r
           refresh · q quit
         </Text>
       </Box>
@@ -351,11 +351,570 @@ export function renderProfileShellSnapshot(
       dimensions.columns,
     ),
     clipped(
-      '↑↓/jk answer · ←→/hl subject · tab region · a qualification lab · r refresh · q quit',
+      '↑↓/jk answer · ←→/hl subject · tab region · [a] Agent Work Lab · r refresh · q quit',
       dimensions.columns,
     ),
   ];
   while (lines.length < dimensions.rows)
     lines.push(' '.repeat(dimensions.columns));
   return lines.slice(0, dimensions.rows).join('\n');
+}
+
+// Generic two-session workbench. Product adapters supply all domain copy,
+// event interpretation, verdict meaning, and next-step policy.
+export type PlaybackTiming = {
+  eventIntervalMs: number;
+  verdictIntervalMs: number;
+};
+export type IncrementalPlayback<TEvent> = {
+  enqueue(event: TEvent): void;
+  finish(): Promise<boolean>;
+  cancel(): void;
+};
+export type WorkbenchFocus = 'session-1' | 'session-2' | 'correct' | 'failed';
+export type WorkbenchReportDetail = 'correct' | 'failed';
+export type WorkbenchNextPrompt = { title: string; instruction: string };
+export type WorkbenchLine = {
+  session: 1 | 2;
+  source: string;
+  text: string;
+  tone: 'normal' | 'running' | 'good' | 'bad' | 'dim';
+};
+export type WorkbenchCheck = {
+  id: string;
+  passed: boolean;
+  title: string;
+  meaning: string;
+};
+
+export function createIncrementalPlayback<TEvent>({
+  timing,
+  onEvent,
+  onAssessing,
+  isCurrent = () => true,
+  wait = (milliseconds) =>
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, milliseconds);
+    }),
+}: {
+  timing: PlaybackTiming;
+  onEvent: (event: TEvent) => void;
+  onAssessing: () => void;
+  isCurrent?: () => boolean;
+  wait?: (milliseconds: number) => Promise<void>;
+}): IncrementalPlayback<TEvent> {
+  let active = true;
+  let queue = Promise.resolve();
+  return {
+    enqueue(event) {
+      queue = queue
+        .then(() => wait(timing.eventIntervalMs))
+        .then(() => {
+          if (active && isCurrent()) onEvent(event);
+        });
+    },
+    async finish() {
+      await queue;
+      if (!active || !isCurrent()) return false;
+      onAssessing();
+      await wait(timing.verdictIntervalMs);
+      return active && isCurrent();
+    },
+    cancel() {
+      active = false;
+    },
+  };
+}
+
+const WORKBENCH_FOCUS_ORDER: WorkbenchFocus[] = [
+  'session-1',
+  'session-2',
+  'correct',
+  'failed',
+];
+
+export function nextWorkbenchFocus(
+  current: WorkbenchFocus,
+  reportAvailable: boolean,
+): WorkbenchFocus {
+  const available = reportAvailable
+    ? WORKBENCH_FOCUS_ORDER
+    : WORKBENCH_FOCUS_ORDER.slice(0, 2);
+  const currentIndex = Math.max(0, available.indexOf(current));
+  return available[(currentIndex + 1) % available.length];
+}
+
+export function isWorkbenchReturnInput(input: string): boolean {
+  return (
+    input === '\r' ||
+    input === '\n' ||
+    input === '\u001b' ||
+    input === '\u007f' ||
+    input === '\b' ||
+    input === 'b' ||
+    input === 'B' ||
+    input === '\u001b[D'
+  );
+}
+
+export function sessionTitleBar({
+  session,
+  title,
+  active,
+  running,
+  columns,
+  activityFrame = 0,
+}: {
+  session: 1 | 2;
+  title: string;
+  active: boolean;
+  running: boolean;
+  columns: number;
+  activityFrame?: number;
+}): string {
+  const prefix = `${active ? '>' : ' '} S${session} · `;
+  const spinner = ['◐', '◓', '◑', '◒'][activityFrame % 4];
+  const status = running ? `${spinner} RUNNING` : 'READY';
+  const titleColumns = Math.max(0, columns - prefix.length - status.length - 1);
+  const compactTitle =
+    title.length <= titleColumns
+      ? title
+      : titleColumns > 1
+        ? `${title.slice(0, titleColumns - 1)}…`
+        : '';
+  const left = `${prefix}${compactTitle}`;
+  const gap = ' '.repeat(Math.max(1, columns - left.length - status.length));
+  return `${left}${gap}${status}`.padEnd(columns).slice(0, columns);
+}
+
+export function boundedPromptRows(
+  value: string,
+  columns: number,
+  maxRows = 2,
+): string[] {
+  const width = Math.max(1, columns);
+  const rows: string[] = [];
+  let remaining = value.trim();
+  while (remaining && rows.length < maxRows) {
+    if (remaining.length <= width) {
+      rows.push(remaining);
+      remaining = '';
+      break;
+    }
+    const space = remaining.lastIndexOf(' ', width);
+    const cut = space > 0 ? space : width;
+    rows.push(remaining.slice(0, cut).trimEnd());
+    remaining = remaining.slice(cut).trimStart();
+  }
+  if (remaining && rows.length > 0) {
+    const last = rows.length - 1;
+    rows[last] = `${rows[last].slice(0, Math.max(0, width - 1))}…`;
+  }
+  while (rows.length < maxRows) rows.push('');
+  return rows;
+}
+
+function workbenchLineColor(tone: WorkbenchLine['tone']) {
+  if (tone === 'running') return 'yellow';
+  if (tone === 'good') return 'green';
+  if (tone === 'bad') return 'red';
+  if (tone === 'dim') return 'gray';
+  return undefined;
+}
+
+function WorkbenchSessionPane({
+  session,
+  title,
+  lines,
+  active,
+  scrollBack,
+  viewportRows,
+  running,
+  titleBarColumns,
+  activityFrame,
+}: {
+  session: 1 | 2;
+  title: string;
+  lines: WorkbenchLine[];
+  active: boolean;
+  scrollBack: number;
+  viewportRows: number;
+  running: boolean;
+  titleBarColumns: number;
+  activityFrame: number;
+}) {
+  const sessionLines = lines.filter((line) => line.session === session);
+  const liveStart = Math.max(0, sessionLines.length - viewportRows);
+  const start = Math.max(0, liveStart - scrollBack);
+  const visible = sessionLines.slice(start, start + viewportRows);
+  return (
+    <Box
+      width="50%"
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={active ? 'cyan' : 'gray'}
+      overflow="hidden"
+    >
+      <Text
+        bold
+        color={active ? 'black' : 'white'}
+        backgroundColor={active ? 'cyan' : 'gray'}
+        wrap="truncate-end"
+      >
+        {sessionTitleBar({
+          session,
+          title,
+          active,
+          running,
+          columns: titleBarColumns,
+          activityFrame,
+        })}
+      </Text>
+      <Box paddingX={1}>
+        <Text dimColor>PUBLIC ACTIVITY · SENSITIVE INTERNALS HIDDEN</Text>
+      </Box>
+      <Box
+        flexDirection="column"
+        height={viewportRows}
+        overflow="hidden"
+        paddingX={1}
+      >
+        {visible.length === 0 ? (
+          <Text dimColor>Activity will appear one event at a time.</Text>
+        ) : null}
+        {visible.map((line, index) => (
+          <Text
+            key={`${start + index}-${line.source}-${line.text}`}
+            color={workbenchLineColor(line.tone)}
+            wrap="truncate-end"
+          >
+            {String(start + index + 1).padStart(2, '0')}{' '}
+            {line.source.padEnd(11)} {line.text}
+          </Text>
+        ))}
+      </Box>
+      <Box paddingX={1}>
+        <Text dimColor>
+          ↑↓ scroll focused Session · Tab switch ·{' '}
+          {scrollBack > 0 ? `${scrollBack} lines back` : 'following live'}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function WorkbenchReportDetail({
+  dimensions,
+  checks,
+  detail,
+  caption,
+}: {
+  dimensions: TerminalDimensions;
+  checks: WorkbenchCheck[];
+  detail: WorkbenchReportDetail;
+  caption: string;
+}) {
+  const rows = checks.filter(
+    (check) => (detail === 'correct') === check.passed,
+  );
+  const correct = detail === 'correct';
+  return (
+    <Box
+      width={dimensions.columns}
+      height={terminalCanvasRows(dimensions.rows)}
+      flexDirection="column"
+      borderStyle="double"
+      borderColor={correct ? 'green' : 'red'}
+      paddingX={1}
+      overflow="hidden"
+    >
+      <Text bold color={correct ? 'green' : 'red'}>
+        {correct ? '✓ CORRECT CHECKS' : '× FAILED CHECKS'} · {rows.length}
+      </Text>
+      <Text dimColor>{caption}</Text>
+      <Box flexDirection="column" flexGrow={1} minHeight={0} marginTop={1}>
+        {rows.length === 0 ? (
+          <Text color={correct ? 'yellow' : 'green'}>
+            {correct
+              ? 'No correct checks were recorded.'
+              : 'No failed checks. This is the expected result.'}
+          </Text>
+        ) : null}
+        {rows.map((row, index) => (
+          <Box key={row.id} flexDirection="column" marginBottom={1}>
+            <Text bold color={row.passed ? 'green' : 'red'}>
+              {String(index + 1).padStart(2, '0')} {row.passed ? '✓' : '×'}{' '}
+              {row.title}
+            </Text>
+            <Text dimColor>{row.meaning}</Text>
+          </Box>
+        ))}
+      </Box>
+      <Box borderStyle="round" borderColor="cyan" paddingX={1}>
+        <Text bold color="cyan" wrap="truncate-end">
+          ← RETURN TO RESULT CARDS · Esc / Enter / Backspace / b
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+function WorkbenchResultCard({
+  kind,
+  count,
+  active,
+  available,
+  emphasized,
+}: {
+  kind: WorkbenchReportDetail;
+  count: number;
+  active: boolean;
+  available: boolean;
+  emphasized: boolean;
+}) {
+  const correct = kind === 'correct';
+  const tone = correct || count === 0 ? 'green' : 'red';
+  const cardColor = !available ? 'gray' : active || emphasized ? 'cyan' : tone;
+  return (
+    <Box
+      width="50%"
+      height={3}
+      borderStyle={emphasized ? 'double' : 'round'}
+      borderColor={cardColor}
+      paddingX={1}
+      overflow="hidden"
+    >
+      <Text bold color={cardColor} wrap="truncate-end">
+        {active ? '> ' : '  '}
+        {correct ? '✓' : '×'} {count} {correct ? 'CORRECT' : 'FAILED'}
+        {available ? ' · Enter details' : ' · waiting'}
+      </Text>
+    </Box>
+  );
+}
+
+function opaqueWorkbenchLine(value: string, columns: number): string {
+  return value.slice(0, columns).padEnd(columns);
+}
+
+export type SessionWorkbenchProps = {
+  dimensions: TerminalDimensions;
+  heading: string;
+  collectionLabel: string;
+  caseLabel: string;
+  relationship: string;
+  controls: string;
+  help: string;
+  sourceLabel: string;
+  targetLabel: string;
+  lines: WorkbenchLine[];
+  checks: WorkbenchCheck[];
+  reportAvailable: boolean;
+  reportPassed: boolean;
+  verdictSuccess: string;
+  verdictFailure: string;
+  detailCaption: string;
+  busy: string;
+  progress: string;
+  error: string;
+  activeFocus: WorkbenchFocus;
+  scrollBack: Record<1 | 2, number>;
+  showHelp: boolean;
+  activityFrame: number;
+  runningSession?: 1 | 2;
+  nextPrompt?: WorkbenchNextPrompt;
+  reportDetail?: WorkbenchReportDetail;
+  emphasizedResult?: WorkbenchReportDetail;
+};
+
+export function SessionWorkbench(props: SessionWorkbenchProps) {
+  const {
+    dimensions,
+    heading,
+    collectionLabel,
+    caseLabel,
+    relationship,
+    controls,
+    help,
+    sourceLabel,
+    targetLabel,
+    lines,
+    checks,
+    reportAvailable,
+    reportPassed,
+    verdictSuccess,
+    verdictFailure,
+    detailCaption,
+    busy,
+    progress,
+    error,
+    activeFocus,
+    scrollBack,
+    showHelp,
+    activityFrame,
+    runningSession,
+    nextPrompt,
+    reportDetail,
+    emphasizedResult,
+  } = props;
+  if (reportAvailable && reportDetail) {
+    return (
+      <WorkbenchReportDetail
+        dimensions={dimensions}
+        checks={checks}
+        detail={reportDetail}
+        caption={detailCaption}
+      />
+    );
+  }
+  const titleColumns = Math.max(1, Math.floor(dimensions.columns / 2) - 2);
+  const textColumns = Math.max(1, titleColumns - 2);
+  const wrappedRows = (text: string) =>
+    Math.max(1, Math.ceil(text.length / textColumns));
+  const chromeRows =
+    4 +
+    (showHelp ? 1 : 0) +
+    6 +
+    2 +
+    1 +
+    wrappedRows('PUBLIC ACTIVITY · SENSITIVE INTERNALS HIDDEN') +
+    wrappedRows('↑↓ scroll focused Session · Tab switch · 999 lines back');
+  const viewportRows = Math.max(
+    4,
+    terminalCanvasRows(dimensions.rows) - chromeRows,
+  );
+  const passedCount = checks.filter((check) => check.passed).length;
+  const failedCount = checks.length - passedCount;
+  const promptWidth = Math.min(
+    dimensions.columns,
+    Math.min(68, Math.max(24, dimensions.columns - 8)),
+  );
+  const promptColumns = Math.max(1, promptWidth - 2);
+  const promptRows = nextPrompt
+    ? boundedPromptRows(
+        `${nextPrompt.title} · ${nextPrompt.instruction}`,
+        Math.max(1, promptColumns - 2),
+      )
+    : [];
+  return (
+    <Box
+      width={dimensions.columns}
+      height={terminalCanvasRows(dimensions.rows)}
+      flexDirection="column"
+      overflow="hidden"
+    >
+      <Box paddingX={1} justifyContent="space-between">
+        <Text bold color="cyan">
+          {heading.toUpperCase()}
+        </Text>
+        <Text>
+          {collectionLabel} · {caseLabel}
+        </Text>
+      </Box>
+      <Text wrap="truncate-end">
+        S1 {sourceLabel} {relationship} S2 {targetLabel}
+      </Text>
+      <Text dimColor wrap="truncate-end">
+        {controls}
+      </Text>
+      {showHelp ? (
+        <Text dimColor wrap="truncate-end">
+          {help}
+        </Text>
+      ) : null}
+      <Box flexGrow={1} minHeight={0}>
+        <WorkbenchSessionPane
+          session={1}
+          title={sourceLabel}
+          lines={lines}
+          active={activeFocus === 'session-1'}
+          scrollBack={scrollBack[1]}
+          viewportRows={viewportRows}
+          running={Boolean(progress) && runningSession === 1}
+          titleBarColumns={titleColumns}
+          activityFrame={activityFrame}
+        />
+        <WorkbenchSessionPane
+          session={2}
+          title={targetLabel}
+          lines={lines}
+          active={activeFocus === 'session-2'}
+          scrollBack={scrollBack[2]}
+          viewportRows={viewportRows}
+          running={Boolean(progress) && runningSession === 2}
+          titleBarColumns={titleColumns}
+          activityFrame={activityFrame}
+        />
+      </Box>
+      <Box
+        height={6}
+        borderStyle="round"
+        borderColor={
+          reportAvailable ? (reportPassed ? 'green' : 'red') : 'gray'
+        }
+        paddingX={1}
+        flexDirection="column"
+        overflow="hidden"
+      >
+        <Text
+          color={reportAvailable ? (reportPassed ? 'green' : 'red') : 'yellow'}
+          bold
+          wrap="truncate-end"
+        >
+          {reportAvailable
+            ? reportPassed
+              ? verdictSuccess
+              : verdictFailure
+            : error || busy || progress || 'Ready · choose a test case'}
+        </Text>
+        <Box>
+          <WorkbenchResultCard
+            kind="correct"
+            count={passedCount}
+            active={activeFocus === 'correct'}
+            available={reportAvailable}
+            emphasized={emphasizedResult === 'correct'}
+          />
+          <WorkbenchResultCard
+            kind="failed"
+            count={failedCount}
+            active={activeFocus === 'failed'}
+            available={reportAvailable}
+            emphasized={emphasizedResult === 'failed'}
+          />
+        </Box>
+      </Box>
+      {nextPrompt ? (
+        <Box
+          position="absolute"
+          width={promptWidth}
+          height={6}
+          marginTop={Math.max(4, Math.floor(dimensions.rows / 2) - 2)}
+          marginLeft={Math.max(
+            2,
+            Math.floor((dimensions.columns - promptWidth) / 2),
+          )}
+          borderStyle="double"
+          borderColor="yellow"
+          flexDirection="column"
+          overflow="hidden"
+        >
+          <Text bold color="yellow" backgroundColor="blue">
+            {opaqueWorkbenchLine(' WHAT TO TRY NEXT', promptColumns)}
+          </Text>
+          {promptRows.map((row, index) => (
+            <Text key={`${index}-${row}`} color="white" backgroundColor="blue">
+              {opaqueWorkbenchLine(` ${row}`, promptColumns)}
+            </Text>
+          ))}
+          <Text color="white" backgroundColor="blue">
+            {opaqueWorkbenchLine(
+              ' Closes automatically in 5 seconds.',
+              promptColumns,
+            )}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
 }

--- a/framework/tui/src/qualification-lab-view.test.ts
+++ b/framework/tui/src/qualification-lab-view.test.ts
@@ -16,7 +16,9 @@ import {
   sessionTitleBar,
 } from './profile-shell.js';
 import {
+  AGENT_WORK_LAB_QUICK_COMMANDS,
   QualificationLabView,
+  agentWorkLabActionReturnsToControls,
   isQualificationReportReturnInput,
   nextQualificationFocus,
   qualificationEventLines,
@@ -313,7 +315,7 @@ test('completed modes coach the next qualification step', () => {
   );
   assert.match(
     qualificationNextModePrompt('offline-demo').instruction,
-    /Press x to start it/,
+    /Run \/same, or press Esc then x/,
   );
   assert.doesNotMatch(
     qualificationNextModePrompt('offline-demo').instruction,
@@ -321,12 +323,30 @@ test('completed modes coach the next qualification step', () => {
   );
   assert.match(
     qualificationNextModePrompt('same-agent').instruction,
-    /press m/i,
+    /Run \/handoff.*press m/i,
   );
   assert.match(
     qualificationNextModePrompt('cross-agent').instruction,
     /Open Correct or Failed/,
   );
+});
+
+test('Suite commands and Lab control keys share one action vocabulary', () => {
+  assert.deepEqual(
+    AGENT_WORK_LAB_QUICK_COMMANDS.map(({ command, action }) => ({
+      command,
+      action,
+    })),
+    [
+      { command: '/demo', action: 'lab-demo' },
+      { command: '/same', action: 'lab-same' },
+      { command: '/handoff', action: 'lab-handoff' },
+      { command: '/report', action: 'lab-report' },
+      { command: '/focus', action: 'lab-focus-next' },
+    ],
+  );
+  assert.equal(agentWorkLabActionReturnsToControls('lab-report'), true);
+  assert.equal(agentWorkLabActionReturnsToControls('lab-demo'), false);
 });
 
 test('report details accept obvious return keys', () => {
@@ -370,13 +390,13 @@ test('TUI host streams events and preserves the one-second rhythm', () => {
   assert.match(hostSource, /nextQualificationFocus/);
   assert.match(hostSource, /isQualificationReportReturnInput/);
   assert.match(hostSource, /setReportDetail\(activeFocus\)/);
+  assert.match(hostSource, /performSuiteAction\('lab-demo'\)/);
+  assert.match(hostSource, /performSuiteAction\('lab-same'\)/);
+  assert.match(hostSource, /performSuiteAction\('lab-handoff'\)/);
   assert.doesNotMatch(hostSource, /input === 'p'/);
   assert.doesNotMatch(hostSource, /lab\.planAgent/);
   assert.match(hostSource, /lab\.runDemo\(onEvent\)/);
-  assert.match(
-    hostSource,
-    /lab\.runAgent\(profiles\[selected\]\.id, onEvent\)/,
-  );
+  assert.match(hostSource, /lab\.runAgent\(source\.id, onEvent\)/);
   assert.match(hostSource, /lab\.runMigration\(/);
   assert.match(mainSource, /void lab\s*\.inspect\(\)/);
   assert.doesNotMatch(mainSource, /startup = lab\.inspectSync\(\)/);

--- a/framework/tui/src/qualification-lab-view.test.ts
+++ b/framework/tui/src/qualification-lab-view.test.ts
@@ -11,6 +11,11 @@ import type {
 import { render } from 'ink';
 import React from 'react';
 import {
+  createIncrementalPlayback,
+  nextWorkbenchFocus,
+  sessionTitleBar,
+} from './profile-shell.js';
+import {
   QualificationLabView,
   isQualificationReportReturnInput,
   nextQualificationFocus,
@@ -21,6 +26,61 @@ import {
   qualificationSessionTitleBar,
 } from './qualification-lab-view.js';
 import { IncrementalTerminalOutput } from './terminal-canvas.js';
+
+test('generic workbench has no product-specific test or oracle vocabulary', () => {
+  const moduleSource = readFileSync(
+    new URL('./profile-shell.tsx', import.meta.url),
+    'utf8',
+  );
+  const source = moduleSource.slice(
+    moduleSource.indexOf('// Generic two-session workbench'),
+  );
+  assert.doesNotMatch(
+    source,
+    /Agent Work Lab|offline-demo|same-agent|cross-agent|qualification-lab|oracle/i,
+  );
+});
+
+test('generic playback serializes events before the verdict boundary', async () => {
+  const calls: string[] = [];
+  const delays: number[] = [];
+  const playback = createIncrementalPlayback<string>({
+    timing: { eventIntervalMs: 1000, verdictIntervalMs: 520 },
+    onEvent: (event) => calls.push(event),
+    onAssessing: () => calls.push('assessing'),
+    wait: async (milliseconds) => {
+      delays.push(milliseconds);
+    },
+  });
+  playback.enqueue('first');
+  playback.enqueue('second');
+  assert.equal(await playback.finish(), true);
+  assert.deepEqual(calls, ['first', 'second', 'assessing']);
+  assert.deepEqual(delays, [1000, 1000, 520]);
+});
+
+test('title-bar focus changes style without changing geometry', () => {
+  const active = sessionTitleBar({
+    session: 1,
+    title: 'Local provider',
+    active: true,
+    running: true,
+    columns: 40,
+    activityFrame: 1,
+  });
+  const inactive = sessionTitleBar({
+    session: 1,
+    title: 'Local provider',
+    active: false,
+    running: true,
+    columns: 40,
+    activityFrame: 1,
+  });
+  assert.equal(active.length, 40);
+  assert.equal(inactive.length, 40);
+  assert.equal(active.slice(1), inactive.slice(1));
+  assert.equal(nextWorkbenchFocus('session-2', true), 'correct');
+});
 
 class CaptureOutput extends EventEmitter {
   isTTY = true;
@@ -102,36 +162,43 @@ test('TUI renders admitted provider narration without raw commands', () => {
 });
 
 test('TUI qualification layout keeps two Sessions and the verdict dock fixed', () => {
-  const source = readFileSync(
+  const adapterSource = readFileSync(
     new URL('./qualification-lab-view.tsx', import.meta.url),
     'utf8',
   );
+  const frameworkSource = readFileSync(
+    new URL('./profile-shell.tsx', import.meta.url),
+    'utf8',
+  );
 
-  assert.match(source, /width="50%"/);
-  assert.match(source, /PUBLIC STATUS/);
-  assert.match(source, /PRIVATE REASONING \+ RAW OUTPUT HIDDEN/);
-  assert.match(source, /CONTINUITY PROVED/);
-  assert.match(source, /height=\{6\}/);
-  assert.match(source, /↑↓ scroll focused Session/);
-  assert.match(source, /borderColor="gray"/);
-  assert.match(source, /color=\{active \? 'black' : 'white'\}/);
-  assert.match(source, /backgroundColor=\{active \? 'cyan' : 'gray'\}/);
-  assert.match(source, /qualificationSessionTitleBar/);
+  assert.match(frameworkSource, /width="50%"/);
+  assert.match(frameworkSource, /PUBLIC ACTIVITY/);
+  assert.match(frameworkSource, /SENSITIVE INTERNALS HIDDEN/);
+  assert.match(adapterSource, /WORK CONTINUITY PROVED/);
+  assert.match(frameworkSource, /height=\{6\}/);
+  assert.match(frameworkSource, /↑↓ scroll focused Session/);
+  assert.match(frameworkSource, /borderColor=\{active \? 'cyan' : 'gray'\}/);
+  assert.match(frameworkSource, /color=\{active \? 'black' : 'white'\}/);
   assert.match(
-    source,
+    frameworkSource,
+    /backgroundColor=\{active \? 'cyan' : 'gray'\}/,
+  );
+  assert.match(frameworkSource, /sessionTitleBar/);
+  assert.match(
+    frameworkSource,
     /running=\{Boolean\(progress\) && runningSession === 1\}/,
   );
   assert.match(
-    source,
+    frameworkSource,
     /running=\{Boolean\(progress\) && runningSession === 2\}/,
   );
-  assert.match(source, /Enter details/);
-  assert.match(source, /WHAT TO TRY NEXT/);
-  assert.match(source, /backgroundColor="blue"/);
-  assert.match(source, /opaquePromptLine/);
-  assert.doesNotMatch(source, /\[p\] prepare/);
-  assert.match(source, /\[Tab\]\s*focus/);
-  assert.match(source, /\[\?\] explain/);
+  assert.match(frameworkSource, /Enter details/);
+  assert.match(frameworkSource, /WHAT TO TRY NEXT/);
+  assert.match(frameworkSource, /backgroundColor="blue"/);
+  assert.match(frameworkSource, /opaqueWorkbenchLine/);
+  assert.doesNotMatch(adapterSource, /\[p\] prepare/);
+  assert.match(adapterSource, /\[Tab\]\s*focus/);
+  assert.match(adapterSource, /\[\?\]\s*explain/);
 });
 
 test('Session title bars keep focus and running state visible at fixed width', () => {
@@ -240,22 +307,25 @@ test('Tab focus includes result cards only after a report exists', () => {
 });
 
 test('completed modes coach the next qualification step', () => {
-  assert.deepEqual(qualificationNextModePrompt('offline-demo'), {
-    title: 'Offline complete · now test your real agent',
-    instruction:
-      'Press x to test same-agent continuity with your selected agent.',
-  });
+  assert.equal(
+    qualificationNextModePrompt('offline-demo').title,
+    'Offline complete · now test your real agent',
+  );
+  assert.match(
+    qualificationNextModePrompt('offline-demo').instruction,
+    /Press x to start it/,
+  );
   assert.doesNotMatch(
     qualificationNextModePrompt('offline-demo').instruction,
     /Press p/,
   );
   assert.match(
     qualificationNextModePrompt('same-agent').instruction,
-    /press m to test handoff/i,
+    /press m/i,
   );
   assert.match(
     qualificationNextModePrompt('cross-agent').instruction,
-    /press Enter to open its details/,
+    /Open Correct or Failed/,
   );
 });
 
@@ -277,32 +347,44 @@ test('report details accept obvious return keys', () => {
 });
 
 test('TUI host streams events and preserves the one-second rhythm', () => {
-  const source = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8');
+  const mainSource = readFileSync(
+    new URL('./main.tsx', import.meta.url),
+    'utf8',
+  );
+  const hostSource = readFileSync(
+    new URL('./qualification-lab-view.tsx', import.meta.url),
+    'utf8',
+  );
+  const playbackSource = readFileSync(
+    new URL('./profile-shell.tsx', import.meta.url),
+    'utf8',
+  );
 
-  assert.match(source, /execFileEvents:/);
-  assert.match(source, /setTimeout\(resolve, 1000\)/);
-  assert.match(source, /setTimeout\(resolve, 520\)/);
-  assert.match(source, /qualificationRunProgressLabel/);
-  assert.match(source, /qualificationLabStartupSurface/);
+  assert.match(mainSource, /execFileEvents:/);
+  assert.match(playbackSource, /wait\(timing\.eventIntervalMs\)/);
+  assert.match(playbackSource, /wait\(timing\.verdictIntervalMs\)/);
+  assert.match(hostSource, /qualificationRunProgressLabel/);
+  assert.match(mainSource, /qualificationLabStartupSurface/);
+  assert.match(hostSource, /quietProgressIntervalMs/);
+  assert.match(hostSource, /recommendationDurationMs/);
+  assert.match(hostSource, /nextQualificationFocus/);
+  assert.match(hostSource, /isQualificationReportReturnInput/);
+  assert.match(hostSource, /setReportDetail\(activeFocus\)/);
+  assert.doesNotMatch(hostSource, /input === 'p'/);
+  assert.doesNotMatch(hostSource, /lab\.planAgent/);
+  assert.match(hostSource, /lab\.runDemo\(onEvent\)/);
   assert.match(
-    source,
-    /setInterval\(\(\) => setProgressNow\(Date\.now\(\)\), 1000\)/,
+    hostSource,
+    /lab\.runAgent\(profiles\[selected\]\.id, onEvent\)/,
   );
-  assert.match(
-    source,
-    /setTimeout\(\(\) => setNextPrompt\(undefined\), 5000\)/,
+  assert.match(hostSource, /lab\.runMigration\(/);
+  assert.match(mainSource, /void lab\s*\.inspect\(\)/);
+  assert.doesNotMatch(mainSource, /startup = lab\.inspectSync\(\)/);
+  assert.match(mainSource, /Terminal product is open/);
+  assert.doesNotMatch(
+    mainSource,
+    /setRunProgress|setNextPrompt|setReportDetail/,
   );
-  assert.match(source, /nextQualificationFocus/);
-  assert.match(source, /isQualificationReportReturnInput/);
-  assert.match(source, /setReportDetail\(activeFocus\)/);
-  assert.doesNotMatch(source, /input === 'p'/);
-  assert.doesNotMatch(source, /lab\.planAgent/);
-  assert.match(source, /lab\.runDemo\(onEvent\)/);
-  assert.match(source, /lab\.runAgent\(profiles\[selected\]\.id, onEvent\)/);
-  assert.match(source, /lab\.runMigration\(/);
-  assert.match(source, /void lab\s*\.inspect\(\)/);
-  assert.doesNotMatch(source, /startup = lab\.inspectSync\(\)/);
-  assert.match(source, /Terminal product is open/);
 });
 
 test('state updates use incremental terminal painting instead of clearTerminal', async () => {
@@ -359,7 +441,7 @@ test('the real Ink 80x24 Lab keeps both Session headers visible', async () => {
   instance.cleanup();
   assert.match(frame, /│> S1 · Bundled Demo Agent\s+READY│/);
   assert.match(frame, /S2 · Fresh Demo Agent\s+READY/);
-  assert.match(frame, /AGENT QUALIFICATION LAB/);
+  assert.match(frame, /AGENT WORK LAB/);
 });
 
 test('the real Ink 80x24 title bars show only the active running Session', async () => {

--- a/framework/tui/src/qualification-lab-view.tsx
+++ b/framework/tui/src/qualification-lab-view.tsx
@@ -282,11 +282,13 @@ export function AgentWorkLabHost({
   startup,
   dimensions,
   onOpenWork,
+  isInputCaptured = () => false,
 }: {
   lab: QualificationLab;
   startup: QualificationLabStartupRoute;
   dimensions: DimensionSource;
   onOpenWork?: () => void;
+  isInputCaptured?: () => boolean;
 }) {
   const { exit } = useApp();
   const [size, setSize] = React.useState(dimensions.get());
@@ -458,6 +460,7 @@ export function AgentWorkLabHost({
   );
   React.useEffect(() => {
     const onData = (chunk: Buffer | string) => {
+      if (isInputCaptured()) return;
       const input = String(chunk);
       if (reportDetail && isQualificationReportReturnInput(input)) {
         return setReportDetail(undefined);
@@ -539,6 +542,7 @@ export function AgentWorkLabHost({
     busy,
     activeFocus,
     exit,
+    isInputCaptured,
     lab,
     onOpenWork,
     profiles,

--- a/framework/tui/src/qualification-lab-view.tsx
+++ b/framework/tui/src/qualification-lab-view.tsx
@@ -1,122 +1,62 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {
+  QualificationLab,
   QualificationLabEvent,
   QualificationLabReport,
+  QualificationLabStartupRoute,
 } from '@kungfu-tech/api/capability';
-import { Box, Text } from 'ink';
+import { qualificationRunProgressLabel } from '@kungfu-tech/api/capability';
+import {
+  AGENT_WORK_LAB_CHECKS,
+  AGENT_WORK_LAB_SUITE,
+  type AgentWorkLabCaseId,
+  agentWorkLabCase,
+  agentWorkLabRecommendation,
+} from '@kungfu-tech/kfx';
+import { useApp } from 'ink';
 import React from 'react';
-import type { TerminalDimensions } from './profile-shell.js';
-import { terminalCanvasRows } from './terminal-canvas.js';
+import { boundedIndex, decodeShellKey } from './navigation.js';
+import {
+  SessionWorkbench,
+  type TerminalDimensions,
+  type WorkbenchCheck,
+  type WorkbenchFocus,
+  type WorkbenchLine,
+  type WorkbenchNextPrompt,
+  type WorkbenchReportDetail,
+  boundedPromptRows,
+  createIncrementalPlayback,
+  isWorkbenchReturnInput,
+  nextWorkbenchFocus,
+  sessionTitleBar,
+} from './profile-shell.js';
 
-export type TuiQualificationMode =
-  | 'offline-demo'
-  | 'same-agent'
-  | 'cross-agent';
+export type TuiQualificationMode = AgentWorkLabCaseId;
+export type TuiQualificationFocus = WorkbenchFocus;
+export type TuiQualificationReportDetail = WorkbenchReportDetail;
+export type TuiQualificationNextPrompt = WorkbenchNextPrompt;
+export type TuiQualificationLine = WorkbenchLine;
 
-export type TuiQualificationFocus =
-  | 'session-1'
-  | 'session-2'
-  | 'correct'
-  | 'failed';
-
-export type TuiQualificationReportDetail = 'correct' | 'failed';
-
-export type TuiQualificationNextPrompt = {
-  title: string;
-  instruction: string;
-};
-
-export type TuiQualificationLine = {
-  session: 1 | 2;
-  source:
-    | 'kungfu'
-    | 'task'
-    | 'agent/guide'
-    | 'agent/live'
-    | 'tool/live'
-    | 'evidence';
-  text: string;
-  tone: 'normal' | 'running' | 'good' | 'bad' | 'dim';
-};
-
-const FOCUS_ORDER: TuiQualificationFocus[] = [
-  'session-1',
-  'session-2',
-  'correct',
-  'failed',
-];
-
-const CHECK_COPY: Record<string, { title: string; meaning: string }> = {
-  'distinct-fresh-processes': {
-    title: 'Two genuinely fresh processes',
-    meaning: 'Session 2 did not reuse the Session 1 provider process.',
-  },
-  'first-attempt-ended-partial': {
-    title: 'Session 1 stopped at a bounded partial result',
-    meaning:
-      'The first process left durable evidence instead of pretending to finish.',
-  },
-  'second-attempt-no-transcript-or-explanation': {
-    title: 'Session 2 received no copied chat',
-    meaning:
-      'Continuation came from governed Work, not hidden transcript transfer.',
-  },
-  'second-attempt-recognized-partial-state': {
-    title: 'Session 2 recovered the partial state',
-    meaning: 'The fresh process found what was done and what remained.',
-  },
-  'fixture-completed': {
-    title: 'The original Work was completed',
-    meaning:
-      'The second process continued the same identity to its expected result.',
-  },
-};
-
-export function nextQualificationFocus(
-  current: TuiQualificationFocus,
-  reportAvailable: boolean,
-): TuiQualificationFocus {
-  const available = reportAvailable ? FOCUS_ORDER : FOCUS_ORDER.slice(0, 2);
-  const currentIndex = Math.max(0, available.indexOf(current));
-  return available[(currentIndex + 1) % available.length];
-}
+export const nextQualificationFocus = nextWorkbenchFocus;
+export const isQualificationReportReturnInput = isWorkbenchReturnInput;
+export const qualificationSessionTitleBar = sessionTitleBar;
+export const qualificationPromptRows = boundedPromptRows;
 
 export function qualificationNextModePrompt(
   mode: TuiQualificationMode,
 ): TuiQualificationNextPrompt {
-  if (mode === 'offline-demo') {
-    return {
-      title: 'Offline complete · now test your real agent',
-      instruction:
-        'Press x to test same-agent continuity with your selected agent.',
-    };
-  }
-  if (mode === 'same-agent') {
-    return {
-      title: 'Same-agent complete · now test a handoff',
-      instruction:
-        'Choose a different target with [ or ], then press m to test handoff.',
-    };
-  }
+  const recommendation = agentWorkLabRecommendation(mode);
+  const shortcut =
+    recommendation.nextCase === 'same-agent'
+      ? ' Press x to start it.'
+      : recommendation.nextCase === 'cross-agent'
+        ? ' Choose a different target with [ or ], then press m.'
+        : '';
   return {
-    title: 'Handoff complete · inspect the evidence',
-    instruction:
-      'Tab to CORRECT or FAILED, then press Enter to open its details.',
+    title: recommendation.title,
+    instruction: `${recommendation.instruction}${shortcut}`,
   };
-}
-
-export function isQualificationReportReturnInput(input: string): boolean {
-  return (
-    input === '\r' ||
-    input === '\n' ||
-    input === '\u001b' ||
-    input === '\u007f' ||
-    input === '\b' ||
-    input === 'b' ||
-    input === 'B' ||
-    input === '\u001b[D'
-  );
 }
 
 export function qualificationEventRunningSession(
@@ -197,7 +137,7 @@ export function qualificationEventLines(
     return [
       ...(event.publicOutput?.lines ?? []).map((text) => ({
         session,
-        source: 'agent/live' as const,
+        source: 'agent/live',
         text,
         tone: good ? ('good' as const) : ('bad' as const),
       })),
@@ -223,7 +163,7 @@ export function qualificationEventLines(
       {
         session: 2,
         source: 'kungfu',
-        text: 'Continuity oracle compared process identity and governed state.',
+        text: 'Continuity checks compared process identity and governed state.',
         tone: 'normal',
       },
       {
@@ -237,185 +177,9 @@ export function qualificationEventLines(
   return [];
 }
 
-function lineColor(tone: TuiQualificationLine['tone']) {
-  if (tone === 'running') return 'yellow';
-  if (tone === 'good') return 'green';
-  if (tone === 'bad') return 'red';
-  if (tone === 'dim') return 'gray';
-  return undefined;
-}
-
-export function qualificationSessionTitleBar({
-  session,
-  title,
-  active,
-  running,
-  columns,
-  activityFrame = 0,
-}: {
-  session: 1 | 2;
-  title: string;
-  active: boolean;
-  running: boolean;
-  columns: number;
-  activityFrame?: number;
-}): string {
-  const prefix = `${active ? '>' : ' '} S${session} · `;
-  const spinner = ['◐', '◓', '◑', '◒'][activityFrame % 4];
-  const status = running ? `${spinner} RUNNING` : 'READY';
-  const titleColumns = Math.max(0, columns - prefix.length - status.length - 1);
-  const compactTitle =
-    title.length <= titleColumns
-      ? title
-      : titleColumns > 1
-        ? `${title.slice(0, titleColumns - 1)}…`
-        : '';
-  const left = `${prefix}${compactTitle}`;
-  const gap = ' '.repeat(Math.max(1, columns - left.length - status.length));
-  return `${left}${gap}${status}`.padEnd(columns).slice(0, columns);
-}
-
-export function qualificationPromptRows(
-  value: string,
-  columns: number,
-  maxRows = 2,
-): string[] {
-  const width = Math.max(1, columns);
-  const rows: string[] = [];
-  let remaining = value.trim();
-  while (remaining && rows.length < maxRows) {
-    if (remaining.length <= width) {
-      rows.push(remaining);
-      remaining = '';
-      break;
-    }
-    const space = remaining.lastIndexOf(' ', width);
-    const cut = space > 0 ? space : width;
-    rows.push(remaining.slice(0, cut).trimEnd());
-    remaining = remaining.slice(cut).trimStart();
-  }
-  if (remaining && rows.length > 0) {
-    const last = rows.length - 1;
-    rows[last] = `${rows[last].slice(0, Math.max(0, width - 1))}…`;
-  }
-  while (rows.length < maxRows) rows.push('');
-  return rows;
-}
-
-function opaquePromptLine(value: string, columns: number): string {
-  return value.slice(0, columns).padEnd(columns);
-}
-
-function SessionPane({
-  session,
-  title,
-  lines,
-  active,
-  scrollBack,
-  viewportRows,
-  running,
-  titleBarColumns,
-  activityFrame,
-}: {
-  session: 1 | 2;
-  title: string;
-  lines: TuiQualificationLine[];
-  active: boolean;
-  scrollBack: number;
-  viewportRows: number;
-  running: boolean;
-  titleBarColumns: number;
-  activityFrame: number;
-}) {
-  const sessionLines = lines.filter((line) => line.session === session);
-  const lastStart = Math.max(0, sessionLines.length - viewportRows);
-  const start = Math.max(0, lastStart - scrollBack);
-  const visible = sessionLines.slice(start, start + viewportRows);
-  return (
-    <Box
-      width="50%"
-      flexDirection="column"
-      borderStyle="round"
-      borderColor="gray"
-      overflow="hidden"
-    >
-      <Text
-        bold
-        color={active ? 'black' : 'white'}
-        backgroundColor={active ? 'cyan' : 'gray'}
-        wrap="truncate-end"
-      >
-        {qualificationSessionTitleBar({
-          session,
-          title,
-          active,
-          running,
-          columns: titleBarColumns,
-          activityFrame,
-        })}
-      </Text>
-      <Box paddingX={1}>
-        <Text dimColor>
-          PUBLIC STATUS · PRIVATE REASONING + RAW OUTPUT HIDDEN
-        </Text>
-      </Box>
-      <Box
-        flexDirection="column"
-        height={viewportRows}
-        overflow="hidden"
-        paddingX={1}
-      >
-        {visible.length === 0 ? (
-          <Text dimColor>Agent activity will appear one event at a time.</Text>
-        ) : null}
-        {visible.map((line, index) => (
-          <Text
-            key={`${start + index}-${line.source}-${line.text}`}
-            color={lineColor(line.tone)}
-            wrap="truncate-end"
-          >
-            {String(start + index + 1).padStart(2, '0')}{' '}
-            {line.source.padEnd(11)} {line.text}
-          </Text>
-        ))}
-      </Box>
-      <Box paddingX={1}>
-        <Text dimColor>
-          ↑↓ scroll focused Session · Tab switch ·{' '}
-          {scrollBack > 0 ? `${scrollBack} lines back` : 'following live'}
-        </Text>
-      </Box>
-    </Box>
-  );
-}
-
-function reportChecks(report: QualificationLabReport | undefined): {
-  passed: number;
-  failed: number;
-} {
-  const checks = Array.isArray(report?.assessment?.oracleChecks)
-    ? report.assessment.oracleChecks
-    : [];
-  return {
-    passed: checks.filter(
-      (check) =>
-        check &&
-        typeof check === 'object' &&
-        (check as Record<string, unknown>).passed === true,
-    ).length,
-    failed: checks.filter(
-      (check) =>
-        check &&
-        typeof check === 'object' &&
-        (check as Record<string, unknown>).passed === false,
-    ).length,
-  };
-}
-
-function reportCheckRows(
+function reportChecks(
   report: QualificationLabReport | undefined,
-  detail: TuiQualificationReportDetail,
-): Array<{ id: string; passed: boolean; title: string; meaning: string }> {
+): WorkbenchCheck[] {
   const checks = Array.isArray(report?.assessment?.oracleChecks)
     ? report.assessment.oracleChecks
     : [];
@@ -424,100 +188,12 @@ function reportCheckRows(
     const row = check as Record<string, unknown>;
     if (typeof row.id !== 'string' || typeof row.passed !== 'boolean')
       return [];
-    if ((detail === 'correct') !== row.passed) return [];
-    const copy = CHECK_COPY[row.id] ?? {
+    const copy = AGENT_WORK_LAB_CHECKS[row.id] ?? {
       title: row.id.replaceAll('-', ' '),
-      meaning: 'This check came from the canonical continuity assessment.',
+      meaning: 'This check came from the canonical Work assessment.',
     };
     return [{ id: row.id, passed: row.passed, ...copy }];
   });
-}
-
-function ReportDetailPage({
-  dimensions,
-  report,
-  detail,
-}: {
-  dimensions: TerminalDimensions;
-  report: QualificationLabReport;
-  detail: TuiQualificationReportDetail;
-}) {
-  const rows = reportCheckRows(report, detail);
-  const correct = detail === 'correct';
-  return (
-    <Box
-      width={dimensions.columns}
-      height={terminalCanvasRows(dimensions.rows)}
-      flexDirection="column"
-      borderStyle="double"
-      borderColor={correct ? 'green' : 'red'}
-      paddingX={1}
-      overflow="hidden"
-    >
-      <Text bold color={correct ? 'green' : 'red'}>
-        {correct ? '✓ CORRECT CHECKS' : '× FAILED CHECKS'} · {rows.length}
-      </Text>
-      <Text dimColor>
-        Canonical continuity oracle details · private reasoning remains hidden
-      </Text>
-      <Box flexDirection="column" flexGrow={1} minHeight={0} marginTop={1}>
-        {rows.length === 0 ? (
-          <Text color={correct ? 'yellow' : 'green'}>
-            {correct
-              ? 'No correct checks were recorded.'
-              : 'No failed checks. This is the expected result.'}
-          </Text>
-        ) : null}
-        {rows.map((row, index) => (
-          <Box key={row.id} flexDirection="column" marginBottom={1}>
-            <Text bold color={row.passed ? 'green' : 'red'}>
-              {String(index + 1).padStart(2, '0')} {row.passed ? '✓' : '×'}{' '}
-              {row.title}
-            </Text>
-            <Text dimColor>{row.meaning}</Text>
-          </Box>
-        ))}
-      </Box>
-      <Box borderStyle="round" borderColor="cyan" paddingX={1}>
-        <Text bold color="cyan" wrap="truncate-end">
-          ← RETURN TO RESULT CARDS · Esc / Enter / Backspace / b
-        </Text>
-      </Box>
-    </Box>
-  );
-}
-
-function ResultCard({
-  kind,
-  count,
-  active,
-  available,
-}: {
-  kind: TuiQualificationReportDetail;
-  count: number;
-  active: boolean;
-  available: boolean;
-}) {
-  const correct = kind === 'correct';
-  const label = correct ? 'CORRECT' : 'FAILED';
-  const tone = correct || count === 0 ? 'green' : 'red';
-  const cardColor = !available ? 'gray' : active ? 'cyan' : tone;
-  return (
-    <Box
-      width="50%"
-      height={3}
-      borderStyle="round"
-      borderColor={cardColor}
-      paddingX={1}
-      overflow="hidden"
-    >
-      <Text bold color={cardColor} wrap="truncate-end">
-        {active ? '> ' : '  '}
-        {correct ? '✓' : '×'} {count} {label}
-        {available ? ' · Enter details' : ' · waiting'}
-      </Text>
-    </Box>
-  );
 }
 
 export function QualificationLabView({
@@ -537,6 +213,7 @@ export function QualificationLabView({
   runningSession,
   nextPrompt,
   reportDetail,
+  emphasizedResult,
 }: {
   dimensions: TerminalDimensions;
   mode: TuiQualificationMode;
@@ -554,165 +231,370 @@ export function QualificationLabView({
   runningSession?: 1 | 2;
   nextPrompt?: TuiQualificationNextPrompt;
   reportDetail?: TuiQualificationReportDetail;
+  emphasizedResult?: TuiQualificationReportDetail;
 }) {
-  if (report && reportDetail) {
-    return (
-      <ReportDetailPage
-        dimensions={dimensions}
-        report={report}
-        detail={reportDetail}
-      />
-    );
-  }
-  const paneTitleColumns = Math.max(1, Math.floor(dimensions.columns / 2) - 2);
-  const paneTextColumns = Math.max(1, paneTitleColumns - 2);
-  const wrappedRows = (text: string) =>
-    Math.max(1, Math.ceil(text.length / paneTextColumns));
-  const chromeRows =
-    3 +
-    (showHelp ? 1 : 0) +
-    6 +
-    2 +
-    1 +
-    wrappedRows('PUBLIC STATUS · PRIVATE REASONING + RAW OUTPUT HIDDEN') +
-    wrappedRows('↑↓ scroll focused Session · Tab switch · 999 lines back');
-  const viewportRows = Math.max(
-    4,
-    terminalCanvasRows(dimensions.rows) - chromeRows,
-  );
-  const checks = reportChecks(report);
-  const passed = Boolean(report && report.status !== 'failed');
-  const promptWidth = Math.min(
-    dimensions.columns,
-    Math.min(68, Math.max(24, dimensions.columns - 8)),
-  );
-  const promptColumns = Math.max(1, promptWidth - 2);
-  const promptRows = nextPrompt
-    ? qualificationPromptRows(
-        `${nextPrompt.title} · ${nextPrompt.instruction}`,
-        Math.max(1, promptColumns - 2),
-      )
-    : [];
+  const selectedCase = agentWorkLabCase(mode);
   return (
-    <Box
-      width={dimensions.columns}
-      height={terminalCanvasRows(dimensions.rows)}
-      flexDirection="column"
-      overflow="hidden"
-    >
-      <Box paddingX={1} justifyContent="space-between">
-        <Text bold color="cyan">
-          AGENT QUALIFICATION LAB
-        </Text>
-        <Text>{mode}</Text>
-      </Box>
-      <Text wrap="truncate-end">
-        S1 {sourceLabel || 'Bundled Demo Agent'} → governed evidence → S2{' '}
-        {targetLabel || 'Fresh Demo Agent'}
-      </Text>
-      <Text dimColor wrap="truncate-end">
-        [d] demo [j/k] source [brackets] target [x] same [m] handoff [Tab] focus
-        [?] explain [w] Work [q] quit
-      </Text>
-      {showHelp ? (
-        <Text dimColor wrap="truncate-end">
-          Good: fresh Session 2 finds the same Work and continues. Bad: restart,
-          copied chat, lost identity. Live labels are admitted provider events;
-          guide labels are Kungfu previews.
-        </Text>
-      ) : null}
-      <Box flexGrow={1} minHeight={0}>
-        <SessionPane
-          session={1}
-          title={sourceLabel || 'Bundled Demo Agent'}
-          lines={lines}
-          active={activeFocus === 'session-1'}
-          scrollBack={scrollBack[1]}
-          viewportRows={viewportRows}
-          running={Boolean(progress) && runningSession === 1}
-          titleBarColumns={paneTitleColumns}
-          activityFrame={activityFrame}
-        />
-        <SessionPane
-          session={2}
-          title={targetLabel || 'Fresh Demo Agent'}
-          lines={lines}
-          active={activeFocus === 'session-2'}
-          scrollBack={scrollBack[2]}
-          viewportRows={viewportRows}
-          running={Boolean(progress) && runningSession === 2}
-          titleBarColumns={paneTitleColumns}
-          activityFrame={activityFrame}
-        />
-      </Box>
-      <Box
-        height={6}
-        borderStyle="round"
-        borderColor={report ? (passed ? 'green' : 'red') : 'gray'}
-        paddingX={1}
-        flexDirection="column"
-        overflow="hidden"
-      >
-        <Text
-          color={report ? (passed ? 'green' : 'red') : 'yellow'}
-          bold
-          wrap="truncate-end"
-        >
-          {report
-            ? passed
-              ? 'CONTINUITY PROVED'
-              : 'CONTINUITY NOT PROVED'
-            : error ||
-              busy ||
-              progress ||
-              'Ready · choose demo, same-agent, or handoff'}
-        </Text>
-        <Box>
-          <ResultCard
-            kind="correct"
-            count={checks.passed}
-            active={activeFocus === 'correct'}
-            available={Boolean(report)}
-          />
-          <ResultCard
-            kind="failed"
-            count={checks.failed}
-            active={activeFocus === 'failed'}
-            available={Boolean(report)}
-          />
-        </Box>
-      </Box>
-      {nextPrompt ? (
-        <Box
-          position="absolute"
-          width={promptWidth}
-          height={6}
-          marginTop={Math.max(4, Math.floor(dimensions.rows / 2) - 2)}
-          marginLeft={Math.max(
-            2,
-            Math.floor((dimensions.columns - promptWidth) / 2),
-          )}
-          borderStyle="double"
-          borderColor="yellow"
-          flexDirection="column"
-          overflow="hidden"
-        >
-          <Text bold color="yellow" backgroundColor="blue">
-            {opaquePromptLine(' WHAT TO TRY NEXT', promptColumns)}
-          </Text>
-          {promptRows.map((row, index) => (
-            <Text key={`${index}-${row}`} color="white" backgroundColor="blue">
-              {opaquePromptLine(` ${row}`, promptColumns)}
-            </Text>
-          ))}
-          <Text color="white" backgroundColor="blue">
-            {opaquePromptLine(
-              ' Closes automatically in 5 seconds.',
-              promptColumns,
-            )}
-          </Text>
-        </Box>
-      ) : null}
-    </Box>
+    <SessionWorkbench
+      dimensions={dimensions}
+      heading={AGENT_WORK_LAB_SUITE.title}
+      collectionLabel={AGENT_WORK_LAB_SUITE.collection.title}
+      caseLabel={selectedCase.title}
+      relationship="→ governed Work →"
+      controls="[d] demo [j/k] source [brackets] target [x] same [m] handoff [Tab] focus [?] explain [w] Work [q] quit"
+      help={`${selectedCase.description} Good: a fresh Session 2 finds the same Work and continues. Bad: restart, copied chat, or lost identity.`}
+      sourceLabel={sourceLabel || 'Bundled Demo Agent'}
+      targetLabel={targetLabel || 'Fresh Demo Agent'}
+      lines={lines}
+      checks={reportChecks(report)}
+      reportAvailable={Boolean(report)}
+      reportPassed={Boolean(report && report.status !== 'failed')}
+      verdictSuccess="WORK CONTINUITY PROVED"
+      verdictFailure="WORK CONTINUITY NOT PROVED"
+      detailCaption="Canonical Work continuity checks · sensitive internals remain hidden"
+      busy={busy}
+      progress={progress}
+      error={error}
+      activeFocus={activeFocus}
+      scrollBack={scrollBack}
+      showHelp={showHelp}
+      activityFrame={activityFrame}
+      runningSession={runningSession}
+      nextPrompt={nextPrompt}
+      reportDetail={reportDetail}
+      emphasizedResult={emphasizedResult}
+    />
+  );
+}
+
+type DimensionSource = {
+  get(): TerminalDimensions;
+  subscribe(listener: (dimensions: TerminalDimensions) => void): () => void;
+};
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+export function AgentWorkLabHost({
+  lab,
+  startup,
+  dimensions,
+  onOpenWork,
+}: {
+  lab: QualificationLab;
+  startup: QualificationLabStartupRoute;
+  dimensions: DimensionSource;
+  onOpenWork?: () => void;
+}) {
+  const { exit } = useApp();
+  const [size, setSize] = React.useState(dimensions.get());
+  const [agents, setAgents] = React.useState<
+    Awaited<ReturnType<QualificationLab['discoverAgents']>> | undefined
+  >();
+  const [mode, setMode] = React.useState<TuiQualificationMode>('offline-demo');
+  const [selected, setSelected] = React.useState(0);
+  const [target, setTarget] = React.useState(0);
+  const [report, setReport] = React.useState<QualificationLabReport>();
+  const [lines, setLines] = React.useState<
+    ReturnType<typeof qualificationEventLines>
+  >([]);
+  const [activeFocus, setActiveFocus] =
+    React.useState<TuiQualificationFocus>('session-1');
+  const [reportDetail, setReportDetail] =
+    React.useState<TuiQualificationReportDetail>();
+  const [emphasizedResult, setEmphasizedResult] =
+    React.useState<TuiQualificationReportDetail>();
+  const [nextPrompt, setNextPrompt] =
+    React.useState<TuiQualificationNextPrompt>();
+  const [scrollBack, setScrollBack] = React.useState<Record<1 | 2, number>>({
+    1: 0,
+    2: 0,
+  });
+  const [showHelp, setShowHelp] = React.useState(false);
+  const [busy, setBusy] = React.useState('');
+  const [error, setError] = React.useState('');
+  const [runProgress, setRunProgress] = React.useState<{
+    startedAt: number;
+    lastEventAt: number;
+    eventCount: number;
+    phase: 'running' | 'assessing';
+  }>();
+  const [runningSession, setRunningSession] = React.useState<1 | 2>();
+  const [progressNow, setProgressNow] = React.useState(() => Date.now());
+  const playbackGeneration = React.useRef(0);
+  const profiles = React.useMemo(
+    () =>
+      Array.from(
+        new Map(
+          [
+            ...(agents?.configured ?? []),
+            ...(agents?.discovered.map((row) => row.profile) ?? []),
+          ].map((profile) => [profile.id, profile]),
+        ).values(),
+      ),
+    [agents],
+  );
+  const discover = React.useCallback(async () => {
+    setBusy('discovering agents');
+    try {
+      setAgents(await lab.discoverAgents());
+      setError('');
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      setBusy('');
+    }
+  }, [lab]);
+  React.useEffect(() => {
+    void discover();
+  }, [discover]);
+  React.useEffect(
+    () => dimensions.subscribe((next) => setSize(next)),
+    [dimensions],
+  );
+  React.useEffect(() => {
+    if (!runProgress) return undefined;
+    setProgressNow(Date.now());
+    const timer = setInterval(
+      () => setProgressNow(Date.now()),
+      AGENT_WORK_LAB_SUITE.timing.quietProgressIntervalMs,
+    );
+    return () => clearInterval(timer);
+  }, [runProgress]);
+  React.useEffect(() => {
+    if (!nextPrompt) return undefined;
+    const timer = setTimeout(
+      () => setNextPrompt(undefined),
+      AGENT_WORK_LAB_SUITE.timing.recommendationDurationMs,
+    );
+    return () => clearTimeout(timer);
+  }, [nextPrompt]);
+  const runQualification = React.useCallback(
+    (
+      nextMode: TuiQualificationMode,
+      execute: (
+        onEvent: Parameters<QualificationLab['runDemo']>[0],
+      ) => Promise<QualificationLabReport>,
+    ) => {
+      const generation = playbackGeneration.current + 1;
+      playbackGeneration.current = generation;
+      const selectedCase = agentWorkLabCase(nextMode);
+      setMode(nextMode);
+      setBusy(selectedCase.runLabel);
+      setReport(undefined);
+      setLines([]);
+      setActiveFocus('session-1');
+      setReportDetail(undefined);
+      setEmphasizedResult(undefined);
+      setNextPrompt(undefined);
+      setScrollBack({ 1: 0, 2: 0 });
+      setError('');
+      const startedAt = Date.now();
+      setProgressNow(startedAt);
+      setRunProgress({
+        startedAt,
+        lastEventAt: startedAt,
+        eventCount: 0,
+        phase: 'running',
+      });
+      setRunningSession(1);
+      const playback = createIncrementalPlayback<QualificationLabEvent>({
+        timing: AGENT_WORK_LAB_SUITE.timing,
+        isCurrent: () => playbackGeneration.current === generation,
+        onEvent: (event) => {
+          setRunningSession(qualificationEventRunningSession(event));
+          setLines((current) => [
+            ...current,
+            ...qualificationEventLines(event),
+          ]);
+          setRunProgress((current) =>
+            current
+              ? {
+                  ...current,
+                  lastEventAt: Date.now(),
+                  eventCount: current.eventCount + 1,
+                }
+              : current,
+          );
+        },
+        onAssessing: () => {
+          setRunningSession(undefined);
+          setRunProgress((current) =>
+            current ? { ...current, phase: 'assessing' } : current,
+          );
+        },
+      });
+      void execute((event) => playback.enqueue(event))
+        .then(async (value) => {
+          if (!(await playback.finish())) return;
+          setReport(value);
+          setActiveFocus('correct');
+          setEmphasizedResult('correct');
+          await wait(AGENT_WORK_LAB_SUITE.timing.verdictIntervalMs);
+          if (playbackGeneration.current !== generation) return;
+          setEmphasizedResult('failed');
+          await wait(AGENT_WORK_LAB_SUITE.timing.verdictIntervalMs);
+          if (playbackGeneration.current !== generation) return;
+          setEmphasizedResult(undefined);
+          setNextPrompt(qualificationNextModePrompt(nextMode));
+          setError('');
+        })
+        .catch((reason) => {
+          playback.cancel();
+          if (playbackGeneration.current !== generation) return;
+          setError(reason instanceof Error ? reason.message : String(reason));
+        })
+        .finally(() => {
+          if (playbackGeneration.current === generation) {
+            setBusy('');
+            setRunProgress(undefined);
+            setRunningSession(undefined);
+          }
+        });
+    },
+    [],
+  );
+  React.useEffect(() => {
+    const onData = (chunk: Buffer | string) => {
+      const input = String(chunk);
+      if (reportDetail && isQualificationReportReturnInput(input)) {
+        return setReportDetail(undefined);
+      }
+      const key = decodeShellKey(input);
+      if (key === 'quit') return exit();
+      if (input === '\t')
+        return setActiveFocus((current) =>
+          nextQualificationFocus(current, Boolean(report)),
+        );
+      if (
+        report &&
+        (input === '\r' || input === '\n') &&
+        (activeFocus === 'correct' || activeFocus === 'failed')
+      ) {
+        return setReportDetail(activeFocus);
+      }
+      const focusedSession =
+        activeFocus === 'session-1'
+          ? 1
+          : activeFocus === 'session-2'
+            ? 2
+            : undefined;
+      if (input === '\u001b[A' && focusedSession)
+        return setScrollBack((current) => ({
+          ...current,
+          [focusedSession]: current[focusedSession] + 1,
+        }));
+      if (input === '\u001b[B' && focusedSession)
+        return setScrollBack((current) => ({
+          ...current,
+          [focusedSession]: Math.max(0, current[focusedSession] - 1),
+        }));
+      if (input === '?') return setShowHelp((current) => !current);
+      if (key === 'next-card')
+        return setSelected((current) =>
+          boundedIndex(current, 1, profiles.length),
+        );
+      if (key === 'previous-card')
+        return setSelected((current) =>
+          boundedIndex(current, -1, profiles.length),
+        );
+      if (input === ']')
+        return setTarget((current) =>
+          boundedIndex(current, 1, profiles.length),
+        );
+      if (input === '[')
+        return setTarget((current) =>
+          boundedIndex(current, -1, profiles.length),
+        );
+      if (input === 'w' && onOpenWork) return onOpenWork();
+      if (input === 'd' && !busy) {
+        return runQualification('offline-demo', (onEvent) =>
+          lab.runDemo(onEvent),
+        );
+      }
+      if (input === 'x' && !busy && profiles[selected]) {
+        return runQualification('same-agent', (onEvent) =>
+          lab.runAgent(profiles[selected].id, onEvent),
+        );
+      }
+      if (
+        input === 'm' &&
+        !busy &&
+        profiles[selected] &&
+        profiles[target] &&
+        selected !== target
+      ) {
+        return runQualification('cross-agent', (onEvent) =>
+          lab.runMigration(profiles[selected].id, profiles[target].id, onEvent),
+        );
+      }
+    };
+    process.stdin.on('data', onData);
+    return () => {
+      process.stdin.off('data', onData);
+    };
+  }, [
+    busy,
+    activeFocus,
+    exit,
+    lab,
+    onOpenWork,
+    profiles,
+    report,
+    reportDetail,
+    selected,
+    target,
+    runQualification,
+  ]);
+  const sourceLabel =
+    mode === 'offline-demo' ? '' : profiles[selected]?.label || '';
+  const targetLabel =
+    mode === 'offline-demo'
+      ? ''
+      : mode === 'same-agent'
+        ? sourceLabel
+        : profiles[target]?.label || '';
+  const progress = runProgress
+    ? qualificationRunProgressLabel({
+        elapsedMs: progressNow - runProgress.startedAt,
+        quietMs: progressNow - runProgress.lastEventAt,
+        eventCount: runProgress.eventCount,
+        phase: runProgress.phase,
+      })
+    : '';
+  return (
+    <QualificationLabView
+      dimensions={size}
+      mode={mode}
+      sourceLabel={sourceLabel}
+      targetLabel={targetLabel}
+      lines={lines}
+      report={report}
+      busy={busy}
+      progress={progress}
+      error={
+        error ||
+        (startup.route === 'diagnostic'
+          ? `${startup.state} · ${startup.reasonCode}`
+          : '')
+      }
+      activeFocus={activeFocus}
+      scrollBack={scrollBack}
+      showHelp={showHelp}
+      activityFrame={
+        runProgress
+          ? Math.floor(
+              (progressNow - runProgress.startedAt) /
+                AGENT_WORK_LAB_SUITE.timing.quietProgressIntervalMs,
+            )
+          : 0
+      }
+      runningSession={runningSession}
+      nextPrompt={nextPrompt}
+      reportDetail={reportDetail}
+      emphasizedResult={emphasizedResult}
+    />
   );
 }

--- a/framework/tui/src/qualification-lab-view.tsx
+++ b/framework/tui/src/qualification-lab-view.tsx
@@ -18,6 +18,7 @@ import { useApp } from 'ink';
 import React from 'react';
 import { boundedIndex, decodeShellKey } from './navigation.js';
 import {
+  type QuickCommand,
   SessionWorkbench,
   type TerminalDimensions,
   type WorkbenchCheck,
@@ -38,6 +39,63 @@ export type TuiQualificationReportDetail = WorkbenchReportDetail;
 export type TuiQualificationNextPrompt = WorkbenchNextPrompt;
 export type TuiQualificationLine = WorkbenchLine;
 
+export type AgentWorkLabSuiteAction =
+  | 'lab-demo'
+  | 'lab-same'
+  | 'lab-handoff'
+  | 'lab-report'
+  | 'lab-focus-next';
+
+export type AgentWorkLabActionRequest = {
+  id: number;
+  action: AgentWorkLabSuiteAction;
+};
+
+export const AGENT_WORK_LAB_QUICK_COMMANDS: QuickCommand<AgentWorkLabSuiteAction>[] =
+  [
+    {
+      id: 'lab-demo',
+      command: '/demo',
+      title: 'Run Offline Demo',
+      summary: 'Show the two-Session continuity experiment without an Agent.',
+      action: 'lab-demo',
+    },
+    {
+      id: 'lab-same',
+      command: '/same',
+      title: 'Test Same Agent',
+      summary: 'Run two fresh Sessions with the selected Agent provider.',
+      action: 'lab-same',
+    },
+    {
+      id: 'lab-handoff',
+      command: '/handoff',
+      title: 'Test Agent Handoff',
+      summary: 'Continue the same Work with a different Agent provider.',
+      action: 'lab-handoff',
+    },
+    {
+      id: 'lab-report',
+      command: '/report',
+      title: 'Open Latest Report',
+      summary: 'Open the strongest result detail from the completed test.',
+      action: 'lab-report',
+    },
+    {
+      id: 'lab-focus-next',
+      command: '/focus',
+      title: 'Move Lab Focus',
+      summary: 'Move focus across Session windows and available result cards.',
+      action: 'lab-focus-next',
+    },
+  ];
+
+export function agentWorkLabActionReturnsToControls(
+  action: AgentWorkLabSuiteAction,
+): boolean {
+  return action === 'lab-report';
+}
+
 export const nextQualificationFocus = nextWorkbenchFocus;
 export const isQualificationReportReturnInput = isWorkbenchReturnInput;
 export const qualificationSessionTitleBar = sessionTitleBar;
@@ -49,9 +107,9 @@ export function qualificationNextModePrompt(
   const recommendation = agentWorkLabRecommendation(mode);
   const shortcut =
     recommendation.nextCase === 'same-agent'
-      ? ' Press x to start it.'
+      ? ' Run /same, or press Esc then x.'
       : recommendation.nextCase === 'cross-agent'
-        ? ' Choose a different target with [ or ], then press m.'
+        ? ' Run /handoff, or press Esc, choose a target with [ or ], then press m.'
         : '';
   return {
     title: recommendation.title,
@@ -283,12 +341,16 @@ export function AgentWorkLabHost({
   dimensions,
   onOpenWork,
   isInputCaptured = () => false,
+  actionRequest,
+  onActionHandled,
 }: {
   lab: QualificationLab;
   startup: QualificationLabStartupRoute;
   dimensions: DimensionSource;
   onOpenWork?: () => void;
   isInputCaptured?: () => boolean;
+  actionRequest?: AgentWorkLabActionRequest;
+  onActionHandled?: (id: number) => void;
 }) {
   const { exit } = useApp();
   const [size, setSize] = React.useState(dimensions.get());
@@ -326,6 +388,7 @@ export function AgentWorkLabHost({
   const [runningSession, setRunningSession] = React.useState<1 | 2>();
   const [progressNow, setProgressNow] = React.useState(() => Date.now());
   const playbackGeneration = React.useRef(0);
+  const handledActionRequest = React.useRef(0);
   const profiles = React.useMemo(
     () =>
       Array.from(
@@ -458,6 +521,70 @@ export function AgentWorkLabHost({
     },
     [],
   );
+  const performSuiteAction = React.useCallback(
+    (action: AgentWorkLabSuiteAction) => {
+      if (action === 'lab-focus-next') {
+        setActiveFocus((current) =>
+          nextQualificationFocus(current, Boolean(report)),
+        );
+        return;
+      }
+      if (action === 'lab-report') {
+        if (!report) {
+          setError('No report yet. Run /demo, /same, or /handoff first.');
+          return;
+        }
+        const detail = reportChecks(report).some((check) => !check.passed)
+          ? 'failed'
+          : 'correct';
+        setActiveFocus(detail);
+        setReportDetail(detail);
+        setError('');
+        return;
+      }
+      if (busy) {
+        setError('A Lab test is already running.');
+        return;
+      }
+      if (action === 'lab-demo') {
+        runQualification('offline-demo', (onEvent) => lab.runDemo(onEvent));
+        return;
+      }
+      const source = profiles[selected];
+      if (!source) {
+        setError('No configured Agent is available for this test.');
+        return;
+      }
+      if (action === 'lab-same') {
+        runQualification('same-agent', (onEvent) =>
+          lab.runAgent(source.id, onEvent),
+        );
+        return;
+      }
+      const destination = profiles[target];
+      if (!destination) {
+        setError('Choose an available handoff target first.');
+        return;
+      }
+      if (source.id === destination.id) {
+        setError(
+          'Handoff needs two different Agents. Choose the target in LAB CONTROLS.',
+        );
+        return;
+      }
+      runQualification('cross-agent', (onEvent) =>
+        lab.runMigration(source.id, destination.id, onEvent),
+      );
+    },
+    [busy, lab, profiles, report, runQualification, selected, target],
+  );
+  React.useEffect(() => {
+    if (!actionRequest || actionRequest.id <= handledActionRequest.current)
+      return;
+    handledActionRequest.current = actionRequest.id;
+    performSuiteAction(actionRequest.action);
+    onActionHandled?.(actionRequest.id);
+  }, [actionRequest, onActionHandled, performSuiteAction]);
   React.useEffect(() => {
     const onData = (chunk: Buffer | string) => {
       if (isInputCaptured()) return;
@@ -467,10 +594,7 @@ export function AgentWorkLabHost({
       }
       const key = decodeShellKey(input);
       if (key === 'quit') return exit();
-      if (input === '\t')
-        return setActiveFocus((current) =>
-          nextQualificationFocus(current, Boolean(report)),
-        );
+      if (input === '\t') return performSuiteAction('lab-focus-next');
       if (
         report &&
         (input === '\r' || input === '\n') &&
@@ -512,45 +636,23 @@ export function AgentWorkLabHost({
           boundedIndex(current, -1, profiles.length),
         );
       if (input === 'w' && onOpenWork) return onOpenWork();
-      if (input === 'd' && !busy) {
-        return runQualification('offline-demo', (onEvent) =>
-          lab.runDemo(onEvent),
-        );
-      }
-      if (input === 'x' && !busy && profiles[selected]) {
-        return runQualification('same-agent', (onEvent) =>
-          lab.runAgent(profiles[selected].id, onEvent),
-        );
-      }
-      if (
-        input === 'm' &&
-        !busy &&
-        profiles[selected] &&
-        profiles[target] &&
-        selected !== target
-      ) {
-        return runQualification('cross-agent', (onEvent) =>
-          lab.runMigration(profiles[selected].id, profiles[target].id, onEvent),
-        );
-      }
+      if (input === 'd') return performSuiteAction('lab-demo');
+      if (input === 'x') return performSuiteAction('lab-same');
+      if (input === 'm') return performSuiteAction('lab-handoff');
     };
     process.stdin.on('data', onData);
     return () => {
       process.stdin.off('data', onData);
     };
   }, [
-    busy,
     activeFocus,
     exit,
     isInputCaptured,
-    lab,
     onOpenWork,
+    performSuiteAction,
     profiles,
     report,
     reportDetail,
-    selected,
-    target,
-    runQualification,
   ]);
   const sourceLabel =
     mode === 'offline-demo' ? '' : profiles[selected]?.label || '';

--- a/framework/tui/src/work-control-contribution.ts
+++ b/framework/tui/src/work-control-contribution.ts
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Profile } from '@kungfu-tech/api/capability';
+import type { ChildProcessByStdio } from 'node:child_process';
+import type { Readable } from 'node:stream';
+
+import type {
+  GlobalWorkSnapshot,
+  ProductSearchDocument,
+  Profile,
+} from '@kungfu-tech/api/capability';
+import {
+  globalWorkSearchDocuments,
+  parseGlobalWorkSnapshot,
+} from '@kungfu-tech/api/capability';
 import type { KfxLoadPlan } from '@kungfu-tech/kfx';
 
 import type { ProfileShellModel } from './profile-shell.js';
@@ -178,5 +189,242 @@ export function degradedWorkControlModel(error: unknown): ProfileShellModel {
     cards: [],
     evidence: [],
     notice: message,
+  };
+}
+
+type ObserverChild = ChildProcessByStdio<null, Readable, Readable>;
+
+export type GlobalWorkContribution = {
+  model: ProfileShellModel;
+  searchDocuments: ProductSearchDocument[];
+};
+
+export type GlobalWorkObserverDeps = {
+  bin: string;
+  env: NodeJS.ProcessEnv;
+  statePath: string;
+  spawn: (
+    file: string,
+    args: string[],
+    options: { env: NodeJS.ProcessEnv; stdio: ['ignore', 'pipe', 'pipe'] },
+  ) => ObserverChild;
+  onSnapshot: (snapshot: GlobalWorkSnapshot) => void;
+  onError: (error: Error) => void;
+};
+
+export function globalWorkContribution(
+  snapshot: GlobalWorkSnapshot,
+): GlobalWorkContribution {
+  const rows = snapshot.global_work.visible_work;
+  const initiativeCount = rows.filter(
+    (row) => row.object_kind === 'initiative',
+  ).length;
+  const assignmentCount = rows.filter(
+    (row) => row.object_kind === 'assignment',
+  ).length;
+  const state = snapshot.aggregate.state ?? 'unknown';
+  const verified = snapshot.verification?.ok === true;
+  return {
+    model: {
+      profile: {
+        id: 'kungfu.global-work',
+        title: 'Work',
+        version: 'Global Portfolio',
+        suiteRoot: snapshot.global_work.projection_root ?? '',
+        qualified: verified,
+        qualificationLabel: 'Global proof',
+      },
+      subject: {
+        id: 'portfolio',
+        title: `Portfolio · ${rows.length} current work items`,
+        subtitle: `${initiativeCount} Initiatives · ${assignmentCount} Assignments · ${snapshot.aggregate.component_count ?? 0} local workspaces`,
+      },
+      navigation: [
+        {
+          id: 'portfolio',
+          label: 'Global Portfolio',
+          status: state,
+        },
+      ],
+      cards: rows.map((row) => {
+        const status =
+          row.display.status?.trim() ||
+          row.display.portfolio_state?.trim() ||
+          'open';
+        const next = (row.display.next_actions ?? []).filter(Boolean);
+        return {
+          id: row.canonical_root,
+          title: row.display.title?.trim() || row.subject || row.canonical_root,
+          status: row.conflict ? 'degraded' : status,
+          summary: [
+            row.object_kind,
+            row.subject,
+            next.length > 0 ? `Next: ${next.join(' · ')}` : '',
+          ]
+            .filter(Boolean)
+            .join(' · '),
+        };
+      }),
+      evidence: [
+        {
+          label: 'query proof',
+          value: snapshot.proof?.proof_root ?? '',
+        },
+        {
+          label: 'projection',
+          value: snapshot.global_work.projection_root ?? '',
+        },
+        {
+          label: 'available workspaces',
+          value: String(snapshot.aggregate.available_component_count ?? 0),
+        },
+      ],
+      notice:
+        state === 'complete'
+          ? undefined
+          : `${state} Portfolio · ${snapshot.aggregate.unknown_component_count ?? 0} workspace observations unknown`,
+    },
+    searchDocuments: globalWorkSearchDocuments(snapshot),
+  };
+}
+
+export function degradedGlobalWorkModel(error: unknown): ProfileShellModel {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    profile: {
+      id: 'kungfu.global-work',
+      title: 'Work',
+      version: 'Global Portfolio',
+      suiteRoot: '',
+      qualified: false,
+      qualificationLabel: 'Global proof',
+    },
+    subject: {
+      id: 'portfolio',
+      title: 'Global Portfolio unavailable',
+      subtitle: 'No mutation was attempted.',
+    },
+    navigation: [],
+    cards: [],
+    evidence: [],
+    notice: message,
+  };
+}
+
+export function loadLatestGlobalWorkCache(
+  readFile: (path: string) => string,
+  paths: string[],
+): GlobalWorkSnapshot | null {
+  const snapshots: GlobalWorkSnapshot[] = [];
+  for (const candidate of paths) {
+    try {
+      snapshots.push(parseGlobalWorkSnapshot(JSON.parse(readFile(candidate))));
+    } catch {
+      // A missing, partial, or old cache never blocks the live observer.
+    }
+  }
+  return (
+    snapshots.sort((left, right) =>
+      (right.observed_at ?? '').localeCompare(left.observed_at ?? ''),
+    )[0] ?? null
+  );
+}
+
+export function parseGlobalWorkObserverLine(
+  line: string,
+): GlobalWorkSnapshot | Error | null {
+  try {
+    const value = JSON.parse(line) as {
+      schema?: string;
+      kind?: string;
+      error?: string;
+    };
+    if (
+      value.schema !== 'kungfu.gui.global-work-observer-event/v1' ||
+      (value.kind !== 'snapshot' && value.kind !== 'error')
+    ) {
+      return null;
+    }
+    if (value.kind === 'error') {
+      return new Error(value.error || 'global Work observer failed');
+    }
+    return parseGlobalWorkSnapshot(value);
+  } catch {
+    return null;
+  }
+}
+
+export function startGlobalWorkObserver(
+  deps: GlobalWorkObserverDeps,
+): () => void {
+  let child: ObserverChild | null = null;
+  let restartTimer: NodeJS.Timeout | null = null;
+  let stopped = false;
+
+  const start = () => {
+    if (stopped || child) return;
+    let stdout = '';
+    let stderr = '';
+    const launched = deps.spawn(
+      deps.bin,
+      [
+        'workspace',
+        'work',
+        '--scope',
+        'all',
+        '--max-workers',
+        '8',
+        '--observe',
+        '--observer-state',
+        deps.statePath,
+        '--json',
+      ],
+      {
+        env: { ...deps.env, PYTHONDONTWRITEBYTECODE: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    child = launched;
+    launched.stdout.on('data', (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+      for (;;) {
+        const newline = stdout.indexOf('\n');
+        if (newline < 0) break;
+        const line = stdout.slice(0, newline).trim();
+        stdout = stdout.slice(newline + 1);
+        if (!line) continue;
+        const value = parseGlobalWorkObserverLine(line);
+        if (value instanceof Error) deps.onError(value);
+        else if (value) deps.onSnapshot(value);
+      }
+    });
+    launched.stderr.on('data', (chunk: Buffer | string) => {
+      stderr = `${stderr}${chunk.toString()}`.slice(-8192);
+    });
+    launched.on('error', deps.onError);
+    launched.on('exit', (_code, signal) => {
+      if (child !== launched) return;
+      child = null;
+      if (stopped) return;
+      deps.onError(
+        new Error(
+          stderr.trim() ||
+            `global Work observer exited${signal ? ` (${signal})` : ''}`,
+        ),
+      );
+      restartTimer = setTimeout(() => {
+        restartTimer = null;
+        start();
+      }, 1000);
+    });
+  };
+
+  start();
+  return () => {
+    stopped = true;
+    if (restartTimer) clearTimeout(restartTimer);
+    restartTimer = null;
+    child?.kill('SIGTERM');
+    child = null;
   };
 }

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -259,6 +259,7 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
   fs.writeFileSync(operatorCatalog, operatorBytes);
 
   const invocations = [];
+  let capturedRequest;
   runInstalledKungfuAssignmentAdmissionSmoke({
     installRoot,
     kungfuBin: path.join(installRoot, 'kungfu'),
@@ -276,6 +277,10 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
         'catalog.json',
       );
       if (invocation.args.includes('capture')) {
+        const requestIndex = invocation.args.indexOf('--request');
+        capturedRequest = JSON.parse(
+          fs.readFileSync(invocation.args[requestIndex + 1], 'utf8'),
+        );
         fs.mkdirSync(path.dirname(isolatedCatalog), { recursive: true });
         fs.writeFileSync(
           isolatedCatalog,
@@ -303,6 +308,14 @@ test('Assignment admission smoke isolates the operator Workspace Catalog', (t) =
   });
 
   assert.equal(fs.readFileSync(operatorCatalog, 'utf8'), operatorBytes);
+  assert.equal(
+    capturedRequest.workDefinition.initiative_id,
+    'installed-product-qualification',
+  );
+  assert.equal(
+    capturedRequest.workDefinition.assignment_id,
+    'installed-product-admission-smoke',
+  );
   assert.equal(invocations.length, 2);
   assert.deepEqual(
     invocations.map(({ args }) => args.slice(0, 2)),

--- a/scripts/run-kfx-profile-suite-tests.mjs
+++ b/scripts/run-kfx-profile-suite-tests.mjs
@@ -38,7 +38,7 @@ run('GUI Profile navigation projection', 'pnpm', [
   path.join(root, 'framework/gui/src/navigation.test.ts'),
 ]);
 
-run('GUI Agent Qualification Lab visual contract', 'pnpm', [
+run('GUI Agent Work Lab visual contract', 'pnpm', [
   '--filter',
   '@kungfu-tech/tui',
   'exec',

--- a/scripts/run-kfx-profile-suite-tests.mjs
+++ b/scripts/run-kfx-profile-suite-tests.mjs
@@ -47,6 +47,15 @@ run('GUI Agent Work Lab visual contract', 'pnpm', [
   path.join(root, 'framework/gui/src/qualification-lab.test.ts'),
 ]);
 
+run('GUI product search contract', 'pnpm', [
+  '--filter',
+  '@kungfu-tech/tui',
+  'exec',
+  'tsx',
+  '--test',
+  path.join(root, 'framework/gui/src/product-search.test.ts'),
+]);
+
 run('GUI KFX shared-module contract', 'pnpm', [
   '--filter',
   '@kungfu-tech/tui',

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -507,7 +507,10 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
   const guiTypeScript = files.filter(
     (file) => file.startsWith('framework/gui/src/') && /\.tsx?$/.test(file),
   );
-  if (guiTypeScript.length) {
+  if (
+    guiTypeScript.length &&
+    process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE !== '1'
+  ) {
     plan.push({
       label: 'changed GUI TypeScript check',
       command: process.execPath,

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -457,6 +457,29 @@ test('changed GUI TypeScript receives a file-scoped semantic check', () => {
   ]);
 });
 
+test('cold read-only source acceptance skips dependency-backed GUI TypeScript', () => {
+  const previous = process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE;
+  process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE = '1';
+  try {
+    const plan = sourceAcceptancePlan([
+      'framework/gui/src/renderer/src/runtime.ts',
+    ]);
+    assert.equal(
+      plan.some((step) => step.label === 'changed GUI TypeScript check'),
+      false,
+    );
+  } finally {
+    if (previous === undefined) {
+      Reflect.deleteProperty(
+        process.env,
+        'KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE',
+      );
+    } else {
+      process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE = previous;
+    }
+  }
+});
+
 test('RocksDB source archive keeps an explicit tar filename', () => {
   const recipe = fs.readFileSync(
     path.join(ROOT, 'framework/core/.conan/recipes/rocksdb/conanfile.py'),


### PR DESCRIPTION
## Summary

- introduce Agent Work Lab as a reusable KFX Suite with shared TUI framework primitives
- add the interactive TUI command plane and aligned GUI/TUI Work search
- open Assignment search results in the exact Work detail view and keep Profile refresh non-blocking
- extend the accepted local artifact catalog decision with an explicitly unqualified preview promotion path

## Verification

- project-cut merge queue admission: qualified
- Agent Work Lab and Profile Suite contract tests: passed
- GUI product search tests: 4 passed
- semantic amplification tests: 5 passed
- complete product dist and installed CLI smoke: passed before the final rebase
- full shifu check: all affected gates passed; the existing canonical-policy mismatch remains outside this branch diff

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-019f86da-4f90-7885-9597-bfdcb4fd4453"],
  "summary": "Deliver the Agent Work Lab product experience and the bounded preview promotion path used for local review.",
  "verification": ["Project Cut merge queue admission", "Agent Work Lab and Profile Suite contract tests", "GUI product search regression tests", "semantic amplification checks", "complete local product distribution and installed CLI smoke"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The preview path remains explicitly unqualified and does not create release or publication authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated for the preview promotion semantics