### PR TITLE
fix(deps): consume Linux ARM64 libnode resolver

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "efac6806c4d82d904d60446fb2e3dea73414e1294e4c83d871dd3ac87f2d3dbd",
-    "digest": "sha256:be35e27c91ca913cd60f006dafc07380c2bd21bb88a56554c78a55ded1d9a5a4"
+    "sha256": "71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc",
+    "digest": "sha256:2f6954cd36dd83e56472a2a96782a55110e540ac215a82cb69b81b5a87ad26c7"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -23,12 +23,12 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.1",
+      "libnode": "22.22.3-kf.5-alpha.2",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:dd0dd0218025d2a22e14d815d0edac3b53c4bc43466eafad42e964ac1bda316c"
+    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
   },
-  "collaborationInterfaceDigest": "sha256:de4d637c55fe5d6687a2f3ad15e145d5c0e5aa7b38faa33db4b00b4fac3d647e",
+  "collaborationInterfaceDigest": "sha256:cc9f1c58bc675c37ccdba138274351123a335131fcc0004e6ea7b79aa083140b",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "520c12c4c1c6725eecbd05e09c2b437a220e9e27",
+    "sourceSha": "9d5f7dd650c9ad888564e2270eedbb63e61210b8",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:be35e27c91ca913cd60f006dafc07380c2bd21bb88a56554c78a55ded1d9a5a4"
+    "registryDigest": "sha256:2f6954cd36dd83e56472a2a96782a55110e540ac215a82cb69b81b5a87ad26c7"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "efac6806c4d82d904d60446fb2e3dea73414e1294e4c83d871dd3ac87f2d3dbd",
-    "digest": "sha256:be35e27c91ca913cd60f006dafc07380c2bd21bb88a56554c78a55ded1d9a5a4"
+    "sha256": "71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc",
+    "digest": "sha256:2f6954cd36dd83e56472a2a96782a55110e540ac215a82cb69b81b5a87ad26c7"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -26,15 +26,15 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.1",
+      "libnode": "22.22.3-kf.5-alpha.2",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:dd0dd0218025d2a22e14d815d0edac3b53c4bc43466eafad42e964ac1bda316c"
+    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
   },
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:de4d637c55fe5d6687a2f3ad15e145d5c0e5aa7b38faa33db4b00b4fac3d647e",
+  "collaborationInterfaceDigest": "sha256:cc9f1c58bc675c37ccdba138274351123a335131fcc0004e6ea7b79aa083140b",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -54,10 +54,10 @@
       ],
       "packageVersions": {
         "kfd": "1.0.0-alpha.47",
-        "libnode": "22.22.3-kf.5-alpha.1",
+        "libnode": "22.22.3-kf.5-alpha.2",
         "buildchain": "3.0.0"
       },
-      "digest": "sha256:dd0dd0218025d2a22e14d815d0edac3b53c4bc43466eafad42e964ac1bda316c"
+      "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
     },
     "surfaces": [
       {

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -62,10 +62,10 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.1",
+      "libnode": "22.22.3-kf.5-alpha.2",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:dd0dd0218025d2a22e14d815d0edac3b53c4bc43466eafad42e964ac1bda316c"
+    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
   },
   "surfaces": [
     {

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -145,7 +145,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-3/surfaces.json",
-            "sha256": "sha256:efac6806c4d82d904d60446fb2e3dea73414e1294e4c83d871dd3ac87f2d3dbd"
+            "sha256": "sha256:71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc"
           },
           {
             "path": ".buildchain/kfd/kfd-3/capability-query.json",

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -62,10 +62,10 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.1",
+      "libnode": "22.22.3-kf.5-alpha.2",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:dd0dd0218025d2a22e14d815d0edac3b53c4bc43466eafad42e964ac1bda316c"
+    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
   },
   "surfaces": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -145,7 +145,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-3/surfaces.json",
-            "sha256": "sha256:efac6806c4d82d904d60446fb2e3dea73414e1294e4c83d871dd3ac87f2d3dbd"
+            "sha256": "sha256:71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc"
           },
           {
             "path": ".buildchain/kfd/kfd-3/capability-query.json",

--- a/developer/sdk/kfd/upstream-aggregate.json
+++ b/developer/sdk/kfd/upstream-aggregate.json
@@ -73,7 +73,7 @@
       "role": "embedded-node-runtime-provider",
       "package": {
         "name": "@kungfu-tech/libnode",
-        "version": "22.22.3-kf.5-alpha.1"
+        "version": "22.22.3-kf.5-alpha.2"
       },
       "repository": "kungfu-systems/libnode",
       "kfd": {
@@ -88,12 +88,12 @@
         "nodeTag": "v22.22.3",
         "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
         "libnodeRevision": 5,
-        "npmVersion": "22.22.3-kf.5-alpha.1"
+        "npmVersion": "22.22.3-kf.5-alpha.2"
       },
       "assets": [
         {
           "path": "libnode.release.json",
-          "sha256": "sha256:c29741c757402b17ff91b026899c8ba91a9a4d9f58ccf817848b4cf7ef7d7bcf"
+          "sha256": "sha256:492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0"
         }
       ],
       "residualRisk": [
@@ -193,7 +193,7 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.1",
+      "libnode": "22.22.3-kf.5-alpha.2",
       "buildchain": "3.0.0"
     }
   }

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -71,7 +71,7 @@
     "sywac": "^1.3.0"
   },
   "devDependencies": {
-    "@kungfu-tech/libnode": "22.22.3-kf.5-alpha.1",
+    "@kungfu-tech/libnode": "22.22.3-kf.5-alpha.2",
     "@mapbox/node-pre-gyp": "^2.0.3",
     "cmake-js": "^8.0.0",
     "copyfiles": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,8 +470,8 @@ importers:
         version: 1.3.0
     devDependencies:
       '@kungfu-tech/libnode':
-        specifier: 22.22.3-kf.5-alpha.1
-        version: 22.22.3-kf.5-alpha.1
+        specifier: 22.22.3-kf.5-alpha.2
+        version: 22.22.3-kf.5-alpha.2
       '@mapbox/node-pre-gyp':
         specifier: ^2.0.3
         version: 2.0.3(encoding@0.1.13)
@@ -1459,28 +1459,28 @@ packages:
     resolution: {integrity: sha512-tFyFev5UKm2snujWB0FXwHkwLpKhWxmE16MPjn1zSyl0X/y7QTERG7oCL0TIBuMpKC20QnNi6r0oVKRawyQ7fA==}
     hasBin: true
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.1':
-    resolution: {integrity: sha512-l8ifBJc6vKBxTK9U7Bk40YLqBj8EACqgViv+ZeXIfrrF/EfLAe6YkNoe+g1S7r+te+lGfzqYmpkEkNtX/zuPOg==}
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.2':
+    resolution: {integrity: sha512-j8SN3IxWQGD2z/gWV1GZDZMXjaZPGCQ5W+RwsrPWfT3lDFYX0cS+BoktRKwdJmmgx4SHbz4JhaH46W/Y3SLXdQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.1':
-    resolution: {integrity: sha512-GGK9MRGrnhEdqnciJejxp0ROdqNfTaiZK/Fe3UpJQmHNnMu4fDs2/rXCrBmt7V91WuGmCV0CaZfeRPwIA9/dFA==}
+  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.2':
+    resolution: {integrity: sha512-O3ZrIJMsgRdH54Rm3sshrecMY+feVs+c/CDSBZYT/h1YiPAcP4jnaNVUkm7CyhBRinv6CoBk2Gbh6Thg364TcA==}
     cpu: [arm64]
     os: [linux]
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.1':
-    resolution: {integrity: sha512-zghUj7rBXliMqXvSz6U32AYAFRLbLiaq3N89qnWTRotbG3fB91abmKodBYYaP2zIamzinGQYtD8goaqQlFOxIA==}
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.2':
+    resolution: {integrity: sha512-fX84zNMb4KNtaP2hNuwYnzw2PQ+T5R1mwdcigAkd5pfXXmXuZwHTNJi8+qGZLKw7PLLhnuAiCcBpBZDTfdRFDQ==}
     cpu: [x64]
     os: [linux]
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.1':
-    resolution: {integrity: sha512-xC8fJf1KKHPvMfXlW0NsQjFC1smhSCebxI1qGvnu294zC71CLqc8o0IUpNhkX2NgI4ef8FKEekIxnkWJDOPRSA==}
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.2':
+    resolution: {integrity: sha512-WvC5O82ddNEtCmKE13xbS2tQMMGlgOlsQfRNvSK+dHp+zx4YAp07Lx4NIpwRtQGaneJtFIc0pdbkzxCew7G79Q==}
     cpu: [x64]
     os: [win32]
 
-  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.1':
-    resolution: {integrity: sha512-c8QN4Y6Nk9NZRz63/WmT7ypDwWe5Nev/ImR2wmaysX4VU/Zbv7tVBK+3Qcum6Mj2HUxIUctaOw154YhCbhAChg==}
+  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.2':
+    resolution: {integrity: sha512-DIoRQ/GxxA7m1tK/hYWK13WuVnursooe/3Y1LMvSp5oQkQJ/M//z3XxLpONWqqPUWmfWoWCBCRPCVfCLKfYVdg==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -5815,24 +5815,24 @@ snapshots:
 
   '@kungfu-tech/kfd@1.0.0-alpha.47': {}
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.1':
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.2':
     optional: true
 
-  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.1':
+  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.2':
     optional: true
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.1':
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.2':
     optional: true
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.1':
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.2':
     optional: true
 
-  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.1':
+  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.2':
     optionalDependencies:
-      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.5-alpha.1
-      '@kungfu-tech/libnode-linux-arm64': 22.22.3-kf.5-alpha.1
-      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.5-alpha.1
-      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.5-alpha.1
+      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.5-alpha.2
+      '@kungfu-tech/libnode-linux-arm64': 22.22.3-kf.5-alpha.2
+      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.5-alpha.2
+      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.5-alpha.2
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:


### PR DESCRIPTION
Supersedes #1685 with one linear, Project-Cut-replayable commit on the latest dev base.

## Summary

- consume `@kungfu-tech/libnode@22.22.3-kf.5-alpha.2`, whose aggregate resolver includes the published Linux ARM64 platform package
- refresh the KFD-3 collaboration witnesses, upstream aggregate, and KFD support-matrix evidence root
- preserve the governed support boundary: KFD-1/2/3/7 shipped, KFD-4/5 candidate-only, KFD-6 unsupported, and KFD-8 through KFD-13 draft-evidence-only

## Validation

- `./shifu kfd:buildchain`
- `./shifu kfd:buildchain:check`
- `./shifu kfd:support-matrix`
- `./shifu kfd:support-matrix:check`
- `node --test scripts/kfd-support-matrix.test.mjs`
- `./shifu check:source` (686 passed, 10 platform/tooling skips, 0 failed)
- DCO and repository staged gate

## Release evidence

- `@kungfu-tech/libnode@22.22.3-kf.5-alpha.2` is public on npm with integrity `sha512-DIoRQ/GxxA7m1tK/hYWK13WuVnursooe/3Y1LMvSp5oQkQJ/M//z3XxLpONWqqPUWmfWoWCBCRPCVfCLKfYVdg==`
- `@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.2` is public on npm with integrity `sha512-O3ZrIJMsgRdH54Rm3sshrecMY+feVs+c/CDSBZYT/h1YiPAcP4jnaNVUkm7CyhBRinv6CoBk2Gbh6Thg364TcA==`
- the independent libnode GitHub Release Passport remains non-qualifying under Buildchain issue `kungfu-systems/buildchain#1978`; this PR relies only on the public npm bytes and does not claim that upstream Passport as Kungfu release evidence

<!-- kungfu-adr-release:v1 {"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This dependency repair consumes an already reviewed libnode platform resolver and refreshes generated KFD evidence without changing architecture decisions."} -->

