### PR TITLE
fix(release): grant reusable promotion permissions

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -123,12 +123,14 @@ jobs:
     needs: promotion-contract
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     permissions:
-      actions: read
+      actions: write
       artifact-metadata: write
       attestations: write
+      checks: write
       contents: write
       issues: write
       id-token: write
+      pull-requests: write
     uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@c83cb444d79c2e647de6e12a0bfde68dfaf57701 # v3.0.2-alpha.7 auditable demo + Linux attestation + safe notarization diagnostics
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -2178,7 +2178,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:3ed3d37fb3b7518c0d6345809deff70bf7b4fdf5102f99597559918e705e86dd",
+          "definitionDigest": "sha256:54f82c0f9d9821a54a059d599c6ab2271d1616bd453e8491a5219d258c292fe4",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:13bba3d8469c4ec5d50acd2dd380832cbd42808c287642fc5cfe82b423260628",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:3bae5430b2ad23f81c660863e370afd847632e0a215ed3fcf65d43cd63018ff6",
+  "sourceRoot": "sha256:b781cc85ea58882668857201b28819d0935cc0b151dfe4dca3c1a866f7a67d72",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1011,9 +1011,9 @@
         },
         {
           "path": ".github/workflows/release-new-version.yml",
-          "currentLines": 384,
+          "currentLines": 386,
           "baselineLines": 362,
-          "currentRoot": "sha256:40b02a006d82a6b1bab1ec08d1ef15139a6c96659fc94b6443da49c158e6c806",
+          "currentRoot": "sha256:92b331d7748c6ffa1cbac43020b794acd790a88dfbc8ace99592b6d062ab11cc",
           "baselineRoot": "sha256:3bdd847c80a05030de1d826282cef2e76a85e31dc0904df02c7f0cdda7a5eb74",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -228,7 +228,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:40b02a006d82a6b1bab1ec08d1ef15139a6c96659fc94b6443da49c158e6c806"
+          "sourceRoot": "sha256:92b331d7748c6ffa1cbac43020b794acd790a88dfbc8ace99592b6d062ab11cc"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:a22b3dda63e68a8197a4f6dc1db8a684c25b23d433684d0255cfcffbe90e434e"
+  "registryRoot": "sha256:74db4089f0dbcb967326bc59fe71f54607f41ce36f1cbd724bf7b5d7bc488112"
 }

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -101,6 +101,18 @@ test('Linux artifact attestation subject and provider permissions fail closed on
   );
 });
 
+test('promotion caller grants the write permissions required by Buildchain', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, CONTRACT.workflows.promotion),
+    'utf8',
+  );
+  const promote = extractWorkflowJob(workflow, 'promote');
+  assert.ok(promote);
+  for (const permission of ['actions', 'checks', 'pull-requests']) {
+    assert.match(promote, new RegExp(`^      ${permission}: write$`, 'mu'));
+  }
+});
+
 test('promotion rejects an event-scoped Buildchain runtime override', () => {
   const promotionPath = CONTRACT.workflows.promotion;
   const original = fs.readFileSync(path.join(ROOT, promotionPath), 'utf8');


### PR DESCRIPTION
## Summary

Fix the Alpha/Release publication workflow startup failure by granting the exact caller permissions required by the pinned Buildchain reusable workflow.

## Related issue

KFD support governance release closeout.

## Changes

- grant `actions: write`, `checks: write`, and `pull-requests: write` to the `promote` reusable-workflow caller
- refresh the governed workflow-authority projection
- add a regression assertion for the Buildchain caller permission contract

## Verification

- `actionlint .github/workflows/release-new-version.yml`
- `node scripts/kungfu-workflow-authority.mjs --check`
- `node --test scripts/release-promotion-rehearsal.test.mjs` (15 passed)
- complete staged pre-commit gate, including KFD support matrix and negative fixtures

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This restores the permissions already required by the pinned Buildchain release contract and does not change product or architecture semantics."}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to GitHub Actions job permissions and is validated against the pinned reusable workflow permission request.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation projection updated for changed workflow authority
