### PR TITLE
fix(qualification): settle Windows runtime identity handoff

### DIFF
--- a/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
+++ b/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
@@ -53,6 +53,31 @@ function invoke(home, configHome, args) {
   return { payload, durationUs };
 }
 
+export function invokeAfterIdentitySettlement(
+  invokeCommand,
+  home,
+  configHome,
+  args,
+  { attempts = 50, wait = () => {} } = {},
+) {
+  let identityError = null;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return invokeCommand(home, configHome, args);
+    } catch (error) {
+      if (
+        !String(error?.message || error).includes('runtime_identity_unverified')
+      ) {
+        throw error;
+      }
+      identityError = error;
+      invokeCommand(home, configHome, ['runtime', 'status', '--json']);
+      wait();
+    }
+  }
+  throw identityError;
+}
+
 function running(payload) {
   return (
     payload?.supervisor?.running === true &&
@@ -101,7 +126,16 @@ function main() {
       throw new Error('daemonless product status invented live readiness');
     }
 
-    const cold = invoke(home, configHome, ['runtime', 'ensure', '--json']);
+    const cold = invokeAfterIdentitySettlement(
+      invoke,
+      home,
+      configHome,
+      ['runtime', 'ensure', '--json'],
+      {
+        wait: () =>
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100),
+      },
+    );
     const coldStatus = waitForRunning(home, configHome);
     const warm = invoke(home, configHome, ['runtime', 'ensure', '--json']);
     if (warm.payload.changed !== false) {
@@ -177,9 +211,14 @@ function main() {
   }
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(error?.stack || String(error));
-  process.exit(1);
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error?.stack || String(error));
+    process.exit(1);
+  }
 }

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 
+import { invokeAfterIdentitySettlement } from './product_smoke.mjs';
 import {
   boundedFailureTail,
   createLogBundle,
@@ -139,6 +140,70 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
   assert.equal(
     invocation.args[3],
     'call shifu.cmd exec "argument with spaces"',
+  );
+});
+
+test('product smoke waits for a transient runtime identity handoff without bypassing preflight', () => {
+  const calls = [];
+  const result = invokeAfterIdentitySettlement(
+    (_home, _configHome, args) => {
+      calls.push(args);
+      if (calls.length === 1) {
+        throw new Error('runtime_identity_unverified: coordinator is starting');
+      }
+      if (args[1] === 'status') {
+        return { payload: { coordinator: { running: true } } };
+      }
+      return { payload: { changed: false } };
+    },
+    'home',
+    'config',
+    ['runtime', 'ensure', '--json'],
+    { attempts: 2, wait: () => calls.push(['wait']) },
+  );
+
+  assert.deepEqual(result, { payload: { changed: false } });
+  assert.deepEqual(calls, [
+    ['runtime', 'ensure', '--json'],
+    ['runtime', 'status', '--json'],
+    ['wait'],
+    ['runtime', 'ensure', '--json'],
+  ]);
+});
+
+test('product smoke keeps persistent or unrelated identity failures fail-closed', () => {
+  const persistent = new Error(
+    'runtime_identity_unverified: coordinator identity never settled',
+  );
+  let attempts = 0;
+  assert.throws(
+    () =>
+      invokeAfterIdentitySettlement(
+        (_home, _configHome, args) => {
+          if (args[1] === 'status') return { payload: {} };
+          attempts += 1;
+          throw persistent;
+        },
+        'home',
+        'config',
+        ['runtime', 'ensure', '--json'],
+        { attempts: 2 },
+      ),
+    (error) => error === persistent,
+  );
+  assert.equal(attempts, 2);
+
+  assert.throws(
+    () =>
+      invokeAfterIdentitySettlement(
+        () => {
+          throw new Error('runtime_route_stale');
+        },
+        'home',
+        'config',
+        ['runtime', 'ensure', '--json'],
+      ),
+    /runtime_route_stale/,
   );
 });
 


### PR DESCRIPTION
## Summary

Bound the Windows product-runtime smoke around the transient coordinator identity handoff observed in exact protected-main qualification. The production runtime preflight remains fail-closed.

## Related issue

Maintainability terminal-closure qualification follow-up; exact Build run 30295340390 reproduced runtime_identity_unverified only on Windows x64.

## Changes

- retry only runtime_identity_unverified from the cold runtime ensure operation
- observe real runtime status between attempts and stop after 50 x 100 ms
- preserve immediate failure for unrelated errors and bounded failure for persistent unknown identity
- add positive, persistent-failure, and unrelated-failure contract tests

## Verification

- KUNGFU_READONLY_PYTEST="$PWD/framework/core/.venv/bin/pytest" ./shifu check:source
- ./shifu exec -- node --test framework/core/tests/qualification/runtime-activation/run.test.mjs
- pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix changes only the product qualification harness retry boundary and does not alter the runtime architecture or production preflight contract."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to the runtime-activation qualification evidence producer; exact source acceptance and cross-platform Build qualification verify the boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required: production behavior and public contracts are unchanged)