### PR TITLE
fix(ci): grant reusable qualification issue scope

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: aws-us-linux-burst-${{ github.run_id }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -680,7 +680,7 @@
     {
       "path": ".github/workflows/aws-us-linux-burst-qualification.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:6d3dce83fd46bd0c8df1abfde698d6c83a555770130d2ffcffcadca21ea9c05a",
+      "definitionDigest": "sha256:2ceb58f323b6d996b5b7a9a80c2ab652059db3aa6186f2bfd0b8944236928cfb",
       "jobs": [
         {
           "id": "qualify",
@@ -688,7 +688,7 @@
           "publication": "none",
           "receipt": "diagnostic",
           "definitionDigest": "sha256:2a23496189129a8b4d62cf12ca048f05327e6f103f744eb8b3dbce56f896f174",
-          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -52,7 +52,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/affected-native-pr.yml` | `source_acceptance` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
-| `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:write | none | 0 |
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-passport` | qualification | none | qualifying | token:read | none | 4 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,7 +96,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:975fdc85c440a96afb2ee25bad20b79c56e977e74d44f0a9e2a07797ad2fa900"
+          "sourceRoot": "sha256:03ca9367883a07560b050faeac9bef402d220f751c6d75117df9a0b6a22360df"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:30b160dacbb40b984804960191f8da255f9ab0122293a0093abfc4cefe6d4932"
+  "registryRoot": "sha256:098204100a2926372b30741d5dcd43e2c6699bd49c2ba78dd5404b0a13fa2ef5"
 }


### PR DESCRIPTION
## Summary

- Grant only `issues: write` to the maintainer-dispatch CodeBuild qualification caller.
- Keep OIDC disabled, secrets absent, and publication disabled.
- Refresh closed-world workflow and release-publication authority roots.

## Verification

- Full staged commit gate passed.
- `actionlint .github/workflows/aws-us-linux-burst-qualification.yml`
- 41 focused Buildchain, workflow authority, gate catalog, and publication-control tests passed.
- Workflow authority and publication root checks passed.

## Live regression

Run `30367692905` failed before job creation because the reusable Buildchain workflow could not elevate caller permissions. Buildchain PR #2009 now leaves token permissions caller-owned; this caller supplies only the issue scope used by Buildchain diagnostics without granting OIDC or publication authority.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects least-privilege CI caller permissions without changing a product or architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- Provider integration and release evidence surfaces are touched only for bounded qualification.
- No static AWS credentials, repository secrets, OIDC, signing, publication, or deployment authority is added.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Generated authority projections are refreshed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoibm9uLW5hdGl2ZS1mYXN0IiwiZGV2SGVhZCI6IjIwNjYyODNkNmJhNWRmY2ViYWE2ZWRiZWUxZDhmYWYxZTYxOTU3M2EiLCJwdWxsUmVxdWVzdEhlYWQiOiI4ZjY1MDg2NzM0YjMxZjQ3NmI4ZjMwZjc5NjJiOWM1ZDA1MmQ3OTg4IiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJiMDNmNjQ4YTk0ZWMxNTA1ZDc1YzQzNGZmZTA5ZTQ2YWI5NDEwOGEyIiwicmVwbGF5ZWRUcmVlIjoiOTA1ZjU1MzdiZGVkY2FiMjI4YjUwMzhhMzA5NDBjNjRkOWYwYzlkNyIsInF1ZXVlQXR0ZW1wdCI6IjhmNjUwODY3MzRiMzFmNDc2YjhmMzBmNzk2MmI5YzVkMDUyZDc5ODhAMjA2NjI4M2Q2YmE1ZGZjZWJhYTZlZGJlZTFkOGZhZjFlNjE5NTczYSIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1Njo4NGM1NmI3ZDVjZTk4Y2Q1NWMzMTEyOThjYmRmZTQ3YThjZGI0NzFjMWJkMTIwYjg4MjBjMmZmZDI5ZTgzNTc2IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6NWNkMjJhZDgxYTdhNzc4ZjJlNWJmYWYyOWNlZTk1YjVhZTc5YjgyNDA0ZmRkZDNlYjBiNWUxYTg4MGFjZjJlZCIsInNoYTI1Njo4NGM1NmI3ZDVjZTk4Y2Q1NWMzMTEyOThjYmRmZTQ3YThjZGI0NzFjMWJkMTIwYjg4MjBjMmZmZDI5ZTgzNTc2Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1NjplZGZmMjM1YmM1Zjg2ZmY4ZWZlN2MzN2JlMzMzZTE5ZjEyMjZiYTc2NjE3MWVmOGU3MjY2OTE5MzQ2NDFiNzJiIn0 -->