### PR TITLE
fix(ci): support rootless Patrol bind mounts

### DIFF
--- a/docs/qualification/agent-patrol-agent-121.md
+++ b/docs/qualification/agent-patrol-agent-121.md
@@ -17,6 +17,10 @@ off agent-120, which remains the Dev build primary.
 - Endpoint: the explicit loopback OpenAI-compatible tunnel on port `11435`
 - Container runtime: a runner-owned rootless Docker socket at
   `/run/user/996/docker.sock`
+- Container identity: the adapter verifies Docker `SecurityOptions`; only a
+  rootless daemon uses container `0:0`, which maps back to the unprivileged
+  runner account and preserves writable bind-mount ownership. Rootful daemons
+  continue to use the invoking host UID/GID.
 - Concurrency: one Patrol run at a time
 - Credentials: none admitted to the model or Dogfood payload
 

--- a/framework/agent-repository-work/opencode-docker-proxy.mjs
+++ b/framework/agent-repository-work/opencode-docker-proxy.mjs
@@ -84,13 +84,14 @@ function config({ baseUrl, model, context, mode }) {
 export function dockerArgs(options, cwd = process.cwd()) {
   const uid = typeof process.getuid === 'function' ? process.getuid() : 1000;
   const gid = typeof process.getgid === 'function' ? process.getgid() : 1000;
+  const containerUser = options.rootless ? '0:0' : `${uid}:${gid}`;
   const volume =
     options.mode === 'read-only' ? `${cwd}:/workspace:ro` : `${cwd}:/workspace`;
   return [
     'run',
     '--rm',
     '--user',
-    `${uid}:${gid}`,
+    containerUser,
     '--read-only',
     '--tmpfs',
     '/tmp:rw,noexec,nosuid,nodev,size=512m',
@@ -132,12 +133,48 @@ export function dockerArgs(options, cwd = process.cwd()) {
   ];
 }
 
+export function dockerIsRootless(output) {
+  let securityOptions;
+  try {
+    securityOptions = JSON.parse(output);
+  } catch {
+    fail('Docker SecurityOptions are not valid JSON');
+  }
+  if (
+    !Array.isArray(securityOptions) ||
+    securityOptions.some((option) => typeof option !== 'string')
+  )
+    fail('Docker SecurityOptions must be a string array');
+  return securityOptions.some(
+    (option) => option === 'rootless' || option === 'name=rootless',
+  );
+}
+
 export function runProxy(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
-  const result = spawnSync('docker', dockerArgs(options), {
-    cwd: process.cwd(),
-    stdio: 'inherit',
-  });
+  const info = spawnSync(
+    'docker',
+    ['info', '--format', '{{json .SecurityOptions}}'],
+    {
+      encoding: 'utf8',
+    },
+  );
+  if (info.error) {
+    process.stderr.write(`${info.error.message}\n`);
+    return 127;
+  }
+  if (info.status !== 0) {
+    process.stderr.write(info.stderr || 'docker info failed\n');
+    return info.status ?? 1;
+  }
+  const result = spawnSync(
+    'docker',
+    dockerArgs({ ...options, rootless: dockerIsRootless(info.stdout.trim()) }),
+    {
+      cwd: process.cwd(),
+      stdio: 'inherit',
+    },
+  );
   if (result.error) {
     process.stderr.write(`${result.error.message}\n`);
     return 127;

--- a/scripts/run-agent-repository-work-experiment.test.mjs
+++ b/scripts/run-agent-repository-work-experiment.test.mjs
@@ -8,7 +8,10 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { dockerArgs } from '../framework/agent-repository-work/opencode-docker-proxy.mjs';
+import {
+  dockerArgs,
+  dockerIsRootless,
+} from '../framework/agent-repository-work/opencode-docker-proxy.mjs';
 import {
   parseInvestigationClaim,
   runExperiment,
@@ -150,6 +153,34 @@ test('Docker profile is digest-pinned, bounded, and mode-specific', () => {
   assert.ok(!args.includes('--privileged'));
   assert.ok(!args.includes('/var/run/docker.sock'));
   assert.ok(!args.includes('host'));
+});
+
+test('Docker bind-mount identity follows rootful and rootless ownership', () => {
+  const options = {
+    image:
+      'example.invalid/opencode-ci@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    baseUrl: 'http://host.docker.internal:11435/v1',
+    model: 'qwen3-coder:30b-opencode-64k',
+    context: 65_536,
+    mode: 'bounded-write',
+    command: ['run', '--pure', 'prompt'],
+  };
+  const rootlessArgs = dockerArgs(
+    { ...options, rootless: true },
+    '/tmp/disposable-workspace',
+  );
+  const rootfulArgs = dockerArgs(
+    { ...options, rootless: false },
+    '/tmp/disposable-workspace',
+  );
+  const userIndex = rootlessArgs.indexOf('--user');
+  assert.equal(rootlessArgs[userIndex + 1], '0:0');
+  assert.equal(
+    rootfulArgs[userIndex + 1],
+    `${process.getuid?.() ?? 1000}:${process.getgid?.() ?? 1000}`,
+  );
+  assert.equal(dockerIsRootless('["name=seccomp","name=rootless"]'), true);
+  assert.equal(dockerIsRootless('["name=seccomp","name=cgroupns"]'), false);
 });
 
 test('Agent A claim and final report require deterministic continuity evidence', () => {


### PR DESCRIPTION
## Summary

- detect rootless Docker from the daemon SecurityOptions before launching OpenCode
- use namespace-mapped container root only for rootless daemons so runner-owned bind mounts remain writable
- preserve invoking host UID/GID for rootful daemons and add regression coverage

## Live evidence

- agent-121 rootless bind mount appeared as container root and rejected UID 996 writes
- the same digest-pinned image completed a real Qwen canary with container 0:0, which maps back to the unprivileged gha-runner host account
- no host Docker group, privileged container, Docker socket mount, or host network was introduced

## Verification

- `./shifu build:core`: passed
- `./shifu test:agent-repository-work`: 11/11 passed
- `./shifu test:agent-patrol`: 20/20 passed
- `./shifu check:gate-catalog`: 38 gates and 27 workflows aligned
- staged pre-commit gate: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a bounded runtime compatibility correction for the existing agent Patrol and does not change an ADR or architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commit is signed off (DCO)
- [x] Rootful least-privilege behavior is preserved
- [x] Rootless ownership behavior is covered by tests