### PR TITLE
docs(onboarding): route system readers through evolution map

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,7 +41,7 @@ Feature PRs targeting `dev/*` must replace the block with:
 Alpha and stable promotion manifests are documented in the release design;
 do not use the ADR-neutral form for a channel promotion.
 
-## Evolution map impact
+## [Evolution Map](../docs/evolution/README.md) impact
 
 Evolution impact: <!-- none | extends | opens | settles | supersedes -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,21 @@ restating them.
 - **Building or contributing to this repo** — read the rest of this file, then
   [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+### Establish orientation before a repository-wide analysis
+
+When a person or agent is trying to understand Kungfu as a whole, do not start
+by walking the current directories and modules side by side. Read the
+[`Evolution Map`](docs/evolution/README.md), its generated
+[`timeline`](docs/evolution/timeline.md), and
+[`reader routes`](docs/evolution/reader-routes.md) first. They establish the
+historical pressures, abstraction compressions, and authority transitions that
+make the current cross-section intelligible; follow their current-authority
+links before treating a historical surface as an implementation owner.
+
+This is an orientation rule, not a requirement to load the whole history for
+every task. When the job is already bounded to one component or operation,
+proceed directly to the verified task-specific route below.
+
 ## Load verified context before implementation
 
 Do not treat this router, a README, chat history, or the first plausible file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,14 @@ an append-only Era or Stage record under `docs/evolution/` and regenerate its
 projections with `./shifu evolution:map`. Settled records are immutable; publish
 an amendment or successor instead of rewriting history.
 
+Before a cross-layer change, contributors who cannot yet place the affected
+capability and authority transition should read the
+[Evolution Map timeline](docs/evolution/timeline.md) and
+[current-authority projection](docs/evolution/current-authority.md) first. Use
+that historical orientation to find the current owner; do not infer ownership
+from a retired or compatibility surface. A bounded change with an already-known
+owner can proceed directly through its task-specific Xinfa route.
+
 It checks the
 whole Markdown graph so deleting or renaming a target cannot evade a
 changed-file filter. The intentionally small Markdownlint rule baseline lives
@@ -384,7 +392,7 @@ dev/<major>/<version>  →  alpha/<major>/<version>  →  release/<major>/<versi
 - Open pull requests against the relevant `dev/*` branch.
 - Declare the pull request's Evolution impact as `none`, `extends`, `opens`,
   `settles`, or `supersedes`. Any value other than `none` must be reflected in
-  the append-only Evolution Map corpus.
+  the append-only [Evolution Map corpus](docs/evolution/README.md).
 - Keep exactly one `kungfu-adr-release:v1` block from the pull-request
   template. Feature branches must declare `stage-ready` or `implemented`
   delivery intent and reference accepted ADRs; fixes and chores with no

--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ when an agent continues to run elsewhere.
 
 ## Go deeper
 
+If your goal is to understand Kungfu as a system, do not begin by comparing
+repository directories and current modules side by side. Start with the
+[Evolution Map](docs/evolution/README.md): it establishes the historical
+pressures, abstraction compressions, and authority transitions that produced
+the current cross-section. Then use its reader routes to enter the exact
+current module, contract, and source authority for your question.
+
+If you already have one bounded implementation or operational task, use
+[AGENTS.md](AGENTS.md) and the task-specific Xinfa route instead of loading the
+whole history first.
+
+- [Start with Kungfu's longitudinal Evolution Map](docs/evolution/README.md)
 - [Why Kungfu begins with a minimal human sovereign core](docs/concepts/bootstrapping-agent-work.md)
 - [Inspect and reanalyze the bounded public work sample](https://kungfu.tech/about/bootstrapping/evidence/)
 - [How the complete Kungfu system works](docs/concepts/system-overview.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,14 @@ matches your job, then go deeper only when you need to.
 
 ## Understand Kungfu
 
+For whole-system understanding, do not begin with a directory-by-directory or
+module-by-module comparison of the current repository. That cross-section is
+the result of several completed abstraction compressions and authority
+transitions. Establish the longitudinal anchors below first, then cross into
+the current contracts and source through the generated reader routes. If your
+job is already a bounded local task, choose its responsibility section or
+verified Xinfa route directly instead.
+
 Read these in order for the product model:
 
 1. [Evolution Map](evolution/README.md) — how repeated implementation pressure,

--- a/docs/adr/KF-ADR-019fa773-aae4-7f50-80a5-ce53b08490d2.md
+++ b/docs/adr/KF-ADR-019fa773-aae4-7f50-80a5-ce53b08490d2.md
@@ -43,11 +43,12 @@ silent rewrites of settled interpretation.
 
 ## Decision
 
-Kungfu owns a versioned longitudinal Evolution Map organized as Era, Stage, and
-Evidence records. An Era names a sustained abstraction thesis. A Stage exists
-only for a load-bearing capability compression or authority transition, not
-for each feature. Evidence is exact public PR, commit, ADR, or current document
-material retained by the Stage.
+Kungfu owns a versioned longitudinal
+[Evolution Map](../evolution/README.md) organized as Era, Stage, and Evidence
+records. An Era names a sustained abstraction thesis. A Stage exists only for
+a load-bearing capability compression or authority transition, not for each
+feature. Evidence is exact public PR, commit, ADR, or current document material
+retained by the Stage.
 
 Era and Stage Markdown records carry one typed JSON fence. Once a record exists
 on the protected base its meaning is append-only: later correction or

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,12 @@
 # Architecture
 
+This section is the current architecture cross-section. First-time readers who
+need to understand the whole system should begin with the
+[Evolution Map](../evolution/README.md), then use its
+[reader routes](../evolution/reader-routes.md) to enter the current owner for
+one historical pressure. Start here directly when the component or boundary is
+already known.
+
 For the KFD-7 library ownership split, current ABI inventory, and staged
 successor membrane, see
 [`kfd7-library-boundary.md`](kfd7-library-boundary.md) and

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,11 @@
 # Architecture
 
-How the Kungfu repository is layered, and the principle that shapes it. For the
-accountability stance behind the product, see
+How the Kungfu repository is layered, and the principle that shapes it. This is
+a cross-sectional view of the current system. If you are new to the repository
+or the number of layers is the problem, first read the longitudinal
+[Evolution Map](../evolution/README.md) and choose the closest pressure in its
+[reader routes](../evolution/reader-routes.md); then return here for the current
+module boundaries. For the accountability stance behind the product, see
 [`facts-before-trust.md`](../concepts/facts-before-trust.md); for the two first principles
 the whole design follows from, see
 [`design-philosophy.md`](../concepts/design-philosophy.md); for the vocabulary

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -3,8 +3,10 @@
 This section owns Kungfu's public mental model: the complete system overview,
 journal-backed Fact state, Episode causal experience, the fact-first trust
 boundary, the name's recursive technical meaning, canonical vocabulary,
-implementation concepts, and product layers. Start with
-[System Overview](system-overview.md), continue with
+implementation concepts, and product layers. If you do not yet have a
+longitudinal model of how these concepts accumulated, read the
+[Evolution Map](../evolution/README.md) before comparing them in the current
+system. Then start with [System Overview](system-overview.md), continue with
 [Facts Before Trust](facts-before-trust.md), then read [The Episode](the-episode.md)
 and use the [Vocabulary Reference](vocabulary.md) for precise terms. The
 canonical integration model is

--- a/docs/concepts/system-overview.md
+++ b/docs/concepts/system-overview.md
@@ -4,9 +4,12 @@ Kungfu is a local-first runtime that records real-world agent work and verifies
 what actually got done. It works alongside the agents and execution surfaces
 you already use.
 
-This page is the second layer behind the concise project
-[README](../../README.md). It explains the complete system model without making
-new users understand that model before they receive value.
+This page is the current-system cross-section behind the concise project
+[README](../../README.md). For whole-system study, it is the second layer after
+the longitudinal [Evolution Map](../evolution/README.md): establish why the
+major abstractions and authority boundaries appeared, then use this page to see
+how they fit together now. A reader with one bounded product question can
+enter this overview directly without loading the complete history.
 
 Kungfu turns execution into **Episodes**, bounded causal units that bind Facts,
 Artifacts, Receipts, dependencies, and verification roots into one inspectable

--- a/docs/evolution/README.md
+++ b/docs/evolution/README.md
@@ -30,6 +30,27 @@ Rewind and the Fact ledger, sealed Episodes, Profile Suite composition, Project
 Cut and Xinfa continuity, native Fact and Action authority, portable Work,
 Primitive governance, native Work Control, and recursive first-party dogfood.
 
+## Recommended system-understanding sequence
+
+Use this order when the goal is to understand Kungfu across modules:
+
+1. Read the project [README](../../README.md) for the current product promise.
+2. Read the generated [timeline](timeline.md) to establish the longitudinal
+   pressures and abstraction compressions.
+3. Choose the closest pressure in [reader routes](reader-routes.md) and verify
+   its owner in [current authority](current-authority.md).
+4. Read the current [System Overview](../concepts/system-overview.md).
+5. Enter only the relevant Concepts, Architecture, Profile, contract, and
+   source modules.
+6. Use ADRs, qualification, and exact evidence when auditing a decision or
+   claim.
+
+Do not reverse this order into an exhaustive directory walk unless a
+cross-sectional inventory is itself the task. The map supplies orientation;
+current contracts and source still supply authority. A bounded task with a
+known owner can skip the historical prelude and use its verified Xinfa route
+directly.
+
 ## Record protocol
 
 An Era groups a sustained abstraction thesis. A Stage is created only when a

--- a/docs/guides/xinfa-agent-context.md
+++ b/docs/guides/xinfa-agent-context.md
@@ -6,6 +6,14 @@ Xinfa compiles one immutable Atlas and selects a bounded Task Chart from that
 verified cut. It prevents a convenient README, stale summary, or guessed route
 from silently becoming authority.
 
+Repository orientation and task context are different cuts. When an Agent is
+first trying to understand Kungfu as a whole, request the
+`kungfu-evolution-map-agent` route to establish longitudinal anchors, then
+select the bounded Core, kfx, documentation, or user route for the actual task.
+Do not inject the complete [Evolution Map](../evolution/README.md) into every
+known local task: once the component or operation is clear, the task-specific
+route should remain the smaller authoritative context.
+
 ## Source checkout: compile the Task Chart
 
 Start with the project-owned inventory. Its route declarations are the

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -5,6 +5,12 @@ agent-work and application scenarios. They may define higher-level workflows
 and action objects, but they do not redefine journal authority or the core
 execution vocabulary.
 
+If Profile Suite, Project Cut, portable Work, and native Work Control appear to
+be parallel systems, first follow the corresponding progression in the
+[Evolution reader routes](../evolution/reader-routes.md). Return here after the
+historical compression and current authority for the relevant profile are
+clear.
+
 - [KFX Profile Suite Lifecycle](profile-lifecycle.md)
 - [Agent-first Profile Authoring](profile-authoring.md)
 - [Agent Work State](agent-work-state.md)

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b8b9c591c4e123b18dadc49c7b2a1d4a9c4c06998b673d8ce8711575340764de",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:0a2d94d9b4bc4d97d39007207b02e82472df3fe0b41382cbdb876da56ad62942",
+  "sourceRoot": "sha256:5d9f5f8990c0ae8352cd04622756fedae9cc5ff56d01af9b9d7c1c673f0e6724",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -201,9 +201,9 @@
         },
         {
           "path": "docs/architecture/overview.md",
-          "currentLines": 311,
+          "currentLines": 315,
           "baselineLines": 311,
-          "currentRoot": "sha256:bdfae936c9be86ccb89ff89bd9bcd982a8ca3d6e756f03042e5ccf80c8f0795f",
+          "currentRoot": "sha256:039944c1fe1b8c8f411adec7799c3766c0aaf12c15ef9e6ef1c9461bc32bb974",
           "baselineRoot": "sha256:eae378faa493c52311a66d5a66d9e29aaa484938812f89654e91ce4473f35048",
           "changedSinceBaseline": true
         }

--- a/scripts/evolution-map.test.mjs
+++ b/scripts/evolution-map.test.mjs
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 
 import {
   buildEvolutionMap,
+  findUnlinkedEvolutionMapMentions,
   parseEvolutionRecord,
   renderAuthority,
   renderReaderRoutes,
@@ -146,5 +147,31 @@ test('rejects duplicate identities and forward era dependencies', () => {
         contract,
       ),
     /dangling or forward buildsOn/,
+  );
+});
+
+test('requires authored Evolution Map mentions to be navigable', () => {
+  assert.deepEqual(
+    findUnlinkedEvolutionMapMentions([
+      {
+        file: 'README.md',
+        text: '[Evolution Map](docs/evolution/README.md)\n',
+      },
+      {
+        file: 'docs/evolution/README.md',
+        text: '# Kungfu Evolution Map\n\nThe Evolution Map is this page.\n',
+      },
+      {
+        file: 'docs/adr/example.md',
+        text: '# ADR: Evolution Map\n\n```sh\nextend evolution map\n```\n',
+      },
+    ]),
+    [],
+  );
+  assert.deepEqual(
+    findUnlinkedEvolutionMapMentions([
+      { file: 'CONTRIBUTING.md', text: 'Read the Evolution Map first.\n' },
+    ]),
+    ['CONTRIBUTING.md:1'],
   );
 });

--- a/scripts/evolution-map/index.mjs
+++ b/scripts/evolution-map/index.mjs
@@ -528,6 +528,45 @@ function checkPullRequestTemplate(contract) {
   );
 }
 
+export function findUnlinkedEvolutionMapMentions(entries) {
+  const violations = [];
+  for (const { file, text } of entries) {
+    if (file === 'docs/evolution/README.md') continue;
+    let fenced = false;
+    for (const [index, line] of text.split(/\r?\n/).entries()) {
+      if (/^\s*```/.test(line)) {
+        fenced = !fenced;
+        continue;
+      }
+      if (fenced || !/\bevolution map\b/i.test(line)) continue;
+      if (
+        file.startsWith('docs/adr/') &&
+        /^#\s+.*\bevolution map\b/i.test(line)
+      )
+        continue;
+      if (/\[[^\]]*\bevolution map\b[^\]]*\]\([^)]+\)/i.test(line)) continue;
+      violations.push(`${file}:${index + 1}`);
+    }
+  }
+  return violations;
+}
+
+function checkEvolutionMapNavigation() {
+  const markdownFiles = runGit(['ls-files', '--', '*.md'])
+    .split('\n')
+    .filter(Boolean);
+  const violations = findUnlinkedEvolutionMapMentions(
+    markdownFiles.map((file) => ({
+      file,
+      text: fs.readFileSync(path.join(ROOT, file), 'utf8'),
+    })),
+  );
+  invariant(
+    violations.length === 0,
+    `Evolution Map mentions must link to a navigation target: ${violations.join(', ')}`,
+  );
+}
+
 function outputs() {
   const contract = JSON.parse(
     fs.readFileSync(path.join(ROOT, CONTRACT_PATH), 'utf8'),
@@ -537,6 +576,7 @@ function outputs() {
   const projection = buildEvolutionMap(eras, stages, contract, ROOT);
   checkHistoricalIntegrity();
   checkPullRequestTemplate(contract);
+  checkEvolutionMapNavigation();
   return new Map([
     [OUTPUTS.map, `${JSON.stringify(projection, null, 2)}\n`],
     [OUTPUTS.timeline, renderTimeline(projection)],


### PR DESCRIPTION
## Summary

- Make the Evolution Map the explicit longitudinal-first orientation path for people and Agents studying Kungfu as a whole.
- Preserve direct Xinfa routing for bounded component or operational work.
- Require every authored reader-facing Evolution Map mention to link to a navigation target.

## Related issue

None.

## Changes

- Added a progressive reading sequence across the repository, documentation, concepts, architecture, Profile, contribution, and Agent entry surfaces.
- Linked existing Evolution Map mentions, including the pull-request declaration and accepted ADR body.
- Added a repository-wide Markdown ratchet with focused positive and negative fixtures.
- Refreshed the governed semantic-amplification projection.

## Verification

- `./shifu evolution:map:check`
- `./shifu docs:check`
- `./shifu docs validate --json`
- `./shifu docs inventory --json`
- `./shifu docs:prose:required`
- `./shifu check:source`
- commit staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["KF-ADR-019fa773-aae4-7f50-80a5-ce53b08490d2"],
  "summary": "Complete the first-party longitudinal onboarding route and make its navigation guarantee fail closed",
  "verification": ["./shifu evolution:map:check", "./shifu docs:check", "./shifu check:source"]
}
-->

## [Evolution Map](https://github.com/kungfu-systems/kungfu/blob/dev/v4/v4.0/docs/evolution/README.md) impact

Evolution impact: none

This change improves navigation and enforcement without opening or changing an Era, Stage, capability compression, or authority transition.

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
