### PR TITLE
fix(kfx): restore candidate qualification gates

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/kfx/native_authority.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_authority.cpp
@@ -494,8 +494,9 @@ json plan(const json &packages, const std::string &registry_root, const std::str
       refuse("KF_KFX_RECOVERY_WARRANT_INVALID", "recovery Warrant issuer must be workspace-owner or core-system");
     if (recovery.value("operation", "") != operation ||
         recovery.value("packageRoot", "") != package.at("packageRoot").get<std::string>() ||
-        recovery.at("expectedCutRoot") != prior_cut || !recovery.at("expectedRevision").is_number_unsigned() ||
-        recovery.at("expectedRevision").get<uint64_t>() != revision)
+        recovery.at("expectedCutRoot") != prior_cut || !recovery.at("expectedRevision").is_number_integer() ||
+        recovery.at("expectedRevision").get<int64_t>() < 0 ||
+        static_cast<uint64_t>(recovery.at("expectedRevision").get<int64_t>()) != revision)
       refuse("KF_KFX_RECOVERY_WARRANT_INVALID", "recovery Warrant does not bind the exact package and prior Cut");
     if (!recovery.at("issuedAt").is_number_integer() || !recovery.at("expiresAt").is_number_integer() ||
         recovery.at("issuedAt").get<int64_t>() < 0 ||

--- a/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
@@ -419,7 +419,7 @@ nlohmann::json recovery_authorized_request(nlohmann::json request, const std::st
                                 {"operation", operation},
                                 {"packageRoot", package.at("packageRoot")},
                                 {"expectedCutRoot", status.at("cutRoot")},
-                                {"expectedRevision", status.at("revision")},
+                                {"expectedRevision", status.at("revision").get<int64_t>()},
                                 {"approvalRoots", request.at("approvalRoots")},
                                 {"issuedAt", authorization_time - 1},
                                 {"expiresAt", authorization_time + 100},

--- a/framework/core/tests/storage-node-binding.test.js
+++ b/framework/core/tests/storage-node-binding.test.js
@@ -8,6 +8,14 @@ const { spawnSync } = require('node:child_process');
 const kungfuFactory = require('../lib/kungfu');
 
 const coreDir = path.resolve(__dirname, '..');
+const nativeKfxFixtureRoot = path.resolve(
+  coreDir,
+  'src/libkungfu/tests/fixtures/native_kfx_registry/roots/workspace',
+);
+const nativeKfxEnvelope = path.resolve(
+  coreDir,
+  'src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json',
+);
 const bindingDir = path.join(coreDir, 'dist', 'kungfu');
 const kungfu = kungfuFactory();
 const nativeAvailable =
@@ -224,19 +232,8 @@ test(
         : 'built native storage binding is unavailable',
   },
   () => {
-    const fixtureRoot = path.join(
-      coreDir,
-      'src',
-      'libkungfu',
-      'tests',
-      'fixtures',
-      'native_kfx_registry',
-      'roots',
-      'workspace',
-    );
     const request = {
-      roots: [{ kind: 'workspace', path: fixtureRoot }],
-      runtimeTiers: { 'optional-view': 'verified-third-party' },
+      roots: [{ kind: 'workspace', path: nativeKfxFixtureRoot }],
     };
     const plan = kungfu.runStorageServiceOperation('kfx_runtime', '', {
       action: 'plan',
@@ -261,37 +258,24 @@ test(
         : 'built native storage binding is unavailable',
   },
   () => {
-    const fixtureRoot = path.join(
-      coreDir,
-      'src',
-      'libkungfu',
-      'tests',
-      'fixtures',
-      'native_kfx_registry',
-      'roots',
-      'workspace',
-    );
-    const fixture = JSON.parse(
-      fs.readFileSync(
-        path.join(
-          coreDir,
-          'src',
-          'libkungfu',
-          'tests',
-          'fixtures',
-          'native_kfx_contract',
-          'buildchain-2.13.0-alpha.0-envelope.json',
-        ),
-        'utf8',
-      ),
-    );
+    const fixture = JSON.parse(fs.readFileSync(nativeKfxEnvelope, 'utf8'));
+    const inspected = kungfu.runStorageServiceOperation('kfx_runtime', '', {
+      action: 'inspect',
+      request: {
+        roots: [{ kind: 'workspace', path: nativeKfxFixtureRoot }],
+        packageKey: 'optional-view',
+      },
+    });
+    const attestation = structuredClone(fixture.projection.attestation);
+    const trustInputs = structuredClone(fixture.projection.trustInputs);
+    attestation.bindings.packageRoot = inspected.package.packageRoot;
+    trustInputs.packageRoot = inspected.package.packageRoot;
     const request = {
-      roots: [{ kind: 'workspace', path: fixtureRoot }],
-      runtimeTiers: { 'optional-view': 'verified-third-party' },
+      roots: [{ kind: 'workspace', path: nativeKfxFixtureRoot }],
       ...fixture.admission,
       assessmentTime: fixture.assessmentTime,
-      attestation: fixture.projection.attestation,
-      trustInputs: fixture.projection.trustInputs,
+      attestation,
+      trustInputs,
       kfdAssessment: fixture.projection.kfdAssessment,
     };
     const result = kungfu.runStorageServiceOperation('kfx_runtime', '', {

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b8b9c591c4e123b18dadc49c7b2a1d4a9c4c06998b673d8ce8711575340764de",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:e1b00026dc1a333a4c44b2a800ffd03dbedafaf16cfe4d724325bc1b76a0faaa",
+  "sourceRoot": "sha256:79c8d7ec00991298abaeeea749fe56c1da1f5302d5626d4320e7d7d7cc122f65",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -25,7 +25,7 @@
     "families": 6,
     "authorities": 6,
     "mappedSurfaces": 77,
-    "changedMappedSurfaces": 46,
+    "changedMappedSurfaces": 47,
     "blockingIssues": 0
   },
   "families": [
@@ -801,12 +801,13 @@
       "amplification": {
         "mappedSurfaces": 13,
         "nonAuthoritySurfaces": 10,
-        "changedSurfaces": 4,
+        "changedSurfaces": 5,
         "changedPaths": [
           "framework/core/src/python/kungfu/storage/service.py",
           "framework/storage/generated/work-lifecycle-v1.js",
           "framework/storage/python/kungfu_sdk/generated/work_lifecycle_v1.py",
-          "scripts/check-work-lifecycle-operation-matrix.test.mjs"
+          "scripts/check-work-lifecycle-operation-matrix.test.mjs",
+          "framework/core/tests/storage-node-binding.test.js"
         ]
       },
       "surfaces": [
@@ -936,11 +937,11 @@
         },
         {
           "path": "framework/core/tests/storage-node-binding.test.js",
-          "currentLines": 1645,
+          "currentLines": 1629,
           "baselineLines": 1645,
-          "currentRoot": "sha256:3eb747f265ed900ca5219fd1b0b12bce270595ee9e43f0880314afe2a1e91d1b",
+          "currentRoot": "sha256:766a8280617ca0c022a0dedb610c0f83b4067e1e912c1fd05641bc54633f6134",
           "baselineRoot": "sha256:3eb747f265ed900ca5219fd1b0b12bce270595ee9e43f0880314afe2a1e91d1b",
-          "changedSinceBaseline": false
+          "changedSinceBaseline": true
         },
         {
           "path": "docs/qualification/fact-storage-authority.md",

--- a/product/scripts/libwasm-artifact.mjs
+++ b/product/scripts/libwasm-artifact.mjs
@@ -5,6 +5,14 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { qualificationAuthority } from '../../tests/fixtures/_kfx-authority.mjs';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
 
 export function libwasmArtifactPaths(platform = process.platform) {
   const host =
@@ -84,10 +92,114 @@ export function runLibwasmExecutionQualification(
 ) {
   const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-libwasm-'));
   try {
-    const module = path.join(temporary, 'qualification.wasm');
+    const home = path.join(temporary, 'home');
+    const runtimeDir = path.join(home, 'runtime');
+    const sourceRoot = path.join(temporary, 'source');
+    const packageDir = path.join(sourceRoot, 'libwasm-qualification');
+    fs.mkdirSync(packageDir, { recursive: true });
+    const module = path.join(packageDir, 'qualification.wasm');
     const bytes = Buffer.from(QUALIFICATION_WASM_HEX, 'hex');
     fs.writeFileSync(module, bytes);
     const digest = createHash('sha256').update(bytes).digest('hex');
+    fs.writeFileSync(
+      path.join(packageDir, 'kungfu.kfx.json'),
+      `${JSON.stringify(
+        {
+          schema: 'kungfu.kfx.manifest/v1',
+          name: '@kungfu-test/libwasm-qualification',
+          version: '1.0.0',
+          kungfuConfig: {
+            key: 'libwasm-qualification',
+            config: {
+              wasm: {
+                world: 'kungfu:journal/batch@1.0.0',
+                entry: 'qualification.wasm',
+                sha256: digest,
+                capabilities: ['journal.read.batch'],
+                engine: 'wasmtime',
+                fallback: 'wasmer',
+                limits: {
+                  fuel: 100000,
+                  memoryPages: 2,
+                  batchFrames: 1,
+                  moduleBytes: 4096,
+                  outputBytes: 64,
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const executable = path.join(
+      root,
+      platform === 'win32' ? 'kungfu.exe' : 'kungfu',
+    );
+    const runKungfu = (args, label) => {
+      const result = spawnSync(executable, ['-H', home, ...args], {
+        encoding: 'utf8',
+      });
+      if (result.status !== 0) {
+        throw new Error(
+          `${label} failed (exit ${result.status}): ${(result.stderr || result.stdout || '').trim()}`,
+        );
+      }
+      return result;
+    };
+    const inspect = JSON.parse(
+      runKungfu(
+        [
+          'kfx',
+          'native',
+          'inspect',
+          'libwasm-qualification',
+          '--root',
+          `workspace=${sourceRoot}`,
+        ],
+        'production libwasm package inspection',
+      ).stdout,
+    );
+    const authorityFile = path.join(temporary, 'authority.json');
+    fs.writeFileSync(
+      authorityFile,
+      `${JSON.stringify(
+        qualificationAuthority(
+          REPO_ROOT,
+          inspect.package.packageRoot,
+          inspect.package.declaredCapabilities,
+        ),
+        null,
+        2,
+      )}\n`,
+    );
+    runKungfu(
+      ['kfx', 'install', packageDir, '--authority-file', authorityFile],
+      'production libwasm package admission',
+    );
+    const plan = JSON.parse(
+      runKungfu(
+        [
+          'kfx',
+          'native',
+          'plan',
+          '--root',
+          `user=${path.join(home, 'extensions')}`,
+        ],
+        'production libwasm host plan',
+      ).stdout,
+    );
+    const descriptor = plan.hostContract;
+    const authorization = descriptor.runtimeAuthorizations.find(
+      (item) =>
+        item.packageKey === 'libwasm-qualification' && item.host === 'wasm',
+    );
+    if (!authorization) {
+      throw new Error(
+        'production libwasm host plan has no admitted WASM authorization',
+      );
+    }
     const host = path.join(
       root,
       platform === 'win32' ? 'kungfu-wasm-host.exe' : 'kungfu-wasm-host',
@@ -96,11 +208,25 @@ export function runLibwasmExecutionQualification(
     for (const engine of ['wasmtime', 'wasmer']) {
       const args = [
         '--runtime-dir',
-        temporary,
+        runtimeDir,
         '--module',
         module,
         '--expected-sha256',
         digest,
+        '--package-key',
+        'libwasm-qualification',
+        '--package-root',
+        authorization.packageRoot,
+        '--authorization-root',
+        authorization.authorizationRoot,
+        '--capability-grant-root',
+        authorization.capabilityGrantRoot,
+        '--generation-root',
+        descriptor.generationRoot,
+        '--cut-root',
+        descriptor.cutRoot,
+        '--revision',
+        String(descriptor.revision),
         '--world',
         'kungfu:journal/batch@1.0.0',
         '--capabilities',

--- a/tests/fixtures/_harness.mjs
+++ b/tests/fixtures/_harness.mjs
@@ -12,6 +12,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  qualificationAuthority,
+  removalAuthority,
+} from './_kfx-authority.mjs';
 
 const isWin = process.platform === 'win32';
 
@@ -149,6 +153,92 @@ export function json(result) {
   } catch (e) {
     fail(`expected JSON on stdout, got: ${result.stdout?.slice(0, 200)}`);
   }
+}
+
+function writeFixtureJson(prefix, value) {
+  const file = path.join(tmpDir(prefix), 'authority.json');
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+  return file;
+}
+
+/** Build exact-root admission evidence for one source package fixture. */
+export function kfxQualificationAuthorityFile(
+  coreDir,
+  home,
+  sourceRoot,
+  packageKey,
+) {
+  const inspected = json(
+    kfc(coreDir, home, [
+      'kfx',
+      'native',
+      'inspect',
+      packageKey,
+      '--root',
+      `workspace=${sourceRoot}`,
+    ]),
+  );
+  const repoDir = path.resolve(coreDir, '..', '..');
+  return writeFixtureJson(
+    'kfx-qualification-authority-',
+    qualificationAuthority(
+      repoDir,
+      inspected.package.packageRoot,
+      inspected.package.declaredCapabilities,
+    ),
+  );
+}
+
+/**
+ * Recreate the package directory seen by `kungfu kfx install <tgz>` so the
+ * qualification authority binds the exact npm transport closure, not the
+ * larger source checkout that produced it.
+ */
+export function extractPackedKfx(coreDir, tgz) {
+  const root = tmpDir('kfx-packed-root-');
+  const packageRoot = path.join(root, 'package');
+  fs.mkdirSync(packageRoot);
+  uvPython(coreDir, [
+    '-c',
+    [
+      'import pathlib, sys, tarfile',
+      'source, destination = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])',
+      'with tarfile.open(source, "r:gz") as archive:',
+      '    members = [member for member in archive.getmembers() if member.name.startswith("package/")]',
+      '    for member in members: member.name = member.name[len("package/"):]',
+      '    archive.extractall(destination, members=[member for member in members if member.name], filter="data")',
+    ].join('\n'),
+    tgz,
+    packageRoot,
+  ]);
+  return packageRoot;
+}
+
+/** Build a current owner recovery Warrant for one installed fixture package. */
+export function kfxRemovalAuthorityFile(coreDir, home, packageKey) {
+  const installedRoot = path.join(home, 'extensions');
+  const rootArg = `user=${installedRoot}`;
+  const inspected = json(
+    kfc(coreDir, home, [
+      'kfx',
+      'native',
+      'inspect',
+      packageKey,
+      '--root',
+      rootArg,
+    ]),
+  );
+  const status = json(
+    kfc(coreDir, home, ['kfx', 'native', 'status', '--root', rootArg]),
+  );
+  return writeFixtureJson(
+    'kfx-removal-authority-',
+    removalAuthority(
+      inspected.package.packageRoot,
+      status,
+      `${packageKey}-fixture-removal`,
+    ),
+  );
 }
 
 /** sha256 of a file, pure Node (replaces sha256sum/shasum). */

--- a/tests/fixtures/_kfx-authority.mjs
+++ b/tests/fixtures/_kfx-authority.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Qualification-only KFX authority fixtures. These values exercise Core's
+// exact-root admission and recovery contracts; they are not Product authority
+// and must never be used outside tests or release qualification probes.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const APPROVAL_ROOT = `sha256:${'a'.repeat(64)}`;
+const HIGH_CONSEQUENCE_CAPABILITIES = new Set([
+  'agentRuntime',
+  'kfxControl',
+  'process',
+  'storage',
+]);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function qualificationAuthority(
+  repoDir,
+  packageRoot,
+  declaredCapabilities,
+) {
+  const fixture = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        repoDir,
+        'framework',
+        'core',
+        'src',
+        'libkungfu',
+        'tests',
+        'fixtures',
+        'native_kfx_contract',
+        'buildchain-2.13.0-alpha.0-envelope.json',
+      ),
+      'utf8',
+    ),
+  );
+  const projection = fixture.projection;
+  const attestation = clone(projection.attestation);
+  const trustInputs = clone(projection.trustInputs);
+  attestation.bindings.packageRoot = packageRoot;
+  trustInputs.packageRoot = packageRoot;
+  const capabilities = [...declaredCapabilities];
+  const policy = clone(fixture.admission.policy);
+  policy.allowedCapabilities = [
+    ...new Set([...policy.allowedCapabilities, ...capabilities]),
+  ].sort();
+  policy.autoOperations = ['install', 'update', 'enable', 'activate', 'qualify'];
+  return {
+    purpose: fixture.admission.purpose,
+    policy,
+    assessmentTime: fixture.assessmentTime,
+    authorizationTime: fixture.assessmentTime,
+    attestation,
+    trustInputs,
+    kfdAssessment: clone(projection.kfdAssessment),
+    requestedCapabilities: capabilities,
+    approvalRoots: capabilities.some((capability) =>
+      HIGH_CONSEQUENCE_CAPABILITIES.has(capability),
+    )
+      ? [APPROVAL_ROOT]
+      : [],
+  };
+}
+
+export function removalAuthority(packageRoot, status, nonce) {
+  const authorizationTime = 1000 + Number(status.revision);
+  return {
+    authorizationTime,
+    approvalRoots: [APPROVAL_ROOT],
+    recoveryWarrant: {
+      schema: 'kungfu.kfx-recovery-warrant/v1',
+      issuerClass: 'workspace-owner',
+      operation: 'remove',
+      packageRoot,
+      expectedCutRoot: status.cutRoot,
+      expectedRevision: status.revision,
+      approvalRoots: [APPROVAL_ROOT],
+      issuedAt: authorizationTime - 1,
+      expiresAt: authorizationTime + 100,
+      nonce,
+    },
+  };
+}

--- a/tests/fixtures/kfx-demo-install/run.mjs
+++ b/tests/fixtures/kfx-demo-install/run.mjs
@@ -11,7 +11,17 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { locate, tmpDir, run, kfc, uvPython, fail } from '../_harness.mjs';
+import {
+  locate,
+  tmpDir,
+  run,
+  kfc,
+  uvPython,
+  fail,
+  extractPackedKfx,
+  kfxQualificationAuthorityFile,
+  kfxRemovalAuthorityFile,
+} from '../_harness.mjs';
 
 const { fixtureDir, coreDir } = locate(import.meta.url);
 const repoDir = path.resolve(coreDir, '..', '..');
@@ -31,19 +41,38 @@ const tgzName = packed.stdout.trim().split(/\r?\n/).pop();
 const tgz = path.join(packdir, tgzName);
 if (!fs.existsSync(tgz)) fail('npm pack produced no tgz');
 
-k(['kfx', 'install', tgz]);
+const authority = kfxQualificationAuthorityFile(
+  coreDir,
+  home,
+  extractPackedKfx(coreDir, tgz),
+  'work-dashboard',
+);
+const installArgs = ['kfx', 'install', tgz, '--authority-file', authority];
+k(installArgs);
 k(['kfx', 'list']);
 
 // double install must refuse without --force, succeed with it
-if (k(['kfx', 'install', tgz], { allowFail: true }).status === 0) {
+if (k(installArgs, { allowFail: true }).status === 0) {
   fail('double install did not refuse');
 }
-k(['kfx', 'install', tgz, '--force']);
+k([...installArgs, '--force']);
 
 uvPython(coreDir, [path.join(fixtureDir, 'check_install.py'), home]);
 
-k(['kfx', 'remove', 'work-dashboard']);
-if (k(['kfx', 'remove', 'work-dashboard'], { allowFail: true }).status === 0) {
+const removalAuthority = kfxRemovalAuthorityFile(
+  coreDir,
+  home,
+  'work-dashboard',
+);
+const removeArgs = [
+  'kfx',
+  'remove',
+  'work-dashboard',
+  '--authority-file',
+  removalAuthority,
+];
+k(removeArgs);
+if (k(removeArgs, { allowFail: true }).status === 0) {
   fail('removing a missing key did not fail');
 }
 if (fs.existsSync(path.join(home, 'extensions', 'work-dashboard'))) fail('not removed');

--- a/tests/fixtures/kfx-demo-scaffold/run.mjs
+++ b/tests/fixtures/kfx-demo-scaffold/run.mjs
@@ -20,6 +20,9 @@ import {
   kfc,
   assertContains,
   fail,
+  extractPackedKfx,
+  kfxQualificationAuthorityFile,
+  kfxRemovalAuthorityFile,
 } from '../_harness.mjs';
 
 const { coreDir } = locate(import.meta.url);
@@ -83,11 +86,24 @@ const tgzName = packed.stdout.trim().split(/\r?\n/).pop();
 const tgz = path.join(packdir, tgzName);
 if (!fs.existsSync(tgz)) fail('npm pack produced no tgz');
 
-k(['kfx', 'install', tgz]);
+const authority = kfxQualificationAuthorityFile(
+  coreDir,
+  home,
+  extractPackedKfx(coreDir, tgz),
+  'my-view',
+);
+k(['kfx', 'install', tgz, '--authority-file', authority]);
 assertContains(k(['kfx', 'list']), 'my-view', 'installed kfx not listed');
 if (!fs.existsSync(path.join(home, 'extensions', 'my-view', 'dist', 'view', 'index.js'))) {
   fail('bundle missing from install root');
 }
-k(['kfx', 'remove', 'my-view']);
+const removalAuthority = kfxRemovalAuthorityFile(coreDir, home, 'my-view');
+k([
+  'kfx',
+  'remove',
+  'my-view',
+  '--authority-file',
+  removalAuthority,
+]);
 if (fs.existsSync(path.join(home, 'extensions', 'my-view'))) fail('not removed');
 console.log('[kfx-demo-scaffold] scaffold-to-install ok');


### PR DESCRIPTION
## Summary

Restore the exact KFX authority inputs required by the candidate qualification path so the existing KFD support claims can be verified on production artifacts.

## Related issue

Atlas goal: 2026-07-26-kungfu-kfd-support-governance

## Changes

- Bind production libwasm execution probes to an admitted KFX package and exact host contract.
- Supply exact admission and recovery authority to install/scaffold qualification fixtures.
- Align the Node storage assessment with the native Buildchain envelope.
- Accept the signed JSON integer representation of a non-negative recovery revision at the native boundary.

## Verification

- ./shifu check:source
- ./shifu verify --skip-episode-qualification
- ./shifu test:native-kfx-admission
- ./shifu --filter @kungfu-tech/core test:storage-binding
- ./shifu exec node tests/fixtures/kfx-demo-install/run.mjs
- ./shifu exec node tests/fixtures/kfx-demo-scaffold/run.mjs
- ./shifu exec node --test product/scripts/compatibility.test.mjs
- ./shifu kfd:support-matrix:check

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair restores qualification fixtures and exact authority binding for already accepted KFX contracts; it does not alter architecture authority or widen KFD support claims."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The changed release qualification paths remain fail-closed and are source-bound by the checks above.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no public behavior change; qualification fixtures and exact authority binding only)

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI2LWt1bmdmdS1rZmQtc3VwcG9ydC1nb3Zlcm5hbmNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiI2ZTAyYzE5OGQzZWJhMjY0MDMxYjY2M2I1ZjYyYThjY2Q5YzZkZWYyIiwicHVsbFJlcXVlc3RIZWFkIjoiNzFlMzZmMDJkMmNlZjFiMDhjNjkzYTNlZjRlNTc5YTJhNjNlZjFkNSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMGU0ODc4MzY1NzgyOGNlOGEzY2ZhNGJkNTE5MmEzMGIxYzcyZmQ2YiIsInJlcGxheWVkVHJlZSI6Ijc2OTgzNjIzZDY0NjljYjUxODcxYzc2ZDU3YzE5MTUyOTY0ZjBlMWUiLCJxdWV1ZUF0dGVtcHQiOiI3MWUzNmYwMmQyY2VmMWIwOGM2OTNhM2VmNGU1NzlhMmE2M2VmMWQ1QDZlMDJjMTk4ZDNlYmEyNjQwMzFiNjYzYjVmNjJhOGNjZDljNmRlZjIiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6MGE5ZTY5M2IwYzA5N2FkYzQzMmE4ZjFhZjA5M2JhNjg3MDZiZTQwOGU5OTVjNmZhYTg4OGZlNTNlYTMyOTlkMiIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjBhOWU2OTNiMGMwOTdhZGM0MzJhOGYxYWYwOTNiYTY4NzA2YmU0MDhlOTk1YzZmYWE4ODhmZTUzZWEzMjk5ZDIiLCJzaGEyNTY6YjI4YWM4YzE1YzNkNTAzZmE5ZGYwMjVkOTc1ZjZhNzA1NjkxZGMyNmE5OTcwOTFiYjUxNWY5Y2RkNTI0ZjYyYSJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6MGRkNmU4ODc4ZTdlNjFkMDNkOTgxZTZmNTAwNTM1ODU2NmNmNjZmYzlhOGI4ODJkNjIzOGE4ZjQ1YTYwYzkxYiJ9 -->