### PR TITLE
fix(build): hydrate Linux ARM64 libnode dependency

### DIFF
--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -143,6 +143,12 @@ export function buildchainBuildPlan(
     return [{ args: ['dist'], env: {} }];
   }
   return [
+    // The Buildchain install stage intentionally omits optional dependencies
+    // so full-product lanes cannot consume prebuilt Kungfu artifacts. The
+    // bounded native ARM64 Core lane still needs libnode's exact host package
+    // to link from source, so restore platform optionals under the frozen lock
+    // before entering the Core lifecycle.
+    { args: ['install', '--frozen-lockfile'], env: {} },
     { args: ['rebuild:core'], env: {} },
     { args: ['freeze'], env: { KF_REQUIRE_NATIVE_HOST: '1' } },
     {

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -33,6 +33,7 @@ test('Buildchain keeps full product builds on the three established platforms', 
 
 test('Buildchain gives Linux ARM64 one bounded Core-only build lane', () => {
   assert.deepEqual(buildchainBuildPlan('linux', 'arm64'), [
+    { args: ['install', '--frozen-lockfile'], env: {} },
     { args: ['rebuild:core'], env: {} },
     { args: ['freeze'], env: { KF_REQUIRE_NATIVE_HOST: '1' } },
     {


### PR DESCRIPTION
## Summary

Restore the exact native libnode optional dependency before the Linux ARM64 Core-only Buildchain lifecycle. This closes the deterministic failure observed in final run 30317031750 without widening the ARM64 lane into a desktop build or changing publication behavior.

## Related issue

Atlas goal 2026-07-25-kungfu-npm-core-platform-distribution-closure; follow-up to #1616.

## Changes

- retain the Buildchain no-optional install boundary for full-product lanes
- run one frozen-lock optional hydration step only for the native Linux ARM64 Core lane
- verify the ARM64 lifecycle plan before rebuild:core

## Verification

- ./shifu test:npm-core-platform-distribution (83 tests; 80 passed, 3 Windows-only skipped)
- staged repository checks passed through source, gate, invariant, and Markdown structure checks; one unrelated Git-sensitive synthetic Alpha fixture reported an outer-harness failure after its inner ADR report passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["KF-ADR-019f86da-4f90-7c91-9cc2-6dbd18d68dff"],
  "summary": "Complete the Linux ARM64 Core-only distribution lane by hydrating its exact native libnode dependency under the frozen lockfile.",
  "verification": ["./shifu test:npm-core-platform-distribution", "GitHub required checks", "native Linux ARM64 Buildchain replay"]
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No publication is performed. The final Alpha/Release rehearsal remains non-publishing and continues to use the mandatory S3 relay.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Tests cover the lifecycle change
