### PR TITLE
fix(agent-patrol): forward rootless Docker runtime

### DIFF
--- a/framework/agent-patrol/classify.mjs
+++ b/framework/agent-patrol/classify.mjs
@@ -207,7 +207,7 @@ export function classifyReport(
   };
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const result = {
     report: '',
     output: '',
@@ -219,6 +219,7 @@ function parseArgs(argv) {
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
+    if (arg === '--') continue;
     if (arg === '--report') result.report = argv[++index] || '';
     else if (arg === '--output') result.output = argv[++index] || '';
     else if (arg === '--runner-exit')

--- a/framework/agent-patrol/dogfood-capture.mjs
+++ b/framework/agent-patrol/dogfood-capture.mjs
@@ -256,7 +256,7 @@ export function captureFinding(
   });
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const result = {
     classification: '',
     output: '',
@@ -265,6 +265,7 @@ function parseArgs(argv) {
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
+    if (arg === '--') continue;
     if (arg === '--classification') result.classification = argv[++index] || '';
     else if (arg === '--output') result.output = argv[++index] || '';
     else if (arg === '--intent') result.intent = argv[++index] || '';

--- a/framework/agent-repository-work/opencode-docker-proxy.mjs
+++ b/framework/agent-repository-work/opencode-docker-proxy.mjs
@@ -17,6 +17,7 @@ function parseArgs(argv) {
     model: '',
     context: 65_536,
     mode: '',
+    dockerHost: '',
     command: [],
   };
   let index = 0;
@@ -32,6 +33,7 @@ function parseArgs(argv) {
     else if (value === '--context')
       result.context = Number.parseInt(argv[++index] || '', 10);
     else if (value === '--mode') result.mode = argv[++index] || '';
+    else if (value === '--docker-host') result.dockerHost = argv[++index] || '';
     else fail(`unknown proxy argument: ${value}`);
   }
   if (!result.image.includes('@sha256:'))
@@ -44,9 +46,30 @@ function parseArgs(argv) {
     fail('--context must be an integer of at least 8192');
   if (!['read-only', 'bounded-write'].includes(result.mode))
     fail('--mode must be read-only or bounded-write');
+  try {
+    result.dockerHost = validateDockerHost(result.dockerHost);
+  } catch (error) {
+    fail(error.message);
+  }
   if (result.command[0] !== 'run')
     fail('only the OpenCode run command is supported');
   return result;
+}
+
+export function validateDockerHost(
+  dockerHost,
+  uid = typeof process.getuid === 'function' ? process.getuid() : 1000,
+) {
+  if (!dockerHost) return '';
+  const allowed = new Set([
+    'unix:///var/run/docker.sock',
+    `unix:///run/user/${uid}/docker.sock`,
+  ]);
+  if (!allowed.has(dockerHost))
+    throw new Error(
+      '--docker-host must be the default rootful socket or the current user rootless socket',
+    );
+  return dockerHost;
 }
 
 function config({ baseUrl, model, context, mode }) {
@@ -152,11 +175,15 @@ export function dockerIsRootless(output) {
 
 export function runProxy(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
+  const dockerEnvironment = options.dockerHost
+    ? { ...process.env, DOCKER_HOST: options.dockerHost }
+    : process.env;
   const info = spawnSync(
     'docker',
     ['info', '--format', '{{json .SecurityOptions}}'],
     {
       encoding: 'utf8',
+      env: dockerEnvironment,
     },
   );
   if (info.error) {
@@ -173,6 +200,7 @@ export function runProxy(argv = process.argv.slice(2)) {
     {
       cwd: process.cwd(),
       stdio: 'inherit',
+      env: dockerEnvironment,
     },
   );
   if (result.error) {

--- a/framework/agent-repository-work/run.mjs
+++ b/framework/agent-repository-work/run.mjs
@@ -193,6 +193,7 @@ export function runtimeProfile({
   baseUrl,
   opencode,
   agent,
+  dockerHost = '',
 }) {
   const nodeAdapter = opencode.endsWith('.mjs');
   const executable = !opencode || nodeAdapter ? process.execPath : opencode;
@@ -212,6 +213,7 @@ export function runtimeProfile({
         '65536',
         '--mode',
         mode,
+        ...(dockerHost ? ['--docker-host', dockerHost] : []),
         '--',
       ];
   return {
@@ -452,6 +454,7 @@ export function runExperiment(options = {}) {
       image: normalized.image,
       baseUrl: normalized.baseUrl,
       opencode: normalized.opencode,
+      dockerHost: process.env.DOCKER_HOST || '',
       // OpenCode's built-in plan agent disables shell execution. Use the
       // tool-capable agent while the Docker mount and permission policy keep
       // this runtime strictly read-only.
@@ -464,6 +467,7 @@ export function runExperiment(options = {}) {
       image: normalized.image,
       baseUrl: normalized.baseUrl,
       opencode: normalized.opencode,
+      dockerHost: process.env.DOCKER_HOST || '',
       agent: 'build',
     });
     const context = {

--- a/scripts/agent-patrol.test.mjs
+++ b/scripts/agent-patrol.test.mjs
@@ -9,8 +9,12 @@ import test from 'node:test';
 import {
   classifyReport,
   jsonRoot,
+  parseArgs as parseClassificationArgs,
 } from '../framework/agent-patrol/classify.mjs';
-import { captureFinding } from '../framework/agent-patrol/dogfood-capture.mjs';
+import {
+  captureFinding,
+  parseArgs as parseDogfoodCaptureArgs,
+} from '../framework/agent-patrol/dogfood-capture.mjs';
 
 const IMAGE =
   'ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3';
@@ -67,6 +71,39 @@ function options(overrides = {}) {
     ...overrides,
   };
 }
+
+test('Patrol CLIs accept the Shifu argument separator', () => {
+  const classification = parseClassificationArgs([
+    '--',
+    '--report',
+    '/tmp/report.json',
+    '--output',
+    '/tmp/classification.json',
+    '--runner-exit',
+    '1',
+    '--source-head',
+    SOURCE_HEAD,
+    '--model',
+    MODEL,
+    '--image',
+    IMAGE,
+  ]);
+  assert.equal(classification.report, '/tmp/report.json');
+  assert.equal(classification.runnerExit, 1);
+  const capture = parseDogfoodCaptureArgs([
+    '--',
+    '--classification',
+    '/tmp/classification.json',
+    '--output',
+    '/tmp/receipt.json',
+    '--intent',
+    '/tmp/intent.json',
+    '--workspace',
+    '/tmp/workspace',
+  ]);
+  assert.equal(capture.classification, '/tmp/classification.json');
+  assert.equal(capture.workspace, '/tmp/workspace');
+});
 
 test('passing Patrol report creates no Dogfood Finding intent', () => {
   const report = baseReport();

--- a/scripts/run-agent-repository-work-experiment.test.mjs
+++ b/scripts/run-agent-repository-work-experiment.test.mjs
@@ -141,6 +141,12 @@ test('Docker profile is digest-pinned, bounded, and mode-specific', () => {
     profile.launch.argv[dockerHostIndex + 1],
     'unix:///run/user/996/docker.sock',
   );
+  const rootfulProfile = runtimeProfile({
+    ...input,
+    mode: 'read-only',
+    dockerHost: '',
+  });
+  assert.equal(rootfulProfile.launch.argv.includes('--docker-host'), false);
   const args = dockerArgs(
     {
       image: input.image,

--- a/scripts/run-agent-repository-work-experiment.test.mjs
+++ b/scripts/run-agent-repository-work-experiment.test.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import {
   dockerArgs,
   dockerIsRootless,
+  validateDockerHost,
 } from '../framework/agent-repository-work/opencode-docker-proxy.mjs';
 import {
   parseInvestigationClaim,
@@ -128,12 +129,18 @@ test('Docker profile is digest-pinned, bounded, and mode-specific', () => {
     baseUrl: 'http://host.docker.internal:11435/v1',
     opencode: '',
     agent: 'plan',
+    dockerHost: 'unix:///run/user/996/docker.sock',
   };
   const profile = runtimeProfile({ ...input, mode: 'read-only' });
   assert.equal(profile.provider, 'opencode');
   assert.equal(profile.launch.executable, process.execPath);
   assert.ok(profile.launch.argv.includes('--mode'));
   assert.ok(profile.launch.argv.includes('read-only'));
+  const dockerHostIndex = profile.launch.argv.indexOf('--docker-host');
+  assert.equal(
+    profile.launch.argv[dockerHostIndex + 1],
+    'unix:///run/user/996/docker.sock',
+  );
   const args = dockerArgs(
     {
       image: input.image,
@@ -181,6 +188,22 @@ test('Docker bind-mount identity follows rootful and rootless ownership', () => 
   );
   assert.equal(dockerIsRootless('["name=seccomp","name=rootless"]'), true);
   assert.equal(dockerIsRootless('["name=seccomp","name=cgroupns"]'), false);
+  assert.equal(
+    validateDockerHost('unix:///run/user/996/docker.sock', 996),
+    'unix:///run/user/996/docker.sock',
+  );
+  assert.equal(
+    validateDockerHost('unix:///var/run/docker.sock', 996),
+    'unix:///var/run/docker.sock',
+  );
+  assert.throws(
+    () => validateDockerHost('tcp://127.0.0.1:2375', 996),
+    /current user rootless socket/u,
+  );
+  assert.throws(
+    () => validateDockerHost('unix:///run/user/1000/docker.sock', 996),
+    /current user rootless socket/u,
+  );
 });
 
 test('Agent A claim and final report require deterministic continuity evidence', () => {


### PR DESCRIPTION
## Summary

- forward the workflow-selected Unix Docker host into the internal OpenCode proxy
- allow only the default rootful socket or the invoking user rootless socket; reject TCP and cross-user sockets
- accept the standard Shifu `--` argument separator in Patrol classification and Dogfood capture CLIs

## Live evidence

- agent-121 formal Patrol reached the repository-work experiment but the nested OpenCode proxy fell back to `/var/run/docker.sock`
- the rootless daemon remains owned by the unprivileged `gha-runner` account at `/run/user/996/docker.sock`
- no Docker group, privileged container, socket bind mount, host networking, or LAN Ollama listener is introduced

## Verification

- `./shifu docs context ... --route kungfu-core-development-agent --json`: pass
- `pnpm exec biome check <six changed files>`: pass
- `./shifu check:source`: pass
- `./shifu check:staged`: pass, including 112/112 documentation tests and 50/50 latency contract tests
- targeted Patrol assertions: new Docker-host and CLI-separator cases pass
- full Patrol native suite will be rerun on agent-121 after protected merge, where the required Core native build is provisioned

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a least-privilege runner compatibility correction for the existing Agent Patrol and does not change an ADR or architecture contract."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commit is signed off (DCO)
- [x] Rootful Docker behavior remains the default
- [x] Rootless Docker forwarding is restricted to the current user socket
- [x] Dogfood Issue admission remains prohibited

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hZ2VudC1wYXRyb2wtYWdlbnQtMTIxIiwiZGVsaXZlcnlDbGFzcyI6Im5vbi1uYXRpdmUtZmFzdCIsImRldkhlYWQiOiJlOGExMWJkOWU5ZmY3ZThiNjQ1MGUxZWM1ODkyNTE1M2YxOWUwYTBlIiwicHVsbFJlcXVlc3RIZWFkIjoiOTFkYWNhOTdkNThhOTVhODA2MTBiNTk0ODYwMjEzNjVhZmFiMjliZiIsInJlcGxheWVkQ2FuZGlkYXRlIjoiYTcyMzZhZmNiNmNlMzNhY2EzZjU3Mjk5MmQ1YTQ0YjAwZWY0YjBhYiIsInJlcGxheWVkVHJlZSI6IjdjZWMwOTNlYTJhYjRjNzU2ZGYyMjMzNDE4ODcyYWY1ZjFkZjQwOTkiLCJxdWV1ZUF0dGVtcHQiOiI5MWRhY2E5N2Q1OGE5NWE4MDYxMGI1OTQ4NjAyMTM2NWFmYWIyOWJmQGU4YTExYmQ5ZTlmZjdlOGI2NDUwZTFlYzU4OTI1MTUzZjE5ZTBhMGUiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6NGI2ZWExM2YyNjQ2MGY4MGY4MGJmNTE1MGM5ZmNlM2NiYzYwYTI5OTIyNjAwYTJmZjM1OGViMThjZTJmYTljOSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjRiNmVhMTNmMjY0NjBmODBmODBiZjUxNTBjOWZjZTNjYmM2MGEyOTkyMjYwMGEyZmYzNThlYjE4Y2UyZmE5YzkiLCJzaGEyNTY6N2Q1M2I4YTZkNTcyMzAxZWQyNjliOWIyN2VjMTk2NDhjYWM1MDcwMGJlYjRlZDcyODlmMWFkMjEyOWE0YzE4ZiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6OTA1ODEwYzk2MGQ1YjdjMjY3ZTM5NGJlY2E0MGM3N2FhOTQ2NzFiNjRhMzg4OTQzNDQ3Y2VjOTdkN2MxNTk4ZCJ9 -->