### PR TITLE
fix(ci): grant reusable qualification issue scope

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: aws-us-linux-burst-${{ github.run_id }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -680,7 +680,7 @@
     {
       "path": ".github/workflows/aws-us-linux-burst-qualification.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:6d3dce83fd46bd0c8df1abfde698d6c83a555770130d2ffcffcadca21ea9c05a",
+      "definitionDigest": "sha256:2ceb58f323b6d996b5b7a9a80c2ab652059db3aa6186f2bfd0b8944236928cfb",
       "jobs": [
         {
           "id": "qualify",
@@ -688,7 +688,7 @@
           "publication": "none",
           "receipt": "diagnostic",
           "definitionDigest": "sha256:2a23496189129a8b4d62cf12ca048f05327e6f103f744eb8b3dbce56f896f174",
-          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -52,7 +52,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/affected-native-pr.yml` | `source_acceptance` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
-| `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:write | none | 0 |
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-passport` | qualification | none | qualifying | token:read | none | 4 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,7 +96,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:975fdc85c440a96afb2ee25bad20b79c56e977e74d44f0a9e2a07797ad2fa900"
+          "sourceRoot": "sha256:03ca9367883a07560b050faeac9bef402d220f751c6d75117df9a0b6a22360df"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:30b160dacbb40b984804960191f8da255f9ab0122293a0093abfc4cefe6d4932"
+  "registryRoot": "sha256:098204100a2926372b30741d5dcd43e2c6699bd49c2ba78dd5404b0a13fa2ef5"
 }


### PR DESCRIPTION
## Summary

- grant only `issues: write` to the maintainer-dispatch CodeBuild qualification caller
- keep OIDC disabled, secrets absent, and publication disabled
- refresh closed-world workflow and release-publication authority roots

## Validation

- staged commit gate passed
- `node --test scripts/readonly-agent-bootstrap.test.mjs`
- `node --test scripts/buildchain-install.test.mjs scripts/kungfu-workflow-authority.test.mjs scripts/check-kungfu-gate-catalog.test.mjs`
- `node framework/release/publication-control-plane.mjs check`
- `actionlint .github/workflows/aws-us-linux-burst-qualification.yml`

## Live regression

Run `30367692905` failed before job creation because the reusable Buildchain workflow could not elevate permissions. Buildchain PR #2009 now leaves token permissions caller-owned; this caller supplies the issue scope used by Buildchain diagnostics without granting OIDC or publication authority.