### PR TITLE
fix(kfx): close Alpha qualification authority drift

### DIFF
--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -83,7 +83,7 @@ jobs:
         {
           "schema": "kungfu.adr-release-pr/v1",
           "kind": "alpha-settlement",
-          "no_adr_progress_reason": "The qualified development delta changes candidate admission plumbing without modifying an accepted ADR record"
+          "no_adr_progress_reason": "The qualified development delta aligns runtime-authority projections and candidate admission plumbing without modifying an accepted ADR record"
         }
         -->
       settlement-authorized: ${{ github.event_name != 'workflow_dispatch' || inputs.create-pull-request }}

--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -70,14 +70,22 @@ jobs:
       pull-requests: write
     # The reusable workflow and its runtime are pinned to the same merged,
     # immutable Buildchain source.
-    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@1ccbb93811ccd52cd83eda156d89fba05cc60c75
+    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@4449bf319a4507009212b9302156d42117b9b703
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '1ccbb93811ccd52cd83eda156d89fba05cc60c75' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || '4449bf319a4507009212b9302156d42117b9b703' }}
       source-branch: ${{ needs.resolve-channels.outputs.source-branch }}
       target-branch: ${{ needs.resolve-channels.outputs.target-branch }}
       dev-workflow-path: .github/workflows/dev-verify-patrol.yml
       alpha-workflow-path: .github/workflows/alpha-promotion-preflight.yml
       max-age-seconds: 604800
+      pull-request-body-prefix: |
+        <!-- kungfu-adr-release:v1
+        {
+          "schema": "kungfu.adr-release-pr/v1",
+          "kind": "alpha-settlement",
+          "no_adr_progress_reason": "The qualified development delta changes candidate admission plumbing without modifying an accepted ADR record"
+        }
+        -->
       settlement-authorized: ${{ github.event_name != 'workflow_dispatch' || inputs.create-pull-request }}
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
     secrets:

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1242,9 +1242,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5500861f95f91b96e669f0293b2bf0e9cf995da8617322ee3436ef24fd90944d",
+          "definitionDigest": "sha256:029632b0ca605793c8a5a120982dac8d7cadd43704032fd3912e2b7772cb69f3",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@1ccbb93811ccd52cd83eda156d89fba05cc60c75"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@4449bf319a4507009212b9302156d42117b9b703"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1242,7 +1242,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:029632b0ca605793c8a5a120982dac8d7cadd43704032fd3912e2b7772cb69f3",
+          "definitionDigest": "sha256:f16df1b6553f9c57d192b3bd73cb7cec254408f088d0ad502dedd881cfc4ea73",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@4449bf319a4507009212b9302156d42117b9b703"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -155,7 +155,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:58c33a4e8558f4a19c4a24774f2cd13abfcfdb05cb21bf8e14b180e0f8ab6449"
+          "sourceRoot": "sha256:9309570e0417dd3357a1175a1d5c2f37836497b254702e0c4792d7c8fb9add15"
         },
         {
           "path": ".github/workflows/stable-candidate-patrol.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:098204100a2926372b30741d5dcd43e2c6699bd49c2ba78dd5404b0a13fa2ef5"
+  "registryRoot": "sha256:4b4838a62f5557e99d59afe5d1f8a744156af5b7651b93ae29894995d81afd50"
 }

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -24,7 +24,7 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
     /uses: kungfu-systems\/buildchain\/.github\/workflows\/dev-alpha-candidate-patrol\.yml@([0-9a-f]{40})/u,
   )?.[1];
   assert.match(reusableRef || '', /^[0-9a-f]{40}$/u);
-  assert.equal(reusableRef, '1ccbb93811ccd52cd83eda156d89fba05cc60c75');
+  assert.equal(reusableRef, '4449bf319a4507009212b9302156d42117b9b703');
   assert.match(
     source,
     new RegExp(
@@ -32,8 +32,14 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
       'u',
     ),
   );
-  assert.match(source, /source-branch: dev\/v4\/v4\.0/u);
-  assert.match(source, /target-branch: alpha\/v4\/v4\.0/u);
+  assert.match(
+    source,
+    /source-branch: \$\{\{ needs\.resolve-channels\.outputs\.source-branch \}\}/u,
+  );
+  assert.match(
+    source,
+    /target-branch: \$\{\{ needs\.resolve-channels\.outputs\.target-branch \}\}/u,
+  );
   assert.match(
     source,
     /dev-workflow-path: \.github\/workflows\/dev-verify-patrol\.yml/u,
@@ -54,7 +60,14 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
   assert.match(source, /workflow_run:/u);
   assert.match(source, /Dev Verify Patrol/u);
   assert.match(source, /Alpha promotion preflight/u);
-  assert.match(source, /head_branch == 'dev\/v4\/v4\.0'/u);
+  assert.match(
+    source,
+    /head_branch == needs\.resolve-channels\.outputs\.source-branch/u,
+  );
+  assert.match(source, /pull-request-body-prefix: \|/u);
+  assert.match(source, /kungfu-adr-release:v1/u);
+  assert.match(source, /"kind": "alpha-settlement"/u);
+  assert.match(source, /"no_adr_progress_reason":/u);
   assert.doesNotMatch(source, /cron: "0 22 \* \* \*"/u);
   assert.match(
     source,


### PR DESCRIPTION
## Summary

Close the exact authority drift exposed by Alpha candidate qualification and make future candidate PRs carry their repository-owned ADR settlement at creation time.

The authoritative KFX manifest contract no longer permits packages to self-declare runtime placement or system authority. This repair aligns the Python Profile audit and TypeScript projection with that contract: host policy supplies GUI confinement, source authority supplies the integrated trust verdict, and the boot-critical product role preserves recovery navigation without granting runtime authority.

## Related issue

Atlas goal: 2026-07-24-buildchain-linux-github-attestation

## Changes

- pass one bounded repository-owned PR body prefix into the merged Buildchain candidate patrol workflow
- create Alpha candidate PRs with exactly one ADR settlement manifest
- derive Profile custom-view placement from the native KFX host policy rather than removed manifest fields
- remove stale TypeScript runtime and system manifest projections
- derive non-disableable recovery navigation from the non-authorizing boot-critical product role
- update focused Python and Node regression coverage and the public KFX architecture guide

## Verification

- repository pre-commit staged gate: passed, including 112/112 documentation and promotion rehearsals
- node --test scripts/dev-alpha-candidate-patrol.test.mjs: 3/3 passed
- ./shifu check:gate-catalog: 38 gates, 6 profiles, 27 structured invocations, 28 workflows aligned
- ./shifu test:kfx-profile-suite: passed
- ./shifu exec pnpm --filter @kungfu-tech/kfx build: passed
- focused Profile facet authority smoke: passed
- Ruff format/lint and Biome staged checks: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair aligns stale language projections and candidate admission plumbing with already accepted runtime and release authority; it does not change an accepted architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The candidate body prefix is bounded and rejects managed-controller marker injection in Buildchain. Runtime placement remains fail-closed and cannot be authored by a package manifest.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated where behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI0LWJ1aWxkY2hhaW4tbGludXgtZ2l0aHViLWF0dGVzdGF0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJiYTAzOGQxNzYyMGE4ZTFkMWFlNTRkZDc4ZWQxYWY3NDhlYTVhODQ5IiwicHVsbFJlcXVlc3RIZWFkIjoiZWMxNDcyY2FlNDU0MGUyYmIzYjllM2JjMDc5MmNiNGUwNDJkMDRkMSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiNDhkZTg1NjlmZGQ2Zjk2MTVhMjQ4NTcwNzY1YTdlZTU3OWI2NDJkMyIsInJlcGxheWVkVHJlZSI6ImFmZGZkNjRlNDUwYzczMTY3NjNiMzA2NDkxM2JkMGM5NWU5ZDQ0YjEiLCJxdWV1ZUF0dGVtcHQiOiJlYzE0NzJjYWU0NTQwZTJiYjNiOWUzYmMwNzkyY2I0ZTA0MmQwNGQxQGJhMDM4ZDE3NjIwYThlMWQxYWU1NGRkNzhlZDFhZjc0OGVhNWE4NDkiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6OTQyMmExYjJlOWQ4OGRlMWFjZWQ2ZjliY2IxMGYzZWY0N2RmNGQ5NjZmN2I2OGQzZWQ5ZmI1MTNhMjliZDk1MCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjM5NTJhNzBlNDkzMzM2Njg5ZTk4NTVjZjgzMjU3NDIzYjQxMTg3NWFhYzJhMWRiYjNmMjQ0MDliMTQ3NDIyYWUiLCJzaGEyNTY6OTQyMmExYjJlOWQ4OGRlMWFjZWQ2ZjliY2IxMGYzZWY0N2RmNGQ5NjZmN2I2OGQzZWQ5ZmI1MTNhMjliZDk1MCJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6NjVjZTQ0M2E2NWY0M2VmMWJmOGQ1OTRiNzc0NzIxNDc0NWU1ZDJlZTUyN2JkOGMxNDU2NGVhZTIzYTRjYzU4NyJ9 -->