### PR TITLE
fix(qualification): await verified runtime identity

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "a55db319fd4004eb45673a646358348e7a52a1c2",
+    "sourceSha": "bcfa8bf0503243a44042d14805088e48f2cbb0aa",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:2d8563983d8a4b0052ea4789d62d9ae279eb402e3e08f0e8a5699b33c947c60b"
   },

--- a/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
+++ b/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
@@ -89,10 +89,12 @@ export function invokeAfterIdentitySettlement(
   throw identityError;
 }
 
-function running(payload) {
+export function runtimeReady(payload) {
   return (
     payload?.supervisor?.running === true &&
-    payload?.coordinator?.running === true
+    payload?.supervisor?.identityVerified === true &&
+    payload?.coordinator?.running === true &&
+    payload?.coordinator?.identityVerified === true
   );
 }
 
@@ -100,7 +102,7 @@ function waitForRunning(home, configHome) {
   let latest;
   for (let attempt = 0; attempt < 50; attempt += 1) {
     latest = invoke(home, configHome, ['runtime', 'status', '--json']);
-    if (running(latest.payload)) return latest;
+    if (runtimeReady(latest.payload)) return latest;
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
   }
   throw new Error(
@@ -171,10 +173,10 @@ function main() {
           outcomes: {
             daemonlessStatus: before.payload.product,
             coldChanged: cold.payload.changed,
-            coldRunning: running(coldStatus.payload),
+            coldRunning: runtimeReady(coldStatus.payload),
             warmChanged: warm.payload.changed,
             restartSchema: restart.payload.schema,
-            restartRunning: running(restartStatus.payload),
+            restartRunning: runtimeReady(restartStatus.payload),
             stopped: stop.payload.changed,
           },
           latency: {

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -6,7 +6,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 
-import { invokeAfterIdentitySettlement } from './product_smoke.mjs';
+import {
+  invokeAfterIdentitySettlement,
+  runtimeReady,
+} from './product_smoke.mjs';
 import {
   boundedFailureTail,
   createLogBundle,
@@ -140,6 +143,30 @@ test('Windows suites invoke the repository Shifu shim through ComSpec', () => {
   assert.equal(
     invocation.args[3],
     'call shifu.cmd exec "argument with spaces"',
+  );
+});
+
+test('product smoke does not report runtime readiness before both identities settle', () => {
+  assert.equal(
+    runtimeReady({
+      supervisor: { running: true, identityVerified: true },
+      coordinator: { running: true, identityVerified: false },
+    }),
+    false,
+  );
+  assert.equal(
+    runtimeReady({
+      supervisor: { running: true, identityVerified: false },
+      coordinator: { running: true, identityVerified: true },
+    }),
+    false,
+  );
+  assert.equal(
+    runtimeReady({
+      supervisor: { running: true, identityVerified: true },
+      coordinator: { running: true, identityVerified: true },
+    }),
+    true,
   );
 });
 


### PR DESCRIPTION
## Summary

Make the frozen product runtime smoke wait for both the supervisor and coordinator process identities to be verified before issuing the warm ensure command.

## Related issue

Maintainability terminal-closure exact Windows qualification follow-up. Build run 30328150323 passed the 72/72 base verification and every other runtime-activation suite, but product-runtime-smoke raced from process liveness into a fail-closed warm ensure before the coordinator identity handoff settled.

## Changes

- define product runtime readiness as running plus identityVerified for both supervisor and coordinator
- reuse the stricter readiness predicate for cold and restart evidence
- add regression cases for both partial identity handoffs and the fully verified state
- refresh the KFD-3 prebuild witness

## Verification

- `./shifu exec node --test framework/core/tests/qualification/runtime-activation/run.test.mjs` (15 pass, 0 fail)
- `./shifu kfd:buildchain:check` (pass)
- `./shifu check:source` (complete pass before witness refresh; repeated source suite reached 695 pass and one environment-only failure because pytest was absent from PATH)
- DCO pre-commit staged gate (pass)
- `git diff --check` (pass)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the existing runtime identity fence and product qualification contract; it only prevents the qualification harness from treating PID liveness as verified process authority."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only the exact-source product qualification readiness predicate and its content-addressed witness. It does not publish or deploy artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added
- [x] Documentation is unchanged because the runtime identity contract is preserved
