### PR TITLE
fix(ci): follow default dev ruleset authority

### DIFF
--- a/.github/alpha-attention-operations.json
+++ b/.github/alpha-attention-operations.json
@@ -79,7 +79,7 @@
       }
     ],
     "requiredActiveRulesets": [
-      "Buildchain dev merge queue: admitted dev channel family"
+      "Buildchain dev merge queue: admitted default dev channel"
     ],
     "requiredLiveReadback": {
       "issues": true,

--- a/docs/qualification/gates/dev-queue-admission.contract.json
+++ b/docs/qualification/gates/dev-queue-admission.contract.json
@@ -33,17 +33,14 @@
   "rulesetActivation": {
     "required": true,
     "rulesetId": 19057118,
-    "rulesetName": "Buildchain dev merge queue: admitted dev channel family",
+    "rulesetName": "Buildchain dev merge queue: admitted default dev channel",
     "target": {
       "include": [
-        "refs/heads/dev/v*/v*"
+        "~DEFAULT_BRANCH"
       ],
-      "exclude": [
-        "refs/heads/dev/v1/v*",
-        "refs/heads/dev/v2/v*",
-        "refs/heads/dev/v3/v*"
-      ]
+      "exclude": []
     },
+    "providerConstraint": "GitHub merge queue rulesets reject wildcard ref targets. The repository default branch is the moving authority pointer, and resolveDevBranch admits it only when it belongs to the v4+ dev family.",
     "expectedSource": "any",
     "reason": "The pull-request lease is a user-authored commit status while the merge-group continuation is a GitHub Actions check."
   },

--- a/scripts/candidate-timeline-events.cjs
+++ b/scripts/candidate-timeline-events.cjs
@@ -202,30 +202,36 @@ function checkDevChannelAuthority(root = ROOT) {
       'utf8',
     ),
   );
-  const expectedInclude = ['refs/heads/dev/v*/v*'];
-  const expectedExclude = [
+  const expectedFamilyInclude = ['refs/heads/dev/v*/v*'];
+  const expectedFamilyExclude = [
     'refs/heads/dev/v1/v*',
     'refs/heads/dev/v2/v*',
     'refs/heads/dev/v3/v*',
   ];
+  const expectedRulesetInclude = ['~DEFAULT_BRANCH'];
+  const expectedRulesetExclude = [];
   if (
     contract.branchPattern !== 'dev/v*/v*' ||
     contract.admittedFamily?.minimumMajor !== 4 ||
+    JSON.stringify(contract.admittedFamily?.include) !==
+      JSON.stringify(expectedFamilyInclude) ||
+    JSON.stringify(contract.admittedFamily?.exclude) !==
+      JSON.stringify(expectedFamilyExclude) ||
     JSON.stringify(activation?.target?.include) !==
-      JSON.stringify(expectedInclude) ||
+      JSON.stringify(expectedRulesetInclude) ||
     JSON.stringify(activation?.target?.exclude) !==
-      JSON.stringify(expectedExclude)
+      JSON.stringify(expectedRulesetExclude)
   )
-    issues.push('admitted dev family or legacy exclusions drifted');
+    issues.push('admitted dev family or default-branch ruleset target drifted');
   if (
     activation?.rulesetId !== 19057118 ||
     activation?.rulesetName !==
-      'Buildchain dev merge queue: admitted dev channel family' ||
+      'Buildchain dev merge queue: admitted default dev channel' ||
     !operations.activation?.requiredActiveRulesets?.includes(
       activation?.rulesetName,
     )
   )
-    issues.push('dev family ruleset identity drifted');
+    issues.push('default dev ruleset identity drifted');
   if (
     !isAdmittedDevBranch(`dev/v${4}/v${4}.0`, contract) ||
     !isAdmittedDevBranch(`dev/v${10}/v${10}.2`, contract) ||

--- a/scripts/check-alpha-attention-operations.mjs
+++ b/scripts/check-alpha-attention-operations.mjs
@@ -103,7 +103,7 @@ export function checkAlphaAttentionOperations(root = ROOT) {
           },
         ]) &&
       contract.activation?.requiredActiveRulesets?.includes(
-        'Buildchain dev merge queue: admitted dev channel family',
+        'Buildchain dev merge queue: admitted default dev channel',
       ) &&
       community.defaultRepository?.target === 'kungfu-systems/.github' &&
       community.defaultRepository?.requiredFiles?.length === 8,
@@ -172,7 +172,7 @@ export function checkAlphaAttentionOperations(root = ROOT) {
       privateVulnerabilityReporting: true,
       activeRulesets: [
         {
-          name: 'Buildchain dev merge queue: admitted dev channel family',
+          name: 'Buildchain dev merge queue: admitted default dev channel',
           enforcement: 'active',
         },
       ],

--- a/scripts/check-alpha-attention-operations.test.mjs
+++ b/scripts/check-alpha-attention-operations.test.mjs
@@ -38,7 +38,7 @@ test('live activation planning is deterministic and remains non-executable', asy
     privateVulnerabilityReporting: true,
     activeRulesets: [
       {
-        name: 'Buildchain dev merge queue: admitted dev channel family',
+        name: 'Buildchain dev merge queue: admitted default dev channel',
         enforcement: 'active',
       },
     ],

--- a/scripts/queue-admission-lease.test.mjs
+++ b/scripts/queue-admission-lease.test.mjs
@@ -48,12 +48,16 @@ test('queue admission lease has distinct PR-head and merge-group authorities', (
   assert.equal(CONTRACT.rulesetActivation.rulesetId, 19057118);
   assert.equal(
     CONTRACT.rulesetActivation.rulesetName,
-    'Buildchain dev merge queue: admitted dev channel family',
+    'Buildchain dev merge queue: admitted default dev channel',
   );
   assert.deepEqual(CONTRACT.rulesetActivation.target, {
-    include: CONTRACT.admittedFamily.include,
-    exclude: CONTRACT.admittedFamily.exclude,
+    include: ['~DEFAULT_BRANCH'],
+    exclude: [],
   });
+  assert.match(
+    CONTRACT.rulesetActivation.providerConstraint,
+    /reject wildcard ref targets/u,
+  );
   assert.equal(CONTRACT.rulesetActivation.expectedSource, 'any');
 });
 


### PR DESCRIPTION
## Summary

Use the repository default branch as the moving GitHub merge-queue ruleset authority because GitHub rejects wildcard ref targets when merge queue is enabled. Kungfu still admits only the v4+ dev family.

## Verification

- dev channel authority tests pass
- queue admission lease tests pass
- alpha attention operations tests pass
- gate catalog passes
- staged repository gate passes

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix corrects a provider-constrained ruleset target without changing an architecture contract."
}
-->

## Evolution map impact

Evolution impact: none

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated for the provider constraint