### PR TITLE
fix(ci): require native latency SLO

### DIFF
--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -255,10 +255,12 @@ affected plan look unchanged; the delivery report measures that cost without
 authorizing base-forward reuse.
 
 The current dev objective is queue-inclusive P50 at most 300 seconds and P95 at
-most 600 seconds. A report is an observation, not a release credential, and a
-small passing sample does not by itself qualify the objective. Rebuild a recent
-window only after it contains at least 20 total samples and 10 native samples;
-otherwise the machine verdict remains non-qualifying. Rebuild it with:
+most 600 seconds. These thresholds apply independently to the overall and
+native strata; a fast non-native majority cannot mask a slow native tail. A
+report is an observation, not a release credential, and a small passing sample
+does not by itself qualify the objective. Rebuild a recent window only after it
+contains at least 20 total samples and 10 native samples; otherwise the machine
+verdict remains non-qualifying. Rebuild it with:
 
 ```sh
 ./shifu gate:latency:measure --branch dev/v4/v4.0 --limit 30

--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -1876,7 +1876,8 @@ export function report(
     statistics.all.sampleCount >= MINIMUM_SAMPLE_COUNT &&
     statistics.native.sampleCount >= MINIMUM_NATIVE_SAMPLE_COUNT;
   const meetsTarget =
-    statistics.all.p50Ms <= 300000 && statistics.all.p95Ms <= 600000;
+    Math.max(statistics.all.p50Ms, statistics.native.p50Ms) <= 300000 &&
+    Math.max(statistics.all.p95Ms, statistics.native.p95Ms) <= 600000;
   const cache = {
     warmCount: samples.filter(({ cache: value }) => value?.warm).length,
     coldCount: samples.filter(({ cache: value }) => value?.cold).length,
@@ -1962,16 +1963,15 @@ export function report(
           : !enoughSamples
             ? 'insufficient overall or native sample count'
             : !meetsTarget
-              ? 'observed sample exceeds target'
+              ? 'observed overall or native sample exceeds target'
               : !nativeCacheEvidenceComplete
                 ? 'native cache evidence is incomplete'
-                : 'observed sample meets target with complete native cache evidence',
+                : 'observed overall and native samples meet target with complete native cache evidence',
     },
     samples,
     exclusions: records.filter(({ excluded }) => excluded),
   };
 }
-
 async function main() {
   const options = parseDevRequiredLatencyArgs(process.argv.slice(2));
   const repository = options.repository || repositoryFromOrigin();

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -983,6 +983,28 @@ test('a passing latency window still requires complete native cache evidence', (
   assert.equal(complete.cache.coldCount, 1);
 });
 
+test('an overall passing window cannot mask a native P95 violation', () => {
+  const records = Array.from({ length: 20 }, (_, index) => ({
+    excluded: false,
+    pullRequest: index + 1,
+    sourceSha: index.toString(16).padStart(40, '0'),
+    durationMs: index === 0 ? 700000 : 120000,
+    classification: { kind: index < 10 ? 'native' : 'non-native' },
+    cache:
+      index < 10
+        ? { outcome: 'compatible', warm: true, cold: false }
+        : { outcome: 'not-applicable' },
+  }));
+  const value = report('owner/repo', 'dev', ['required'], records);
+  assert.equal(value.statistics.all.p95Ms, 120000);
+  assert.equal(value.statistics.native.p95Ms, 700000);
+  assert.equal(value.verdict.qualified, false);
+  assert.equal(
+    value.verdict.reason,
+    'observed overall or native sample exceeds target',
+  );
+});
+
 test('summary reports sample count and queue-inclusive distribution', () => {
   assert.deepEqual(
     summarize([


### PR DESCRIPTION
## Summary

Fail closed when either the overall or native queue-inclusive required-gate
latency stratum exceeds the dev SLO. This prevents a fast non-native majority
from masking a slow native tail.

## Related issue

Atlas Assignment `2026-07-17-kungfu-dev-gate-latency-slo`.

## Changes

- Apply the P50 <= 300 seconds and P95 <= 600 seconds thresholds independently
  to the overall and native strata.
- Add a regression where overall P95 passes while native P95 fails.
- Document the independent-stratum qualification rule.

## Verification

- `./shifu test:gate-latency` (67 passed)
- `node scripts/code-complexity-budget.mjs`
- `node scripts/run-docs-check.mjs`
- Source-acceptance contract suite (690 passed, 10 skipped); its final Biome
  finding was corrected and the Biome and complexity checks were rerun.
- DCO and staged repository hooks passed during commit.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fail-closed bug fix corrects SLO verdict evaluation without changing an architecture contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
