### PR TITLE
fix(kfd): bind profile view qualification to core placement

### DIFF
--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -989,6 +989,8 @@ def _agent_interface_authority() -> dict[str, Any]:
 def _profile_facet_audit(resolved: Mapping[str, Any]) -> dict[str, Any]:
     """Reject executable/custom surfaces that can bypass the shared service."""
 
+    host_contract = kfx_contract.load_contract()["nativeRuntime"]["experienceFlowHost"]
+    gui_placement = host_contract["placements"]["gui"]
     package_dirs = {
         "suite": Path(str(resolved["source"])),
         **{
@@ -1004,18 +1006,16 @@ def _profile_facet_audit(resolved: Mapping[str, Any]) -> dict[str, Any]:
         view = config.get("view")
         if view is not None:
             capabilities = sorted(view.get("capabilities") or [])
-            runtime = view.get("runtime") or "node-integrated"
+            runtime = str(gui_placement or "")
             entry = str(view.get("entry") or "dist/view/index.js")
             entry_path = _confined(package_dir, entry)
             reasons = []
             if runtime != "sandboxed-ipc":
-                reasons.append("custom Profile views must use sandboxed-ipc")
+                reasons.append("Core must place custom Profile views in sandboxed-ipc")
             if capabilities:
                 reasons.append(
                     "custom Profile views may not receive capability handles"
                 )
-            if view.get("system"):
-                reasons.append("custom Profile views may not claim system authority")
             if not entry_path.is_file():
                 reasons.append("custom Profile view bundle is missing")
             row = {

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -633,7 +633,6 @@ def test_kfd3_qualification_rejects_custom_view_mutation_boundary(tmp_path):
     manifest["kungfuConfig"]["config"] = {
         "view": {
             "title": "Private mutation view",
-            "runtime": "node-integrated",
             "capabilities": ["profile"],
         }
     }
@@ -661,7 +660,6 @@ def test_kfd3_qualification_allows_capability_free_sandboxed_view(tmp_path):
     manifest["kungfuConfig"]["config"] = {
         "view": {
             "title": "Presentational view",
-            "runtime": "sandboxed-ipc",
             "capabilities": [],
         }
     }
@@ -677,6 +675,7 @@ def test_kfd3_qualification_allows_capability_free_sandboxed_view(tmp_path):
     receipt = profile_sdk.qualify_kfd3(source, runtime)
 
     assert receipt["noBypass"]["customViews"][0]["passed"] is True
+    assert receipt["noBypass"]["customViews"][0]["runtime"] == "sandboxed-ipc"
     assert receipt["noBypass"]["customViews"][0]["bundleRoot"].startswith("sha256:")
 
 

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b8b9c591c4e123b18dadc49c7b2a1d4a9c4c06998b673d8ce8711575340764de",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:79c8d7ec00991298abaeeea749fe56c1da1f5302d5626d4320e7d7d7cc122f65",
+  "sourceRoot": "sha256:28bdc67f30ffe6ee45eb6358111a2293e0db545bf74e41eb2051edee6f5542fd",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -385,7 +385,7 @@
           "path": "framework/core/src/python/kungfu/profile_sdk.py",
           "currentLines": 3135,
           "baselineLines": 3138,
-          "currentRoot": "sha256:17cc36818018ae1721305fe1d6298699730c1d83cf7f754746ce57910e3c63aa",
+          "currentRoot": "sha256:639a4c4de1c3c2be60c139ca26d3f4bf1b3ae6fae1c48a2422e2d86e78c143db",
           "baselineRoot": "sha256:fb62fb8c4e1e944811c954d22786ebaeb21ff45dbb3fc1db705feb37fbb5dc1c",
           "changedSinceBaseline": true
         },
@@ -562,7 +562,7 @@
           "path": "framework/core/src/python/kungfu/profile_sdk.py",
           "currentLines": 3135,
           "baselineLines": 3138,
-          "currentRoot": "sha256:17cc36818018ae1721305fe1d6298699730c1d83cf7f754746ce57910e3c63aa",
+          "currentRoot": "sha256:639a4c4de1c3c2be60c139ca26d3f4bf1b3ae6fae1c48a2422e2d86e78c143db",
           "baselineRoot": "sha256:fb62fb8c4e1e944811c954d22786ebaeb21ff45dbb3fc1db705feb37fbb5dc1c",
           "changedSinceBaseline": true
         },


### PR DESCRIPTION
## Summary

Fix the Alpha release qualification regression exposed by PR #1746. KFD-3 Profile view auditing now consumes the Core-owned GUI placement from the welded KFX contract instead of trusting retired manifest runtime and system fields.

The capability-bearing custom view still fails closed, while a capability-free view qualifies only when Core places GUI facets in sandboxed-ipc.

## Verification

- Profile SDK regression: 64 passed
- ./shifu check:source
- KFD support matrix: 13 rows, 4 shipped, 17 negative fixtures passed
- pre-commit staged gate

This is an ADR-neutral bug fix; it does not widen any KFD support claim.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores KFD-3 qualification against the existing Core-owned placement contract; it changes no architecture decision and does not widen any KFD support claim."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The qualification behavior remains fail-closed and is source-bound by the checks above.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no public contract change; stale qualification fixtures only)