### PR TITLE
fix(build): root ARM64 package staging

### DIFF
--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -138,6 +138,7 @@ export function runShifuWithCache(args, options = {}) {
 export function buildchainBuildPlan(
   platform = process.platform,
   arch = process.arch,
+  root = ROOT,
 ) {
   if (platform !== 'linux' || arch !== 'arm64') {
     return [{ args: ['dist'], env: {} }];
@@ -153,7 +154,9 @@ export function buildchainBuildPlan(
     { args: ['freeze'], env: { KF_REQUIRE_NATIVE_HOST: '1' } },
     {
       args: ['pack:core-platform'],
-      env: { KF_PACKAGE_STAGE_DIR: 'product/release/npm' },
+      env: {
+        KF_PACKAGE_STAGE_DIR: path.join(root, 'product', 'release', 'npm'),
+      },
     },
   ];
 }

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -32,13 +32,16 @@ test('Buildchain keeps full product builds on the three established platforms', 
 });
 
 test('Buildchain gives Linux ARM64 one bounded Core-only build lane', () => {
-  assert.deepEqual(buildchainBuildPlan('linux', 'arm64'), [
+  const root = path.resolve('/repo');
+  assert.deepEqual(buildchainBuildPlan('linux', 'arm64', root), [
     { args: ['install', '--frozen-lockfile'], env: {} },
     { args: ['rebuild:core'], env: {} },
     { args: ['freeze'], env: { KF_REQUIRE_NATIVE_HOST: '1' } },
     {
       args: ['pack:core-platform'],
-      env: { KF_PACKAGE_STAGE_DIR: 'product/release/npm' },
+      env: {
+        KF_PACKAGE_STAGE_DIR: path.join(root, 'product', 'release', 'npm'),
+      },
     },
   ]);
 });


### PR DESCRIPTION
## Summary

Write Linux ARM64 Core platform packages to the repository release directory that the exact-source qualification verifies.

## Related issue

Maintainability terminal-closure qualification follow-up. Exact protected-main Build run 30323776730 completed both Linux ARM64 build lifecycles, but product and Hub CLI verification could not find kungfu-tech-core-linux-arm64-4.0.0-alpha.1.tgz because the Buildchain lifecycle passed a repository-relative stage path that the Core packer resolved below framework/core.

## Changes

- resolve the Linux ARM64 Buildchain package stage as an absolute repository-root path
- preserve the bounded Core-only build plan and all non-ARM64 lifecycle behavior
- bind the regression test to an injected repository root

## Verification

- node --test scripts/run-shifu-lifecycle.test.mjs scripts/run-release-qualification.test.mjs (42 tests: 39 pass, 3 expected Windows skips, 0 fail)
- exact latest-base focused suite including isolated ARM64 workflow (44 tests: 41 pass, 3 expected Windows skips, 0 fail)
- full Shifu source acceptance (703 tests: 693 pass, 10 expected skips, 0 fail; Python 40 + 116; desktop 69; tooling type check and Biome pass)
- DCO pre-commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the existing Linux ARM64 Core-only build and release qualification contracts; it corrects only the repository-root resolution of the declared artifact staging directory."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change only aligns the exact build artifact location with the existing qualification reader and does not publish or deploy.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added
- [x] Full source acceptance passed