### PR TITLE
fix(ci): bind cache measurement to current profile

### DIFF
--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -161,6 +161,13 @@ test('portable-off qualification profile covers every native Build lane', () => 
     'utf8',
   );
   assert.equal(buildWorkflow.split(`sha256:${digest}`).length - 1, 2);
+  assert.match(
+    fs.readFileSync(
+      path.join(ROOT, 'scripts/measure-layer-gate-baseline.ps1'),
+      'utf8',
+    ),
+    new RegExp(`SHIFU_CACHE_PROFILE_DIGEST = 'sha256:${digest}'`, 'u'),
+  );
 });
 
 for (const [label, args, source] of [

--- a/scripts/measure-layer-gate-baseline.ps1
+++ b/scripts/measure-layer-gate-baseline.ps1
@@ -17,7 +17,7 @@ if (-not $RunLabel) {
 }
 
 $env:SHIFU_CACHE_PROFILE_REF = 'docs/shifu/qualification-portable-off.cache-profile.json'
-$env:SHIFU_CACHE_PROFILE_DIGEST = 'sha256:251ecdb33a34b770a6fbd40b0b05c5c8c0d629a06d9144e6d2d89c9c8e70258b'
+$env:SHIFU_CACHE_PROFILE_DIGEST = 'sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c'
 $env:SHIFU_CACHE_SCOPE = 'self-hosted-runner'
 $env:KUNGFU_BUILDCHAIN_NO_OPTIONAL = '1'
 $env:KUNGFU_BUILDCHAIN_SOURCE_BUILD = '1'


### PR DESCRIPTION
## Summary

- Bind the Windows layer-gate measurement harness to the exact checked-in portable-off cache profile bytes.
- Extend the cache-contract regression so future profile changes must update both Build lanes and the measurement harness.
- Keep KFD support claims and release channel contracts unchanged.

## Related delivery

- #1665 already repaired the two Build workflow bindings and added their byte-derived regression.
- This PR closes the remaining measurement-harness drift on top of that protected merge instead of duplicating its workflow changes.

## Verification

- node --test scripts/check-shifu-cache-contract.test.mjs: 28 passed, 0 failed.
- node scripts/check-kungfu-gate-catalog.mjs: 38 gates, 6 profiles, 26 invocations, 23 workflows aligned.
- node framework/release/publication-control-plane.mjs check: passed.
- ./shifu check:source: passed on the rebased two-file change.
- git diff --check: passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the exact current cache-profile digest in a qualification measurement harness and adds a regression fence; it does not change architecture or ADR delivery state."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; qualification harness wiring only)