### PR TITLE
fix(qualification): settle diagnostic identity handoff

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "d22606161449e7c6c84fcbf890506594e55b1b62",
+    "sourceSha": "d90df10a33f1a3fd4ab77debd771cc160a165d4f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:2d8563983d8a4b0052ea4789d62d9ae279eb402e3e08f0e8a5699b33c947c60b"
   },

--- a/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
+++ b/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
@@ -71,7 +71,18 @@ export function invokeAfterIdentitySettlement(
         throw error;
       }
       identityError = error;
-      invokeCommand(home, configHome, ['runtime', 'status', '--json']);
+      try {
+        invokeCommand(home, configHome, ['runtime', 'status', '--json']);
+      } catch (statusError) {
+        if (
+          !String(statusError?.message || statusError).includes(
+            'runtime_identity_unverified',
+          )
+        ) {
+          throw statusError;
+        }
+        identityError = statusError;
+      }
       wait();
     }
   }

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -171,16 +171,49 @@ test('product smoke waits for a transient runtime identity handoff without bypas
   ]);
 });
 
+test('product smoke settles when status inspection shares the transient identity handoff', () => {
+  const calls = [];
+  let ensureAttempts = 0;
+  const identityError = new Error(
+    'runtime_identity_unverified: coordinator is starting',
+  );
+  const result = invokeAfterIdentitySettlement(
+    (_home, _configHome, args) => {
+      calls.push(args);
+      if (args[1] === 'status') throw identityError;
+      ensureAttempts += 1;
+      if (ensureAttempts === 1) throw identityError;
+      return { payload: { changed: false } };
+    },
+    'home',
+    'config',
+    ['runtime', 'ensure', '--json'],
+    { attempts: 2, wait: () => calls.push(['wait']) },
+  );
+
+  assert.deepEqual(result, { payload: { changed: false } });
+  assert.deepEqual(calls, [
+    ['runtime', 'ensure', '--json'],
+    ['runtime', 'status', '--json'],
+    ['wait'],
+    ['runtime', 'ensure', '--json'],
+  ]);
+});
+
 test('product smoke keeps persistent or unrelated identity failures fail-closed', () => {
   const persistent = new Error(
     'runtime_identity_unverified: coordinator identity never settled',
   );
   let attempts = 0;
+  let statusAttempts = 0;
   assert.throws(
     () =>
       invokeAfterIdentitySettlement(
         (_home, _configHome, args) => {
-          if (args[1] === 'status') return { payload: {} };
+          if (args[1] === 'status') {
+            statusAttempts += 1;
+            throw persistent;
+          }
           attempts += 1;
           throw persistent;
         },
@@ -192,6 +225,7 @@ test('product smoke keeps persistent or unrelated identity failures fail-closed'
     (error) => error === persistent,
   );
   assert.equal(attempts, 2);
+  assert.equal(statusAttempts, 2);
 
   assert.throws(
     () =>


### PR DESCRIPTION
## Summary

Keep the Windows product-runtime smoke bounded retry alive when the diagnostic runtime status call observes the same transient identity handoff as runtime ensure.

## Related issue

Maintainability terminal-closure qualification follow-up. Exact protected-main Build run 30315492974 completed install and build on Windows, then product-runtime-smoke failed immediately because the diagnostic status call rethrew runtime_identity_unverified before the existing bounded settlement loop could retry.

## Changes

- treat runtime_identity_unverified from diagnostic status as the same transient settlement state
- preserve immediate failure for unrelated status errors
- retain the existing bounded attempt count and fail-closed terminal error
- add recovery and persistent-failure regression coverage
- refresh the exact-source KFD prebuild projection

## Verification

- node --test framework/core/tests/qualification/runtime-activation/run.test.mjs (14/14)
- node scripts/buildchain-kfd-evidence.mjs --check (166 KFD-3 surfaces)
- node scripts/kfd-support-matrix.mjs --check (13 rows)
- full Shifu source acceptance (703 tests: 693 pass, 10 expected skips, 0 fail; Python 40 + 116; desktop 69; tooling type check and Biome pass)
- DCO pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the runtime activation protocol and existing bounded fail-closed policy; it only lets the qualification harness observe the already-declared transient identity handoff."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only exact-source qualification observation and does not publish, deploy, or grant credentials.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage and exact-source projection updated
