### PR TITLE
fix(packaging): anchor explicit stage paths to repository

### DIFF
--- a/framework/core/.gyp/core-platform-package.js
+++ b/framework/core/.gyp/core-platform-package.js
@@ -28,10 +28,21 @@ const {
 const rootDir = path.dirname(__dirname);
 const repositoryRoot = path.resolve(rootDir, '..', '..');
 const bindingDir = path.join(rootDir, BINDING_SUBDIR);
-const stageDir = path.resolve(
-  rootDir,
-  process.env.KF_PACKAGE_STAGE_DIR || path.join('build', 'stage', 'npm'),
-);
+
+/**
+ * Explicit lifecycle stage paths are repository-relative: callers such as the
+ * native ARM64 Hub lane publish into product/release/npm. Keep the historical
+ * Core-local default only when no override is supplied.
+ * @param {string | undefined} configured
+ * @returns {string}
+ */
+function resolvePackageStageDir(configured) {
+  return configured
+    ? path.resolve(repositoryRoot, configured)
+    : path.join(rootDir, 'build', 'stage', 'npm');
+}
+
+const stageDir = resolvePackageStageDir(process.env.KF_PACKAGE_STAGE_DIR);
 const packageBuildDir = path.join(rootDir, 'build', 'npm');
 const packageContract = fs.readJsonSync(
   path.join(rootDir, 'core-platform-package.contract.json'),
@@ -738,4 +749,5 @@ if (require.main === module)
 
 module.exports = {
   linuxReleaseStripCandidates,
+  resolvePackageStageDir,
 };

--- a/framework/core/tests/core-platform-package.test.js
+++ b/framework/core/tests/core-platform-package.test.js
@@ -13,7 +13,21 @@ const {
 } = require('../lib/platform-packages');
 const {
   linuxReleaseStripCandidates,
+  resolvePackageStageDir,
 } = require('../.gyp/core-platform-package');
+
+test('explicit package stage paths resolve from the repository root', () => {
+  const repositoryRoot = path.resolve(__dirname, '..', '..', '..');
+
+  assert.equal(
+    resolvePackageStageDir('product/release/npm'),
+    path.join(repositoryRoot, 'product', 'release', 'npm'),
+  );
+  assert.equal(
+    resolvePackageStageDir(undefined),
+    path.join(repositoryRoot, 'framework', 'core', 'build', 'stage', 'npm'),
+  );
+});
 
 test('Core platform package authority is exact and source package is neutral', () => {
   assert.deepEqual(platformPackages, contract.platformPackages);


### PR DESCRIPTION
## Summary

Fix the native Linux ARM64 Hub CLI package lane so its explicit package stage directory is resolved from the repository root. The previous Core-relative resolution created an untracked `framework/core/product/` tree and correctly caused source-exact qualification to fail closed.

## Changes

- resolve explicit `KF_PACKAGE_STAGE_DIR` values from the repository root
- preserve the historical Core-local default when no override is supplied
- add a regression test for both explicit and default stage paths

## Verification

- `node --test framework/core/tests/core-platform-package.test.js scripts/run-shifu-lifecycle.test.mjs` (21 passed, 3 platform skips)
- `pnpm --filter @kungfu-tech/core run test:tooling` (31 passed, 2 native-build skips)
- `pnpm exec biome check framework/core/.gyp/core-platform-package.js framework/core/tests/core-platform-package.test.js`
- signed-commit staged gate completed before commit

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix preserves the existing package-stage and source-exactness contracts; it corrects only the base directory used to interpret an already repository-relative lifecycle path."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No publication or deployment is performed by this change. It restores the declared repository-level package stage location.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Source-exactness gate remains fail-closed
- [x] Targeted and full staged checks pass
