### PR TITLE
fix(release): preserve execution context compatibility

### DIFF
--- a/scripts/run-release-qualification.mjs
+++ b/scripts/run-release-qualification.mjs
@@ -306,7 +306,6 @@ export function releaseQualificationStages(
     '--execution-context',
     JSON.stringify({
       executionProfile: execution.name,
-      artifactScope,
       effectiveParameters: execution.parameters,
       policyDigest: execution.policyDigest,
       policyRef: execution.policyRef,

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -476,7 +476,13 @@ test('Hub CLI scope retains headless evidence without claiming desktop or SDK ar
   assert.ok(!gate.includes('layers.sdk'));
   assert.ok(!gate.includes('layers.surfaces'));
   const context = JSON.parse(gate[gate.indexOf('--execution-context') + 1]);
-  assert.equal(context.artifactScope, 'hub-cli');
+  assert.deepEqual(Object.keys(context).sort(), [
+    'effectiveParameters',
+    'executionProfile',
+    'policyDigest',
+    'policyRef',
+  ]);
+  assert.ok(!Object.hasOwn(context, 'artifactScope'));
 });
 
 test('execution profile parsing fails closed on missing, duplicate, and unknown values', () => {


### PR DESCRIPTION
## Summary

- Keep `artifactScope` local to release orchestration and qualification summaries.
- Preserve the existing strict Gate `--execution-context` schema for Product and Hub CLI qualification.
- Add an exact-key regression assertion so future scope metadata cannot leak into the shared protocol.

## Failure evidence

- Alpha Build run 30309951990, macOS job 90123376255: `shifu: --execution-context has unknown or missing fields`.
- The product build and zero-burden suites passed before the strict Gate consumer rejected the added field.

## Verification

- `node --test scripts/run-release-qualification.test.mjs` — 23/23 pass.
- `node --test scripts/check-kungfu-gate-catalog.test.mjs` — 23/23 pass.
- Full staged pre-commit gate — pass.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This compatibility fix removes orchestration-only metadata from an existing strict execution-context protocol; it does not change an architecture contract or qualification coverage."}
-->