### PR TITLE
fix(qualification): recalibrate hosted alpha budget

### DIFF
--- a/docs/qualification/gates/execution-profiles.json
+++ b/docs/qualification/gates/execution-profiles.json
@@ -2,8 +2,8 @@
   "schema": "kungfu.qualification-execution-profiles/v1",
   "profiles": {
     "alpha": {
-      "budgetSeconds": 5400,
-      "upstreamBudgetSeconds": 2400,
+      "budgetSeconds": 8400,
+      "upstreamBudgetSeconds": 4200,
       "reserveSeconds": 600,
       "fuzzSecondsPerTarget": 90,
       "episodeProfile": "mvp-smoke-v1",

--- a/docs/qualification/gates/policy-matrix.md
+++ b/docs/qualification/gates/policy-matrix.md
@@ -54,7 +54,7 @@ Do not hand-edit the generated block. A mode applies when the corresponding
 
 | Execution profile | Budget (s) | Upstream build (s) | Reserve (s) | Episode profile | Episode ceiling (s) | Fuzz seconds/target |
 | --- | ---: | ---: | ---: | --- | ---: | ---: |
-| `alpha` | 5400 | 2400 | 600 | `mvp-smoke-v1` | 600 | 90 |
+| `alpha` | 8400 | 4200 | 600 | `mvp-smoke-v1` | 600 | 90 |
 | `release-candidate` | 3600 | 900 | 600 | `mvp-candidate-v1` | 1200 | 90 |
 | `full-patrol` | 23400 | 900 | 900 | `mvp-baseline-v1` | 19800 | 90 |
 

--- a/docs/qualification/layer-gate-timing-baseline.md
+++ b/docs/qualification/layer-gate-timing-baseline.md
@@ -9,8 +9,8 @@ confidence: high
 sensitivity: internal
 evidence_grade: B
 review_state: self-reviewed
-last_reviewed: 2026-07-15
-ai_provenance: GPT-5 via Codex on 2026-07-15; visible local source, three-host lifecycle logs, hosted CI logs, Gate receipts, qualification reports, and host identity; no private publication state inspected
+last_reviewed: 2026-07-28
+ai_provenance: GPT-5 via Codex on 2026-07-15 and 2026-07-28; visible local source, three-host lifecycle logs, hosted CI logs, Gate receipts, qualification reports, and host identity; no private publication state inspected
 ---
 
 # Layer Gate timing baseline
@@ -247,7 +247,7 @@ bounding only the Episode seeds and accumulation/contention counts:
 
 | Execution profile | End-to-end budget | Upstream allowance | Reserve | Episode workload |
 | --- | ---: | ---: | ---: | --- |
-| `alpha` | 5400s | 2400s | 600s | `mvp-smoke-v1` |
+| `alpha` | 8400s | 4200s | 600s | `mvp-smoke-v1` |
 | `release-candidate` | 3600s | 900s | 600s | `mvp-candidate-v1` |
 | `full-patrol` | 14400s | 900s | 900s | unchanged `mvp-baseline-v1` |
 
@@ -257,6 +257,20 @@ The first exact-source hosted acceptance run then measured `1467s` inside the
 qualification process because runtime activation intentionally rebuilds and
 verifies the complete product distribution. That raised the execution
 allowance from `810s` to `1710s`.
+
+The exact protected Linux x64 Build qualification at
+`82e145eec619e1bc920c4de3aca2e968f8f89016` (GitHub Actions run
+`30306399387`, job `90111969613`) later measured `2633s` for the upstream build
+lifecycle and `2529s` for the complete verify lifecycle. Every visible
+qualification and invariant completed successfully, but the wrapper then
+failed solely because the inherited `2400s` execution allowance had expired.
+The same exact-source Windows x64 job (`90111969578`) completed its upstream
+build successfully in `3537s` before its verify step failed after `2573s`.
+The alpha total is therefore raised to `8400s`, with a `4200s` upstream
+allowance, `3600s` execution allowance, and unchanged `600s` reserve. This
+covers the slowest observed successful upstream build and the Linux
+qualification failure without removing or shortening any Gate. The workflow's
+independent `180` minute lifecycle ceiling remains the outer fail-closed limit.
 
 GitHub run `29410685685` later exercised the expanded exact-source product gate
 on hosted Linux. Install plus build consumed `2086s`; the qualification wrapper

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -412,8 +412,8 @@ test('execution profiles propagate bounded Episode and receipt parameters', () =
       reserveSeconds: alpha.parameters.reserveSeconds,
     },
     {
-      budgetSeconds: 5400,
-      upstreamBudgetSeconds: 2400,
+      budgetSeconds: 8400,
+      upstreamBudgetSeconds: 4200,
       reserveSeconds: 600,
     },
   );
@@ -421,7 +421,7 @@ test('execution profiles propagate bounded Episode and receipt parameters', () =
     alpha.parameters.budgetSeconds -
       alpha.parameters.upstreamBudgetSeconds -
       alpha.parameters.reserveSeconds,
-    2400,
+    3600,
   );
   const release = loadExecutionProfile('release-candidate');
   const stages = releaseQualificationStages('linux', release);
@@ -577,7 +577,7 @@ test('execution profile numeric constraints reject zero and negative values', ()
       () => loadExecutionProfile('alpha', file),
       /positive integer/,
     );
-    valid.profiles.alpha.budgetSeconds = 5400;
+    valid.profiles.alpha.budgetSeconds = 8400;
     valid.profiles.alpha.reserveSeconds = -1;
     fs.writeFileSync(file, JSON.stringify(valid));
     assert.throws(


### PR DESCRIPTION
## Summary

Recalibrate the fail-closed Alpha qualification budget from current exact protected-main Build timings. No Gate is skipped, shortened, or weakened; the independent 180-minute workflow ceiling remains unchanged.

## Related issue

Maintainability terminal-closure qualification follow-up. Exact protected-main Build run 30306399387 completed every visible Linux qualification and invariant, then failed only because the inherited 2400-second execution allowance expired. Its Windows build also established the current slowest successful upstream lifecycle.

## Changes

- raise Alpha end-to-end budget from 5400s to 8400s
- raise the upstream allowance from 2400s to 4200s
- retain the 600s reserve, yielding a 3600s execution allowance
- regenerate the policy matrix and record exact Linux/Windows timing evidence
- update execution-profile contract tests

## Verification

- `node scripts/run-release-qualification.test.mjs` (23/23)
- `node scripts/check-kungfu-gate-catalog.mjs --write`
- `node scripts/check-kungfu-gate-catalog.test.mjs` (23/23)
- `PATH=/Users/dkr/Worktrees/kungfu/feature/maintainability-terminal-closure/framework/core/.venv/bin:$PATH ./shifu check:source` (698 tests: 688 pass, 10 expected skips, 0 fail; Python 40 + 116; desktop 69; tooling type check and Biome pass)
- pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This operational qualification calibration preserves the existing Gate set, workload profiles, fail-closed behavior, and outer workflow timeout; it does not alter product architecture."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change only recalibrates exact-source Alpha qualification timing from retained hosted evidence. It does not publish, deploy, or grant credentials.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and generated policy projection updated
