### PR TITLE
fix(ci): disable local checkout cache for CodeBuild

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -82,7 +82,7 @@ jobs:
       lifecycle-timeout-minutes: 105
       artifact-transfer-mode: github-artifacts
       artifact-retention-days: 14
-      checkout-cache-mode: github
+      checkout-cache-mode: off
       checkout-cache-fallback: github
       checkout-cache-github-timeout-seconds: 1200
       publish-channel: none

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -687,7 +687,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:2a23496189129a8b4d62cf12ca048f05327e6f103f744eb8b3dbce56f896f174",
+          "definitionDigest": "sha256:ddb830fef0e931abd526e3f7d0a268aee2b41eec607c2a6f5ee4a57435158919",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,7 +96,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:03ca9367883a07560b050faeac9bef402d220f751c6d75117df9a0b6a22360df"
+          "sourceRoot": "sha256:7aa718bad3854524f225c7df59059e7f027d6c33adba9d04afaa6d067aa89af2"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:098204100a2926372b30741d5dcd43e2c6699bd49c2ba78dd5404b0a13fa2ef5"
+  "registryRoot": "sha256:c4d67bd332b7dc80f8ba9bf64b2bfe267881d49a4c311571b0cdb824b575eece"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -202,6 +202,8 @@ test('AWS Linux burst workflow is trusted exact-train qualification only', () =>
   assert.match(workflow, /publish-channel: none/);
   assert.match(workflow, /release-candidate: false/);
   assert.match(workflow, /artifact-transfer-mode: github-artifacts/);
+  assert.match(workflow, /checkout-cache-mode: off/);
+  assert.doesNotMatch(workflow, /checkout-cache-mode: (?:auto|require|github)/);
   assert.doesNotMatch(
     workflow,
     /secrets:|notar|signing|npm-publish|release-new-version|deploy/,


### PR DESCRIPTION
## Summary

- Set the AWS CodeBuild qualification checkout cache mode to `off`.
- Fetch the locked Buildchain runtime and consumer source directly from GitHub on the cloud runner.
- Add a regression assertion and refresh workflow/publication authority roots.

## Verification

- `node --test scripts/buildchain-install.test.mjs` (7/7)
- `./shifu check:source` (build-free source gate passed; 720 Node tests, 40 Agent Work tests, 116 runtime upgrade tests, 69 desktop adapter tests, plus contract gates)
- Full staged commit gate passed.

## Live regression

Run `30377374760` proved the v4 CodeConnections webhook and CodeBuild runner path, then failed because `checkout-cache-mode: github` is outside the current `off / auto / require` contract. `off` is intentional for the cloud runner so it does not attempt the office-only `192.168.100.222` mirror before the exact GitHub fetch.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects a bounded CI configuration value without changing product or architecture contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- No credentials, OIDC, signing, publication, or deployment authority is added.
- Exact-source trust gates and the dedicated reviewed Buildchain train remain unchanged.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Generated authority projections are refreshed