### PR TITLE
fix(qualification): declare source runtime boundary

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "476a6126d113537fbd9931cfb907ccaaece2bc5df90ff744f857b0b2c572df2e"
+    "sha256": "c2264e2c4db9fb853fa6bfcf18a01119a5872f848ac331cd45a085d5e02b91da"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -88,7 +88,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "2acdd06f34e46235059c0462350fa71f3be9fa2b7c9a74aa0871cb53a34d9fe5",
+      "preBuildWitnessSha256": "c3d7026db26573dc1cd07d92e28656b276e69e13348603985a630201ce8ab870",
       "sourceHashes": {
         "sha256": "990ae1d76720e30829c2a69dc780535b73804bf9dc799be8ed36197e79d82c22",
         "surfaceCount": 21
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "476a6126d113537fbd9931cfb907ccaaece2bc5df90ff744f857b0b2c572df2e"
+          "sha256": "c2264e2c4db9fb853fa6bfcf18a01119a5872f848ac331cd45a085d5e02b91da"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "520c12c4c1c6725eecbd05e09c2b437a220e9e27",
+    "sourceSha": "2ffc85e0326ea65132e3ddcb41a779e8ad5064fc",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:be35e27c91ca913cd60f006dafc07380c2bd21bb88a56554c78a55ded1d9a5a4"
   },

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "476a6126d113537fbd9931cfb907ccaaece2bc5df90ff744f857b0b2c572df2e"
+    "sha256": "c2264e2c4db9fb853fa6bfcf18a01119a5872f848ac331cd45a085d5e02b91da"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -88,7 +88,7 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "2acdd06f34e46235059c0462350fa71f3be9fa2b7c9a74aa0871cb53a34d9fe5",
+      "preBuildWitnessSha256": "c3d7026db26573dc1cd07d92e28656b276e69e13348603985a630201ce8ab870",
       "sourceHashes": {
         "sha256": "990ae1d76720e30829c2a69dc780535b73804bf9dc799be8ed36197e79d82c22",
         "surfaceCount": 21
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "476a6126d113537fbd9931cfb907ccaaece2bc5df90ff744f857b0b2c572df2e"
+          "sha256": "c2264e2c4db9fb853fa6bfcf18a01119a5872f848ac331cd45a085d5e02b91da"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",

--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -39,6 +39,16 @@ function coordinatorEnvironment(
   return environment;
 }
 
+function sourceCheckoutCoordinatorEnvironment(
+  inherited = process.env,
+  platform = process.platform,
+) {
+  return {
+    ...coordinatorEnvironment(inherited, platform),
+    KUNGFU_ALLOW_FOREIGN_RUNTIME: '1',
+  };
+}
+
 test('Windows coordinator launch preserves the inherited Path key', () => {
   const environment = coordinatorEnvironment(
     { Path: 'C:\\host-tools', HOME: 'C:\\home' },
@@ -46,6 +56,15 @@ test('Windows coordinator launch preserves the inherited Path key', () => {
   );
   assert.equal(environment.Path, `${CORE_DIST};C:\\host-tools`);
   assert.equal(environment.PATH, undefined);
+});
+
+test('source-checkout coordinator declares the named foreign-runtime allowance', () => {
+  const inherited = { CUSTOM_MARKER: 'preserved' };
+  const environment = sourceCheckoutCoordinatorEnvironment(inherited, 'darwin');
+  assert.equal(environment.CUSTOM_MARKER, 'preserved');
+  assert.equal(environment.KUNGFU_ALLOW_FOREIGN_RUNTIME, '1');
+  assert.equal(environment.DYLD_FALLBACK_LIBRARY_PATH, CORE_DIST);
+  assert.equal(inherited.KUNGFU_ALLOW_FOREIGN_RUNTIME, undefined);
 });
 
 function waitForJsonLine(child, type, timeout = 20_000) {
@@ -245,7 +264,7 @@ test(
       {
         cwd: CORE_DIR,
         detached: process.platform !== 'win32',
-        env: coordinatorEnvironment(),
+        env: sourceCheckoutCoordinatorEnvironment(),
         stdio: ['ignore', output, output],
       },
     );

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -523,13 +523,13 @@
       },
       "source": {
         "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
-        "sha256": "sha256:b15ef92c54e3e63eccb1446382179cc6d321d63625df31ed19a2a68cfb751681",
-        "renderedSha256": "sha256:b15ef92c54e3e63eccb1446382179cc6d321d63625df31ed19a2a68cfb751681",
+        "sha256": "sha256:d9dd641ae6d7ffccb326ad39c81be2cc5d50b02708b80d31d7b1832b97cfa410",
+        "renderedSha256": "sha256:d9dd641ae6d7ffccb326ad39c81be2cc5d50b02708b80d31d7b1832b97cfa410",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/primitive/kungfu-primitive-catalog.contract.json",
-        "expectedSha256": "sha256:b15ef92c54e3e63eccb1446382179cc6d321d63625df31ed19a2a68cfb751681"
+        "expectedSha256": "sha256:d9dd641ae6d7ffccb326ad39c81be2cc5d50b02708b80d31d7b1832b97cfa410"
       }
     }
   ]

--- a/framework/maintainability/terminal-evidence-matrix.json
+++ b/framework/maintainability/terminal-evidence-matrix.json
@@ -62,6 +62,7 @@
       ],
       "rawChecks": [
         "framework/maintainability/semantic-amplification.test.mjs",
+        "framework/agent-session/tests/runtime-port.native.test.mjs",
         "scripts/check-kungfu-gate-catalog.test.mjs",
         "scripts/run-agent-work-state-tests.mjs"
       ],


### PR DESCRIPTION
## Summary

- declare the named foreign-runtime allowance only for the source-checkout native coordinator fixture; production runtime guards remain unchanged
- register the native AgentSession runtime-port test as raw terminal evidence
- synchronize the primitive catalog policy digest and regenerate its KFD witness/release-gate projections

## Validation

- `./shifu node --test framework/agent-session/tests/runtime-port.native.test.mjs` (4/4, including mmap + nng native E2E)
- `./shifu node developer/sdk/src/sdk.js contract audit --json` (`ok: true`, `status: current`)
- `node scripts/buildchain-kfd-evidence.mjs --check --json` (`ok: true`)
- `./shifu check` (`changed-scope gate passed`)

## Release boundary

- [x] No package or channel publication is performed by this PR.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Close a source-checkout qualification boundary and refresh exact derived contract evidence without changing production runtime or release authority"
}
-->