### PR TITLE
fix(ci): preserve KFD vector bytes on Windows

### DIFF
--- a/.github/workflows/embedding-membrane-spike.yml
+++ b/.github/workflows/embedding-membrane-spike.yml
@@ -279,6 +279,10 @@ jobs:
         run: |
           kfd_root="${RUNNER_TEMP}/kfd-runtime-100"
           git init "$kfd_root"
+          # Runtime 100 vectors are hashed as raw bytes. Keep their canonical
+          # LF representation on Windows regardless of runner Git defaults.
+          git -C "$kfd_root" config core.autocrlf false
+          git -C "$kfd_root" config core.eol lf
           git -C "$kfd_root" remote add origin https://github.com/kungfu-systems/kfd.git
           git -C "$kfd_root" fetch --no-tags --depth=1 origin "$KFD_SHA"
           git -C "$kfd_root" checkout --detach "$KFD_SHA"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1463,7 +1463,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5067a806e4d8dbbf194387c062741f272cf205e95b535518a59f75ec31fa8244",
+          "definitionDigest": "sha256:5e30a0b403effd1740f8df343bada09a19740839efd5f8c246dd27eca62d59b4",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -1542,7 +1542,7 @@
             {
               "index": 14,
               "label": "name:Materialize exact KFD Runtime 100",
-              "definitionDigest": "sha256:e138b795a81dc221702018286bcfcf9473822651332c6b989160b3be8e30369c"
+              "definitionDigest": "sha256:853c5fa53a2fb1fc7734baa7356e76a1e5ee85f9cc29aac908305d44b0766174"
             },
             {
               "index": 15,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -181,7 +181,7 @@
           "classification": "non-publication",
           "owner": "kungfu-runtime",
           "surfaceIds": [],
-          "sourceRoot": "sha256:e564f05af8911af07dbdc61e628a57f39d94c3389211a56b7f33a8161e8ba169"
+          "sourceRoot": "sha256:412723bd879a96b272665602209e1cc336d51c3ca8df156668a540b7b5e1f60b"
         },
         {
           "path": ".github/workflows/gate-measurement.yml",
@@ -767,5 +767,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:0394a497583db9ae53a81b143c29764336be8f0ae7ae4b1e5d2f8effccb4a6bd"
+  "registryRoot": "sha256:2fc2e2cdd636d8be3977328e044fb65d10b1a6ae7c403ea8e3fd65de47a3697d"
 }

--- a/scripts/check-kfd-agent-runtime-boundary.mjs
+++ b/scripts/check-kfd-agent-runtime-boundary.mjs
@@ -27,6 +27,40 @@ const cmake = fs.readFileSync(cmakePath, 'utf8');
 const workflow = fs.readFileSync(workflowPath, 'utf8');
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
+const kfdCheckoutStart = workflow.indexOf(
+  'kfd_root="${RUNNER_TEMP}/kfd-runtime-100"',
+);
+const kfdCheckoutEnd = workflow.indexOf(
+  'echo "KFD_PACKAGE_ROOT=$kfd_root"',
+  kfdCheckoutStart,
+);
+assert.notEqual(
+  kfdCheckoutStart,
+  -1,
+  'the workflow must materialize the exact KFD Runtime 100 checkout',
+);
+assert.notEqual(
+  kfdCheckoutEnd,
+  -1,
+  'the KFD Runtime 100 checkout must publish its package root',
+);
+const kfdCheckout = workflow.slice(kfdCheckoutStart, kfdCheckoutEnd);
+const kfdAutocrlfConfig = kfdCheckout.indexOf(
+  'git -C "$kfd_root" config core.autocrlf false',
+);
+const kfdEolConfig = kfdCheckout.indexOf(
+  'git -C "$kfd_root" config core.eol lf',
+);
+const kfdCheckoutCommand = kfdCheckout.indexOf(
+  'git -C "$kfd_root" checkout --detach "$KFD_SHA"',
+);
+assert.ok(
+  kfdAutocrlfConfig >= 0 &&
+    kfdEolConfig > kfdAutocrlfConfig &&
+    kfdCheckoutCommand > kfdEolConfig,
+  'the workflow must force canonical LF bytes before checking out KFD Runtime 100',
+);
+
 const kungfuIncludes = [...main.matchAll(/#include\s+[<"]([^>"]+)[>"]/g)]
   .map((match) => match[1])
   .filter((include) => include.startsWith('kungfu/'));


### PR DESCRIPTION
## Summary

Preserve the canonical LF bytes of the external KFD Runtime 100 vectors on Windows so the embedding membrane qualification hashes the same source bytes on every platform.

## Related issue

Release qualification follow-up for #1448.

## Changes

- Disable Git line-ending conversion before materializing the exact KFD checkout.
- Add a source regression that requires the LF configuration to precede checkout.
- Refresh the closed Gate workflow authority and release publication source roots.

## Verification

- ./shifu check:kfd-agent-runtime-boundary
- ./shifu check:source
- git diff --check
- Staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes cross-platform checkout byte preservation without changing an architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow authority and publication-control roots are refreshed from the checked source, and source acceptance verifies both closed-world projections.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed