### PR TITLE
fix(qualification): expose source exactness drift

### DIFF
--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -23,6 +23,13 @@ function git(args) {
   return result.status === 0 ? (result.stdout || '').trim() : null;
 }
 
+export function sourceChanges(status) {
+  return status
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+}
+
 export function sourceFacts() {
   const status = git(['status', '--porcelain']);
   return {
@@ -30,12 +37,7 @@ export function sourceFacts() {
     tree: git(['rev-parse', 'HEAD^{tree}']) || 'unknown',
     dirty: status === null || status !== '',
     changes:
-      status === null
-        ? ['git-status-unavailable']
-        : status
-            .split('\n')
-            .map((line) => line.trimEnd())
-            .filter(Boolean),
+      status === null ? ['git-status-unavailable'] : sourceChanges(status),
   };
 }
 

--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -29,6 +29,13 @@ export function sourceFacts() {
     revision: git(['rev-parse', 'HEAD']) || 'unknown',
     tree: git(['rev-parse', 'HEAD^{tree}']) || 'unknown',
     dirty: status === null || status !== '',
+    changes:
+      status === null
+        ? ['git-status-unavailable']
+        : status
+            .split('\n')
+            .map((line) => line.trimEnd())
+            .filter(Boolean),
   };
 }
 
@@ -440,6 +447,12 @@ async function main() {
   console.log(
     `[live-peer-continuity] verdict=${report.verdict} report=${path.join(outputDir, 'report.json')}`,
   );
+  for (const violation of report.violations)
+    console.error(`[live-peer-continuity] violation=${violation}`);
+  if (report.source.dirty)
+    console.error(
+      `[live-peer-continuity] source-status=${JSON.stringify(report.source.changes)}`,
+    );
   if (report.verdict !== 'passed') process.exit(1);
 }
 

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -18,6 +18,7 @@ import {
   pythonInvocation,
   qualificationPlan,
   retainQualificationArtifacts,
+  sourceChanges,
 } from './run.mjs';
 
 const source = (dirty = false) => ({
@@ -51,6 +52,13 @@ test('default evidence is outside the Core build tree', () => {
   const output = defaultOutputDir('qualification-test');
   assert.match(output, /live-peer-continuity/u);
   assert.doesNotMatch(output, /framework[/\\]core[/\\]build/u);
+});
+
+test('source status evidence preserves porcelain paths without blank rows', () => {
+  assert.deepEqual(sourceChanges(' M tracked.mjs  \n?? generated.json\n\n'), [
+    ' M tracked.mjs',
+    '?? generated.json',
+  ]);
 });
 
 test('native state-machine leg fails when CTest discovers no matching test', () => {


### PR DESCRIPTION
## Summary

Expose the exact bounded Git porcelain paths when live Peer continuity qualification rejects an otherwise-passing run as source-dirty. The existing fail-closed verdict is unchanged.

## Changes

- retain bounded source status paths in the qualification report
- print every violation and exact source status on failure
- preserve source revision, tree, and dirty semantics

## Verification

- node --test framework/core/tests/qualification/live-peer-continuity/run.test.mjs (12/12)
- full signed-commit staged gate (47 latency/cache tests, 17 invariant tests, 107 documentation tests, Biome and repository contracts)
- Candidate Source Acceptance passed on exact PR head in run 30325314287

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This diagnostic bugfix preserves the existing live Peer continuity protocol and fail-closed source-exactness policy; it only makes the rejected paths observable."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No publication or deployment is performed. Diagnostics are limited to repository-relative Git status entries.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Existing verdict remains fail-closed
- [x] Targeted and full staged checks pass