### PR TITLE
fix(release): scope ARM64 Hub qualification to CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,10 @@ jobs:
       require-build: true
       require-verify: true
       lifecycle-timeout-minutes: 180
-      verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip
+      # The native ARM64 lane publishes only the headless Hub CLI. Keep its
+      # runtime, Episode, ADR, portable-format, and invariant evidence, but do
+      # not ask it to manufacture desktop or cross-language SDK artifacts.
+      verify-command: node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip --artifact-scope hub-cli
       release-candidate: true
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
       artifact-transfer-mode: s3-to-github-artifacts

--- a/docs/qualification/gates/native-qualification.md
+++ b/docs/qualification/gates/native-qualification.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain layers.contract --profile <profile>`; reproduce with `./shifu gate run layers.contract` on a capable runner.
 - **Cost:** light; timeout 900 seconds.
-- **Current source:** .github/workflows/build.yml (build; alpha or release pull request)
+- **Current source:** .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/build.yml (hub-cli-linux-arm64; alpha or release pull request, or selected manual Linux ARM64 qualification)
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:layers.contract -->
 
@@ -36,7 +36,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified source-bound Gate receipt, required `kungfu.layer-qualification.gate-evidence/v1` pointers, and `product/release/qualification/layer-format-report.json`.
 - **Diagnosis:** `./shifu gate explain layers.format --profile alpha-pr`; plan with `./shifu gate plan alpha-pr --platform <platform>` before reproducing on a capable host.
 - **Cost:** heavy; timeout 900 seconds.
-- **Current source:** .github/workflows/build.yml (build; alpha or release pull request)
+- **Current source:** .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/build.yml (hub-cli-linux-arm64; alpha or release pull request, or selected manual Linux ARM64 qualification)
 - **Retirement:** remove only after the portable artifact is retired or a replacement Gate preserves exact archive, budget, report, profile, and workflow-binding coverage.
 <!-- /gate-doc:layers.format -->
 
@@ -118,6 +118,14 @@ from [`execution-profiles.json`](execution-profiles.json): alpha uses
 `mvp-smoke-v1`, release-candidate uses `mvp-candidate-v1`, and full-patrol keeps
 the complete baseline. The unified layer receipt records the selected profile,
 effective ceilings, reserve, fuzz duration, and policy digest.
+
+The dedicated native Linux ARM64 Hub CLI lane selects the explicit
+`hub-cli` artifact scope. It retains source fuzzing, live-Peer and runtime
+activation, Episode and ADR evidence, portable-format qualification, and
+source/native/runtime invariants. Desktop zero-burden evidence, assembled
+desktop surfaces, and cross-language SDK packages remain owned by the full
+Product matrix; their absence from a headless-only runner is not converted
+into a false product failure or a product-wide qualification claim.
 
 The standalone Gate ceilings cover their complete declared actions rather than
 the shorter profile-specific reuse path: the smoke ceiling includes all four

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -854,7 +854,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e6305adae11b3207995daa414fc106118500a958dd99f2440df1ad6fe90c77c4",
+          "definitionDigest": "sha256:d1c1499bddf2e924f3039a906fc6107378b5de78008dcd9631b1701af2168fe7",
           "credentials": {
             "githubToken": "write",
             "oidc": true,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -486,6 +486,8 @@
         "release-pr"
       ],
       "gates": [
+        "layers.contract",
+        "layers.format",
         "product.distribution",
         "episode.smoke",
         "episode.release"
@@ -511,7 +513,7 @@
           "require-install": true,
           "require-build": true,
           "require-verify": true,
-          "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip",
+          "verify-command": "node scripts/run-release-qualification.mjs --execution-profile ${{ startsWith(github.base_ref, 'release/') && 'release-candidate' || 'alpha' }} --native-upgrade-policy skip --artifact-scope hub-cli",
           "release-candidate": true,
           "publish-channel": "${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}",
           "artifact-transfer-mode": "s3-to-github-artifacts",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:85829360a77ec44639ba99defd7692d96844002e554e115b72a34d0bd5cacf47",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:f55fa4e6183c45697992b3d051f6faa683e8f3f557ad3ccd79fae2600737dc83",
+  "sourceRoot": "sha256:1854b2b15c8a4b024dee3b1c51701e974873402d38c856f0e424fbe09b991db0",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1031,9 +1031,9 @@
         },
         {
           "path": "docs/qualification/gates/workflow-bindings.json",
-          "currentLines": 630,
+          "currentLines": 632,
           "baselineLines": 580,
-          "currentRoot": "sha256:002e13cfabfd66226544ea89b6e2ecf5eb19ddb4855d9b019b94dda17a2f699b",
+          "currentRoot": "sha256:be26ccaa0c70e51bdb7ff634acce1aced29380ba8fcc009cc67dd2c392fa3105",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -100,7 +100,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:f85b0bbf56a3824ae7190bc1dd7fd0bf5a4c478fe64ba7b8439c0c41a3f2f13b"
+          "sourceRoot": "sha256:4a074571e71ec480aee2198eb1c9b125472877729e2919bddfc8dd36971937ef"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -767,5 +767,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:2fc2e2cdd636d8be3977328e044fb65d10b1a6ae7c403ea8e3fd65de47a3697d"
+  "registryRoot": "sha256:e55cb0d96ac9ace1cf33ae775f69d9cfced03112eee5af550c982a877d5c3a06"
 }

--- a/scripts/run-release-qualification.mjs
+++ b/scripts/run-release-qualification.mjs
@@ -117,9 +117,17 @@ export function parseReleaseQualificationOptions(argv) {
   let name = '';
   let nativeUpgradePolicy = 'required';
   let nativeUpgradePolicySeen = false;
+  let artifactScope = 'product';
+  let artifactScopeSeen = false;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (!['--execution-profile', '--native-upgrade-policy'].includes(arg))
+    if (
+      ![
+        '--execution-profile',
+        '--native-upgrade-policy',
+        '--artifact-scope',
+      ].includes(arg)
+    )
       throw new Error(`unknown release qualification option: ${arg}`);
     index += 1;
     if (index >= argv.length) throw new Error(`${arg} requires a value`);
@@ -128,10 +136,17 @@ export function parseReleaseQualificationOptions(argv) {
       name = argv[index];
       continue;
     }
-    if (nativeUpgradePolicySeen)
-      throw new Error('--native-upgrade-policy may be specified once');
-    nativeUpgradePolicySeen = true;
-    nativeUpgradePolicy = argv[index];
+    if (arg === '--native-upgrade-policy') {
+      if (nativeUpgradePolicySeen)
+        throw new Error('--native-upgrade-policy may be specified once');
+      nativeUpgradePolicySeen = true;
+      nativeUpgradePolicy = argv[index];
+      continue;
+    }
+    if (artifactScopeSeen)
+      throw new Error('--artifact-scope may be specified once');
+    artifactScopeSeen = true;
+    artifactScope = argv[index];
   }
   if (!name)
     throw new Error(
@@ -139,7 +154,13 @@ export function parseReleaseQualificationOptions(argv) {
     );
   if (!['required', 'skip'].includes(nativeUpgradePolicy))
     throw new Error('--native-upgrade-policy must be required or skip');
-  return { executionProfile: name, nativeUpgradePolicy };
+  if (!['product', 'hub-cli'].includes(artifactScope))
+    throw new Error('--artifact-scope must be product or hub-cli');
+  if (artifactScope === 'hub-cli' && nativeUpgradePolicy !== 'skip')
+    throw new Error(
+      '--artifact-scope hub-cli requires --native-upgrade-policy skip',
+    );
+  return { executionProfile: name, nativeUpgradePolicy, artifactScope };
 }
 
 export function releaseQualificationEnvironment(
@@ -210,9 +231,14 @@ export function releaseQualificationStages(
   platform = process.platform,
   execution = loadExecutionProfile('full-patrol'),
   nativeUpgradePolicy = 'required',
+  artifactScope = 'product',
 ) {
   if (!['required', 'skip'].includes(nativeUpgradePolicy))
     throw new Error(`unknown native upgrade policy: ${nativeUpgradePolicy}`);
+  if (!['product', 'hub-cli'].includes(artifactScope))
+    throw new Error(`unknown artifact scope: ${artifactScope}`);
+  if (artifactScope === 'hub-cli' && nativeUpgradePolicy !== 'skip')
+    throw new Error('hub-cli qualification cannot require native upgrade');
   const stages = [
     ['release:probe:platform'],
     ['verify', '--fuzz'],
@@ -232,13 +258,14 @@ export function releaseQualificationStages(
       'product/release/qualification/runtime-activation',
     ],
     ['test:upgrade-qualification'],
-    [
+  ];
+  if (artifactScope === 'product')
+    stages.push([
       'zero-burden:qualify',
       '--',
       '--retain',
       'product/release/qualification/zero-burden-desktop',
-    ],
-  ];
+    ]);
   if (platform === 'linux') {
     stages.push([
       'episode:qualify:release',
@@ -257,12 +284,14 @@ export function releaseQualificationStages(
       'product/release/qualification/adr-release-admissibility.json',
     ]);
   }
+  const artifactLayers =
+    artifactScope === 'hub-cli'
+      ? ['layers.format']
+      : ['layers.format', 'layers.sdk', 'layers.surfaces'];
   stages.push([
     'gate',
     'run',
-    'layers.format',
-    'layers.sdk',
-    'layers.surfaces',
+    ...artifactLayers,
     '--capability',
     'node',
     '--capability',
@@ -277,6 +306,7 @@ export function releaseQualificationStages(
     '--execution-context',
     JSON.stringify({
       executionProfile: execution.name,
+      artifactScope,
       effectiveParameters: execution.parameters,
       policyDigest: execution.policyDigest,
       policyRef: execution.policyRef,
@@ -350,6 +380,7 @@ function writeSummary(
   status,
   startedAt,
   nativeUpgradePolicy,
+  artifactScope,
 ) {
   const receiptPath = path.join(
     ROOT,
@@ -400,6 +431,7 @@ function writeSummary(
     startedAt,
     status: withinLimit ? 'passed' : 'failed',
     executionProfile: execution.name,
+    artifactScope,
     nativeUpgradePolicy,
     effectiveParameters: execution.parameters,
     policy: { ref: execution.policyRef, digest: execution.policyDigest },
@@ -439,6 +471,7 @@ export function main(argv = process.argv.slice(2)) {
     process.platform,
     execution,
     options.nativeUpgradePolicy,
+    options.artifactScope,
   )) {
     const started = Date.now();
     const status = runShifuWithCache(args, { env });
@@ -458,6 +491,7 @@ export function main(argv = process.argv.slice(2)) {
     finalStatus,
     startedAt,
     options.nativeUpgradePolicy,
+    options.artifactScope,
   );
   if (finalStatus === 0 && !summary.budget.withinLimit) {
     console.error(

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -448,6 +448,37 @@ test('native upgrade evidence is retained only after exact artifact gates pass',
   }
 });
 
+test('Hub CLI scope retains headless evidence without claiming desktop or SDK artifacts', () => {
+  const stages = releaseQualificationStages(
+    'linux',
+    loadExecutionProfile('alpha'),
+    'skip',
+    'hub-cli',
+  );
+  const stageNames = stages.map(([name]) => name);
+  for (const required of [
+    'release:probe:platform',
+    'verify',
+    'live-peer:qualify',
+    'runtime:qualify',
+    'test:upgrade-qualification',
+    'episode:qualify:release',
+    'adr:release:gate',
+    'gate',
+    'invariant:verify',
+  ])
+    assert.ok(stageNames.includes(required), required);
+  assert.ok(!stageNames.includes('zero-burden:qualify'));
+  assert.ok(!stageNames.includes('upgrade:qualify:native'));
+
+  const gate = stages.find(([name]) => name === 'gate');
+  assert.deepEqual(gate.slice(0, 3), ['gate', 'run', 'layers.format']);
+  assert.ok(!gate.includes('layers.sdk'));
+  assert.ok(!gate.includes('layers.surfaces'));
+  const context = JSON.parse(gate[gate.indexOf('--execution-context') + 1]);
+  assert.equal(context.artifactScope, 'hub-cli');
+});
+
 test('execution profile parsing fails closed on missing, duplicate, and unknown values', () => {
   assert.equal(
     parseExecutionProfile(['--execution-profile', 'alpha']),
@@ -472,7 +503,36 @@ test('execution profile parsing fails closed on missing, duplicate, and unknown 
       '--native-upgrade-policy',
       'skip',
     ]),
-    { executionProfile: 'alpha', nativeUpgradePolicy: 'skip' },
+    {
+      executionProfile: 'alpha',
+      nativeUpgradePolicy: 'skip',
+      artifactScope: 'product',
+    },
+  );
+  assert.deepEqual(
+    parseReleaseQualificationOptions([
+      '--execution-profile',
+      'alpha',
+      '--native-upgrade-policy',
+      'skip',
+      '--artifact-scope',
+      'hub-cli',
+    ]),
+    {
+      executionProfile: 'alpha',
+      nativeUpgradePolicy: 'skip',
+      artifactScope: 'hub-cli',
+    },
+  );
+  assert.throws(
+    () =>
+      parseReleaseQualificationOptions([
+        '--execution-profile',
+        'alpha',
+        '--artifact-scope',
+        'hub-cli',
+      ]),
+    /requires --native-upgrade-policy skip/,
   );
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary
- add a fail-closed `hub-cli` artifact scope to release qualification
- retain runtime, Episode, ADR, portable-format, and invariant evidence
- keep desktop, assembled-surface, and cross-language SDK qualification on the full Product matrix
- bind the dedicated Linux ARM64 workflow and workflow-authority projection to the scoped command

## Validation
- `node --test scripts/run-release-qualification.test.mjs` (23/23)
- `node --test scripts/check-kungfu-gate-catalog.test.mjs` (23/23)
- full repository pre-commit gate
- `pnpm exec biome check --no-errors-on-unmatched ...`
- `git diff --check`

## Release diagnosis
Alpha Build run 30299746748 proved that the native Linux ARM64 Hub CLI build and installed-layout smoke succeeded, then failed only because the headless lane entered `layers.sdk` (unsupported `linux-arm64`) and `layers.surfaces` (missing desktop artifact). This patch keeps those Product-wide gates fail-closed on the full matrix instead of weakening them.

## ADR delivery / release declaration
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix scopes an existing headless release qualification lane to the artifacts it actually builds; it does not alter an architecture contract or weaken the full Product qualification matrix."
}
-->

## Governance risk check
- [x] release evidence, provenance, package publishing, or deployment surfaces

The release evidence boundary is explicit: the Hub CLI lane records its artifact scope while desktop and SDK evidence remain mandatory on the full Product matrix.