### PR TITLE
fix(ci): disable local checkout cache for CodeBuild

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -82,7 +82,7 @@ jobs:
       lifecycle-timeout-minutes: 105
       artifact-transfer-mode: github-artifacts
       artifact-retention-days: 14
-      checkout-cache-mode: github
+      checkout-cache-mode: off
       checkout-cache-fallback: github
       checkout-cache-github-timeout-seconds: 1200
       publish-channel: none

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -687,7 +687,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:2a23496189129a8b4d62cf12ca048f05327e6f103f744eb8b3dbce56f896f174",
+          "definitionDigest": "sha256:ddb830fef0e931abd526e3f7d0a268aee2b41eec607c2a6f5ee4a57435158919",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,7 +96,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:03ca9367883a07560b050faeac9bef402d220f751c6d75117df9a0b6a22360df"
+          "sourceRoot": "sha256:7aa718bad3854524f225c7df59059e7f027d6c33adba9d04afaa6d067aa89af2"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4b4838a62f5557e99d59afe5d1f8a744156af5b7651b93ae29894995d81afd50"
+  "registryRoot": "sha256:cefffa850f6bf513a9e5cb7858720419f0e188be79b62cfee82b3e874cf2fe9a"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -202,6 +202,8 @@ test('AWS Linux burst workflow is trusted exact-train qualification only', () =>
   assert.match(workflow, /publish-channel: none/);
   assert.match(workflow, /release-candidate: false/);
   assert.match(workflow, /artifact-transfer-mode: github-artifacts/);
+  assert.match(workflow, /checkout-cache-mode: off/);
+  assert.doesNotMatch(workflow, /checkout-cache-mode: (?:auto|require|github)/);
   assert.doesNotMatch(
     workflow,
     /secrets:|notar|signing|npm-publish|release-new-version|deploy/,


### PR DESCRIPTION
## Summary

- Set the AWS CodeBuild qualification checkout cache mode to `off`.
- Fetch the locked Buildchain runtime and consumer source directly from GitHub on the cloud runner.
- Add a regression assertion and refresh workflow/publication authority roots from current dev.

## Verification

- `node --test scripts/buildchain-install.test.mjs` (7/7)
- `./shifu check:source` (build-free source gate passed)
- Full staged commit gate passed on current `dev/v4/v4.0`.

## Live regression

Run `30377374760` proved the v4 CodeConnections webhook and CodeBuild runner path, then failed because `checkout-cache-mode: github` is outside the current `off / auto / require` contract. `off` is intentional for the cloud runner so it does not attempt the office-only `192.168.100.222` mirror before the exact GitHub fetch.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects a bounded CI configuration value without changing product or architecture contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- No credentials, OIDC, signing, publication, or deployment authority is added.
- Exact-source trust gates and the dedicated reviewed Buildchain train remain unchanged.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Generated authority projections are refreshed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoibm9uLW5hdGl2ZS1mYXN0IiwiZGV2SGVhZCI6ImI4YmQyZDgxMTk1NGRlZWI3MTU0NjQ0OWFkOTJiZjczNTEyYzAxMTMiLCJwdWxsUmVxdWVzdEhlYWQiOiI0NmM5YTcwOTIzZTZlNmQ1MTk3NzNmMzQyZTExNTQ0MTBlM2E2N2ZlIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiIwNzJkNzE4ZGJhYjQ1ZjMzNTdlMWFiNmNkYTkyYTRhMDQ0NTAyOGFiIiwicmVwbGF5ZWRUcmVlIjoiOWZkOTQyOTU0NzAxYzQwNjI2ZTI3MDA4N2MxZDQzNzFhZTAwYTVjOCIsInF1ZXVlQXR0ZW1wdCI6IjQ2YzlhNzA5MjNlNmU2ZDUxOTc3M2YzNDJlMTE1NDQxMGUzYTY3ZmVAYjhiZDJkODExOTU0ZGVlYjcxNTQ2NDQ5YWQ5MmJmNzM1MTJjMDExMyIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjphZDJiZjc3MGM1NWZkNDVlMjM2YzA4ZWVmZGU3OWFkN2E4MTk5NTE4ZDMzOGU2N2E1MDQxY2M0YmQwOWM5NDE3IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6NWNkMjJhZDgxYTdhNzc4ZjJlNWJmYWYyOWNlZTk1YjVhZTc5YjgyNDA0ZmRkZDNlYjBiNWUxYTg4MGFjZjJlZCIsInNoYTI1NjphZDJiZjc3MGM1NWZkNDVlMjM2YzA4ZWVmZGU3OWFkN2E4MTk5NTE4ZDMzOGU2N2E1MDQxY2M0YmQwOWM5NDE3Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1NjoxNzI1YWI2Y2MxZmZhZGQzZmI0YjQ1ZGNmOGU1OWZiMDc2NThlNmJjZmJlYWViYWNlZTk1OTZjNDY4ZWY1OWFiIn0 -->