### PR TITLE
fix(core): consume qualified libnode alpha.3

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.artifact.json
@@ -10,8 +10,8 @@
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc",
-    "digest": "sha256:2f6954cd36dd83e56472a2a96782a55110e540ac215a82cb69b81b5a87ad26c7"
+    "sha256": "2fd35b71dcc4836740502b6e181e083ba1e553ceb8a1bfd54a279dd46aa7ae0e",
+    "digest": "sha256:2d8563983d8a4b0052ea4789d62d9ae279eb402e3e08f0e8a5699b33c947c60b"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -23,12 +23,12 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.2",
+      "libnode": "22.22.3-kf.5-alpha.3",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
+    "digest": "sha256:5776dcbc5a1d4796a5dd613fab235c7fe49a73b6fee70362a64dd2ef2c09d7d7"
   },
-  "collaborationInterfaceDigest": "sha256:cc9f1c58bc675c37ccdba138274351123a335131fcc0004e6ea7b79aa083140b",
+  "collaborationInterfaceDigest": "sha256:b9114e62336234e04420d1f9831b9c32e86e6c41a1f8f4b97ec410d36909d0b8",
   "exposedSurfaces": [
     {
       "id": "kungfu.agent",

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,15 +6,15 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "0d28838f9201654867ff2140974a066c3a3b061c",
+    "sourceSha": "d22606161449e7c6c84fcbf890506594e55b1b62",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
-    "registryDigest": "sha256:2f6954cd36dd83e56472a2a96782a55110e540ac215a82cb69b81b5a87ad26c7"
+    "registryDigest": "sha256:2d8563983d8a4b0052ea4789d62d9ae279eb402e3e08f0e8a5699b33c947c60b"
   },
   "sourceRegistry": {
     "id": "kungfu",
     "path": ".buildchain/kfd/kfd-3/surfaces.json",
-    "sha256": "71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc",
-    "digest": "sha256:2f6954cd36dd83e56472a2a96782a55110e540ac215a82cb69b81b5a87ad26c7"
+    "sha256": "2fd35b71dcc4836740502b6e181e083ba1e553ceb8a1bfd54a279dd46aa7ae0e",
+    "digest": "sha256:2d8563983d8a4b0052ea4789d62d9ae279eb402e3e08f0e8a5699b33c947c60b"
   },
   "upstreamKfd": {
     "aggregatePath": "developer/sdk/kfd/upstream-aggregate.json",
@@ -26,15 +26,15 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.2",
+      "libnode": "22.22.3-kf.5-alpha.3",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
+    "digest": "sha256:5776dcbc5a1d4796a5dd613fab235c7fe49a73b6fee70362a64dd2ef2c09d7d7"
   },
   "expectedArtifactVerification": {
     "command": "node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json"
   },
-  "collaborationInterfaceDigest": "sha256:cc9f1c58bc675c37ccdba138274351123a335131fcc0004e6ea7b79aa083140b",
+  "collaborationInterfaceDigest": "sha256:b9114e62336234e04420d1f9831b9c32e86e6c41a1f8f4b97ec410d36909d0b8",
   "collaborationInterface": {
     "schemaVersion": 1,
     "contract": "kungfu-buildchain-kfd-3-surface-registry",
@@ -54,10 +54,10 @@
       ],
       "packageVersions": {
         "kfd": "1.0.0-alpha.47",
-        "libnode": "22.22.3-kf.5-alpha.2",
+        "libnode": "22.22.3-kf.5-alpha.3",
         "buildchain": "3.0.0"
       },
-      "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
+      "digest": "sha256:5776dcbc5a1d4796a5dd613fab235c7fe49a73b6fee70362a64dd2ef2c09d7d7"
     },
     "surfaces": [
       {

--- a/.buildchain/kfd/kfd-3/surfaces.json
+++ b/.buildchain/kfd/kfd-3/surfaces.json
@@ -62,10 +62,10 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.2",
+      "libnode": "22.22.3-kf.5-alpha.3",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
+    "digest": "sha256:5776dcbc5a1d4796a5dd613fab235c7fe49a73b6fee70362a64dd2ef2c09d7d7"
   },
   "surfaces": [
     {

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -152,7 +152,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-3/surfaces.json",
-            "sha256": "sha256:71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc"
+            "sha256": "sha256:2fd35b71dcc4836740502b6e181e083ba1e553ceb8a1bfd54a279dd46aa7ae0e"
           },
           {
             "path": ".buildchain/kfd/kfd-3/capability-query.json",

--- a/developer/sdk/kfd/kfd-3-surfaces.json
+++ b/developer/sdk/kfd/kfd-3-surfaces.json
@@ -62,10 +62,10 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.2",
+      "libnode": "22.22.3-kf.5-alpha.3",
       "buildchain": "3.0.0"
     },
-    "digest": "sha256:85ab5eeee63b5ca002cfe343bcbde16727aa251574d482d3efe043dd9f6dca0a"
+    "digest": "sha256:5776dcbc5a1d4796a5dd613fab235c7fe49a73b6fee70362a64dd2ef2c09d7d7"
   },
   "surfaces": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -152,7 +152,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-3/surfaces.json",
-            "sha256": "sha256:71ec2974e5333636d540bfcaab93793b86695f24e8232e68c758d1a2e5fc0edc"
+            "sha256": "sha256:2fd35b71dcc4836740502b6e181e083ba1e553ceb8a1bfd54a279dd46aa7ae0e"
           },
           {
             "path": ".buildchain/kfd/kfd-3/capability-query.json",

--- a/developer/sdk/kfd/upstream-aggregate.json
+++ b/developer/sdk/kfd/upstream-aggregate.json
@@ -73,7 +73,7 @@
       "role": "embedded-node-runtime-provider",
       "package": {
         "name": "@kungfu-tech/libnode",
-        "version": "22.22.3-kf.5-alpha.2"
+        "version": "22.22.3-kf.5-alpha.3"
       },
       "repository": "kungfu-systems/libnode",
       "kfd": {
@@ -88,12 +88,12 @@
         "nodeTag": "v22.22.3",
         "nodeCommit": "fdfa0ff0dbaf0fbf4d7d6d89a2ab807f3177fa5c",
         "libnodeRevision": 5,
-        "npmVersion": "22.22.3-kf.5-alpha.2"
+        "npmVersion": "22.22.3-kf.5-alpha.3"
       },
       "assets": [
         {
           "path": "libnode.release.json",
-          "sha256": "sha256:492be91c6339c74bb6c661fed99e2f4001e78404fe565563ec2f2c8fe35978e0"
+          "sha256": "sha256:30ba96a39aba6cd56222a785b4e9c0e9864ecf414d51a74ddfefee9c3ae8b1bc"
         }
       ],
       "residualRisk": [
@@ -193,7 +193,7 @@
     ],
     "packageVersions": {
       "kfd": "1.0.0-alpha.47",
-      "libnode": "22.22.3-kf.5-alpha.2",
+      "libnode": "22.22.3-kf.5-alpha.3",
       "buildchain": "3.0.0"
     }
   }

--- a/developer/sdk/tests/contract-cli.test.mjs
+++ b/developer/sdk/tests/contract-cli.test.mjs
@@ -19,7 +19,18 @@ const sdk = join(repoRoot, 'developer', 'sdk', 'src', 'sdk.js');
 const require = createRequire(import.meta.url);
 const { contractArtifacts } = require('../../../scripts/contract-registry.cjs');
 const kfdPackage = require('@kungfu-tech/kfd/package.json');
-const buildchainPackage = require('@kungfu-tech/buildchain/package.json');
+const buildchainPackagePath = require.resolve(
+  '@kungfu-tech/buildchain/package.json',
+);
+const buildchainRequire = createRequire(buildchainPackagePath);
+const buildchainPackage = require(buildchainPackagePath);
+const buildchainAlphaPackagePath = require.resolve(
+  '@kungfu-tech/buildchain-alpha/package.json',
+);
+const buildchainAlphaRequire = createRequire(buildchainAlphaPackagePath);
+const buildchainAlphaPackage = buildchainAlphaRequire(
+  '@kungfu-tech/buildchain-alpha/package.json',
+);
 const corePackage = require('../../../framework/core/package.json');
 const buildchainKfdVersion = buildchainPackage.dependencies['@kungfu-tech/kfd'];
 const sdkKfd2ReleaseClaims = JSON.parse(
@@ -88,6 +99,20 @@ function makeContractRepo(t) {
   t.after(() => rmSync(root, { recursive: true, force: true }));
   return root;
 }
+
+test('keeps stable and Alpha Buildchain KFD metadata on their declared lines', () => {
+  const stableKfd = buildchainRequire('@kungfu-tech/kfd/package.json');
+  const alphaKfd = buildchainAlphaRequire('@kungfu-tech/kfd/package.json');
+  assert.equal(
+    stableKfd.version,
+    buildchainPackage.dependencies['@kungfu-tech/kfd'],
+  );
+  assert.equal(
+    alphaKfd.version,
+    buildchainAlphaPackage.dependencies['@kungfu-tech/kfd'],
+  );
+  assert.notEqual(stableKfd.version, alphaKfd.version);
+});
 
 for (const [surface, source] of [
   ['config', 'framework/config/kungfu-config.contract.json'],

--- a/framework/core/package.json
+++ b/framework/core/package.json
@@ -71,7 +71,7 @@
     "sywac": "^1.3.0"
   },
   "devDependencies": {
-    "@kungfu-tech/libnode": "22.22.3-kf.5-alpha.2",
+    "@kungfu-tech/libnode": "22.22.3-kf.5-alpha.3",
     "@mapbox/node-pre-gyp": "^2.0.3",
     "cmake-js": "^8.0.0",
     "copyfiles": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.41
+  '@kungfu-tech/buildchain@3.0.0>@kungfu-tech/kfd': 1.0.0-alpha.41
+  '@kungfu-tech/buildchain@3.0.2-alpha.3>@kungfu-tech/kfd': 1.0.0-alpha.47
   node-gyp: ^13.0.0
   nx>axios: 1.18.1
   brace-expansion: 5.0.8
@@ -470,8 +471,8 @@ importers:
         version: 1.3.0
     devDependencies:
       '@kungfu-tech/libnode':
-        specifier: 22.22.3-kf.5-alpha.2
-        version: 22.22.3-kf.5-alpha.2
+        specifier: 22.22.3-kf.5-alpha.3
+        version: 22.22.3-kf.5-alpha.3
       '@mapbox/node-pre-gyp':
         specifier: ^2.0.3
         version: 2.0.3(encoding@0.1.13)
@@ -1459,28 +1460,28 @@ packages:
     resolution: {integrity: sha512-tFyFev5UKm2snujWB0FXwHkwLpKhWxmE16MPjn1zSyl0X/y7QTERG7oCL0TIBuMpKC20QnNi6r0oVKRawyQ7fA==}
     hasBin: true
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.2':
-    resolution: {integrity: sha512-j8SN3IxWQGD2z/gWV1GZDZMXjaZPGCQ5W+RwsrPWfT3lDFYX0cS+BoktRKwdJmmgx4SHbz4JhaH46W/Y3SLXdQ==}
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.3':
+    resolution: {integrity: sha512-XnSIM15azszq5xZuNzdqj+EJWu+xvq9JSW/V2JbIfHtfWwxFMTzsEXBRhpMoycHqSx+stb11vYORzYXzhCL+0Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.2':
-    resolution: {integrity: sha512-O3ZrIJMsgRdH54Rm3sshrecMY+feVs+c/CDSBZYT/h1YiPAcP4jnaNVUkm7CyhBRinv6CoBk2Gbh6Thg364TcA==}
+  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.3':
+    resolution: {integrity: sha512-fqrNmi3EKXZIy5gs0Rlcq8TXJooCVue5oVnF7c3ES429huR38BXkiiuyZ9y7BL/ZrFFO11PtIE9mUZe2PIc8Yg==}
     cpu: [arm64]
     os: [linux]
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.2':
-    resolution: {integrity: sha512-fX84zNMb4KNtaP2hNuwYnzw2PQ+T5R1mwdcigAkd5pfXXmXuZwHTNJi8+qGZLKw7PLLhnuAiCcBpBZDTfdRFDQ==}
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.3':
+    resolution: {integrity: sha512-CUTNioeq7qwCYu4aynucyVlEbU2c14fFMu8c/RSfHxX+we4tbvH5ciFNCFjP3Z3x/CyKYEgL5BJHELuLzUvDow==}
     cpu: [x64]
     os: [linux]
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.2':
-    resolution: {integrity: sha512-WvC5O82ddNEtCmKE13xbS2tQMMGlgOlsQfRNvSK+dHp+zx4YAp07Lx4NIpwRtQGaneJtFIc0pdbkzxCew7G79Q==}
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.3':
+    resolution: {integrity: sha512-qzchNffwNBh6zLjetVluD5vHJfMvtRK2pXFGaWhOwQi+Dbk6BTpXdtcwvd4zMPJyhSb7xxTdhd9+F+x6CuaMcA==}
     cpu: [x64]
     os: [win32]
 
-  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.2':
-    resolution: {integrity: sha512-DIoRQ/GxxA7m1tK/hYWK13WuVnursooe/3Y1LMvSp5oQkQJ/M//z3XxLpONWqqPUWmfWoWCBCRPCVfCLKfYVdg==}
+  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.3':
+    resolution: {integrity: sha512-x17Ga1/Kqo1Ngvguvb8ci1qClomnEwKM5R6tQvp80QuYVa86xr3wsjnocjS4RNp5tKcKUoRfzuUwyvQhL8K4Dg==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -5815,24 +5816,24 @@ snapshots:
 
   '@kungfu-tech/kfd@1.0.0-alpha.47': {}
 
-  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.2':
+  '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.3':
     optional: true
 
-  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.2':
+  '@kungfu-tech/libnode-linux-arm64@22.22.3-kf.5-alpha.3':
     optional: true
 
-  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.2':
+  '@kungfu-tech/libnode-linux-x64@22.22.3-kf.5-alpha.3':
     optional: true
 
-  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.2':
+  '@kungfu-tech/libnode-win32-x64@22.22.3-kf.5-alpha.3':
     optional: true
 
-  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.2':
+  '@kungfu-tech/libnode@22.22.3-kf.5-alpha.3':
     optionalDependencies:
-      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.5-alpha.2
-      '@kungfu-tech/libnode-linux-arm64': 22.22.3-kf.5-alpha.2
-      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.5-alpha.2
-      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.5-alpha.2
+      '@kungfu-tech/libnode-darwin-arm64': 22.22.3-kf.5-alpha.3
+      '@kungfu-tech/libnode-linux-arm64': 22.22.3-kf.5-alpha.3
+      '@kungfu-tech/libnode-linux-x64': 22.22.3-kf.5-alpha.3
+      '@kungfu-tech/libnode-win32-x64': 22.22.3-kf.5-alpha.3
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@kungfu-tech/buildchain@3.0.0>@kungfu-tech/kfd': 1.0.0-alpha.41
-  '@kungfu-tech/buildchain@3.0.2-alpha.3>@kungfu-tech/kfd': 1.0.0-alpha.47
   node-gyp: ^13.0.0
   nx>axios: 1.18.1
   brace-expansion: 5.0.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,9 +25,10 @@ allowBuilds:
 # it ages past the cutoff, forcing a per-version allow-list. 0 = no minimum age.
 minimumReleaseAge: 0
 overrides:
-  # Keep Buildchain's transitive KFD gate metadata aligned with the version its
-  # package declares; the SDK carries its newer direct KFD dependency separately.
-  '@kungfu-tech/buildchain>@kungfu-tech/kfd': 1.0.0-alpha.41
+  # Preserve the stable SDK contract while the Alpha release gate consumes the
+  # newer support-matrix authority. Each Buildchain line owns its KFD metadata.
+  '@kungfu-tech/buildchain@3.0.0>@kungfu-tech/kfd': 1.0.0-alpha.41
+  '@kungfu-tech/buildchain@3.0.2-alpha.3>@kungfu-tech/kfd': 1.0.0-alpha.47
   # node-gyp 9.x cannot detect Visual Studio 2026; 13.x adds VS2026 support, which
   # the Windows build needs to match the prebuilt (MSVC 19.5) conan dependencies.
   node-gyp: ^13.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,10 +25,6 @@ allowBuilds:
 # it ages past the cutoff, forcing a per-version allow-list. 0 = no minimum age.
 minimumReleaseAge: 0
 overrides:
-  # Preserve the stable SDK contract while the Alpha release gate consumes the
-  # newer support-matrix authority. Each Buildchain line owns its KFD metadata.
-  '@kungfu-tech/buildchain@3.0.0>@kungfu-tech/kfd': 1.0.0-alpha.41
-  '@kungfu-tech/buildchain@3.0.2-alpha.3>@kungfu-tech/kfd': 1.0.0-alpha.47
   # node-gyp 9.x cannot detect Visual Studio 2026; 13.x adds VS2026 support, which
   # the Windows build needs to match the prebuilt (MSVC 19.5) conan dependencies.
   node-gyp: ^13.0.0


### PR DESCRIPTION
## Summary

- adopt `@kungfu-tech/libnode@22.22.3-kf.5-alpha.3`, whose protected four-platform release carries the repaired Linux ARM64 passport and package set
- refresh the exact KFD-3 registry, collaboration witnesses, upstream aggregate, and support-matrix roots from the published package
- remove the stale blanket Buildchain-to-KFD override so stable Buildchain 3.0.0 retains its declared KFD alpha.41 metadata while Buildchain Alpha retains alpha.47, with a regression that prevents either line from silently absorbing the other

## Related delivery

- libnode PR #153 produced `v22.22.3-kf.5-alpha.3` from the protected Alpha source after all four platform lanes passed.
- This PR consumes that published result; it does not duplicate the libnode release implementation.

## Verification

- `corepack pnpm install --lockfile-only --ignore-scripts --registry=https://registry.npmjs.org/` preserves the exact lockfile on a second run.
- `corepack pnpm install --frozen-lockfile --ignore-scripts --offline` passes.
- `node scripts/code-complexity-budget.mjs` passes; the lockfile is one line below its ratchet ceiling.
- `node scripts/buildchain-kfd-evidence.mjs --check` passes with 5 KFD-2 claims and 166 KFD-3 surfaces.
- `node scripts/kfd-support-matrix.mjs --check` passes with 13 rows and 4 bounded shipped-support rows.
- 63 focused SDK, KFD matrix, platform-package, and release-admission tests pass.
- The cold read-only bootstrap regression passes.
- The complete staged pre-commit gate passes on both commits, including documentation, KFD, invariant, lint, complexity, and source checks.

## Release boundary

- [x] No package or channel publication is performed by this PR.
- [x] Exact-source Dev and Alpha qualification remains required after merge before the dependency is a shipped Kungfu release.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Consume the already-qualified libnode alpha.3 release, refresh dependency-bound KFD evidence, and remove a stale dependency override without changing an architecture contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The PR changes only source-bound dependency and release-evidence inputs; publication remains downstream of protected Dev and Alpha workflows.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; generated KFD evidence and regression coverage are updated)