### PR TITLE
fix(qualification): bind explicit KFX runtime authority

### DIFF
--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -236,7 +236,6 @@ test(
     );
     const request = {
       roots: [{ kind: 'workspace', path: fixtureRoot }],
-      runtimeTiers: { 'optional-view': 'verified-third-party' },
     };
     const plan = kungfu.runStorageServiceOperation('kfx_runtime', '', {
       action: 'plan',

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b8b9c591c4e123b18dadc49c7b2a1d4a9c4c06998b673d8ce8711575340764de",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:e1b00026dc1a333a4c44b2a800ffd03dbedafaf16cfe4d724325bc1b76a0faaa",
+  "sourceRoot": "sha256:c0e854799222433428a4526fb6182d37d1571eb5ff9cc39b07ba951a7139155e",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -25,7 +25,7 @@
     "families": 6,
     "authorities": 6,
     "mappedSurfaces": 77,
-    "changedMappedSurfaces": 46,
+    "changedMappedSurfaces": 47,
     "blockingIssues": 0
   },
   "families": [
@@ -801,12 +801,13 @@
       "amplification": {
         "mappedSurfaces": 13,
         "nonAuthoritySurfaces": 10,
-        "changedSurfaces": 4,
+        "changedSurfaces": 5,
         "changedPaths": [
           "framework/core/src/python/kungfu/storage/service.py",
           "framework/storage/generated/work-lifecycle-v1.js",
           "framework/storage/python/kungfu_sdk/generated/work_lifecycle_v1.py",
-          "scripts/check-work-lifecycle-operation-matrix.test.mjs"
+          "scripts/check-work-lifecycle-operation-matrix.test.mjs",
+          "framework/core/tests/storage-node-binding.test.js"
         ]
       },
       "surfaces": [
@@ -936,11 +937,11 @@
         },
         {
           "path": "framework/core/tests/storage-node-binding.test.js",
-          "currentLines": 1645,
+          "currentLines": 1644,
           "baselineLines": 1645,
-          "currentRoot": "sha256:3eb747f265ed900ca5219fd1b0b12bce270595ee9e43f0880314afe2a1e91d1b",
+          "currentRoot": "sha256:38d54219a3aea9e256db95a05bd985ce10aace67c9e54b44fb9618d93494edcd",
           "baselineRoot": "sha256:3eb747f265ed900ca5219fd1b0b12bce270595ee9e43f0880314afe2a1e91d1b",
-          "changedSinceBaseline": false
+          "changedSinceBaseline": true
         },
         {
           "path": "docs/qualification/fact-storage-authority.md",

--- a/product/scripts/libwasm-artifact.mjs
+++ b/product/scripts/libwasm-artifact.mjs
@@ -5,6 +5,80 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const KFX_AUTHORITY_FIXTURE = path.join(
+  REPO_ROOT,
+  'framework',
+  'core',
+  'src',
+  'libkungfu',
+  'tests',
+  'fixtures',
+  'native_kfx_contract',
+  'buildchain-2.13.0-alpha.0-envelope.json',
+);
+
+function runKungfu(root, home, args) {
+  const executable = path.join(
+    root,
+    process.platform === 'win32' ? 'kungfu.exe' : 'kungfu',
+  );
+  const result = spawnSync(executable, ['-H', home, ...args], {
+    encoding: 'utf8',
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `qualification runtime failed (${result.error?.message || `exit ${result.status}`}): ${(result.stderr || result.stdout || '').trim()}`,
+    );
+  }
+  return result;
+}
+
+function runKungfuJson(root, home, args) {
+  const result = runKungfu(root, home, args);
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new Error(
+      `qualification runtime returned non-JSON output: ${result.stdout.slice(0, 200)}`,
+    );
+  }
+}
+
+function writeQualificationAuthority(root, home, packageDir, packageKey) {
+  const inspected = runKungfuJson(root, home, [
+    'kfx',
+    'native',
+    'inspect',
+    packageKey,
+    '--root',
+    `user=${path.dirname(packageDir)}`,
+  ]).package;
+  const fixture = JSON.parse(fs.readFileSync(KFX_AUTHORITY_FIXTURE, 'utf8'));
+  const projection = structuredClone(fixture.projection);
+  projection.attestation.bindings.packageRoot = inspected.packageRoot;
+  projection.trustInputs.packageRoot = inspected.packageRoot;
+  const authority = {
+    purpose: fixture.admission.purpose,
+    policy: fixture.admission.policy,
+    assessmentTime: fixture.assessmentTime,
+    authorizationTime: fixture.assessmentTime,
+    attestation: projection.attestation,
+    trustInputs: projection.trustInputs,
+    kfdAssessment: projection.kfdAssessment,
+    requestedCapabilities: inspected.declaredCapabilities,
+    approvalRoots: [],
+  };
+  const target = path.join(home, 'qualification-authority.json');
+  fs.writeFileSync(target, `${JSON.stringify(authority, null, 2)}\n`);
+  return target;
+}
 
 export function libwasmArtifactPaths(platform = process.platform) {
   const host =
@@ -92,13 +166,94 @@ export function runLibwasmExecutionQualification(
       root,
       platform === 'win32' ? 'kungfu-wasm-host.exe' : 'kungfu-wasm-host',
     );
+    const packageKey = 'libwasm-qualification';
+    const packageDir = path.join(temporary, 'packages', packageKey);
+    fs.mkdirSync(packageDir, { recursive: true });
+    const installedModule = path.join(packageDir, 'qualification.wasm');
+    fs.copyFileSync(module, installedModule);
+    fs.writeFileSync(
+      path.join(packageDir, 'kungfu.kfx.json'),
+      `${JSON.stringify(
+        {
+          schema: 'kungfu.kfx.manifest/v1',
+          name: 'libwasm-qualification',
+          version: '1.0.0',
+          kungfuConfig: {
+            key: packageKey,
+            name: 'libwasm qualification',
+            config: {
+              wasm: {
+                world: 'kungfu:journal/batch@1.0.0',
+                entry: 'qualification.wasm',
+                sha256: digest,
+                capabilities: ['journal.read.batch'],
+                engine: 'wasmtime',
+                fallback: 'wasmer',
+                limits: {
+                  fuel: 100000,
+                  memoryPages: 2,
+                  batchFrames: 1,
+                  moduleBytes: 4096,
+                  outputBytes: 64,
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const authority = writeQualificationAuthority(
+      root,
+      temporary,
+      packageDir,
+      packageKey,
+    );
+    runKungfu(root, temporary, [
+      'kfx',
+      'install',
+      packageDir,
+      '--authority-file',
+      authority,
+    ]);
+    const descriptor = runKungfuJson(root, temporary, [
+      'kfx',
+      'native',
+      'plan',
+      '--root',
+      `user=${path.join(temporary, 'extensions')}`,
+    ]).hostContract;
+    const authorization = descriptor.runtimeAuthorizations.find(
+      (candidate) =>
+        candidate.packageKey === packageKey && candidate.host === 'wasm',
+    );
+    if (!authorization?.executionAllowed) {
+      throw new Error(
+        'Core did not authorize the libwasm qualification package',
+      );
+    }
     const receipts = {};
     for (const engine of ['wasmtime', 'wasmer']) {
       const args = [
         '--runtime-dir',
-        temporary,
+        path.join(temporary, 'runtime'),
         '--module',
-        module,
+        installedModule,
+        '--package-key',
+        packageKey,
+        '--package-root',
+        authorization.packageRoot,
+        '--authorization-root',
+        authorization.authorizationRoot,
+        '--capability-grant-root',
+        authorization.capabilityGrantRoot,
+        '--generation-root',
+        descriptor.generationRoot,
+        '--cut-root',
+        descriptor.cutRoot,
+        '--revision',
+        String(descriptor.revision),
         '--expected-sha256',
         digest,
         '--world',

--- a/tests/fixtures/_harness.mjs
+++ b/tests/fixtures/_harness.mjs
@@ -142,6 +142,129 @@ export function kfc(coreDir, home, args, opts = {}) {
   );
 }
 
+const KFX_AUTHORITY_FIXTURE = path.join(
+  'src',
+  'libkungfu',
+  'tests',
+  'fixtures',
+  'native_kfx_contract',
+  'buildchain-2.13.0-alpha.0-envelope.json',
+);
+
+function nativeKfxPackage(coreDir, home, packageDir, packageKey) {
+  return json(
+    kfc(coreDir, home, [
+      'kfx',
+      'native',
+      'inspect',
+      packageKey,
+      '--root',
+      `user=${path.dirname(packageDir)}`,
+    ]),
+  ).package;
+}
+
+/** Write exact Buildchain/KFD authority for one package install or update. */
+export function writeKfxPassportAuthority(
+  coreDir,
+  home,
+  packageDir,
+  packageKey,
+  target,
+) {
+  const pkg = nativeKfxPackage(coreDir, home, packageDir, packageKey);
+  const fixture = JSON.parse(
+    fs.readFileSync(path.join(coreDir, KFX_AUTHORITY_FIXTURE), 'utf8'),
+  );
+  const projection = structuredClone(fixture.projection);
+  projection.attestation.bindings.packageRoot = pkg.packageRoot;
+  projection.trustInputs.packageRoot = pkg.packageRoot;
+  const requestedCapabilities = [...pkg.declaredCapabilities].sort();
+  const policy = structuredClone(fixture.admission.policy);
+  policy.allowedCapabilities = [
+    ...new Set([...policy.allowedCapabilities, ...requestedCapabilities]),
+  ].sort();
+  policy.autoOperations = [
+    ...new Set([
+      ...policy.autoOperations,
+      'install',
+      'update',
+      'enable',
+      'activate',
+      'qualify',
+    ]),
+  ].sort();
+  const highConsequence = new Set([
+    'agentRuntime',
+    'kfxControl',
+    'process',
+    'storage',
+  ]);
+  const authority = {
+    purpose: fixture.admission.purpose,
+    policy,
+    assessmentTime: fixture.assessmentTime,
+    authorizationTime: fixture.assessmentTime,
+    attestation: projection.attestation,
+    trustInputs: projection.trustInputs,
+    kfdAssessment: projection.kfdAssessment,
+    requestedCapabilities,
+    approvalRoots: requestedCapabilities.some((capability) =>
+      highConsequence.has(capability),
+    )
+      ? [`sha256:${'a'.repeat(64)}`]
+      : [],
+  };
+  fs.writeFileSync(target, `${JSON.stringify(authority, null, 2)}\n`);
+  return target;
+}
+
+/** Write an exact owner recovery Warrant for the currently installed package. */
+export function writeKfxRecoveryAuthority(
+  coreDir,
+  home,
+  packageKey,
+  operation,
+  target,
+) {
+  const installRoot = path.join(home, 'extensions');
+  const pkg = nativeKfxPackage(
+    coreDir,
+    home,
+    path.join(installRoot, packageKey),
+    packageKey,
+  );
+  const status = json(
+    kfc(coreDir, home, [
+      'kfx',
+      'native',
+      'status',
+      '--root',
+      `user=${installRoot}`,
+    ]),
+  );
+  const authorizationTime = 1000 + Number(status.revision);
+  const approvalRoots = [`sha256:${'a'.repeat(64)}`];
+  const authority = {
+    authorizationTime,
+    approvalRoots,
+    recoveryWarrant: {
+      schema: 'kungfu.kfx-recovery-warrant/v1',
+      issuerClass: 'workspace-owner',
+      operation,
+      packageRoot: pkg.packageRoot,
+      expectedCutRoot: status.cutRoot,
+      expectedRevision: status.revision,
+      approvalRoots,
+      issuedAt: authorizationTime - 1,
+      expiresAt: authorizationTime + 100,
+      nonce: `fixture-${packageKey}-${operation}`,
+    },
+  };
+  fs.writeFileSync(target, `${JSON.stringify(authority, null, 2)}\n`);
+  return target;
+}
+
 /** Parse the single JSON object a `--json` command prints to stdout. */
 export function json(result) {
   try {

--- a/tests/fixtures/kfx-demo-install/run.mjs
+++ b/tests/fixtures/kfx-demo-install/run.mjs
@@ -11,7 +11,16 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { locate, tmpDir, run, kfc, uvPython, fail } from '../_harness.mjs';
+import {
+  locate,
+  tmpDir,
+  run,
+  kfc,
+  uvPython,
+  fail,
+  writeKfxPassportAuthority,
+  writeKfxRecoveryAuthority,
+} from '../_harness.mjs';
 
 const { fixtureDir, coreDir } = locate(import.meta.url);
 const repoDir = path.resolve(coreDir, '..', '..');
@@ -30,20 +39,43 @@ const packed = run('npm', ['pack', '--pack-destination', packdir], { cwd: extDir
 const tgzName = packed.stdout.trim().split(/\r?\n/).pop();
 const tgz = path.join(packdir, tgzName);
 if (!fs.existsSync(tgz)) fail('npm pack produced no tgz');
+const passportAuthority = writeKfxPassportAuthority(
+  coreDir,
+  home,
+  extDir,
+  'work-dashboard',
+  path.join(packdir, 'passport-authority.json'),
+);
 
-k(['kfx', 'install', tgz]);
+k(['kfx', 'install', tgz, '--authority-file', passportAuthority]);
 k(['kfx', 'list']);
 
 // double install must refuse without --force, succeed with it
-if (k(['kfx', 'install', tgz], { allowFail: true }).status === 0) {
+if (
+  k(['kfx', 'install', tgz, '--authority-file', passportAuthority], {
+    allowFail: true,
+  }).status === 0
+) {
   fail('double install did not refuse');
 }
-k(['kfx', 'install', tgz, '--force']);
+k(['kfx', 'install', tgz, '--force', '--authority-file', passportAuthority]);
 
 uvPython(coreDir, [path.join(fixtureDir, 'check_install.py'), home]);
 
-k(['kfx', 'remove', 'work-dashboard']);
-if (k(['kfx', 'remove', 'work-dashboard'], { allowFail: true }).status === 0) {
+const recoveryAuthority = writeKfxRecoveryAuthority(
+  coreDir,
+  home,
+  'work-dashboard',
+  'remove',
+  path.join(packdir, 'recovery-authority.json'),
+);
+k(['kfx', 'remove', 'work-dashboard', '--authority-file', recoveryAuthority]);
+if (
+  k(
+    ['kfx', 'remove', 'work-dashboard', '--authority-file', recoveryAuthority],
+    { allowFail: true },
+  ).status === 0
+) {
   fail('removing a missing key did not fail');
 }
 if (fs.existsSync(path.join(home, 'extensions', 'work-dashboard'))) fail('not removed');

--- a/tests/fixtures/kfx-demo-scaffold/run.mjs
+++ b/tests/fixtures/kfx-demo-scaffold/run.mjs
@@ -20,6 +20,8 @@ import {
   kfc,
   assertContains,
   fail,
+  writeKfxPassportAuthority,
+  writeKfxRecoveryAuthority,
 } from '../_harness.mjs';
 
 const { coreDir } = locate(import.meta.url);
@@ -82,12 +84,26 @@ const packed = run('npm', ['pack', '--pack-destination', packdir], { cwd: extDir
 const tgzName = packed.stdout.trim().split(/\r?\n/).pop();
 const tgz = path.join(packdir, tgzName);
 if (!fs.existsSync(tgz)) fail('npm pack produced no tgz');
+const passportAuthority = writeKfxPassportAuthority(
+  coreDir,
+  home,
+  extDir,
+  'my-view',
+  path.join(packdir, 'passport-authority.json'),
+);
 
-k(['kfx', 'install', tgz]);
+k(['kfx', 'install', tgz, '--authority-file', passportAuthority]);
 assertContains(k(['kfx', 'list']), 'my-view', 'installed kfx not listed');
 if (!fs.existsSync(path.join(home, 'extensions', 'my-view', 'dist', 'view', 'index.js'))) {
   fail('bundle missing from install root');
 }
-k(['kfx', 'remove', 'my-view']);
+const recoveryAuthority = writeKfxRecoveryAuthority(
+  coreDir,
+  home,
+  'my-view',
+  'remove',
+  path.join(packdir, 'recovery-authority.json'),
+);
+k(['kfx', 'remove', 'my-view', '--authority-file', recoveryAuthority]);
 if (fs.existsSync(path.join(home, 'extensions', 'my-view'))) fail('not removed');
 console.log('[kfx-demo-scaffold] scaffold-to-install ok');


### PR DESCRIPTION
## Summary

Repair exact-source product qualification after explicit KFX runtime grants landed. The qualification fixtures now exercise the same passport, capability-grant, generation, Cut, and recovery authority that released runtimes require instead of relying on pre-authority shortcuts.

## Related issue

Atlas Assignment `2026-07-26-kungfu-kfd-support-governance`.

Supersedes closed PR #1741, whose GitHub-generated update-branch merge commit failed DCO before merge. This replacement is linear from the current admitted dev head.

## Changes

- bind libwasm execution qualification to an installed KFX package and Core-issued runtime authorization
- issue exact package passport and owner recovery authority in install/scaffold product fixtures
- remove the retired optional-view runtime-tier assumption from the storage Node binding test
- refresh the semantic amplification projection

## Verification

- `RUSTUP_TOOLCHAIN=stable KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu rebuild:core`
- `./shifu test:native-kfx-admission`
- `./shifu freeze`
- `./shifu --filter @kungfu-tech/kfx-view-work-dashboard run build`
- `./shifu verify` (64/64)
- `./shifu check`
- `RUSTUP_TOOLCHAIN=stable KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check:source`
- DCO pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restores qualification fixtures to the already-admitted explicit KFX authority contract without changing architecture authority or release semantics"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This PR changes qualification evidence only. It exercises the existing fail-closed authority path and does not publish or widen any support claim.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; runtime behavior is unchanged)
