### PR TITLE
fix(profile): bind KFD view placement to Core authority

### DIFF
--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -989,6 +989,14 @@ def _agent_interface_authority() -> dict[str, Any]:
 def _profile_facet_audit(resolved: Mapping[str, Any]) -> dict[str, Any]:
     """Reject executable/custom surfaces that can bypass the shared service."""
 
+    native_runtime = kfx_contract.load_contract()["nativeRuntime"]
+    view_placement = native_runtime["experienceFlowHost"]["placements"].get("gui")
+    if view_placement != "sandboxed-ipc":
+        raise ProfileSdkError(
+            "kfd3-view-placement-authority-invalid",
+            "Core does not declare the required sandboxed Profile view placement",
+            placement=view_placement,
+        )
     package_dirs = {
         "suite": Path(str(resolved["source"])),
         **{
@@ -1004,23 +1012,18 @@ def _profile_facet_audit(resolved: Mapping[str, Any]) -> dict[str, Any]:
         view = config.get("view")
         if view is not None:
             capabilities = sorted(view.get("capabilities") or [])
-            runtime = view.get("runtime") or "node-integrated"
             entry = str(view.get("entry") or "dist/view/index.js")
             entry_path = _confined(package_dir, entry)
             reasons = []
-            if runtime != "sandboxed-ipc":
-                reasons.append("custom Profile views must use sandboxed-ipc")
             if capabilities:
                 reasons.append(
                     "custom Profile views may not receive capability handles"
                 )
-            if view.get("system"):
-                reasons.append("custom Profile views may not claim system authority")
             if not entry_path.is_file():
                 reasons.append("custom Profile view bundle is missing")
             row = {
                 "packageKey": key,
-                "runtime": runtime,
+                "runtime": view_placement,
                 "capabilities": capabilities,
                 "entry": entry,
                 "bundleRoot": (

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -633,11 +633,13 @@ def test_kfd3_qualification_rejects_custom_view_mutation_boundary(tmp_path):
     manifest["kungfuConfig"]["config"] = {
         "view": {
             "title": "Private mutation view",
-            "runtime": "node-integrated",
             "capabilities": ["profile"],
         }
     }
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    bundle = member / "dist" / "view" / "index.js"
+    bundle.parent.mkdir(parents=True)
+    bundle.write_text("export function View() { return null; }\n")
     runtime = tmp_path / "runtime"
     for action in ["install", "qualify", "activate"]:
         core_plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
@@ -648,6 +650,9 @@ def test_kfd3_qualification_rejects_custom_view_mutation_boundary(tmp_path):
     except profile_sdk.ProfileSdkError as error:
         assert error.diagnosis["code"] == "kfd3-no-bypass-failed"
         assert error.diagnosis["failures"][0]["facet"] == "view"
+        assert error.diagnosis["failures"][0]["reasons"] == [
+            "custom Profile views may not receive capability handles"
+        ]
     else:
         raise AssertionError("custom mutation view bypass was qualified")
 
@@ -661,7 +666,6 @@ def test_kfd3_qualification_allows_capability_free_sandboxed_view(tmp_path):
     manifest["kungfuConfig"]["config"] = {
         "view": {
             "title": "Presentational view",
-            "runtime": "sandboxed-ipc",
             "capabilities": [],
         }
     }
@@ -677,6 +681,7 @@ def test_kfd3_qualification_allows_capability_free_sandboxed_view(tmp_path):
     receipt = profile_sdk.qualify_kfd3(source, runtime)
 
     assert receipt["noBypass"]["customViews"][0]["passed"] is True
+    assert receipt["noBypass"]["customViews"][0]["runtime"] == "sandboxed-ipc"
     assert receipt["noBypass"]["customViews"][0]["bundleRoot"].startswith("sha256:")
 
 

--- a/framework/core/tests/python/test_kfx_contract.py
+++ b/framework/core/tests/python/test_kfx_contract.py
@@ -176,6 +176,33 @@ def test_kfx_package_manifest_schema_rejects_invalid_view_capabilities(tmp_path)
         kfx_contract.read_manifest_from_dir(str(package_dir))
 
 
+@pytest.mark.parametrize(
+    "field,value", [("runtime", "node-integrated"), ("system", True)]
+)
+def test_kfx_package_manifest_schema_rejects_view_authority_hints(
+    tmp_path, field, value
+):
+    package_dir = tmp_path / f"bad-view-{field}"
+    package_dir.mkdir()
+    (package_dir / kfx_contract.PACKAGE_MANIFEST_FILE).write_text(
+        json.dumps(
+            {
+                "schema": kfx_contract.PACKAGE_MANIFEST_SCHEMA,
+                "name": f"@bad/view-{field}",
+                "version": "1.0.0",
+                "kungfuConfig": {
+                    "key": f"bad-view-{field}",
+                    "config": {"view": {field: value}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=f"Additional properties.*'{field}'"):
+        kfx_contract.read_manifest_from_dir(str(package_dir))
+
+
 def test_kfx_manifest_authority_rejects_legacy_and_dual_declarations(tmp_path):
     package_dir = tmp_path / "legacy"
     package_dir.mkdir()

--- a/framework/core/tests/python/test_profile_composition.py
+++ b/framework/core/tests/python/test_profile_composition.py
@@ -163,6 +163,7 @@ def _dynamic_source(tmp_path):
         "adapter": {
             "targets": ["kungfu.profile.member"],
             "runtimes": ["python"],
+            "capabilities": [],
             "entry": {"python": "adapter.py"},
         }
     }

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b8b9c591c4e123b18dadc49c7b2a1d4a9c4c06998b673d8ce8711575340764de",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:f1673e00645927210589cbb499b6de11b36085c29eaceebfeada6014d871bffa",
+  "sourceRoot": "sha256:f2bd7cd48f004a682cb51e6ca97a497f9a9d14b15c5d3c67a6c5bb51bc67d1d6",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -383,9 +383,9 @@
         },
         {
           "path": "framework/core/src/python/kungfu/profile_sdk.py",
-          "currentLines": 3132,
+          "currentLines": 3135,
           "baselineLines": 3138,
-          "currentRoot": "sha256:5e97fb7c86ecd14d03487e618631d113e8b0030560f03419f1f0bc58d564f3c4",
+          "currentRoot": "sha256:fe9eb75f5d2960e2536d39f98c017e97186e88a32672bd8ac6db90b445b51d38",
           "baselineRoot": "sha256:fb62fb8c4e1e944811c954d22786ebaeb21ff45dbb3fc1db705feb37fbb5dc1c",
           "changedSinceBaseline": true
         },
@@ -560,9 +560,9 @@
         },
         {
           "path": "framework/core/src/python/kungfu/profile_sdk.py",
-          "currentLines": 3132,
+          "currentLines": 3135,
           "baselineLines": 3138,
-          "currentRoot": "sha256:5e97fb7c86ecd14d03487e618631d113e8b0030560f03419f1f0bc58d564f3c4",
+          "currentRoot": "sha256:fe9eb75f5d2960e2536d39f98c017e97186e88a32672bd8ac6db90b445b51d38",
           "baselineRoot": "sha256:fb62fb8c4e1e944811c954d22786ebaeb21ff45dbb3fc1db705feb37fbb5dc1c",
           "changedSinceBaseline": true
         },


### PR DESCRIPTION
## Summary

Bind KFD-3 custom Profile view placement to the Core KFX contract instead of removed member-manifest authority hints, restoring fail-closed release qualification on the identity-neutral KFX base.

## Related issue

Atlas goal: 2026-07-26-kungfu-kfd-support-governance
Assignment work-definition root: `sha256:2f12129a1391b3241c37ccd94e046870e02932f9a76a90ff4286591fbe787a22`
Supersedes: #1750, whose exact head was retained and closed after the serialized wrapper detected a conflict with merged #1744.

## Changes

- Derive custom Profile view placement from `nativeRuntime.experienceFlowHost.placements.gui` in the Core KFX contract.
- Fail closed when Core does not declare the required `sandboxed-ipc` placement.
- Keep capability-bearing custom views rejected without depending on removed `view.runtime` or `view.system` fields.
- Add schema regressions proving member manifests cannot reclaim runtime or system authority.
- Align the Profile composition fixture with the identity-neutral adapter capability contract introduced by #1744.
- Refresh the generated semantic-amplification projection.

## Verification

- 83 related Python tests passed across Profile SDK, KFX contract, profile composition, and Mission Control Profile.
- Code complexity budget and semantic-amplification report checks passed.
- Repository pre-commit staged gate passed, including 50 dev Gate latency contract tests, 17 invariant tests, 112 documentation negative tests, Python format/lint, and Biome.
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix aligns KFD-3 qualification with the already accepted Core KFX authority after member runtime and system hints were removed; it does not change architecture authority or widen KFD support claims."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The qualification repair remains fail-closed and will be accepted for release only through the protected exact-source candidate workflow.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (generated maintainability projection refreshed; no public behavior change)

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI2LWt1bmdmdS1rZmQtc3VwcG9ydC1nb3Zlcm5hbmNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiI0ODY0YzI0ODE5ZmE4NzY2OTY2ZDk3ZTFjYmQ5OWZmMTFmNGUzZWY1IiwicHVsbFJlcXVlc3RIZWFkIjoiYzAzOGJmOTg4ODZlNWVhNDMxMzE5MzEyODY4YTRmYzBmNDAzZTE1ZSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiODUxMDBiMWM1Y2YxYmQxZWE0YTk3ZmU3ZDU1ZjYxM2M5Yjk5OGI2NiIsInJlcGxheWVkVHJlZSI6IjVkNWQwZjQ1NjhkYmRiNThlNTU4MDY5ZjEwZWMyNGIxODI0ODFjZGEiLCJxdWV1ZUF0dGVtcHQiOiJjMDM4YmY5ODg4NmU1ZWE0MzEzMTkzMTI4NjhhNGZjMGY0MDNlMTVlQDQ4NjRjMjQ4MTlmYTg3NjY5NjZkOTdlMWNiZDk5ZmYxMWY0ZTNlZjUiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6MDczNjQ0YTU4NmMxMjk2OWMyNTZjODI0YWYwZjNlNzcwYzcyM2NlZTQxM2MxY2UzNmFlZTk5N2E4NTRlOWU4NSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjA3MzY0NGE1ODZjMTI5NjljMjU2YzgyNGFmMGYzZTc3MGM3MjNjZWU0MTNjMWNlMzZhZWU5OTdhODU0ZTllODUiLCJzaGEyNTY6MmYxMjEyOWExMzkxYjMyNDFjMzdjY2Q5NGUwNDY4NzBlMDI5MzJmOWE3NmE5MGZmNDI4NjU5MWZiZTc4N2EyMiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6NTZlNDU5MzZhNmVkYjEyNWRmZjgzYWE1ZTI1MGZkMzg3MGZhZTViYzkyNmQzNDY2ZjFhOWJiNDIwOWM5YjEwZCJ9 -->