### PR TITLE
fix(ci): fail closed on unknown latency attribution

### DIFF
--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -1854,7 +1854,6 @@ export function summarizeNativeAttribution(samples) {
     },
   };
 }
-
 export function report(
   repository,
   branch,
@@ -1876,6 +1875,7 @@ export function report(
     statistics.all.sampleCount >= MINIMUM_SAMPLE_COUNT &&
     statistics.native.sampleCount >= MINIMUM_NATIVE_SAMPLE_COUNT;
   const meetsTarget =
+    statistics.unknown.sampleCount === 0 &&
     Math.max(statistics.all.p50Ms, statistics.native.p50Ms) <= 300000 &&
     Math.max(statistics.all.p95Ms, statistics.native.p95Ms) <= 600000;
   const cache = {
@@ -1963,7 +1963,7 @@ export function report(
           : !enoughSamples
             ? 'insufficient overall or native sample count'
             : !meetsTarget
-              ? 'observed overall or native sample exceeds target'
+              ? 'unknown impact attribution or observed overall or native sample exceeds target'
               : !nativeCacheEvidenceComplete
                 ? 'native cache evidence is incomplete'
                 : 'observed overall and native samples meet target with complete native cache evidence',

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -999,12 +999,12 @@ test('an overall passing window cannot mask a native P95 violation', () => {
   assert.equal(value.statistics.all.p95Ms, 120000);
   assert.equal(value.statistics.native.p95Ms, 700000);
   assert.equal(value.verdict.qualified, false);
-  assert.equal(
-    value.verdict.reason,
-    'observed overall or native sample exceeds target',
-  );
+  assert.match(value.verdict.reason, /native sample exceeds target/);
+  records[10].classification.kind = 'unknown';
+  const incomplete = report('owner/repo', 'dev', ['required'], records);
+  assert.equal(incomplete.statistics.unknown.sampleCount, 1);
+  assert.match(incomplete.verdict.reason, /unknown impact attribution/);
 });
-
 test('summary reports sample count and queue-inclusive distribution', () => {
   assert.deepEqual(
     summarize([


### PR DESCRIPTION
## Summary

- prevent the dev required-gate SLO from qualifying while any retained sample has unknown impact attribution
- keep overall and native percentile thresholds unchanged
- cover the fail-closed behavior and its diagnostic reason in the existing latency contract suite

## Verification

- `./shifu test:gate-latency` (67 passed)
- Biome check for both changed files
- code complexity budget passed
- full source acceptance reached and passed the changed collector, documentation, and complexity gates; an unrelated cold read-only fixture lacked pytest on PATH
- changed-scope acceptance passed the latency and formatting gates; later unrelated layer fixtures require unbuilt framework/spec dist artifacts

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Measurement integrity fix with no architecture decision changes."}
-->