### PR TITLE
fix(ci): stabilize dev latency cohort selection

### DIFF
--- a/scripts/candidate-timeline-events.cjs
+++ b/scripts/candidate-timeline-events.cjs
@@ -283,6 +283,34 @@ function requiredMergeQueueWindow(requiredContexts, mergeQueue) {
   };
 }
 
+function latestMergedPulls(pulls, limit) {
+  return pulls
+    .filter(({ merged_at: mergedAt }) => Number.isFinite(Date.parse(mergedAt)))
+    .sort((left, right) => {
+      const mergedOrder =
+        Date.parse(right.merged_at) - Date.parse(left.merged_at);
+      return mergedOrder || right.number - left.number;
+    })
+    .slice(0, limit);
+}
+
+async function collectLatestMergedPullWindow(fetchPage, limit, pageSize = 100) {
+  const pulls = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await fetchPage(page, pageSize);
+    if (!Array.isArray(batch)) throw new Error('expected pull request page');
+    pulls.push(...batch);
+    const merged = latestMergedPulls(pulls, limit);
+    if (!batch.length || batch.length < pageSize) return { pulls, merged };
+    if (merged.length < limit) continue;
+    const cutoffMs = Date.parse(merged.at(-1).merged_at);
+    const lastUpdatedMs = Date.parse(batch.at(-1).updated_at);
+    if (Number.isFinite(lastUpdatedMs) && lastUpdatedMs < cutoffMs) {
+      return { pulls, merged };
+    }
+  }
+}
+
 function parseDevRequiredLatencyArgs(argv) {
   const options = {
     repository: process.env.GITHUB_REPOSITORY || '',
@@ -368,6 +396,8 @@ function latencyOnlyEvidence(classification, workflowRunId = null) {
 }
 
 module.exports = {
+  collectLatestMergedPullWindow,
+  latestMergedPulls,
   latencyOnlyEvidence,
   measureCandidateStage,
   measureCandidateStageSync,

--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -16,13 +16,13 @@ import {
 } from '@kungfu-tech/buildchain-alpha/candidate-timeline';
 
 import {
+  collectLatestMergedPullWindow,
   latencyOnlyEvidence,
   parseDevRequiredLatencyArgs,
   requiredMergeQueueWindow,
 } from './candidate-timeline-events.cjs';
 import { planAffectedPaths } from './run-core-affected-native.mjs';
 export { requiredMergeQueueWindow };
-
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MINIMUM_SAMPLE_COUNT = 20;
 const MINIMUM_NATIVE_SAMPLE_COUNT = 10;
@@ -139,7 +139,6 @@ async function githubPages(route, token, limit = Number.POSITIVE_INFINITY) {
   }
   return records.slice(0, limit);
 }
-
 async function githubWorkflowRuns(route, token) {
   const separator = route.includes('?') ? '&' : '?';
   const records = [];
@@ -196,14 +195,14 @@ export function selectMergeQueueCandidatePulls(pulls, merged, runs) {
   );
   return pulls.filter(
     ({ number, merged_at: mergedAt, updated_at: updatedAt }) => {
-      if (selectedNumbers.has(number) || runNumbers.has(number)) return true;
+      if (selectedNumbers.has(number) || (!mergedAt && runNumbers.has(number)))
+        return true;
       if (mergedAt || !Number.isFinite(windowStartMs)) return false;
       const updatedAtMs = Date.parse(updatedAt);
       return Number.isFinite(updatedAtMs) && updatedAtMs >= windowStartMs;
     },
   );
 }
-
 function jobDuration(job) {
   if (!job.started_at) return 0;
   if (!job.completed_at) return null;
@@ -1980,7 +1979,8 @@ async function main() {
     throw new Error('cannot resolve GitHub repository');
   const token = githubToken();
   const branchPath = encodeURIComponent(options.branch);
-  const [effectiveRules, pulls] = await Promise.all([
+  const pullRoute = `/repos/${repository}/pulls?state=all&base=${encodeURIComponent(options.branch)}&sort=updated&direction=desc`;
+  const [effectiveRules, pullWindow] = await Promise.all([
     githubJson(`/repos/${repository}/rules/branches/${branchPath}`, token),
     options.pulls.length
       ? Promise.all(
@@ -1988,12 +1988,13 @@ async function main() {
             githubJson(`/repos/${repository}/pulls/${pullNumber}`, token),
           ),
         )
-      : githubPages(
-          `/repos/${repository}/pulls?state=all&base=${encodeURIComponent(options.branch)}&sort=updated&direction=desc`,
-          token,
-          options.limit * 3,
+      : collectLatestMergedPullWindow(
+          (page, pageSize) =>
+            githubJson(`${pullRoute}&per_page=${pageSize}&page=${page}`, token),
+          options.limit,
         ),
   ]);
+  const pulls = options.pulls.length ? pullWindow : pullWindow.pulls;
   const requiredContexts = requiredContextsFromEffectiveRules(effectiveRules);
   if (!requiredContexts.length)
     throw new Error(`no required contexts on ${options.branch}`);
@@ -2003,12 +2004,11 @@ async function main() {
       requiredContexts,
     );
   }
-  const merged = pulls
-    .filter(({ merged_at: mergedAt }) => mergedAt)
-    .slice(0, options.limit);
-  if (options.pulls.length && merged.length !== options.pulls.length) {
+  const merged = options.pulls.length
+    ? pulls.filter(({ merged_at: mergedAt }) => mergedAt)
+    : pullWindow.merged;
+  if (options.pulls.length && merged.length !== options.pulls.length)
     throw new Error('every requested --pull must be merged');
-  }
   const earliestPullCreatedAt = merged
     .map(({ created_at: createdAt }) => createdAt)
     .filter(Boolean)

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -7,6 +7,10 @@ import test from 'node:test';
 import { createCandidateTimeline } from '@kungfu-tech/buildchain-alpha/candidate-timeline';
 
 import {
+  collectLatestMergedPullWindow,
+  latestMergedPulls,
+} from './candidate-timeline-events.cjs';
+import {
   affectedNativeEvidenceBinding,
   aggregatePartitionEvidence,
   cacheEvidenceFromMembers,
@@ -116,6 +120,55 @@ test('merge-group branch names bind Actions runs to one pull request', () => {
   );
 });
 
+test('latest merged pull window is stable when updated open pulls are added', async () => {
+  const merged = [
+    {
+      number: 11,
+      merged_at: '2026-07-22T13:00:00Z',
+      updated_at: '2026-07-22T13:00:00Z',
+    },
+    {
+      number: 10,
+      merged_at: '2026-07-22T12:00:00Z',
+      updated_at: '2026-07-22T12:00:00Z',
+    },
+    {
+      number: 9,
+      merged_at: '2026-07-22T11:00:00Z',
+      updated_at: '2026-07-22T11:00:00Z',
+    },
+  ];
+  const updatedOpen = Array.from({ length: 4 }, (_, index) => ({
+    number: 100 + index,
+    merged_at: null,
+    updated_at: `2026-07-22T14:0${index}:00Z`,
+  }));
+  const pages = [
+    updatedOpen.slice(0, 3),
+    updatedOpen.slice(3).concat(merged.slice(0, 2)),
+    merged.slice(2),
+  ];
+  const fetchedPages = [];
+  const value = await collectLatestMergedPullWindow(
+    async (page) => {
+      fetchedPages.push(page);
+      return pages[page - 1] || [];
+    },
+    2,
+    3,
+  );
+
+  assert.deepEqual(
+    value.merged.map(({ number }) => number),
+    [11, 10],
+  );
+  assert.deepEqual(
+    latestMergedPulls(merged, 2).map(({ number }) => number),
+    [11, 10],
+  );
+  assert.deepEqual(fetchedPages, [1, 2, 3]);
+});
+
 test('queue candidate discovery retains recent closed attempts without runs', () => {
   const pulls = [
     {
@@ -148,6 +201,10 @@ test('queue candidate discovery retains recent closed attempts without runs', ()
     {
       head_branch:
         'gh-readonly-queue/dev/v4/v4.0/pr-4-7ea9c140b15ef11d4387be4ca84b84e124f5c7aa',
+    },
+    {
+      head_branch:
+        'gh-readonly-queue/dev/v4/v4.0/pr-5-7ea9c140b15ef11d4387be4ca84b84e124f5c7aa',
     },
   ];
 


### PR DESCRIPTION
## Summary

Stabilize the rolling dev required-gate latency cohort without weakening any gate. The collector now identifies the latest merged pull requests by `merged_at` and paginates until later pages cannot enter that window. Updated open pull requests can no longer evict merged delivery samples.

The delivery cohort also excludes merged pull requests outside the selected window even when older merge-group runs are still visible. Unmerged queue attempts remain included for dequeue and runner-waste evidence.

## Related issue

None.

## Changes

- collect a complete, bounded latest-merged pull-request window
- keep merged delivery samples fixed to that selected window
- retain recent unmerged queue attempts and their merge-group evidence
- add a regression fixture with updated open pull requests and an older merged run

## Verification

- `./shifu test:gate-latency` — 64 tests passed
- staged pre-commit gate — passed
- two consecutive live latency-only reports had identical required samples, delivery samples, percentiles, dequeue counts, repeated-validation counts, and runner-waste totals
- local source acceptance passed the changed-code, complexity, documentation, gate, and architecture checks; its broad cold-fixture suite later reported the host environment lacked `pytest` on `PATH`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix stabilizes measurement cohort selection without changing gate, release, or architecture contracts"
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only selection of retained latency evidence. It does not alter required checks, qualification thresholds, or publication authority. Regression tests and consecutive live-report equality cover the boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

No documentation change is required because the metric contract and public CLI remain unchanged.
