### PR TITLE
feat(ci): add AWS CodeBuild burst qualification

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: AWS US Linux Burst Qualification
+
+on:
+  workflow_dispatch:
+    inputs:
+      qualification-id:
+        description: "Auditable slot label for this bounded PoC run"
+        required: true
+      buildchain-ref:
+        description: "Exact reviewed Buildchain train for this campaign"
+        required: true
+        default: "train/v2/v2.3/aws-us-elastic-runner-burst-plane"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aws-us-linux-burst-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  trust:
+    name: Reject non-canonical or untrusted dispatch
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Require canonical repository and reviewed train
+        shell: bash
+        env:
+          EXPECTED_REPOSITORY: kungfu-systems/kungfu
+          EXPECTED_BUILDCHAIN_REF: train/v2/v2.3/aws-us-elastic-runner-burst-plane
+          REQUESTED_BUILDCHAIN_REF: ${{ inputs.buildchain-ref }}
+          QUALIFICATION_ID: ${{ inputs.qualification-id }}
+        run: |
+          set -euo pipefail
+          test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+          test "${GITHUB_REPOSITORY}" = "${EXPECTED_REPOSITORY}"
+          test "${REQUESTED_BUILDCHAIN_REF}" = "${EXPECTED_BUILDCHAIN_REF}"
+          [[ "${QUALIFICATION_ID}" =~ ^poc-(0[1-9]|1[0-7])$ ]]
+
+      - name: Require write-capable actor
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const permission = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            if (!["admin", "maintain", "write"].includes(permission.data.permission || "")) {
+              core.setFailed(`actor permission ${permission.data.permission || "none"} cannot allocate a burst runner`);
+            }
+
+  qualify:
+    name: Exact-source Linux core qualification
+    needs: trust
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane
+    with:
+      buildchain-ref: train/v2/v2.3/aws-us-elastic-runner-burst-plane
+      runner-preset: aws-us-codebuild-linux
+      aws-codebuild-project: kungfu-buildchain-linux-burst-poc
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      rustup-dist-server: https://rsproxy.cn
+      rustup-update-root: https://rsproxy.cn/rustup
+      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
+      artifact-name: kungfu-aws-linux-burst-${{ inputs.qualification-id }}
+      artifact-paths: |
+        product/release/qualification/aws-codebuild-linux.json
+      expected-artifacts-json: >-
+        {"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-codebuild-linux.json"]}
+      require-install: true
+      install-command: node scripts/buildchain-install.mjs
+      require-build: true
+      build-command: ./shifu build:core && node scripts/buildchain-install.mjs qualify-codebuild record
+      require-verify: true
+      verify-command: node scripts/buildchain-install.mjs qualify-codebuild verify
+      lifecycle-timeout-minutes: 105
+      artifact-transfer-mode: github-artifacts
+      artifact-retention-days: 14
+      checkout-cache-mode: github
+      checkout-cache-fallback: github
+      checkout-cache-github-timeout-seconds: 1200
+      publish-channel: none
+      release-candidate: false
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-compatibility-policy: allow-additive
+      buildchain-contract-drift-issue-mode: off

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -648,6 +648,44 @@
       ]
     },
     {
+      "path": ".github/workflows/aws-us-linux-burst-qualification.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:6d3dce83fd46bd0c8df1abfde698d6c83a555770130d2ffcffcadca21ea9c05a",
+      "jobs": [
+        {
+          "id": "qualify",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:2a23496189129a8b4d62cf12ca048f05327e6f103f744eb8b3dbce56f896f174",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
+          "steps": []
+        },
+        {
+          "id": "trust",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:c4f5796c26eafa948658ce4b8d412bd20d1801e3c99e03ddff4893588d0b7a00",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Require canonical repository and reviewed train",
+              "definitionDigest": "sha256:1f7dcb35de9fe34c43b4d544588ece4228538d8e8c052d3f7ff8f514d264294e"
+            },
+            {
+              "index": 2,
+              "label": "name:Require write-capable actor",
+              "definitionDigest": "sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": ".github/workflows/build.yml",
       "authority": "product-publication",
       "definitionDigest": "sha256:aadbb97771ffd89eaec3f3ed67ef3925e1730472a5a722c1a8b956c8ee71b6c1",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -52,6 +52,8 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/affected-native-pr.yml` | `source_acceptance` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
+| `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-linux-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-passport` | qualification | none | qualifying | token:read | none | 4 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -92,6 +92,13 @@
           "sourceRoot": "sha256:ac59ab8ac7eafa7ff1829d94c33e7f5453aa4109ad95ddc5d1b35f7df1e6b9ce"
         },
         {
+          "path": ".github/workflows/aws-us-linux-burst-qualification.yml",
+          "classification": "non-publication",
+          "owner": "kungfu-ci",
+          "surfaceIds": [],
+          "sourceRoot": "sha256:975fdc85c440a96afb2ee25bad20b79c56e977e74d44f0a9e2a07797ad2fa900"
+        },
+        {
           "path": ".github/workflows/build.yml",
           "classification": "qualification",
           "owner": "kungfu-release",
@@ -792,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:f0e028d09cdc8da97dfaa5f5b75b1cbb634b998e1a6627aca4144dca7ee61df6"
+  "registryRoot": "sha256:a7943599321b935e74ac44d643eb5034f27627dc1a6f61ab723a29569cf68013"
 }

--- a/scripts/buildchain-install.mjs
+++ b/scripts/buildchain-install.mjs
@@ -3,6 +3,7 @@
 // @ts-check
 
 import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -14,6 +15,20 @@ const LIFECYCLE_DISPATCHER = path.join(
   'scripts',
   'run-shifu-lifecycle.mjs',
 );
+const CODEBUILD_QUALIFICATION_CONTRACT =
+  'kungfu-aws-codebuild-linux-qualification/v1';
+const FORBIDDEN_CODEBUILD_CREDENTIAL_ENV = [
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'GH_TOKEN',
+  'NPM_TOKEN',
+  'NODE_AUTH_TOKEN',
+  'APPLE_ID',
+  'APPLE_APP_SPECIFIC_PASSWORD',
+  'APPLE_TEAM_ID',
+  'NOTARYTOOL_PASSWORD',
+];
 
 /** @typedef {{command: string, args: string[], cwd?: string}} Command */
 
@@ -105,6 +120,155 @@ export function productToolchainBindings(env = process.env) {
   };
 }
 
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function digest(value) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(canonicalJson(value))
+    .digest('hex')}`;
+}
+
+function codeBuildFileEvidence(root, relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.statSync(absolutePath).isFile())
+    throw new Error(`${relativePath} is not a regular file`);
+  return {
+    path: relativePath,
+    bytes: fs.statSync(absolutePath).size,
+    sha256: crypto
+      .createHash('sha256')
+      .update(fs.readFileSync(absolutePath))
+      .digest('hex'),
+  };
+}
+
+function requiredCodeBuildFiles(root) {
+  const release = path.join(root, 'framework/core/build/Release');
+  const library = fs
+    .readdirSync(release)
+    .find(
+      (entry) => entry === 'libkungfu.so' || /^libkungfu\.so\./u.test(entry),
+    );
+  if (!library)
+    throw new Error('Linux core build did not produce libkungfu.so');
+  return [
+    'framework/core/build/Release/kungfubuildinfo.json',
+    `framework/core/build/Release/${library}`,
+  ];
+}
+
+export function createCodeBuildQualification({
+  root = ROOT,
+  env = process.env,
+  observedAt = new Date().toISOString(),
+} = {}) {
+  if (process.platform !== 'linux' && env.BUILDCHAIN_TEST_PLATFORM !== 'linux')
+    throw new Error('AWS CodeBuild qualification must execute on Linux');
+  const exposedCredentials = FORBIDDEN_CODEBUILD_CREDENTIAL_ENV.filter((name) =>
+    String(env[name] || '').trim(),
+  );
+  if (exposedCredentials.length)
+    throw new Error(
+      `forbidden credential environment is exposed: ${exposedCredentials.join(', ')}`,
+    );
+  const sourceSha = String(env.BUILDCHAIN_SOURCE_SHA || env.GITHUB_SHA || '')
+    .trim()
+    .toLowerCase();
+  if (!/^[0-9a-f]{40}$/u.test(sourceSha))
+    throw new Error('BUILDCHAIN_SOURCE_SHA must be an exact Git commit');
+  const buildId = String(env.CODEBUILD_BUILD_ID || '').trim();
+  const buildArn = String(env.CODEBUILD_BUILD_ARN || '').trim();
+  if (!buildId || !buildArn)
+    throw new Error('CodeBuild build id and ARN are required');
+  const payload = {
+    schemaVersion: 1,
+    contract: CODEBUILD_QUALIFICATION_CONTRACT,
+    status: 'passed',
+    provider: 'aws-codebuild',
+    phase: 'linux-codebuild-poc-under-usd-50',
+    source: {
+      repository: String(env.GITHUB_REPOSITORY || '').trim(),
+      sha: sourceSha,
+      ref: String(env.BUILDCHAIN_SOURCE_REF || env.GITHUB_REF || '').trim(),
+    },
+    github: {
+      runId: String(env.GITHUB_RUN_ID || '').trim(),
+      runAttempt: String(env.GITHUB_RUN_ATTEMPT || '').trim(),
+      workflow: String(env.GITHUB_WORKFLOW || '').trim(),
+      job: String(env.GITHUB_JOB || '').trim(),
+    },
+    aws: {
+      region: String(env.AWS_REGION || env.AWS_DEFAULT_REGION || '').trim(),
+      project: buildId.split(':')[0],
+      buildId,
+      buildArn,
+      initiator: String(env.CODEBUILD_INITIATOR || '').trim(),
+    },
+    isolation: {
+      ephemeralSingleJob: true,
+      forbiddenCredentialEnvironment: exposedCredentials,
+      signing: false,
+      notarization: false,
+      publication: false,
+      deployment: false,
+    },
+    files: requiredCodeBuildFiles(root).map((file) =>
+      codeBuildFileEvidence(root, file),
+    ),
+    observedAt: new Date(observedAt).toISOString(),
+  };
+  return { ...payload, digest: digest(payload) };
+}
+
+export function verifyCodeBuildQualification({ root = ROOT, report } = {}) {
+  if (
+    !report ||
+    report.contract !== CODEBUILD_QUALIFICATION_CONTRACT ||
+    report.status !== 'passed'
+  )
+    throw new Error(
+      `qualification report must be a passed ${CODEBUILD_QUALIFICATION_CONTRACT}`,
+    );
+  const { digest: declaredDigest, ...payload } = report;
+  if (declaredDigest !== digest(payload))
+    throw new Error('qualification report digest mismatch');
+  for (const expected of report.files || []) {
+    const actual = codeBuildFileEvidence(root, expected.path);
+    if (actual.bytes !== expected.bytes || actual.sha256 !== expected.sha256)
+      throw new Error(`qualification file drift: ${expected.path}`);
+  }
+  return report;
+}
+
+function runCodeBuildQualification(mode) {
+  const output = path.resolve(
+    process.env.KUNGFU_AWS_CODEBUILD_REPORT ||
+      'product/release/qualification/aws-codebuild-linux.json',
+  );
+  if (mode === 'record') {
+    const report = createCodeBuildQualification();
+    fs.mkdirSync(path.dirname(output), { recursive: true });
+    fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
+  } else if (mode === 'verify') {
+    verifyCodeBuildQualification({
+      report: JSON.parse(fs.readFileSync(output, 'utf8')),
+    });
+  } else {
+    throw new Error(`unsupported CodeBuild qualification mode: ${mode}`);
+  }
+  console.log(`[buildchain-install] CodeBuild qualification: ${output}`);
+}
+
 /** @param {Command} step */
 function run(step) {
   console.log(`[buildchain-install] $ ${step.command} ${step.args.join(' ')}`);
@@ -121,6 +285,10 @@ function run(step) {
 }
 
 function main() {
+  if (process.argv[2] === 'qualify-codebuild') {
+    runCodeBuildQualification(process.argv[3] || 'record');
+    return;
+  }
   const productBindings = productToolchainBindings();
   if (Object.keys(productBindings).length > 0) {
     if (!process.env.GITHUB_ENV) {

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -1,13 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
+  createCodeBuildQualification,
   installPlan,
   productToolchainBindings,
   sourceToolBindings,
+  verifyCodeBuildQualification,
 } from './buildchain-install.mjs';
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
 
 test('source install provisions only build-free tools from wheels', () => {
   const plan = installPlan({
@@ -103,5 +114,94 @@ test('GitHub-hosted Linux product qualification binds the admitted GCC toolchain
       RUNNER_OS: 'macOS',
     }),
     {},
+  );
+});
+
+function codeBuildFixture() {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-codebuild-qualification-'),
+  );
+  const release = path.join(root, 'framework/core/build/Release');
+  fs.mkdirSync(release, { recursive: true });
+  fs.writeFileSync(path.join(release, 'kungfubuildinfo.json'), '{}\n');
+  fs.writeFileSync(path.join(release, 'libkungfu.so'), 'binary');
+  return root;
+}
+
+function codeBuildEnvironment() {
+  return {
+    BUILDCHAIN_TEST_PLATFORM: 'linux',
+    BUILDCHAIN_SOURCE_SHA: 'a'.repeat(40),
+    BUILDCHAIN_SOURCE_REF: 'refs/heads/dev/v4/v4.0',
+    GITHUB_REPOSITORY: 'kungfu-systems/kungfu',
+    GITHUB_RUN_ID: '123',
+    GITHUB_RUN_ATTEMPT: '1',
+    GITHUB_WORKFLOW: 'AWS US Linux Burst Qualification',
+    GITHUB_JOB: 'qualify',
+    AWS_REGION: 'us-east-1',
+    CODEBUILD_BUILD_ID: 'kungfu-buildchain-linux-burst-poc:build-id',
+    CODEBUILD_BUILD_ARN:
+      'arn:aws:codebuild:us-east-1:123:build/kungfu-buildchain-linux-burst-poc:build-id',
+    CODEBUILD_INITIATOR: 'GitHub-Hookshot/abc',
+  };
+}
+
+test('AWS CodeBuild qualification binds exact source and retained output', () => {
+  const root = codeBuildFixture();
+  const report = createCodeBuildQualification({
+    root,
+    env: codeBuildEnvironment(),
+    observedAt: '2026-07-28T12:00:00Z',
+  });
+  assert.equal(report.status, 'passed');
+  assert.equal(report.files.length, 2);
+  assert.equal(verifyCodeBuildQualification({ root, report }), report);
+  fs.writeFileSync(
+    path.join(root, 'framework/core/build/Release/libkungfu.so'),
+    'changed',
+  );
+  assert.throws(
+    () => verifyCodeBuildQualification({ root, report }),
+    /qualification file drift/,
+  );
+});
+
+test('AWS CodeBuild qualification rejects static and release credentials', () => {
+  const root = codeBuildFixture();
+  for (const credential of ['AWS_ACCESS_KEY_ID', 'NPM_TOKEN']) {
+    assert.throws(
+      () =>
+        createCodeBuildQualification({
+          root,
+          env: { ...codeBuildEnvironment(), [credential]: 'forbidden' },
+        }),
+      /forbidden credential environment/,
+    );
+  }
+});
+
+test('AWS Linux burst workflow is trusted exact-train qualification only', () => {
+  const workflow = fs.readFileSync(
+    path.join(
+      repositoryRoot,
+      '.github/workflows/aws-us-linux-burst-qualification.yml',
+    ),
+    'utf8',
+  );
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
+  assert.match(workflow, /needs: trust/);
+  assert.match(workflow, /train\/v2\/v2\.3\/aws-us-elastic-runner-burst-plane/);
+  assert.match(workflow, /runner-preset: aws-us-codebuild-linux/);
+  assert.match(
+    workflow,
+    /aws-codebuild-project: kungfu-buildchain-linux-burst-poc/,
+  );
+  assert.match(workflow, /publish-channel: none/);
+  assert.match(workflow, /release-candidate: false/);
+  assert.match(workflow, /artifact-transfer-mode: github-artifacts/);
+  assert.doesNotMatch(
+    workflow,
+    /secrets:|notar|signing|npm-publish|release-new-version|deploy/,
   );
 });

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -218,7 +218,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 10);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 27);
+  assert.equal(result.workflowAuthority.workflows.length, 28);
   const agentPatrol = result.workflowAuthority.workflows.find(
     (workflow) => workflow.path === '.github/workflows/kungfu-agent-patrol.yml',
   );

--- a/scripts/readonly-agent-bootstrap.test.mjs
+++ b/scripts/readonly-agent-bootstrap.test.mjs
@@ -176,6 +176,7 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
     'developer/sdk/kfd/support-matrix.json',
     'docs/qualification/kfd-support-matrix.md',
     '.github/workflows/affected-native-pr.yml',
+    '.github/workflows/aws-us-linux-burst-qualification.yml',
     '.github/workflows/cancel-dequeued-merge-group.yml',
     '.github/workflows/core-build-profiles.yml',
     '.github/workflows/kungfu-agent-patrol.yml',


### PR DESCRIPTION
## Summary

- Add a manual-only, canonical-repository AWS Linux burst qualification workflow.
- Require a write-capable actor and the exact reviewed Buildchain train before cloud runner selection.
- Build unsigned Linux Core output and retain exact source and artifact digests without publication, signing, notarization, deployment, static AWS, or long-lived GitHub credentials.

## Related issue

None.

## Changes

- Add the bounded qualification workflow and Buildchain consumer wiring.
- Add exact CodeBuild provenance recording and local byte verification.
- Register the workflow as qualification and explicitly non-publication.

## Verification

- `./shifu check:source` passed after rebasing onto the current `dev/v4/v4.0` head.
- `./shifu build:core` passed.
- Workflow authority: 28 closed-world workflows aligned.
- Publication control plane: 28 workflows, 10 surfaces, qualifying.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Adds an isolated manual CI qualification route without changing a product or architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [x] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This workflow consumes only the default-disabled bounded provider, uses read-only repository permission, and records qualification provenance. It has no publication or release authority and receives no repository secrets.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed