### PR TITLE
fix(qualification): budget cold Gate catalog bootstrap

### DIFF
--- a/docs/qualification/evidence/gate-measurements/ec0d1c2f2d/linux/receipt.json
+++ b/docs/qualification/evidence/gate-measurements/ec0d1c2f2d/linux/receipt.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://libkungfu.dev/schemas/shifu/gate-receipt-v1.schema.json",
+  "schema": "shifu.gate-receipt/v1",
+  "runId": "gate-86e5d275-8f22-4d81-b92d-b2658e27e55c",
+  "project": {
+    "id": "kungfu"
+  },
+  "source": {
+    "sha": "ec0d1c2f2dd406f16083c8f7204420321f35e292",
+    "dirty": false
+  },
+  "registry": {
+    "ref": "shifu.gates.json",
+    "digest": "sha256:94030db29ba8eccd112d2e2dc24afe18466fc2d6e396f3f3daa5cca317e6cd47",
+    "projectId": "kungfu"
+  },
+  "selection": {
+    "profile": null,
+    "includeAdvisory": false,
+    "explicitGates": [
+      "gate.catalog"
+    ]
+  },
+  "environment": {
+    "platform": "linux",
+    "runnerCapabilities": [
+      "native-toolchain",
+      "node",
+      "product-artifacts",
+      "rust"
+    ]
+  },
+  "plan": {
+    "digest": "sha256:1281fb1a5911b5d48a8bd06676adc07aab2663a7b247c3137c7f91fd60a04275",
+    "qualifying": false,
+    "expectedActionIds": [
+      "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843"
+    ],
+    "attemptedActionIds": [
+      "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843"
+    ]
+  },
+  "startedAt": "2026-07-28T02:53:35.106Z",
+  "finishedAt": "2026-07-28T02:53:35.575Z",
+  "durationMs": 469,
+  "status": "pass",
+  "ok": true,
+  "qualifying": false,
+  "results": [
+    {
+      "gateId": "gate.catalog",
+      "policyMode": null,
+      "selectedBy": [
+        "explicit"
+      ],
+      "actionId": "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843",
+      "definitionDigest": "sha256:8140073a2a653c172bdfed324ac59e78a463a602e758807d97219ea40dc81aad",
+      "status": "pass",
+      "attempted": true,
+      "durationMs": 469,
+      "exitCode": 0,
+      "signal": null,
+      "reason": null,
+      "artifacts": [],
+      "evidence": {
+        "expectation": "optional",
+        "schema": null,
+        "present": false,
+        "pointers": []
+      },
+      "reproduce": {
+        "argv": [
+          "./shifu",
+          "gate",
+          "run",
+          "gate.catalog",
+          "--registry",
+          "shifu.gates.json"
+        ]
+      }
+    }
+  ],
+  "skipped": [],
+  "unsupported": [],
+  "integrity": {
+    "digest": "sha256:0a5a32b98e41cae710e233bdde9b143847d80ce8b1bfc1527e8d24b155948d2e"
+  }
+}

--- a/docs/qualification/evidence/gate-measurements/ec0d1c2f2d/macos/receipt.json
+++ b/docs/qualification/evidence/gate-measurements/ec0d1c2f2d/macos/receipt.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://libkungfu.dev/schemas/shifu/gate-receipt-v1.schema.json",
+  "schema": "shifu.gate-receipt/v1",
+  "runId": "gate-e41d1c7e-7abd-4791-a938-efac46cf66cf",
+  "project": {
+    "id": "kungfu"
+  },
+  "source": {
+    "sha": "ec0d1c2f2dd406f16083c8f7204420321f35e292",
+    "dirty": false
+  },
+  "registry": {
+    "ref": "shifu.gates.json",
+    "digest": "sha256:94030db29ba8eccd112d2e2dc24afe18466fc2d6e396f3f3daa5cca317e6cd47",
+    "projectId": "kungfu"
+  },
+  "selection": {
+    "profile": null,
+    "includeAdvisory": false,
+    "explicitGates": [
+      "gate.catalog"
+    ]
+  },
+  "environment": {
+    "platform": "macos",
+    "runnerCapabilities": [
+      "native-toolchain",
+      "node",
+      "product-artifacts",
+      "rust"
+    ]
+  },
+  "plan": {
+    "digest": "sha256:4e27bf62ba41e9c41cfc2c10a5562dea7da80768a2c0974edee8ad76b60ff282",
+    "qualifying": false,
+    "expectedActionIds": [
+      "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843"
+    ],
+    "attemptedActionIds": [
+      "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843"
+    ]
+  },
+  "startedAt": "2026-07-28T01:38:02.937Z",
+  "finishedAt": "2026-07-28T01:38:03.729Z",
+  "durationMs": 792,
+  "status": "pass",
+  "ok": true,
+  "qualifying": false,
+  "results": [
+    {
+      "gateId": "gate.catalog",
+      "policyMode": null,
+      "selectedBy": [
+        "explicit"
+      ],
+      "actionId": "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843",
+      "definitionDigest": "sha256:8140073a2a653c172bdfed324ac59e78a463a602e758807d97219ea40dc81aad",
+      "status": "pass",
+      "attempted": true,
+      "durationMs": 790,
+      "exitCode": 0,
+      "signal": null,
+      "reason": null,
+      "artifacts": [],
+      "evidence": {
+        "expectation": "optional",
+        "schema": null,
+        "present": false,
+        "pointers": []
+      },
+      "reproduce": {
+        "argv": [
+          "./shifu",
+          "gate",
+          "run",
+          "gate.catalog",
+          "--registry",
+          "shifu.gates.json"
+        ]
+      }
+    }
+  ],
+  "skipped": [],
+  "unsupported": [],
+  "integrity": {
+    "digest": "sha256:3a965661feac1516a6caeea8d4848c16fcbe09514f4de6c3869a39ba9cd3bfc9"
+  }
+}

--- a/docs/qualification/evidence/gate-measurements/ec0d1c2f2d/windows/receipt.json
+++ b/docs/qualification/evidence/gate-measurements/ec0d1c2f2d/windows/receipt.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://libkungfu.dev/schemas/shifu/gate-receipt-v1.schema.json",
+  "schema": "shifu.gate-receipt/v1",
+  "runId": "gate-434d9349-71aa-4def-a5b4-7f27591b8ed4",
+  "project": {
+    "id": "kungfu"
+  },
+  "source": {
+    "sha": "ec0d1c2f2dd406f16083c8f7204420321f35e292",
+    "dirty": false
+  },
+  "registry": {
+    "ref": "shifu.gates.json",
+    "digest": "sha256:94030db29ba8eccd112d2e2dc24afe18466fc2d6e396f3f3daa5cca317e6cd47",
+    "projectId": "kungfu"
+  },
+  "selection": {
+    "profile": null,
+    "includeAdvisory": false,
+    "explicitGates": [
+      "gate.catalog"
+    ]
+  },
+  "environment": {
+    "platform": "windows",
+    "runnerCapabilities": [
+      "native-toolchain",
+      "node",
+      "product-artifacts",
+      "rust"
+    ]
+  },
+  "plan": {
+    "digest": "sha256:f9da2f13ff299ed2028a2df4dd638b6f5f06bea4d6b1d204ccdfd25058010a1a",
+    "qualifying": false,
+    "expectedActionIds": [
+      "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843"
+    ],
+    "attemptedActionIds": [
+      "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843"
+    ]
+  },
+  "startedAt": "2026-07-28T03:11:43.929Z",
+  "finishedAt": "2026-07-28T03:11:45.824Z",
+  "durationMs": 1895,
+  "status": "pass",
+  "ok": true,
+  "qualifying": false,
+  "results": [
+    {
+      "gateId": "gate.catalog",
+      "policyMode": null,
+      "selectedBy": [
+        "explicit"
+      ],
+      "actionId": "sha256:0c186e824d1447bf4a755e2fce34159cd82a3be69421ee3d7f2f56afa1243843",
+      "definitionDigest": "sha256:8140073a2a653c172bdfed324ac59e78a463a602e758807d97219ea40dc81aad",
+      "status": "pass",
+      "attempted": true,
+      "durationMs": 1894,
+      "exitCode": 0,
+      "signal": null,
+      "reason": null,
+      "artifacts": [],
+      "evidence": {
+        "expectation": "optional",
+        "schema": null,
+        "present": false,
+        "pointers": []
+      },
+      "reproduce": {
+        "argv": [
+          "shifu.cmd",
+          "gate",
+          "run",
+          "gate.catalog",
+          "--registry",
+          "shifu.gates.json"
+        ]
+      }
+    }
+  ],
+  "skipped": [],
+  "unsupported": [],
+  "integrity": {
+    "digest": "sha256:2d7297e15fc6e5479c631389a1f8c69c5d189980f66301ed7ffefee324838d09"
+  }
+}

--- a/docs/qualification/gates/measurement-coverage.json
+++ b/docs/qualification/gates/measurement-coverage.json
@@ -12,28 +12,28 @@
   "measurements": [
     {
       "gateId": "gate.catalog",
-      "definitionDigest": "sha256:2102f39caca0c0286084c59e552b7f42f5d6df2315adac134e5ae9d834559856",
+      "definitionDigest": "sha256:8140073a2a653c172bdfed324ac59e78a463a602e758807d97219ea40dc81aad",
       "observations": [
         {
           "platform": "linux",
-          "sourceSha": "3c8c3dd547ad69c3c3f74af0a4a0b1b0b29f7e31",
-          "registryDigest": "sha256:ba6be36c14e4708e1c40628cf0e9df3af410bc9a5dd82cd404a25ce2e1dfa078",
-          "durationMs": 450,
-          "receipt": "docs/qualification/evidence/gate-measurements/3c8c3dd547/linux/episode/receipt.json"
+          "sourceSha": "ec0d1c2f2dd406f16083c8f7204420321f35e292",
+          "registryDigest": "sha256:94030db29ba8eccd112d2e2dc24afe18466fc2d6e396f3f3daa5cca317e6cd47",
+          "durationMs": 469,
+          "receipt": "docs/qualification/evidence/gate-measurements/ec0d1c2f2d/linux/receipt.json"
         },
         {
           "platform": "macos",
-          "sourceSha": "3c8c3dd547ad69c3c3f74af0a4a0b1b0b29f7e31",
-          "registryDigest": "sha256:ba6be36c14e4708e1c40628cf0e9df3af410bc9a5dd82cd404a25ce2e1dfa078",
-          "durationMs": 1088,
-          "receipt": "docs/qualification/evidence/gate-measurements/3c8c3dd547/macos/episode/receipt.json"
+          "sourceSha": "ec0d1c2f2dd406f16083c8f7204420321f35e292",
+          "registryDigest": "sha256:94030db29ba8eccd112d2e2dc24afe18466fc2d6e396f3f3daa5cca317e6cd47",
+          "durationMs": 790,
+          "receipt": "docs/qualification/evidence/gate-measurements/ec0d1c2f2d/macos/receipt.json"
         },
         {
           "platform": "windows",
-          "sourceSha": "3c8c3dd547ad69c3c3f74af0a4a0b1b0b29f7e31",
-          "registryDigest": "sha256:ba6be36c14e4708e1c40628cf0e9df3af410bc9a5dd82cd404a25ce2e1dfa078",
-          "durationMs": 4156,
-          "receipt": "docs/qualification/evidence/gate-measurements/3c8c3dd547/windows/episode/receipt.json"
+          "sourceSha": "ec0d1c2f2dd406f16083c8f7204420321f35e292",
+          "registryDigest": "sha256:94030db29ba8eccd112d2e2dc24afe18466fc2d6e396f3f3daa5cca317e6cd47",
+          "durationMs": 1894,
+          "receipt": "docs/qualification/evidence/gate-measurements/ec0d1c2f2d/windows/receipt.json"
         }
       ]
     },

--- a/docs/qualification/gates/measurement-coverage.md
+++ b/docs/qualification/gates/measurement-coverage.md
@@ -20,7 +20,7 @@ Gate's complete platform set.
 <!-- BEGIN GENERATED GATE MEASUREMENTS -->
 | Gate | Coverage | Source-bound observations |
 | --- | --- | --- |
-| `gate.catalog` | measured | [linux: 450 ms @ 3c8c3dd54](../evidence/gate-measurements/3c8c3dd547/linux/episode/receipt.json)<br>[macos: 1088 ms @ 3c8c3dd54](../evidence/gate-measurements/3c8c3dd547/macos/episode/receipt.json)<br>[windows: 4156 ms @ 3c8c3dd54](../evidence/gate-measurements/3c8c3dd547/windows/episode/receipt.json) |
+| `gate.catalog` | measured | [linux: 469 ms @ ec0d1c2f2](../evidence/gate-measurements/ec0d1c2f2d/linux/receipt.json)<br>[macos: 790 ms @ ec0d1c2f2](../evidence/gate-measurements/ec0d1c2f2d/macos/receipt.json)<br>[windows: 1894 ms @ ec0d1c2f2](../evidence/gate-measurements/ec0d1c2f2d/windows/receipt.json) |
 | `governance.dco` | measured | [linux: 12000 ms @ e90b0fb2b](../evidence/gate-measurements/e90b0fb2b/linux/governance.dco.controller-receipt.json) |
 | `governance.adr-delivery` | measured | [linux: 38 ms @ 6b451a4e5](../evidence/gate-measurements/6b451a4e/linux/receipt.json)<br>[macos: 111 ms @ 6b451a4e5](../evidence/gate-measurements/6b451a4e/macos/receipt.json)<br>[windows: 101 ms @ 6b451a4e5](../evidence/gate-measurements/6b451a4e/windows/receipt.json) |
 | `governance.buildchain-config` | measured | [linux: 10000 ms @ aec4e2f07](../evidence/gate-measurements/aec4e2f072/linux/governance.buildchain-config.controller-receipt.json) |

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -17,7 +17,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Failure or skip:** action failure, timeout, unsupported required capability, dependency failure, or missing required artifact is non-qualifying; advisory mode remains visible.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain gate.catalog --profile <profile>`; reproduce with `./shifu gate run gate.catalog` on a capable runner.
-- **Cost:** light; timeout 120 seconds.
+- **Cost:** light; timeout 600 seconds.
 - **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement). The standalone .github/workflows/source-acceptance.yml remains manual-only diagnostic evidence.
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:gate.catalog -->

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b8b9c591c4e123b18dadc49c7b2a1d4a9c4c06998b673d8ce8711575340764de",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:2687217d324f6666a9774d4f87c41762be5c2b11f32c4bb8034f169887d72a5b",
+  "sourceRoot": "sha256:b29c365109a5d9327dcb61ae8804d07dd0d0f83b4c8ae240f9693acef2e40b82",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1044,7 +1044,7 @@
           "path": "shifu.gates.json",
           "currentLines": 2196,
           "baselineLines": 2196,
-          "currentRoot": "sha256:a805d2e7481c47af35a06c8ee18fe5aad787e6e1447653e2b184b41a19d90fae",
+          "currentRoot": "sha256:94030db29ba8eccd112d2e2dc24afe18466fc2d6e396f3f3daa5cca317e6cd47",
           "baselineRoot": "sha256:dc351c7747dc7005f899524caf61a63cb5edc294924aa958db6bd6aec563cb93",
           "changedSinceBaseline": true
         },

--- a/shifu.gates.json
+++ b/shifu.gates.json
@@ -25,7 +25,7 @@
       },
       "cost": {
         "class": "light",
-        "timeoutSeconds": 120
+        "timeoutSeconds": 600
       },
       "action": {
         "kind": "task",


### PR DESCRIPTION
## Summary

- raise `gate.catalog` from 120 seconds to 600 seconds so a cold Dev Patrol workspace can finish the frozen install before the sub-second catalog check runs
- keep the Gate action, command, policy mode, and fail-closed semantics unchanged
- bind fresh exact-source Linux, macOS, and Windows measurements to the new Gate definition and regenerate the measurement coverage and semantic-amplification projections
- supersede #1715 without changing the source tree, restoring dongkeren -> kungfu-origin review separation on the latest dev mainline

## Failure evidence

- Exact Dev Verify run [30319289371](https://github.com/kungfu-systems/kungfu/actions/runs/30319289371) failed on macOS because `gate.catalog` exhausted its 120-second definition budget while installing the cold 994-package workspace; the catalog action itself had not started.
- The fresh exact-source measurements record the actual `gate.catalog` action at 469 ms on Linux, 790 ms on macOS, and 1894 ms on Windows.

## Verification

- `./shifu check:gate-catalog` passes.
- `node --test scripts/check-kungfu-gate-catalog.test.mjs` passes 23/23 tests.
- `./shifu maintainability:amplification --write` reports 6 families, 75 surfaces, and 0 issues.
- The complete staged pre-commit gate passes on every signed repair commit.
- Linux exact clean receipt: `ec0d1c2f2dd406f16083c8f7204420321f35e292`, `gate.catalog` pass in 469 ms.
- macOS exact clean receipt: same source and definition, pass in 790 ms.
- Windows exact clean receipt: [job 90166769627](https://github.com/kungfu-systems/kungfu/actions/runs/30324447657/job/90166769627), same source and definition, pass in 1894 ms.

## Release boundary

- [x] No package or channel publication is performed by this PR.
- [x] Exact-source Dev and Alpha qualification remains required after merge before the repaired budget can support an Alpha release.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair a cold-workspace qualification budget and refresh source-bound measurements without changing the Gate action or architecture contract"
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The PR changes only a qualification timeout and its source-bound measurement evidence; publication remains downstream of protected Dev and Alpha workflows.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated for the changed timeout and generated projections