### PR TITLE
fix(ci): serialize dev merge queue admission

### DIFF
--- a/.github/workflows/cancel-dequeued-merge-group.yml
+++ b/.github/workflows/cancel-dequeued-merge-group.yml
@@ -12,6 +12,7 @@ permissions:
   actions: write
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   cancel:
@@ -29,4 +30,5 @@ jobs:
           DEQUEUED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_GROUP_WORKFLOW: affected-native-pr.yml
+          QUEUE_ADMISSION_CONTEXT: Queue admission lease
         run: ./shifu ci:cancel-dequeued-merge-group

--- a/.github/workflows/queue-admission-lease.yml
+++ b/.github/workflows/queue-admission-lease.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Queue admission lease
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions: {}
+
+jobs:
+  admission:
+    name: Queue admission lease
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Continue the wrapper-issued lease on the exact merge group
+        shell: bash
+        env:
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" != "merge_group" ]; then
+            echo "Queue admission lease accepts only merge_group events." >&2
+            exit 1
+          fi
+          if [ -z "$MERGE_GROUP_HEAD_SHA" ] || [ "$MERGE_GROUP_HEAD_SHA" != "$GITHUB_SHA" ]; then
+            echo "Merge-group head does not match the checked execution source." >&2
+            exit 1
+          fi
+          echo "Wrapper-issued queue admission continues on exact merge group $GITHUB_SHA."

--- a/docs/qualification/gates/dev-queue-admission.contract.json
+++ b/docs/qualification/gates/dev-queue-admission.contract.json
@@ -1,0 +1,27 @@
+{
+  "schema": "kungfu.dev-queue-admission/v1",
+  "branchPattern": "dev/v*/v*",
+  "requiredContext": "Queue admission lease",
+  "authority": {
+    "pullRequestHead": "atlas-serialized-wrapper",
+    "mergeGroup": ".github/workflows/queue-admission-lease.yml",
+    "dequeueRevocation": ".github/workflows/cancel-dequeued-merge-group.yml"
+  },
+  "admission": {
+    "queueMustBeEmpty": true,
+    "requiredPosition": 1,
+    "freshProjectCutReplay": true,
+    "leaseAfterReplay": true
+  },
+  "revocation": {
+    "dequeue": "failure-status-on-exact-pr-head",
+    "headChange": "lease-does-not-transfer",
+    "sameHeadRetry": "forbidden-after-revocation"
+  },
+  "rulesetActivation": {
+    "required": true,
+    "expectedSource": "any",
+    "reason": "The pull-request lease is a user-authored commit status while the merge-group continuation is a GitHub Actions check."
+  },
+  "threatBoundary": "Prevents inadvertent direct queue admission. A write actor that deliberately forges the named status is outside this operational safety boundary."
+}

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -180,6 +180,18 @@ Each section is bound to the registry id by the catalog meta gate.
   version; cross-runner drift therefore remains fail-closed. Shifu workspace
   and KFD remain independent on the producer execution; only a candidate backed
   by that completed-success exact proof may skip them.
+- **Serialized queue admission lease:** the dev ruleset additionally requires
+  `Queue admission lease`. On the pull-request head, only the Atlas serialized
+  wrapper issues that status after observing an empty queue and replaying the
+  Project Cut against the latest base; it then accepts only position one. A
+  merge-group-only workflow continues the same required context on the exact
+  synthetic SHA without satisfying it on ordinary PR events. Every dequeue
+  revokes the exact-head lease and forbids retrying that head; a new head
+  cannot inherit an older status. The bounded contract is
+  `docs/qualification/gates/dev-queue-admission.contract.json`. This prevents
+  an inadvertent direct position-two entry from changing the proof base and
+  turning an exact PR proof into a full native queue rebuild; it does not
+  weaken proof verification when source, plan, or toolchain identity changes.
 - **Dequeue repair admission:** the trusted-base dequeue controller cancels
   active work and writes one PR marker for deterministic `failed_checks`,
   `merge_conflict`, or `invalid_merge_commit` exits. The marker binds the exact

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -922,14 +922,14 @@
     {
       "path": ".github/workflows/cancel-dequeued-merge-group.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:fb8c59a8ba571c6091bdc5663830676b0cbe14a2741a7063ad69f78e1694fb52",
+      "definitionDigest": "sha256:004e56b133945a2edb879cb3caf203e8ef1af9944f61ffa64ac269e00804c130",
       "jobs": [
         {
           "id": "cancel",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:d14354805fbdc7b02ea0ad410361729d6d8cb8da3303fad62f3b26e299c2f3a3",
+          "definitionDigest": "sha256:67f561b539de1ba5df88d375313188e2a83dd5026978a7924f9d574f34c7f3bd",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [
@@ -941,7 +941,7 @@
             {
               "index": 2,
               "label": "name:Cancel active merge-group runs for the dequeued pull request",
-              "definitionDigest": "sha256:47dbc2484365ea0484e9bb75c329d8f55362c2b70057ebf7044856f0868a546e"
+              "definitionDigest": "sha256:04a5277a49a1b9b247f90e98cc1a24160fede52567ca89fbea508cef5112f458"
             }
           ]
         }
@@ -1865,6 +1865,29 @@
               "label": "uses:actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
               "authority": "evidence-publication",
               "definitionDigest": "sha256:a0c5bfd0f26c35c3f71c5b47f48db6322de501714f38f9709c543799841cad87"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/queue-admission-lease.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:835423db04199ffe10917fb66c23a60de9b5c0472d06f9c230667f166d313392",
+      "jobs": [
+        {
+          "id": "admission",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:d73f6a9c29eb100bfae8dd4ca5760103727ae866e684c51dd1ac3f5e40b991f1",
+          "credentials": {"githubToken":"none","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": [],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Continue the wrapper-issued lease on the exact merge group",
+              "definitionDigest": "sha256:50cedddf4af1d2589d5561f3e1c3e582168b92d60ccae987fbf285643e08b917"
             }
           ]
         }

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -87,6 +87,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/publish-layer-artifacts.yml` | `publish-pypi` | product-publication | product | none | token:write, oidc | `adr0049-production-publication` | 2 |
 | `.github/workflows/publish-layer-artifacts.yml` | `verify-portable-format-publication` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/publish-layer-artifacts.yml` | `verify-publication` | qualification | none | diagnostic | token:read | none | 4 |
+| `.github/workflows/queue-admission-lease.yml` | `admission` | qualification | none | diagnostic | token:none | none | 1 |
 | `.github/workflows/release-new-version.yml` | `alpha-timeline` | qualification | none | diagnostic | token:write | none | 11 |
 | `.github/workflows/release-new-version.yml` | `promote` | release-control | channel | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ISSUE_APP_ID+BUILDCHAIN_ISSUE_APP_PRIVATE_KEY+KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY+KUNGFU_GITHUB_TOKEN+KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY | none | 0 |
 | `.github/workflows/release-new-version.yml` | `promotion-contract` | qualification | none | diagnostic | token:read | none | 8 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -117,7 +117,14 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:1d9a795b7e1b4bf7dbbc34e5801d8c4209fb89de088da668a8bddd98e7db6f87"
+          "sourceRoot": "sha256:2d804b7ff0604ce5bb02089ec7ad9750db6a38a47d4934c7e3795eef2be9e84d"
+        },
+        {
+          "path": ".github/workflows/queue-admission-lease.yml",
+          "classification": "non-publication",
+          "owner": "kungfu-ci",
+          "surfaceIds": [],
+          "sourceRoot": "sha256:fb476b7c16cdda4db240b2ae6e24f5f9a2d6f2a92a4fdb00c222868dfd345133"
         },
         {
           "path": ".github/workflows/core-build-profiles.yml",
@@ -778,5 +785,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:ed49284d3d50a911c78ac53b4c722babc598d2bfde6acfa2d201eb6872aa5cf6"
+  "registryRoot": "sha256:c28af71032c3c5d12aab1628fb630a1359d6f095ac9d606bb5009d405da38f26"
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "gate:workflow-authority:refresh": "node scripts/require-shifu.mjs gate:workflow-authority:refresh && node scripts/kungfu-workflow-authority.mjs --refresh",
     "gate:latency:measure": "node scripts/require-shifu.mjs gate:latency:measure && node scripts/measure-dev-required-latency.mjs",
     "ci:cancel-dequeued-merge-group": "node scripts/require-shifu.mjs ci:cancel-dequeued-merge-group && node scripts/cancel-dequeued-merge-group-runs.mjs",
-    "test:gate-latency": "node scripts/require-shifu.mjs test:gate-latency && node --test scripts/affected-native-cache-payload.test.mjs scripts/affected-native-proof.test.mjs scripts/cancel-dequeued-merge-group-runs.test.mjs scripts/candidate-timeline-events.test.mjs scripts/measure-dev-required-latency.test.mjs scripts/run-core-affected-native.test.mjs scripts/write-affected-native-cache-manifests.test.mjs",
+    "test:gate-latency": "node scripts/require-shifu.mjs test:gate-latency && node --test scripts/affected-native-cache-payload.test.mjs scripts/affected-native-proof.test.mjs scripts/cancel-dequeued-merge-group-runs.test.mjs scripts/candidate-timeline-events.test.mjs scripts/measure-dev-required-latency.test.mjs scripts/queue-admission-lease.test.mjs scripts/run-core-affected-native.test.mjs scripts/write-affected-native-cache-manifests.test.mjs",
     "alpha:publication:tail": "node scripts/require-shifu.mjs alpha:publication:tail && node scripts/alpha-publication-tail-plan.mjs",
     "alpha:release:timeline": "node scripts/require-shifu.mjs alpha:release:timeline && node scripts/alpha-release-timeline.mjs",
     "alpha:release:history": "node scripts/require-shifu.mjs alpha:release:history && node scripts/alpha-release-history.mjs",

--- a/scripts/cancel-dequeued-merge-group-runs.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.mjs
@@ -267,25 +267,121 @@ export async function cancelDequeuedMergeGroupRuns({
   };
 }
 
+export async function revokeQueueAdmissionLease({
+  repository,
+  headSha,
+  context,
+  token,
+  request = fetch,
+}) {
+  required(repository, 'repository', /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u);
+  required(headSha, 'head sha', /^[0-9a-f]{40}$/u);
+  required(
+    context,
+    'queue admission context',
+    /^[A-Za-z0-9][A-Za-z0-9 ._/-]{0,99}$/u,
+  );
+  if (!token) throw new Error('GitHub token is unavailable');
+
+  const response = await githubResponse(
+    `/repos/${repository}/statuses/${headSha}`,
+    token,
+    request,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        state: 'failure',
+        context,
+        description:
+          'Lease revoked after merge-queue dequeue; use the serialized wrapper',
+      }),
+    },
+  );
+  if (response.status !== 201) {
+    throw new Error(
+      `GitHub API ${response.status} while revoking queue admission lease`,
+    );
+  }
+  return { headSha, context, state: 'failure' };
+}
+
+export async function settleDequeuedMergeGroup({
+  repository,
+  pullRequest,
+  headSha,
+  workflow,
+  context,
+  token,
+  request = fetch,
+}) {
+  const results = await Promise.allSettled([
+    cancelDequeuedMergeGroupRuns({
+      repository,
+      pullRequest,
+      workflow,
+      token,
+      request,
+    }),
+    recordDequeuedRepairMarker({
+      repository,
+      pullRequest,
+      headSha,
+      token,
+      request,
+    }),
+    revokeQueueAdmissionLease({
+      repository,
+      headSha,
+      context,
+      token,
+      request,
+    }),
+  ]);
+  const failures = results
+    .map((result, index) =>
+      result.status === 'rejected'
+        ? `${['cancellation', 'repair-marker', 'lease-revocation'][index]}: ${
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason)
+          }`
+        : '',
+    )
+    .filter(Boolean);
+  if (failures.length) {
+    throw new Error(`dequeue settlement failed (${failures.join('; ')})`);
+  }
+  const [cancellation, repairMarker, queueAdmissionLease] = results;
+  if (
+    cancellation.status !== 'fulfilled' ||
+    repairMarker.status !== 'fulfilled' ||
+    queueAdmissionLease.status !== 'fulfilled'
+  ) {
+    throw new Error('dequeue settlement result invariant failed');
+  }
+  return {
+    cancellation: cancellation.value,
+    repairMarker: repairMarker.value,
+    queueAdmissionLease: queueAdmissionLease.value,
+  };
+}
+
 async function main() {
   const repository = process.env.GITHUB_REPOSITORY || '';
   const pullRequest = Number(process.env.DEQUEUED_PULL_REQUEST || 0);
   const workflow = process.env.MERGE_GROUP_WORKFLOW || 'affected-native-pr.yml';
   const headSha = process.env.DEQUEUED_HEAD_SHA || '';
+  const context = process.env.QUEUE_ADMISSION_CONTEXT || '';
   const token = process.env.GITHUB_TOKEN || '';
-  const cancellation = await cancelDequeuedMergeGroupRuns({
-    repository,
-    pullRequest,
-    workflow,
-    token,
-  });
-  const repairMarker = await recordDequeuedRepairMarker({
+  const result = await settleDequeuedMergeGroup({
     repository,
     pullRequest,
     headSha,
+    workflow,
+    context,
     token,
   });
-  process.stdout.write(`${JSON.stringify({ cancellation, repairMarker })}\n`);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {

--- a/scripts/cancel-dequeued-merge-group-runs.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.mjs
@@ -26,6 +26,46 @@ function required(value, label, pattern) {
   return value;
 }
 
+export function validateDevRequiredLatencyBaseline(
+  baseline,
+  requiredContexts,
+  allowedContextAdditions = [],
+) {
+  if (baseline.$schema !== 'kungfu.dev-required-latency-baseline/v1') {
+    throw new Error('unsupported dev required latency baseline schema');
+  }
+  const expected = [...baseline.requiredContexts].sort();
+  const actual = [...requiredContexts].sort();
+  const allowed = [...new Set(allowedContextAdditions)].sort();
+  const additions = actual.filter((context) => !expected.includes(context));
+  const removals = expected.filter((context) => !actual.includes(context));
+  if (
+    removals.length ||
+    additions.some((context) => !allowed.includes(context))
+  ) {
+    throw new Error(
+      `live required contexts drifted: expected ${expected.join(', ')}, got ${actual.join(', ')}`,
+    );
+  }
+  return true;
+}
+
+export function queueAdmissionRequiredContexts(contract) {
+  if (contract?.schema !== 'kungfu.dev-queue-admission/v1') {
+    throw new Error('unsupported dev queue admission contract schema');
+  }
+  if (contract.rulesetActivation?.required !== true) {
+    throw new Error(
+      'dev queue admission contract must require ruleset activation',
+    );
+  }
+  const context = String(contract.requiredContext || '');
+  if (!/^[A-Za-z0-9][A-Za-z0-9 ._/-]{0,99}$/u.test(context)) {
+    throw new Error('dev queue admission required context is invalid');
+  }
+  return [context];
+}
+
 export function activeMergeGroupRunsForPull(runs, pullRequest) {
   const branchPattern = new RegExp(`/pr-${pullRequest}-[0-9a-f]{7,40}$`, 'u');
   return runs.filter(

--- a/scripts/cancel-dequeued-merge-group-runs.test.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.test.mjs
@@ -11,6 +11,8 @@ import {
   cancelDequeuedMergeGroupRuns,
   mergeQueueRepairComment,
   recordDequeuedRepairMarker,
+  revokeQueueAdmissionLease,
+  settleDequeuedMergeGroup,
 } from './cancel-dequeued-merge-group-runs.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -59,6 +61,8 @@ test('dequeue workflow executes only the trusted base with least privilege', () 
   assert.match(workflow, /pull_request_target:\n\s+types: \[dequeued\]/u);
   assert.match(workflow, /permissions:\n\s+actions: write\n\s+contents: read/u);
   assert.match(workflow, /\s+pull-requests: write/u);
+  assert.match(workflow, /\s+statuses: write/u);
+  assert.match(workflow, /QUEUE_ADMISSION_CONTEXT: Queue admission lease/u);
   assert.match(
     workflow,
     /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/u,
@@ -68,6 +72,83 @@ test('dequeue workflow executes only the trusted base with least privilege', () 
     workflow,
     /ref:\s+\$\{\{ github\.event\.pull_request\.head/u,
   );
+});
+
+test('dequeue revokes the exact-head queue admission lease', async () => {
+  const requests = [];
+  const headSha = 'c'.repeat(40);
+  const request = async (url, init = {}) => {
+    requests.push({
+      url,
+      method: init.method || 'GET',
+      body: init.body ? JSON.parse(init.body) : null,
+    });
+    return response(201);
+  };
+  assert.deepEqual(
+    await revokeQueueAdmissionLease({
+      repository: 'kungfu-systems/kungfu',
+      headSha,
+      context: 'Queue admission lease',
+      token: 'test-token',
+      request,
+    }),
+    {
+      headSha,
+      context: 'Queue admission lease',
+      state: 'failure',
+    },
+  );
+  assert.deepEqual(requests, [
+    {
+      url: `https://api.github.com/repos/kungfu-systems/kungfu/statuses/${headSha}`,
+      method: 'POST',
+      body: {
+        state: 'failure',
+        context: 'Queue admission lease',
+        description:
+          'Lease revoked after merge-queue dequeue; use the serialized wrapper',
+      },
+    },
+  ]);
+});
+
+test('dequeue settlement still revokes the lease when other cleanup fails', async () => {
+  const headSha = 'd'.repeat(40);
+  const leaseRequests = [];
+  const request = async (url, init = {}) => {
+    if (url.endsWith(`/statuses/${headSha}`)) {
+      leaseRequests.push({
+        method: init.method,
+        body: JSON.parse(init.body),
+      });
+      return response(201);
+    }
+    return response(500);
+  };
+  await assert.rejects(
+    settleDequeuedMergeGroup({
+      repository: 'kungfu-systems/kungfu',
+      pullRequest: 1510,
+      headSha,
+      workflow: 'affected-native-pr.yml',
+      context: 'Queue admission lease',
+      token: 'test-token',
+      request,
+    }),
+    /dequeue settlement failed \(cancellation: .*; repair-marker: .*\)/u,
+  );
+  assert.deepEqual(leaseRequests, [
+    {
+      method: 'POST',
+      body: {
+        state: 'failure',
+        context: 'Queue admission lease',
+        description:
+          'Lease revoked after merge-queue dequeue; use the serialized wrapper',
+      },
+    },
+  ]);
 });
 
 test('failed or conflicting dequeue records one exact-head repair marker', async () => {

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -189,7 +189,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 10);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 25);
+  assert.equal(result.workflowAuthority.workflows.length, 26);
   const linuxArm64Qualification = result.workflowAuthority.workflows.find(
     (workflow) =>
       workflow.path === '.github/workflows/linux-arm64-alpha-qualification.yml',

--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -16,6 +16,10 @@ import {
 } from '@kungfu-tech/buildchain-alpha/candidate-timeline';
 
 import {
+  queueAdmissionRequiredContexts,
+  validateDevRequiredLatencyBaseline,
+} from './cancel-dequeued-merge-group-runs.mjs';
+import {
   collectLatestMergedPullWindow,
   latencyOnlyEvidence,
   parseDevRequiredLatencyArgs,
@@ -34,7 +38,6 @@ const QUEUE_ADMISSION_CONTRACT_PATH = path.join(
   ROOT,
   'docs/qualification/gates/dev-queue-admission.contract.json',
 );
-
 function repositoryFromOrigin() {
   const result = spawnSync('git', ['remote', 'get-url', 'origin'], {
     cwd: ROOT,
@@ -471,46 +474,6 @@ export function summarizeMergeQueueDelivery(samples) {
             : 'merge queue delivery sample meets target',
     },
   };
-}
-
-export function validateBaseline(
-  baseline,
-  requiredContexts,
-  allowedContextAdditions = [],
-) {
-  if (baseline.$schema !== 'kungfu.dev-required-latency-baseline/v1') {
-    throw new Error('unsupported dev required latency baseline schema');
-  }
-  const expected = [...baseline.requiredContexts].sort();
-  const actual = [...requiredContexts].sort();
-  const allowed = [...new Set(allowedContextAdditions)].sort();
-  const additions = actual.filter((context) => !expected.includes(context));
-  const removals = expected.filter((context) => !actual.includes(context));
-  if (
-    removals.length ||
-    additions.some((context) => !allowed.includes(context))
-  ) {
-    throw new Error(
-      `live required contexts drifted: expected ${expected.join(', ')}, got ${actual.join(', ')}`,
-    );
-  }
-  return true;
-}
-
-export function queueAdmissionRequiredContexts(contract) {
-  if (contract?.schema !== 'kungfu.dev-queue-admission/v1') {
-    throw new Error('unsupported dev queue admission contract schema');
-  }
-  if (contract.rulesetActivation?.required !== true) {
-    throw new Error(
-      'dev queue admission contract must require ruleset activation',
-    );
-  }
-  const context = String(contract.requiredContext || '');
-  if (!/^[A-Za-z0-9][A-Za-z0-9 ._/-]{0,99}$/u.test(context)) {
-    throw new Error('dev queue admission required context is invalid');
-  }
-  return [context];
 }
 
 export function requiredContextsFromEffectiveRules(rules) {
@@ -2029,7 +1992,7 @@ async function main() {
   if (!requiredContexts.length)
     throw new Error(`no required contexts on ${options.branch}`);
   if (!options.pulls.length) {
-    validateBaseline(
+    validateDevRequiredLatencyBaseline(
       JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8')),
       requiredContexts,
       queueAdmissionRequiredContexts(

--- a/scripts/measure-dev-required-latency.mjs
+++ b/scripts/measure-dev-required-latency.mjs
@@ -30,6 +30,10 @@ const BASELINE_PATH = path.join(
   ROOT,
   'framework/core/architecture/dev-gate-latency-baseline.json',
 );
+const QUEUE_ADMISSION_CONTRACT_PATH = path.join(
+  ROOT,
+  'docs/qualification/gates/dev-queue-admission.contract.json',
+);
 
 function repositoryFromOrigin() {
   const result = spawnSync('git', ['remote', 'get-url', 'origin'], {
@@ -469,18 +473,44 @@ export function summarizeMergeQueueDelivery(samples) {
   };
 }
 
-export function validateBaseline(baseline, requiredContexts) {
+export function validateBaseline(
+  baseline,
+  requiredContexts,
+  allowedContextAdditions = [],
+) {
   if (baseline.$schema !== 'kungfu.dev-required-latency-baseline/v1') {
     throw new Error('unsupported dev required latency baseline schema');
   }
   const expected = [...baseline.requiredContexts].sort();
   const actual = [...requiredContexts].sort();
-  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+  const allowed = [...new Set(allowedContextAdditions)].sort();
+  const additions = actual.filter((context) => !expected.includes(context));
+  const removals = expected.filter((context) => !actual.includes(context));
+  if (
+    removals.length ||
+    additions.some((context) => !allowed.includes(context))
+  ) {
     throw new Error(
       `live required contexts drifted: expected ${expected.join(', ')}, got ${actual.join(', ')}`,
     );
   }
   return true;
+}
+
+export function queueAdmissionRequiredContexts(contract) {
+  if (contract?.schema !== 'kungfu.dev-queue-admission/v1') {
+    throw new Error('unsupported dev queue admission contract schema');
+  }
+  if (contract.rulesetActivation?.required !== true) {
+    throw new Error(
+      'dev queue admission contract must require ruleset activation',
+    );
+  }
+  const context = String(contract.requiredContext || '');
+  if (!/^[A-Za-z0-9][A-Za-z0-9 ._/-]{0,99}$/u.test(context)) {
+    throw new Error('dev queue admission required context is invalid');
+  }
+  return [context];
 }
 
 export function requiredContextsFromEffectiveRules(rules) {
@@ -2002,6 +2032,9 @@ async function main() {
     validateBaseline(
       JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8')),
       requiredContexts,
+      queueAdmissionRequiredContexts(
+        JSON.parse(fs.readFileSync(QUEUE_ADMISSION_CONTRACT_PATH, 'utf8')),
+      ),
     );
   }
   const merged = options.pulls.length

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -19,7 +19,6 @@ import {
   mergeQueueEvidence,
   nativeEvidenceFromMembers,
   nearestRank,
-  queueAdmissionRequiredContexts,
   report,
   requiredContextsFromEffectiveRules,
   requiredMergeQueueWindow,
@@ -28,7 +27,6 @@ import {
   summarize,
   summarizeMergeQueueDelivery,
   summarizeNativeAttribution,
-  validateBaseline,
 } from './measure-dev-required-latency.mjs';
 import { partitionAffectedNativePlan } from './run-core-affected-native.mjs';
 
@@ -1099,46 +1097,6 @@ test('context admission ignores successful post-merge reruns', () => {
   assert.equal(context.durationMs, 300000);
   assert.deepEqual(context.workflowRunIds, [42]);
   assert.equal(context.endAuthority, 'first-success-no-later-than-pull-merge');
-});
-
-test('live required contexts match baseline or one declared lease expansion', () => {
-  const baseline = {
-    $schema: 'kungfu.dev-required-latency-baseline/v1',
-    requiredContexts: ['a', 'b'],
-  };
-  assert.equal(validateBaseline(baseline, ['b', 'a']), true);
-  assert.equal(
-    validateBaseline(baseline, ['b', 'queue-lease', 'a'], ['queue-lease']),
-    true,
-  );
-  assert.throws(
-    () => validateBaseline(baseline, ['a', 'c']),
-    /live required contexts drifted/,
-  );
-  assert.throws(
-    () => validateBaseline(baseline, ['a', 'queue-lease'], ['queue-lease']),
-    /live required contexts drifted/,
-  );
-});
-
-test('queue admission contract authorizes only one explicit required context', () => {
-  assert.deepEqual(
-    queueAdmissionRequiredContexts({
-      schema: 'kungfu.dev-queue-admission/v1',
-      requiredContext: 'Queue admission lease',
-      rulesetActivation: { required: true },
-    }),
-    ['Queue admission lease'],
-  );
-  assert.throws(
-    () =>
-      queueAdmissionRequiredContexts({
-        schema: 'kungfu.dev-queue-admission/v1',
-        requiredContext: 'Queue admission lease',
-        rulesetActivation: { required: false },
-      }),
-    /must require ruleset activation/,
-  );
 });
 
 test('required contexts come from all effective required-status rules', () => {

--- a/scripts/measure-dev-required-latency.test.mjs
+++ b/scripts/measure-dev-required-latency.test.mjs
@@ -19,6 +19,7 @@ import {
   mergeQueueEvidence,
   nativeEvidenceFromMembers,
   nearestRank,
+  queueAdmissionRequiredContexts,
   report,
   requiredContextsFromEffectiveRules,
   requiredMergeQueueWindow,
@@ -1100,15 +1101,43 @@ test('context admission ignores successful post-merge reruns', () => {
   assert.equal(context.endAuthority, 'first-success-no-later-than-pull-merge');
 });
 
-test('live required contexts must match the retained baseline authority', () => {
+test('live required contexts match baseline or one declared lease expansion', () => {
   const baseline = {
     $schema: 'kungfu.dev-required-latency-baseline/v1',
     requiredContexts: ['a', 'b'],
   };
   assert.equal(validateBaseline(baseline, ['b', 'a']), true);
+  assert.equal(
+    validateBaseline(baseline, ['b', 'queue-lease', 'a'], ['queue-lease']),
+    true,
+  );
   assert.throws(
     () => validateBaseline(baseline, ['a', 'c']),
     /live required contexts drifted/,
+  );
+  assert.throws(
+    () => validateBaseline(baseline, ['a', 'queue-lease'], ['queue-lease']),
+    /live required contexts drifted/,
+  );
+});
+
+test('queue admission contract authorizes only one explicit required context', () => {
+  assert.deepEqual(
+    queueAdmissionRequiredContexts({
+      schema: 'kungfu.dev-queue-admission/v1',
+      requiredContext: 'Queue admission lease',
+      rulesetActivation: { required: true },
+    }),
+    ['Queue admission lease'],
+  );
+  assert.throws(
+    () =>
+      queueAdmissionRequiredContexts({
+        schema: 'kungfu.dev-queue-admission/v1',
+        requiredContext: 'Queue admission lease',
+        rulesetActivation: { required: false },
+      }),
+    /must require ruleset activation/,
   );
 });
 

--- a/scripts/queue-admission-lease.test.mjs
+++ b/scripts/queue-admission-lease.test.mjs
@@ -6,6 +6,11 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import {
+  queueAdmissionRequiredContexts,
+  validateDevRequiredLatencyBaseline,
+} from './cancel-dequeued-merge-group-runs.mjs';
+
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CONTRACT = JSON.parse(
   fs.readFileSync(
@@ -71,5 +76,54 @@ test('trusted dequeue controller revokes the same exact-head context', () => {
   assert.match(
     workflow,
     /DEQUEUED_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/u,
+  );
+});
+
+test('live required contexts match baseline or one declared lease expansion', () => {
+  const baseline = {
+    $schema: 'kungfu.dev-required-latency-baseline/v1',
+    requiredContexts: ['a', 'b'],
+  };
+  assert.equal(validateDevRequiredLatencyBaseline(baseline, ['b', 'a']), true);
+  assert.equal(
+    validateDevRequiredLatencyBaseline(
+      baseline,
+      ['b', 'queue-lease', 'a'],
+      ['queue-lease'],
+    ),
+    true,
+  );
+  assert.throws(
+    () => validateDevRequiredLatencyBaseline(baseline, ['a', 'c']),
+    /live required contexts drifted/,
+  );
+  assert.throws(
+    () =>
+      validateDevRequiredLatencyBaseline(
+        baseline,
+        ['a', 'queue-lease'],
+        ['queue-lease'],
+      ),
+    /live required contexts drifted/,
+  );
+});
+
+test('queue admission contract authorizes only one explicit required context', () => {
+  assert.deepEqual(
+    queueAdmissionRequiredContexts({
+      schema: 'kungfu.dev-queue-admission/v1',
+      requiredContext: 'Queue admission lease',
+      rulesetActivation: { required: true },
+    }),
+    ['Queue admission lease'],
+  );
+  assert.throws(
+    () =>
+      queueAdmissionRequiredContexts({
+        schema: 'kungfu.dev-queue-admission/v1',
+        requiredContext: 'Queue admission lease',
+        rulesetActivation: { required: false },
+      }),
+    /must require ruleset activation/,
   );
 });

--- a/scripts/queue-admission-lease.test.mjs
+++ b/scripts/queue-admission-lease.test.mjs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CONTRACT = JSON.parse(
+  fs.readFileSync(
+    path.join(
+      ROOT,
+      'docs',
+      'qualification',
+      'gates',
+      'dev-queue-admission.contract.json',
+    ),
+    'utf8',
+  ),
+);
+
+test('queue admission lease has distinct PR-head and merge-group authorities', () => {
+  assert.equal(CONTRACT.schema, 'kungfu.dev-queue-admission/v1');
+  assert.equal(CONTRACT.requiredContext, 'Queue admission lease');
+  assert.equal(CONTRACT.authority.pullRequestHead, 'atlas-serialized-wrapper');
+  assert.equal(
+    CONTRACT.authority.mergeGroup,
+    '.github/workflows/queue-admission-lease.yml',
+  );
+  assert.equal(CONTRACT.admission.queueMustBeEmpty, true);
+  assert.equal(CONTRACT.admission.requiredPosition, 1);
+  assert.equal(CONTRACT.admission.freshProjectCutReplay, true);
+  assert.equal(CONTRACT.revocation.sameHeadRetry, 'forbidden-after-revocation');
+  assert.equal(CONTRACT.rulesetActivation.required, true);
+  assert.equal(CONTRACT.rulesetActivation.expectedSource, 'any');
+});
+
+test('merge-group continuation cannot satisfy the PR-head lease', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, CONTRACT.authority.mergeGroup),
+    'utf8',
+  );
+  assert.match(workflow, /^name: Queue admission lease$/mu);
+  assert.match(workflow, /^\s{2}merge_group:$/mu);
+  assert.doesNotMatch(workflow, /^\s{2}pull_request(?:_target)?:$/mu);
+  assert.match(workflow, /^permissions: \{\}$/mu);
+  assert.match(workflow, /^\s{4}name: Queue admission lease$/mu);
+  assert.match(
+    workflow,
+    /MERGE_GROUP_HEAD_SHA: \$\{\{ github\.event\.merge_group\.head_sha \}\}/u,
+  );
+  assert.match(workflow, /MERGE_GROUP_HEAD_SHA" != "\$GITHUB_SHA/u);
+});
+
+test('trusted dequeue controller revokes the same exact-head context', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, CONTRACT.authority.dequeueRevocation),
+    'utf8',
+  );
+  assert.match(workflow, /^\s{2}pull_request_target:$/mu);
+  assert.match(workflow, /^\s+types: \[dequeued\]$/mu);
+  assert.match(workflow, /^\s+statuses: write$/mu);
+  assert.match(
+    workflow,
+    new RegExp(
+      `QUEUE_ADMISSION_CONTEXT: ${CONTRACT.requiredContext.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')}`,
+      'u',
+    ),
+  );
+  assert.match(
+    workflow,
+    /DEQUEUED_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/u,
+  );
+});


### PR DESCRIPTION
## Summary

Serialize dev merge-queue admission with an exact-head `Queue admission lease`. The lease is issued only after the queue is empty and Project Cut is replayed against the latest base, continued on the exact synthetic merge-group SHA, and permanently revoked for a dequeued head.

## Changes

- add a merge-group-only required-context continuation with no token permissions
- extend the trusted dequeue controller to revoke the exact PR-head lease even when cancellation or repair-marker cleanup fails
- declare the bounded admission contract, including position-one-only and no same-head retry after revocation
- allow the latency collector to recognize only this declared required-context expansion without deleting or cutting over historical samples
- refresh the closed-world workflow authority manifest

## Verification

- `./shifu test:gate-latency` (73 passed)
- `./shifu check:gate-catalog` (38 gates, 6 profiles, 27 invocations, 26 workflows aligned)
- `./shifu check` (passed after building the ignored Spec aggregate through its documented package build entry)
- DCO staged gate completed before commit
- `node scripts/check-project-cut-merge-queue-admission.mjs --base origin/dev/v4/v4.0 --head HEAD` (`decision=qualified`)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This operational safety fix preserves the existing required Gate and exact-proof contracts; it serializes admission so position-two source drift cannot invalidate them and adds no weaker proof path."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change uses GitHub commit-status and merge-queue APIs with exact-SHA binding. It adds no credentials, does not publish artifacts, and keeps the credential-free merge-group continuation at `permissions: {}`.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated for the admission and revocation behavior
- [x] Required Gate proof verification remains fail-closed
- [x] Historical latency samples are not deleted or hidden behind a regime cutoff
