### PR TITLE
fix(ci): promote caches through reused native proof

### DIFF
--- a/.github/workflows/affected-native-cache-promote.yml
+++ b/.github/workflows/affected-native-cache-promote.yml
@@ -36,8 +36,9 @@ jobs:
         run: |
           set -euo pipefail
           producer_run=""
+          producer_mode=""
           attempt=1
-          gate_without_payload_polls=0
+          gate_without_authority_polls=0
           while [ "$attempt" -le 60 ]; do
             runs="$(
               gh api --method GET \
@@ -59,16 +60,32 @@ jobs:
               )"
               [ "$gate_success_count" -eq 1 ] || continue
               gate_observed=true
-              artifact_state="$(
+              direct_state="$(
                 gh api \
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
                   --jq "[.artifacts[] | select(.expired == false and (.name | startswith(\"core-affected-native-${GITHUB_SHA}-partition-\"))) | (.name | capture(\"-partition-(?<index>[0-9]+)-of-(?<count>[0-9]+)$\"))] | if length == 0 then \"absent\" elif ((map(.count) | unique | length) == 1 and (.[0].count | tonumber) == length and (map(.index | tonumber) | sort) == [range(0; (.[0].count | tonumber))]) then \"complete\" else \"partial\" end"
               )"
-              if [ "$artifact_state" = "complete" ]; then
+              authority_count="$(
+                gh api \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
+                  --jq "[.artifacts[] | select(.expired == false and .name == \"core-affected-native-cache-promotion-authority-${run_id}\")] | length"
+              )"
+              if [ "$direct_state" = "complete" ] &&
+                [ "$authority_count" -eq 0 ]; then
                 producer_run="$run_id"
+                producer_mode=direct
                 break
               fi
-              if [ "$artifact_state" = "partial" ]; then
+              if [ "$direct_state" = "absent" ] &&
+                [ "$authority_count" -eq 1 ]; then
+                producer_run="$run_id"
+                producer_mode=reused-proof
+                break
+              fi
+              if [ "$direct_state" = "partial" ] ||
+                [ "$authority_count" -gt 1 ] ||
+                { [ "$direct_state" = "complete" ] &&
+                  [ "$authority_count" -ne 0 ]; }; then
                 artifact_partial=true
               fi
             done
@@ -77,12 +94,12 @@ jobs:
             fi
             if [ "$gate_observed" = "true" ] &&
               [ "$artifact_partial" = "false" ]; then
-              gate_without_payload_polls=$((gate_without_payload_polls + 1))
-              if [ "$gate_without_payload_polls" -ge 3 ]; then
+              gate_without_authority_polls=$((gate_without_authority_polls + 1))
+              if [ "$gate_without_authority_polls" -ge 3 ]; then
                 break
               fi
             else
-              gate_without_payload_polls=0
+              gate_without_authority_polls=0
             fi
             sleep 10
             attempt=$((attempt + 1))
@@ -91,44 +108,140 @@ jobs:
             {
               echo "available=false"
               echo "run-id="
+              echo "mode="
             } >> "$GITHUB_OUTPUT"
-            echo "No complete required-Gate cache payload exists for merged source $GITHUB_SHA."
+            echo "No unambiguous cache promotion authority exists for merged source $GITHUB_SHA."
             exit 0
           fi
           {
             echo "available=true"
             echo "run-id=${producer_run}"
+            echo "mode=${producer_mode}"
           } >> "$GITHUB_OUTPUT"
-          echo "Exact merge-group producer run: ${producer_run}"
-      - name: Download exact partition payloads
-        if: ${{ steps.producer.outputs.available == 'true' }}
+          echo "Exact merge-group authority run: ${producer_run} (${producer_mode})"
+      - name: Download reused-proof promotion authority
+        if: ${{ steps.producer.outputs.mode == 'reused-proof' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           repository: ${{ github.repository }}
           run-id: ${{ steps.producer.outputs.run-id }}
           github-token: ${{ github.token }}
-          pattern: core-affected-native-${{ github.sha }}-partition-*-of-*
+          name: core-affected-native-cache-promotion-authority-${{ steps.producer.outputs.run-id }}
+          path: product/qualification/cache-promotion/authority
+      - name: Verify reused-proof promotion authority
+        if: ${{ steps.producer.outputs.mode == 'reused-proof' }}
+        id: authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shifu-entry-contract: allow trusted dev push to reverify immutable merge-group authority
+          node scripts/affected-native-proof.mjs verify-cache-authority \
+            --bundle product/qualification/cache-promotion/authority \
+            --repository "$GITHUB_REPOSITORY" \
+            --target-run-id "${{ steps.producer.outputs.run-id }}" \
+            --target-head-sha "$GITHUB_SHA" \
+            --target-source-tree "$(git rev-parse 'HEAD^{tree}')" \
+            --github-output "$GITHUB_OUTPUT"
+      - name: Select authorized payload producer
+        if: ${{ steps.producer.outputs.available == 'true' }}
+        id: payload-source
+        shell: bash
+        env:
+          MODE: ${{ steps.producer.outputs.mode }}
+          MERGE_GROUP_RUN_ID: ${{ steps.producer.outputs.run-id }}
+          AUTHORITY_DIGEST: ${{ steps.authority.outputs.authority-digest }}
+          AUTHORIZED_RUN_ID: ${{ steps.authority.outputs.producer-run-id }}
+          AUTHORIZED_EVENT: ${{ steps.authority.outputs.producer-event }}
+          AUTHORIZED_TRIGGER_HEAD: ${{ steps.authority.outputs.producer-trigger-head-sha }}
+          AUTHORIZED_PAYLOAD_SOURCE: ${{ steps.authority.outputs.payload-source-sha }}
+        run: |
+          set -euo pipefail
+          if [ "$MODE" = "direct" ]; then
+            producer_run_id="$MERGE_GROUP_RUN_ID"
+            producer_event=merge_group
+            producer_trigger_head="$GITHUB_SHA"
+            payload_source_sha="$GITHUB_SHA"
+            authority_digest=""
+          else
+            producer_run_id="$AUTHORIZED_RUN_ID"
+            producer_event="$AUTHORIZED_EVENT"
+            producer_trigger_head="$AUTHORIZED_TRIGGER_HEAD"
+            payload_source_sha="$AUTHORIZED_PAYLOAD_SOURCE"
+            authority_digest="$AUTHORITY_DIGEST"
+          fi
+          {
+            echo "producer-run-id=${producer_run_id}"
+            echo "producer-event=${producer_event}"
+            echo "producer-trigger-head-sha=${producer_trigger_head}"
+            echo "payload-source-sha=${payload_source_sha}"
+            echo "authority-digest=${authority_digest}"
+          } >> "$GITHUB_OUTPUT"
+      - name: Confirm complete authorized partition payloads
+        if: ${{ steps.producer.outputs.available == 'true' }}
+        id: payload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRODUCER_RUN_ID: ${{ steps.payload-source.outputs.producer-run-id }}
+          PRODUCER_EVENT: ${{ steps.payload-source.outputs.producer-event }}
+          PRODUCER_TRIGGER_HEAD: ${{ steps.payload-source.outputs.producer-trigger-head-sha }}
+          PAYLOAD_SOURCE_SHA: ${{ steps.payload-source.outputs.payload-source-sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          trusted="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${PRODUCER_RUN_ID}" |
+              jq -r \
+                --arg event "$PRODUCER_EVENT" \
+                --arg head "$PRODUCER_TRIGGER_HEAD" \
+                '(.event == $event and .head_sha == $head and .status == "completed" and .conclusion == "success" and .path == ".github/workflows/affected-native-pr.yml")'
+          )"
+          state="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${PRODUCER_RUN_ID}/artifacts?per_page=100" |
+              jq -r \
+                --arg prefix "core-affected-native-${PAYLOAD_SOURCE_SHA}-partition-" \
+                '[.artifacts[] | select(.expired == false and (.name | startswith($prefix))) | (.name | capture("-partition-(?<index>[0-9]+)-of-(?<count>[0-9]+)$"))] | if length == 0 then "absent" elif ((map(.count) | unique | length) == 1 and (.[0].count | tonumber) == length and (map(.index | tonumber) | sort) == [range(0; (.[0].count | tonumber))]) then "complete" else "partial" end'
+          )"
+          if [ "$trusted" != "true" ] || [ "$state" != "complete" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Authorized payload producer is unavailable or incomplete: trusted=${trusted}, state=${state}."
+            exit 0
+          fi
+          echo "available=true" >> "$GITHUB_OUTPUT"
+      - name: Download exact authorized partition payloads
+        if: ${{ steps.payload.outputs.available == 'true' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.payload-source.outputs.producer-run-id }}
+          github-token: ${{ github.token }}
+          pattern: core-affected-native-${{ steps.payload-source.outputs.payload-source-sha }}-partition-*-of-*
           path: product/qualification/cache-promotion/artifacts
       - name: Install pinned cache contract tools
-        if: ${{ steps.producer.outputs.available == 'true' }}
+        if: ${{ steps.payload.outputs.available == 'true' }}
         env:
           BUILDCHAIN_CHECK_MODE: source
         # shifu-entry-contract: allow source-tool bootstrap before the promotion verifier is runnable
         run: node scripts/buildchain-install.mjs
       - name: Verify promotion authority
-        if: ${{ steps.producer.outputs.available == 'true' }}
+        if: ${{ steps.payload.outputs.available == 'true' }}
         id: promotion
         run: |
           # shifu-entry-contract: allow verifying post-merge cache transport evidence outside the candidate Gate
           node scripts/write-affected-native-cache-manifests.mjs promote \
             --artifacts-dir product/qualification/cache-promotion/artifacts \
-            --expected-head-sha "$GITHUB_SHA" \
-            --expected-run-id "${{ steps.producer.outputs.run-id }}" \
+            --expected-target-head-sha "$GITHUB_SHA" \
+            --expected-merge-group-run-id "${{ steps.producer.outputs.run-id }}" \
+            --expected-payload-head-sha "${{ steps.payload-source.outputs.payload-source-sha }}" \
+            --expected-producer-run-id "${{ steps.payload-source.outputs.producer-run-id }}" \
+            --expected-producer-event "${{ steps.payload-source.outputs.producer-event }}" \
             --expected-repository "$GITHUB_REPOSITORY" \
+            --authority-mode "${{ steps.producer.outputs.mode }}" \
+            --authority-digest "${{ steps.payload-source.outputs.authority-digest }}" \
             --output product/qualification/cache-promotion/promotion.json \
             --github-output "$GITHUB_OUTPUT"
       - name: Materialize qualified cache roots
-        if: ${{ steps.producer.outputs.available == 'true' }}
+        if: ${{ steps.payload.outputs.available == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -139,26 +252,28 @@ jobs:
             tar -xf "$compiler_archive" -C "$HOME"
           done < <(jq -r '.compiler.archives[].archive' "$promotion")
       - name: Save default-branch dependency cache
-        if: ${{ steps.producer.outputs.available == 'true' }}
+        if: ${{ steps.payload.outputs.available == 'true' }}
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.conan2/p
           key: ${{ steps.promotion.outputs.dependency-key }}
       - name: Save default-branch compiler cache
-        if: ${{ steps.producer.outputs.available == 'true' }}
+        if: ${{ steps.payload.outputs.available == 'true' }}
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ccache
           key: ${{ steps.promotion.outputs.compiler-key }}
       - name: Summarize promotion
-        if: ${{ steps.producer.outputs.available == 'true' }}
+        if: ${{ steps.payload.outputs.available == 'true' }}
         shell: bash
         run: |
           {
             echo "### Affected-native cache promotion"
             echo
             echo "- merged source: \`$GITHUB_SHA\`"
-            echo "- merge-group producer: \`${{ steps.producer.outputs.run-id }}\`"
-            echo "- authority: complete source-bound partition receipts and payload digests"
+            echo "- merge-group authority: \`${{ steps.producer.outputs.run-id }}\`"
+            echo "- payload producer: \`${{ steps.payload-source.outputs.producer-run-id }}\` (\`${{ steps.payload-source.outputs.producer-event }}\`)"
+            echo "- authority mode: \`${{ steps.producer.outputs.mode }}\`"
+            echo "- authority: exact source-tree proof plus complete partition receipts and payload digests"
             echo "- validation: current-source configure/build/CTest remains mandatory on restore"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -582,7 +582,8 @@ jobs:
       - name: Seal cache promotion payload
         if: >-
           ${{
-            github.event_name == 'merge_group' &&
+            (github.event_name == 'pull_request' ||
+             github.event_name == 'merge_group') &&
             steps.native-gate.outcome == 'success'
           }}
         shell: bash
@@ -909,11 +910,49 @@ jobs:
             --checkout-sha "$(git rev-parse HEAD)"
           echo "proof-created=true" >> "$GITHUB_OUTPUT"
           echo "All affected-native partitions passed."
+      - name: Seal reused-proof cache promotion authority
+        if: >-
+          ${{
+            github.event_name == 'merge_group' &&
+            needs.proof_probe.outputs.reuse == 'true'
+          }}
+        shell: bash
+        env:
+          PRODUCER_RUN_ID: ${{ needs.proof_probe.outputs.producer-run-id }}
+          PRODUCER_EVENT: ${{ needs.proof_probe.outputs.producer-event }}
+          PRODUCER_HEAD_SHA: ${{ needs.proof_probe.outputs.producer-head-sha }}
+        run: |
+          set -euo pipefail
+          admission=product/qualification/affected-native
+          # shifu-entry-contract: allow sealing post-admission cache transport authority
+          node scripts/affected-native-proof.mjs seal-cache-authority \
+            --descriptor "$admission/proof-admission/descriptor.json" \
+            --bundle "$admission/proof-reuse" \
+            --output-dir "$admission/cache-promotion-authority" \
+            --repository "$GITHUB_REPOSITORY" \
+            --target-run-id "$GITHUB_RUN_ID" \
+            --target-head-sha "$GITHUB_SHA" \
+            --target-source-tree "$(git rev-parse 'HEAD^{tree}')" \
+            --producer-run-id "$PRODUCER_RUN_ID" \
+            --producer-event "$PRODUCER_EVENT" \
+            --producer-head-sha "$PRODUCER_HEAD_SHA"
       - name: Upload authoritative producer proof
         if: ${{ steps.admit.outputs.proof-created == 'true' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ needs.proof_probe.outputs.artifact-name }}
           path: product/qualification/affected-native/proof-bundle
+          if-no-files-found: error
+          retention-days: 14
+      - name: Upload reused-proof cache promotion authority
+        if: >-
+          ${{
+            github.event_name == 'merge_group' &&
+            needs.proof_probe.outputs.reuse == 'true'
+          }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: core-affected-native-cache-promotion-authority-${{ github.run_id }}
+          path: product/qualification/affected-native/cache-promotion-authority
           if-no-files-found: error
           retention-days: 14

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -127,15 +127,22 @@ Each section is bound to the registry id by the catalog meta gate.
   retaining source-bound exact keys and always rerunning configure/build/CTest.
   GitHub scopes a cache saved by a merge-group run to its synthetic queue ref,
   so that cache is not itself a reusable base-branch baseline. After a
-  successful native Gate, each partition instead seals its secret-free cache
-  roots into a source-, run-, plan-, partition-, receipt-, and digest-bound
-  artifact. The resulting trusted dev push locates the exact successful
-  merge-group producer, requires the complete partition set, revalidates every
-  payload and receipt, combines the compiler roots, and writes the result into
-  the long-lived base-branch cache scope. A non-native push or any missing,
-  ambiguous, stale, source-drifted, or malformed producer is an auditable no-op.
-  The push workflow transports already-qualified cache data and does not repeat
-  the candidate-equivalent native build.
+  successful native Gate, each pull-request or merge-group partition instead
+  seals its secret-free cache roots into a source-, run-, plan-, partition-,
+  receipt-, and digest-bound artifact. The resulting trusted dev push locates
+  the exact successful merge-group admission. A direct merge-group build
+  supplies its own complete partition set. A merge group that reused an exact
+  pull-request proof instead seals a separate immutable promotion authority
+  that binds the merged head and source tree to the verified proof root,
+  producer run, producer checkout, plan projection, and partition contract.
+  The push independently revalidates that authority before selecting the exact
+  producer payloads; it never rewrites their source-bound receipts as
+  merge-group evidence. It then requires the complete partition set,
+  revalidates every payload and receipt, combines the compiler roots, and writes
+  the result into the long-lived base-branch cache scope. A non-native push or
+  any missing, ambiguous, stale, source-drifted, or malformed producer or
+  authority is an auditable no-op. The push transports already-qualified cache
+  data and does not repeat the candidate-equivalent native build.
 - **Cold-path partitioning:** the authoritative target and CTest lists are split
   deterministically across two GitHub-hosted Linux jobs. Each receipt binds its
   zero-based partition index, partition count, selected targets/tests, partition
@@ -154,14 +161,15 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Repeated-run proof admission:** workflow concurrency prevents concurrent
   executions sharing one synthetic merge-group SHA; `cancel-in-progress: false`
   preserves the active execution while GitHub may coalesce identical pending
-  replacements. The first successful execution produces the authoritative queue
-  proof. A later execution skips the repeated native/SDK, Shifu workspace, and
-  KFD work after a unique completed-success artifact
-  matches that exact SHA and its cryptographically verified identity binds the
-  same base, candidate tree, plan projection, partition set, platform tier,
-  hosted-runner image, and observed compiler/CMake/Ninja facts. PR producers,
-  moved bases, changed trees/toolchains, duplicate artifacts, expired evidence,
-  and every lookup/download/verification failure run the full required set.
+  replacements. A successful pull-request candidate or first queue execution
+  produces an authoritative proof. A merge group or later same-SHA queue
+  execution skips the repeated native/SDK, Shifu workspace, and KFD work only
+  after deterministic lookup selects a completed-success artifact and
+  cryptographic verification binds the same base, candidate tree, plan
+  projection, partition set, platform tier, hosted-runner image, and observed
+  compiler/CMake/Ninja facts. Moved bases, changed trees/toolchains, expired or
+  untrusted evidence, and every lookup/download/verification failure run the
+  full required set.
   The producer workflow must itself be completed-success, so the source-bound
   plan also proves that its SDK, Shifu, and KFD obligations passed before a
   repeated run can skip them. The probe descriptor is handed unchanged to the
@@ -170,8 +178,8 @@ Each section is bound to the registry id by the catalog meta gate.
   substituting facts from a later non-native runner. Every native shard receipt
   must still match the complete probe toolchain, including the hosted image
   version; cross-runner drift therefore remains fail-closed. Shifu workspace
-  and KFD remain independent on the first execution; only a later exact-SHA
-  execution backed by the completed-success producer may skip them.
+  and KFD remain independent on the producer execution; only a candidate backed
+  by that completed-success exact proof may skip them.
 - **Dequeue repair admission:** the trusted-base dequeue controller cancels
   active work and writes one PR marker for deterministic `failed_checks`,
   `merge_conflict`, or `invalid_merge_commit` exits. The marker binds the exact

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -46,7 +46,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:58ea148053076259e8fb5d887ab44fff9131a55a6076c0576a54d1e47be66a29",
+          "definitionDigest": "sha256:e941529f9f9a9647b33644584b5378ce1119b1a07899b314a8848f445e50846d",
           "credentials": {
             "githubToken": "write",
             "oidc": false,
@@ -54,7 +54,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@v6.4.0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830"],
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@v6.4.0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830"],
           "steps": [
             {
               "index": 1,
@@ -69,43 +69,64 @@
             {
               "index": 3,
               "label": "id:producer",
-              "definitionDigest": "sha256:1f4880e2366f083e279cfe8e1980be8cf3d933ca64478f94dbfd37ed07fa83f6"
+              "definitionDigest": "sha256:a08463974270a5baddc298ff195d6f26144fc7c220067c6f4c23f5b23822f53e"
             },
             {
               "index": 4,
-              "label": "name:Download exact partition payloads",
+              "label": "name:Download reused-proof promotion authority",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:eea8a5315f7fd516d02c2f68771a345b394857c61c0d21355bd4a73f0a91e897"
+              "definitionDigest": "sha256:9f8f317df0d7d50c3de4497076856ad59531e6f11ccde77fd6195807a4f096d2"
             },
             {
               "index": 5,
-              "label": "name:Install pinned cache contract tools",
-              "definitionDigest": "sha256:1ea792aaabfae4d87b5e301934af76d2be0986f30f1f640e8a62e9d70329607d"
+              "label": "id:authority",
+              "definitionDigest": "sha256:04e3fb6b93e18dfb76a68a38c58d2716234b11a7f76e5cdd4c9d663035ee95cb"
             },
             {
               "index": 6,
-              "label": "id:promotion",
-              "definitionDigest": "sha256:238d29801273ec70fc3b154c7aa2d7d133674d6824e6020068980aa947050325"
+              "label": "id:payload-source",
+              "definitionDigest": "sha256:06766b19f9fbca9d43a1e55c604630e1d6d13a7d29ef3871d07a2d170837f47d"
             },
             {
               "index": 7,
-              "label": "name:Materialize qualified cache roots",
-              "definitionDigest": "sha256:1b094565f9b248158eb8668d57ed8ba1048e4cd51b59d3c8723c527b6c30be50"
+              "label": "id:payload",
+              "definitionDigest": "sha256:034bdc31fa97a0c2e9a6c9810b7f1f56a67c81b94cc7a0fb19a6c1c22eb66bf1"
             },
             {
               "index": 8,
-              "label": "name:Save default-branch dependency cache",
-              "definitionDigest": "sha256:48ca9d95481afa9aff0ff03818bdc7cd6b6a68c47495d19d721efa6e1df7a700"
+              "label": "name:Download exact authorized partition payloads",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:d1f9ef894cdd352ff101bafcdc4feef6a2ecf146f67ce26d74ecbbc9422db8c4"
             },
             {
               "index": 9,
-              "label": "name:Save default-branch compiler cache",
-              "definitionDigest": "sha256:b323dbabda91082de84ba5cb0c7275f7d3c96713ef378f87c817b70731cf9272"
+              "label": "name:Install pinned cache contract tools",
+              "definitionDigest": "sha256:ea22d81406234a2562088536e2bbd8ed56682c733922caebd0f4dbb26aee536c"
             },
             {
               "index": 10,
+              "label": "id:promotion",
+              "definitionDigest": "sha256:bd76125b30bcb2e630eaaa0561e5195f6b01535eaeee5b6fdc32bca2ecad98f2"
+            },
+            {
+              "index": 11,
+              "label": "name:Materialize qualified cache roots",
+              "definitionDigest": "sha256:e91b19740ebb743887c1cc6f6a8eca90ba36a78f2662dbc6c992886b31462521"
+            },
+            {
+              "index": 12,
+              "label": "name:Save default-branch dependency cache",
+              "definitionDigest": "sha256:da0f0e668b43673eb8a00f8cd55f943d240aa10d6859387cbfaab79d6a01741a"
+            },
+            {
+              "index": 13,
+              "label": "name:Save default-branch compiler cache",
+              "definitionDigest": "sha256:21ca68790f65eb3fe710e1f87f93097248a666ecb9e8d2c46005085173c4e998"
+            },
+            {
+              "index": 14,
               "label": "name:Summarize promotion",
-              "definitionDigest": "sha256:145278d59db41a14aacb6d069297739a40478d43087b019fa146405066142a91"
+              "definitionDigest": "sha256:1c042098dfdded84ad4ffcec45ba29b276b78d70cb8a76a66e3f0ea3ec58f463"
             }
           ]
         }
@@ -121,7 +142,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:ae120c4e72309e2df03eec607999f337152dabd852fcf73b701fc9fc62770ce9",
+          "definitionDigest": "sha256:3d9e020c9bdcd477b68354a5c8aa85a4de697638efb9515576d57c053e39b263",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -239,7 +260,7 @@
             {
               "index": 22,
               "label": "name:Seal cache promotion payload",
-              "definitionDigest": "sha256:8df9b0df2db2468af1ce0466b5979bdfbde7abc42b6aa183c060fdab44d048b0"
+              "definitionDigest": "sha256:d1ad74917689582f700b9015612979f916ded0612950891a158807db8f07558b"
             },
             {
               "index": 23,
@@ -254,7 +275,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c26248a93398a31586f9e859cd042339cbbf522c82ee7a5c0ccaaa282eb1a756",
+          "definitionDigest": "sha256:90f7aa97bc78edecd0246b1312e692e5675f4855fe98775fd284be90d41ad4d4",
           "credentials": {
             "githubToken": "read",
             "oidc": false,
@@ -262,7 +283,7 @@
             "inheritedSecrets": false,
             "environment": null
           },
-          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
+          "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
@@ -311,9 +332,21 @@
             },
             {
               "index": 9,
+              "label": "name:Seal reused-proof cache promotion authority",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:dba0908dcde9277b704c7690eb25ecabac31f48a4dc98ce3a8a26d54b354c241"
+            },
+            {
+              "index": 10,
               "label": "name:Upload authoritative producer proof",
               "authority": "evidence-publication",
               "definitionDigest": "sha256:fe1606def564bd546877397a1b84e548fd45f241c958dbed56376fc448d85336"
+            },
+            {
+              "index": 11,
+              "label": "name:Upload reused-proof cache promotion authority",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:cd6594bf6e2bcb1ebbcbe1aa42683ef6488bb31e68ddc1eb0a060ce6cc749d5f"
             }
           ]
         },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -40,9 +40,9 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | Workflow | Job | Authority | Publication | Receipt | Credentials | Environment | Steps |
 | --- | --- | --- | --- | --- | --- | --- | ---: |
 | `.github/workflows/adr-release-gate.yml` | `adr-release` | qualification | none | diagnostic | token:read | none | 2 |
-| `.github/workflows/affected-native-cache-promote.yml` | `promote` | qualification | none | diagnostic | token:write | none | 10 |
+| `.github/workflows/affected-native-cache-promote.yml` | `promote` | qualification | none | diagnostic | token:write | none | 14 |
 | `.github/workflows/affected-native-pr.yml` | `affected_native_shards` | qualification | none | diagnostic | token:read | none | 23 |
-| `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 9 |
+| `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 11 |
 | `.github/workflows/affected-native-pr.yml` | `candidate_buildchain_config` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/affected-native-pr.yml` | `candidate_preflight` | qualification | none | diagnostic | token:read | none | 6 |
 | `.github/workflows/affected-native-pr.yml` | `dco` | qualification | none | diagnostic | token:read | none | 2 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -68,7 +68,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:107cb2a8e5825f5cc525248185405e059dc3255383d3ec15f593c7a6ccee97c5"
+          "sourceRoot": "sha256:51159fa1e18144ca0285932e8ba08cee75287450c06898698643d878553d507d"
         },
         {
           "path": ".github/workflows/affected-native-pr.yml",
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:f6b0ecaff3594732b52fc10cf0c5eabfdbcc9aa3f0eee3d8d6d06ee3589f0206"
+          "sourceRoot": "sha256:bffa2d04f29ce9ddcc645ef0e5aabf26f0bcb7913527788a22490612bde77ab3"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -767,5 +767,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e55cb0d96ac9ace1cf33ae775f69d9cfced03112eee5af550c982a877d5c3a06"
+  "registryRoot": "sha256:6ad9fb266f9cf5b36cdb607e0f093c5a98f2fffafb76621d1781aa7b7b890661"
 }

--- a/scripts/affected-native-cache-payload.test.mjs
+++ b/scripts/affected-native-cache-payload.test.mjs
@@ -109,6 +109,7 @@ function createPartitionArtifact({
   partitionCount,
   repository,
   runId,
+  event = 'merge_group',
   compilerSymlinkTarget = '',
   dependencyMarker = 'package',
   dependencySymlinkTarget = '',
@@ -180,7 +181,7 @@ function createPartitionArtifact({
     partitionCount,
     repository,
     runId,
-    event: 'merge_group',
+    event,
     headSha: plan.head,
     compilerArchive,
     dependencyArchive,
@@ -208,11 +209,18 @@ test('qualified merge-group partitions form one default-branch cache promotion',
   }
   const promotion = createAffectedNativeCachePromotion({
     artifactsDir: root,
-    expectedHeadSha: plan.head,
-    expectedRunId: runId,
+    expectedTargetHeadSha: plan.head,
+    expectedMergeGroupRunId: runId,
+    expectedPayloadHeadSha: plan.head,
+    expectedProducerRunId: runId,
+    expectedProducerEvent: 'merge_group',
     expectedRepository: repository,
+    authorityMode: 'direct',
   });
-  assert.equal(promotion.sourceSha, plan.head);
+  assert.equal(promotion.schema, 'kungfu.affected-native-cache-promotion/v2');
+  assert.equal(promotion.targetSourceSha, plan.head);
+  assert.equal(promotion.payloadSourceSha, plan.head);
+  assert.equal(promotion.authority.mode, 'direct');
   assert.equal(promotion.partitionCount, 2);
   assert.equal(promotion.dependency.partitionIndex, 0);
   assert.equal(promotion.compiler.archives.length, 2);
@@ -240,9 +248,13 @@ test('cache promotion fails closed on an incomplete partition set', (t) => {
     () =>
       createAffectedNativeCachePromotion({
         artifactsDir: root,
-        expectedHeadSha: plan.head,
-        expectedRunId: 12345,
+        expectedTargetHeadSha: plan.head,
+        expectedMergeGroupRunId: 12345,
+        expectedPayloadHeadSha: plan.head,
+        expectedProducerRunId: 12345,
+        expectedProducerEvent: 'merge_group',
         expectedRepository: 'kungfu-systems/kungfu',
+        authorityMode: 'direct',
       }),
     /partition set is incomplete/,
   );
@@ -256,19 +268,72 @@ test('push promotion waits for the exact required Gate instead of whole-run comp
   assert.match(workflow, /head_sha="\$GITHUB_SHA"/u);
   assert.match(workflow, /actions\/runs\/\$\{run_id\}\/jobs/u);
   assert.match(workflow, /\.name == "affected-native \/ linux"/u);
-  assert.match(workflow, /artifact_state.*complete/su);
+  assert.match(workflow, /direct_state.*complete/su);
+  assert.match(workflow, /authority_count.*reused-proof/su);
   assert.match(workflow, /while \[ "\$attempt" -le 60 \]/u);
   assert.doesNotMatch(workflow, /status=completed/u);
 });
 
-test('pull-request proof producers never seal merge-group cache payloads', () => {
+test('PR payload transport requires merge-group reused-proof authority', (t) => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-cache-promotion-reused-proof-'),
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const plan = createPlan();
+  const repository = 'kungfu-systems/kungfu';
+  for (const partitionIndex of [0, 1]) {
+    createPartitionArtifact({
+      artifactsRoot: root,
+      plan,
+      partitionIndex,
+      partitionCount: 2,
+      repository,
+      runId: 12345,
+      event: 'pull_request',
+    });
+  }
+  const authorityDigest = `sha256:${'e'.repeat(64)}`;
+  const promotion = createAffectedNativeCachePromotion({
+    artifactsDir: root,
+    expectedTargetHeadSha: 'f'.repeat(40),
+    expectedMergeGroupRunId: 12346,
+    expectedPayloadHeadSha: plan.head,
+    expectedProducerRunId: 12345,
+    expectedProducerEvent: 'pull_request',
+    expectedRepository: repository,
+    authorityMode: 'reused-proof',
+    authorityDigest,
+  });
+  assert.equal(promotion.targetSourceSha, 'f'.repeat(40));
+  assert.equal(promotion.payloadSourceSha, plan.head);
+  assert.deepEqual(promotion.producer, {
+    runId: 12345,
+    event: 'pull_request',
+  });
+  assert.deepEqual(promotion.authority, {
+    mode: 'reused-proof',
+    digest: authorityDigest,
+  });
+
   const workflow = fs.readFileSync(
     '.github/workflows/affected-native-pr.yml',
     'utf8',
   );
   assert.match(
     workflow,
-    /name: Seal cache promotion payload[\s\S]*?if:\s*>-[\s\S]*?github\.event_name == 'merge_group' &&[\s\S]*?steps\.native-gate\.outcome == 'success'/u,
+    /name: Seal cache promotion payload[\s\S]*?github\.event_name == 'pull_request'[\s\S]*?github\.event_name == 'merge_group'[\s\S]*?steps\.native-gate\.outcome == 'success'/u,
+  );
+  assert.match(
+    workflow,
+    /name: Seal reused-proof cache promotion authority[\s\S]*?seal-cache-authority/u,
+  );
+  const promotionWorkflow = fs.readFileSync(
+    '.github/workflows/affected-native-cache-promote.yml',
+    'utf8',
+  );
+  assert.match(
+    promotionWorkflow,
+    /verify-cache-authority[\s\S]*?expected-payload-head-sha/u,
   );
 });
 

--- a/scripts/affected-native-proof.mjs
+++ b/scripts/affected-native-proof.mjs
@@ -11,6 +11,8 @@ import { pathToFileURL } from 'node:url';
 
 export const IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v3';
 export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v3';
+export const CACHE_PROMOTION_AUTHORITY_SCHEMA =
+  'kungfu.affected-native-cache-promotion-authority/v1';
 export const WORKFLOW_PATH = '.github/workflows/affected-native-pr.yml';
 export const DEFAULT_MAX_AGE_SECONDS = 6 * 60 * 60;
 const PRODUCER_EVENTS = new Set(['pull_request', 'merge_group']);
@@ -45,6 +47,21 @@ function readJson(file) {
 function requireSha(value, label) {
   if (!/^[0-9a-f]{40}$/u.test(value || '')) {
     throw new Error(`${label} must be an exact Git SHA`);
+  }
+  return value;
+}
+
+function requireRunId(value, label) {
+  const runId = Number(value);
+  if (!Number.isInteger(runId) || runId < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return runId;
+}
+
+function requireRepository(value, label) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(value || '')) {
+    throw new Error(`${label} must be an exact repository`);
   }
   return value;
 }
@@ -384,6 +401,120 @@ export function verifyProofBundle(descriptor, bundleDir, options) {
   return proof;
 }
 
+export function createCachePromotionAuthority(
+  descriptor,
+  proofBundleDir,
+  options,
+) {
+  const target = {
+    repository: requireRepository(
+      options.targetRepository,
+      'cache promotion target repository',
+    ),
+    runId: requireRunId(options.targetRunId, 'cache promotion target run id'),
+    event: options.targetEvent,
+    headSha: requireSha(options.targetHeadSha, 'cache promotion target head'),
+    sourceTree: requireSha(
+      options.targetSourceTree,
+      'cache promotion target source tree',
+    ),
+  };
+  if (target.event !== 'merge_group') {
+    throw new Error('cache promotion target must be merge_group');
+  }
+  if (descriptor.identity?.sourceTree !== target.sourceTree) {
+    throw new Error('cache promotion target source tree drift');
+  }
+  const proof = verifyProofBundle(descriptor, proofBundleDir, {
+    repository: options.producerRepository,
+    producerRunId: options.producerRunId,
+    producerEvent: options.producerEvent,
+    producerHeadSha: options.producerHeadSha,
+    maxAgeSeconds:
+      options.maxAgeSeconds === undefined
+        ? DEFAULT_MAX_AGE_SECONDS
+        : Number(options.maxAgeSeconds),
+    now: options.now,
+  });
+  if (proof.producer.repository !== target.repository) {
+    throw new Error('cache promotion producer repository drift');
+  }
+  const body = {
+    schema: CACHE_PROMOTION_AUTHORITY_SCHEMA,
+    target,
+    proof: {
+      proofId: proof.proofId,
+      artifactName: proof.artifactName,
+      proofRoot: proof.proofRoot,
+    },
+    producer: proof.producer,
+    partitionCount: descriptor.identity.partitionCount,
+    planProjectionDigest: descriptor.identity.planProjectionDigest,
+    payloadSourceSha: proof.producer.checkoutSha,
+  };
+  return { ...body, authorityDigest: digest(body) };
+}
+
+export function verifyCachePromotionAuthority(authorityDir, options) {
+  const authority = readJson(path.join(authorityDir, 'authority.json'));
+  const { authorityDigest, ...body } = authority;
+  if (
+    authority.schema !== CACHE_PROMOTION_AUTHORITY_SCHEMA ||
+    authorityDigest !== digest(body)
+  ) {
+    throw new Error('cache promotion authority digest drift');
+  }
+  const expectedTarget = {
+    repository: requireRepository(
+      options.targetRepository,
+      'cache promotion target repository',
+    ),
+    runId: requireRunId(options.targetRunId, 'cache promotion target run id'),
+    event: 'merge_group',
+    headSha: requireSha(options.targetHeadSha, 'cache promotion target head'),
+    sourceTree: requireSha(
+      options.targetSourceTree,
+      'cache promotion target source tree',
+    ),
+  };
+  if (stableJson(authority.target) !== stableJson(expectedTarget)) {
+    throw new Error('cache promotion target authority drift');
+  }
+  const descriptor = readJson(path.join(authorityDir, 'descriptor.json'));
+  if (
+    descriptor.identity?.sourceTree !== expectedTarget.sourceTree ||
+    authority.partitionCount !== descriptor.identity?.partitionCount ||
+    authority.planProjectionDigest !== descriptor.identity?.planProjectionDigest
+  ) {
+    throw new Error('cache promotion descriptor authority drift');
+  }
+  const proof = verifyProofBundle(
+    descriptor,
+    path.join(authorityDir, 'proof'),
+    {
+      repository: authority.producer?.repository,
+      producerRunId: authority.producer?.runId,
+      producerEvent: authority.producer?.event,
+      producerHeadSha: authority.producer?.triggerHeadSha,
+      maxAgeSeconds:
+        options.maxAgeSeconds === undefined
+          ? DEFAULT_MAX_AGE_SECONDS
+          : Number(options.maxAgeSeconds),
+      now: options.now,
+    },
+  );
+  if (
+    authority.proof?.proofId !== proof.proofId ||
+    authority.proof?.artifactName !== proof.artifactName ||
+    authority.proof?.proofRoot !== proof.proofRoot ||
+    stableJson(authority.producer) !== stableJson(proof.producer) ||
+    authority.payloadSourceSha !== proof.producer.checkoutSha
+  ) {
+    throw new Error('cache promotion proof authority drift');
+  }
+  return authority;
+}
+
 export function selectReusableArtifact({
   artifacts,
   runsById,
@@ -533,6 +664,19 @@ function writeJson(file, value) {
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function copyDirectory(source, destination) {
+  fs.mkdirSync(destination, { recursive: true });
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    const sourcePath = path.join(source, entry.name);
+    const destinationPath = path.join(destination, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectory(sourcePath, destinationPath);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(sourcePath, destinationPath);
+    }
+  }
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.command === 'toolchain') {
@@ -642,8 +786,75 @@ async function main() {
     );
     return;
   }
+  if (options.command === 'seal-cache-authority') {
+    const descriptorFile = path.resolve(options.descriptor);
+    const proofBundleDir = path.resolve(options.bundle);
+    const outputDir = path.resolve(options['output-dir']);
+    const authority = createCachePromotionAuthority(
+      readJson(descriptorFile),
+      proofBundleDir,
+      {
+        targetRepository: options.repository,
+        targetRunId: options['target-run-id'],
+        targetEvent: 'merge_group',
+        targetHeadSha: options['target-head-sha'],
+        targetSourceTree:
+          options['target-source-tree'] || git('rev-parse', 'HEAD^{tree}'),
+        producerRepository: options.repository,
+        producerRunId: options['producer-run-id'],
+        producerEvent: options['producer-event'],
+        producerHeadSha: options['producer-head-sha'],
+        maxAgeSeconds: Number(
+          options['max-age-seconds'] || DEFAULT_MAX_AGE_SECONDS,
+        ),
+        now: options.now,
+      },
+    );
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.copyFileSync(descriptorFile, path.join(outputDir, 'descriptor.json'));
+    copyDirectory(proofBundleDir, path.join(outputDir, 'proof'));
+    writeJson(path.join(outputDir, 'authority.json'), authority);
+    console.log(JSON.stringify(authority, null, 2));
+    return;
+  }
+  if (options.command === 'verify-cache-authority') {
+    const authority = verifyCachePromotionAuthority(
+      path.resolve(options.bundle),
+      {
+        targetRepository: options.repository,
+        targetRunId: options['target-run-id'],
+        targetHeadSha: options['target-head-sha'],
+        targetSourceTree:
+          options['target-source-tree'] || git('rev-parse', 'HEAD^{tree}'),
+        maxAgeSeconds: Number(
+          options['max-age-seconds'] || DEFAULT_MAX_AGE_SECONDS,
+        ),
+        now: options.now,
+      },
+    );
+    appendGithubOutput(options['github-output'], {
+      'authority-digest': authority.authorityDigest,
+      'producer-run-id': authority.producer.runId,
+      'producer-event': authority.producer.event,
+      'producer-trigger-head-sha': authority.producer.triggerHeadSha,
+      'payload-source-sha': authority.payloadSourceSha,
+    });
+    console.log(
+      JSON.stringify(
+        {
+          status: 'verified',
+          authorityDigest: authority.authorityDigest,
+          payloadSourceSha: authority.payloadSourceSha,
+          producer: authority.producer,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
   throw new Error(
-    'usage: affected-native-proof.mjs <toolchain|describe|lookup|seal|verify>',
+    'usage: affected-native-proof.mjs <toolchain|describe|lookup|seal|verify|seal-cache-authority|verify-cache-authority>',
   );
 }
 

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -8,11 +8,13 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  createCachePromotionAuthority,
   createProofDescriptor,
   digest,
   nativeToolchainIdentity,
   sealProof,
   selectReusableArtifact,
+  verifyCachePromotionAuthority,
   verifyProofBundle,
 } from './affected-native-proof.mjs';
 
@@ -273,6 +275,112 @@ test('exact PR proof survives the synthetic merge-group commit rewrite', () => {
       maxAgeSeconds: 6 * 60 * 60,
       now: '2026-07-22T01:00:00Z',
     }),
+  );
+  fs.rmSync(value.root, { recursive: true, force: true });
+});
+
+test('merge-group authority admits exact PR cache payload transport', () => {
+  const value = fixture();
+  const pullDescriptor = createProofDescriptor(value.value, TREE, 2, TOOLCHAIN);
+  const queueDescriptor = createProofDescriptor(
+    plan(QUEUE_HEAD),
+    TREE,
+    2,
+    TOOLCHAIN,
+  );
+  const proof = writeBundle(
+    pullDescriptor,
+    value,
+    producer({
+      event: 'pull_request',
+      triggerHeadSha: OTHER_HEAD,
+      checkoutSha: HEAD,
+    }),
+  );
+  const authority = createCachePromotionAuthority(
+    queueDescriptor,
+    value.bundle,
+    {
+      targetRepository: 'kungfu-systems/kungfu',
+      targetRunId: 84,
+      targetEvent: 'merge_group',
+      targetHeadSha: QUEUE_HEAD,
+      targetSourceTree: TREE,
+      producerRepository: 'kungfu-systems/kungfu',
+      producerRunId: 42,
+      producerEvent: 'pull_request',
+      producerHeadSha: OTHER_HEAD,
+      maxAgeSeconds: 6 * 60 * 60,
+      now: '2026-07-22T01:00:00Z',
+    },
+  );
+  const authorityDir = path.join(value.root, 'authority');
+  fs.mkdirSync(path.join(authorityDir, 'proof'), { recursive: true });
+  fs.writeFileSync(
+    path.join(authorityDir, 'descriptor.json'),
+    `${JSON.stringify(queueDescriptor, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(authorityDir, 'authority.json'),
+    `${JSON.stringify(authority, null, 2)}\n`,
+  );
+  for (const entry of fs.readdirSync(value.bundle)) {
+    fs.copyFileSync(
+      path.join(value.bundle, entry),
+      path.join(authorityDir, 'proof', entry),
+    );
+  }
+  const verified = verifyCachePromotionAuthority(authorityDir, {
+    targetRepository: 'kungfu-systems/kungfu',
+    targetRunId: 84,
+    targetHeadSha: QUEUE_HEAD,
+    targetSourceTree: TREE,
+    maxAgeSeconds: 6 * 60 * 60,
+    now: '2026-07-22T01:00:00Z',
+  });
+  assert.equal(verified.proof.proofRoot, proof.proofRoot);
+  assert.equal(verified.payloadSourceSha, HEAD);
+  assert.equal(verified.producer.event, 'pull_request');
+  fs.rmSync(value.root, { recursive: true, force: true });
+});
+
+test('cache promotion authority fails closed on target or proof drift', () => {
+  const value = fixture();
+  const descriptor = createProofDescriptor(value.value, TREE, 2, TOOLCHAIN);
+  writeBundle(descriptor, value);
+  assert.throws(
+    () =>
+      createCachePromotionAuthority(descriptor, value.bundle, {
+        targetRepository: 'kungfu-systems/kungfu',
+        targetRunId: 84,
+        targetEvent: 'merge_group',
+        targetHeadSha: QUEUE_HEAD,
+        targetSourceTree: '6'.repeat(40),
+        producerRepository: 'kungfu-systems/kungfu',
+        producerRunId: 42,
+        producerEvent: 'merge_group',
+        producerHeadSha: HEAD,
+        maxAgeSeconds: 6 * 60 * 60,
+        now: '2026-07-22T01:00:00Z',
+      }),
+    /target source tree drift/,
+  );
+  assert.throws(
+    () =>
+      createCachePromotionAuthority(descriptor, value.bundle, {
+        targetRepository: 'other/repository',
+        targetRunId: 84,
+        targetEvent: 'merge_group',
+        targetHeadSha: QUEUE_HEAD,
+        targetSourceTree: TREE,
+        producerRepository: 'kungfu-systems/kungfu',
+        producerRunId: 42,
+        producerEvent: 'merge_group',
+        producerHeadSha: HEAD,
+        maxAgeSeconds: 6 * 60 * 60,
+        now: '2026-07-22T01:00:00Z',
+      }),
+    /producer repository drift/,
   );
   fs.rmSync(value.root, { recursive: true, force: true });
 });

--- a/scripts/write-affected-native-cache-manifests.mjs
+++ b/scripts/write-affected-native-cache-manifests.mjs
@@ -343,7 +343,10 @@ export function sealAffectedNativeCachePayload({
   const root = path.resolve(qualificationDir);
   const plan = verifyAffectedPlan(readJson(path.join(root, 'plan.json')));
   assert(plan.head === headSha, 'cache payload producer source drift');
-  assert(event === 'merge_group', 'cache payload producer must be merge_group');
+  assert(
+    event === 'pull_request' || event === 'merge_group',
+    'cache payload producer event is invalid',
+  );
   assert(
     /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository),
     'cache payload repository is invalid',
@@ -452,7 +455,7 @@ function verifyPayload(payload, manifestFile, expected) {
     'cache producer repository drift',
   );
   assert(
-    payload.producer?.event === 'merge_group',
+    payload.producer?.event === expected.producerEvent,
     'cache producer event drift',
   );
   assert(
@@ -511,17 +514,59 @@ function verifyPayload(payload, manifestFile, expected) {
 
 export function createAffectedNativeCachePromotion({
   artifactsDir,
-  expectedHeadSha,
-  expectedRunId,
+  expectedTargetHeadSha,
+  expectedMergeGroupRunId,
+  expectedPayloadHeadSha,
+  expectedProducerRunId,
+  expectedProducerEvent,
   expectedRepository,
+  authorityMode,
+  authorityDigest = '',
 }) {
   assert(
-    SHA_RE.test(expectedHeadSha || ''),
-    'expected promotion source is invalid',
+    SHA_RE.test(expectedTargetHeadSha || ''),
+    'expected promotion target source is invalid',
   );
   assert(
-    Number.isInteger(Number(expectedRunId)) && Number(expectedRunId) > 0,
-    'expected promotion run id is invalid',
+    Number.isInteger(Number(expectedMergeGroupRunId)) &&
+      Number(expectedMergeGroupRunId) > 0,
+    'expected merge-group run id is invalid',
+  );
+  assert(
+    SHA_RE.test(expectedPayloadHeadSha || ''),
+    'expected promotion payload source is invalid',
+  );
+  assert(
+    Number.isInteger(Number(expectedProducerRunId)) &&
+      Number(expectedProducerRunId) > 0,
+    'expected producer run id is invalid',
+  );
+  assert(
+    expectedProducerEvent === 'pull_request' ||
+      expectedProducerEvent === 'merge_group',
+    'expected producer event is invalid',
+  );
+  assert(
+    authorityMode === 'direct' || authorityMode === 'reused-proof',
+    'promotion authority mode is invalid',
+  );
+  if (authorityMode === 'direct') {
+    assert(
+      expectedProducerEvent === 'merge_group' &&
+        expectedTargetHeadSha === expectedPayloadHeadSha &&
+        Number(expectedMergeGroupRunId) === Number(expectedProducerRunId) &&
+        !authorityDigest,
+      'direct promotion authority identity drift',
+    );
+  } else {
+    assert(
+      DIGEST_RE.test(authorityDigest),
+      'reused-proof promotion authority digest is invalid',
+    );
+  }
+  assert(
+    /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(expectedRepository || ''),
+    'expected promotion repository is invalid',
   );
   const manifestFiles = findFiles(
     path.resolve(artifactsDir),
@@ -532,8 +577,9 @@ export function createAffectedNativeCachePromotion({
     'no affected-native cache payload manifests found',
   );
   const expected = {
-    headSha: expectedHeadSha,
-    runId: Number(expectedRunId),
+    headSha: expectedPayloadHeadSha,
+    runId: Number(expectedProducerRunId),
+    producerEvent: expectedProducerEvent,
     repository: expectedRepository,
   };
   const payloads = manifestFiles.map((file) =>
@@ -585,9 +631,18 @@ export function createAffectedNativeCachePromotion({
     'dependency cache payload must come uniquely from partition 0',
   );
   const body = {
-    schema: 'kungfu.affected-native-cache-promotion/v1',
-    sourceSha: expectedHeadSha,
-    producerRunId: Number(expectedRunId),
+    schema: 'kungfu.affected-native-cache-promotion/v2',
+    targetSourceSha: expectedTargetHeadSha,
+    payloadSourceSha: expectedPayloadHeadSha,
+    mergeGroupRunId: Number(expectedMergeGroupRunId),
+    producer: {
+      runId: Number(expectedProducerRunId),
+      event: expectedProducerEvent,
+    },
+    authority: {
+      mode: authorityMode,
+      digest: authorityDigest || null,
+    },
     repository: expectedRepository,
     planDigest: payloads[0].planDigest,
     partitionCount: count,
@@ -655,9 +710,18 @@ function main() {
   if (command === 'promote') {
     const promotion = createAffectedNativeCachePromotion({
       artifactsDir: required(options, 'artifacts-dir'),
-      expectedHeadSha: required(options, 'expected-head-sha'),
-      expectedRunId: Number(required(options, 'expected-run-id')),
+      expectedTargetHeadSha: required(options, 'expected-target-head-sha'),
+      expectedMergeGroupRunId: Number(
+        required(options, 'expected-merge-group-run-id'),
+      ),
+      expectedPayloadHeadSha: required(options, 'expected-payload-head-sha'),
+      expectedProducerRunId: Number(
+        required(options, 'expected-producer-run-id'),
+      ),
+      expectedProducerEvent: required(options, 'expected-producer-event'),
       expectedRepository: required(options, 'expected-repository'),
+      authorityMode: required(options, 'authority-mode'),
+      authorityDigest: options['authority-digest'] || '',
     });
     const output = required(options, 'output');
     fs.writeFileSync(


### PR DESCRIPTION
## Summary

Allow a merge group that reuses an exact successful pull-request native proof to promote the producer's qualified cache payloads into the long-lived dev branch scope without repeating the native build or weakening current-source validation.

Supersedes #1695 after the protected base advanced and its pre-queue admission correctly rejected the stale conflicting source.

## Related issue

Dev required-Gate latency SLO follow-up to #1693.

## Changes

- Seal source-, run-, receipt-, partition-, and digest-bound cache payloads on successful pull-request native shards as well as direct merge-group shards.
- Seal an immutable merge-group cache promotion authority after exact proof reuse, binding the merged head and tree to the verified proof root and producer checkout.
- Reverify the authority on the trusted dev push, require the exact successful producer run and complete payload partition set, and keep producer receipts source-honest.
- Separate merged target identity from payload producer identity in the promotion receipt.
- Refresh Gate workflow authority, release publication roots, tests, and documentation on the current dev base.

## Verification

- `./shifu test:gate-latency`
- `actionlint .github/workflows/affected-native-cache-promote.yml .github/workflows/affected-native-pr.yml`
- `./shifu check:gate-catalog`
- `node framework/release/publication-control-plane.mjs check`
- `git diff --check`
- Staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repairs cache transport after an already-qualified exact proof reuse without changing the Gate scope or architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The merge-group authority, producer proof, payload receipts, workflow inventory, and publication roots are exact and fail closed; current-source configure/build/CTest remains mandatory on every restore.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
