### PR TITLE
fix(rewind): bind adapter launch to exact package root

### DIFF
--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -22,7 +22,7 @@ import os
 import json
 from collections.abc import Iterator
 
-from kungfu import kfx_contract, kfx_host
+from kungfu import kfx_contract, kfx_host, profile_sdk
 
 ENV_EXTENSION_PATH = "KF_EXTENSION_PATH"
 ENV_HOST_DESCRIPTOR = "KF_KFX_HOST_DESCRIPTOR"
@@ -102,6 +102,10 @@ def discover_adapters(
                 continue
             seen.add(path)
             key = kfx.get("key")
+            try:
+                package_root = profile_sdk.package_content_root(pkg)
+            except (OSError, ValueError):
+                package_root = None
             authorization = None
             if descriptor is not None and key:
                 for candidate in descriptor.get("runtimeAuthorizations", []):
@@ -117,6 +121,11 @@ def discover_adapters(
                                 candidate.get("authorizationRoot", ""),
                             )
                         except ValueError:
+                            authorization = None
+                        if (
+                            authorization is not None
+                            and authorization.get("packageRoot") != package_root
+                        ):
                             authorization = None
                         break
             if authorization is None:

--- a/framework/core/tests/python/test_adapter_trust.py
+++ b/framework/core/tests/python/test_adapter_trust.py
@@ -7,6 +7,7 @@
 import json
 import os
 
+from kungfu import profile_sdk
 from kungfu.rewind import adapters
 
 
@@ -38,7 +39,7 @@ def _write_adapter(root, key, runtime="python"):
     return pkg
 
 
-def _host_descriptor(package_key, authorization_root):
+def _host_descriptor(package_key, package_root, authorization_root):
     roots = {
         name: f"sha256:{character * 64}"
         for name, character in {
@@ -67,7 +68,7 @@ def _host_descriptor(package_key, authorization_root):
     authorization = {
         "schema": "kungfu.kfx.host-authorization/v2",
         "packageKey": package_key,
-        "packageRoot": roots["package"],
+        "packageRoot": package_root,
         "manifestRoot": roots["manifest"],
         "ownerProviderRoot": roots["provider"],
         "trustRoot": roots["trust"],
@@ -133,7 +134,13 @@ def _host_descriptor(package_key, authorization_root):
 def _write_descriptor(tmp_path, monkeypatch, package_key, authorization_root):
     path = tmp_path / "host-descriptor.json"
     path.write_text(
-        json.dumps(_host_descriptor(package_key, authorization_root)),
+        json.dumps(
+            _host_descriptor(
+                package_key,
+                profile_sdk.package_content_root(tmp_path / "extensions" / package_key),
+                authorization_root,
+            )
+        ),
         encoding="utf-8",
     )
     monkeypatch.setenv("KF_KFX_HOST_DESCRIPTOR", str(path))
@@ -168,11 +175,37 @@ def test_only_the_exact_core_authorization_allows_in_process_injection(
 
 def test_mismatched_authorization_root_fails_closed(tmp_path, monkeypatch):
     _setup(tmp_path, monkeypatch)
-    descriptor = _host_descriptor("bundled-a", f"sha256:{'4' * 64}")
+    descriptor = _host_descriptor(
+        "bundled-a",
+        profile_sdk.package_content_root(tmp_path / "extensions" / "bundled-a"),
+        f"sha256:{'4' * 64}",
+    )
     descriptor["admission"]["runtimeAuthorizationRoots"][0] = f"sha256:{'5' * 64}"
     path = tmp_path / "host-descriptor.json"
     path.write_text(json.dumps(descriptor), encoding="utf-8")
     monkeypatch.setenv("KF_KFX_HOST_DESCRIPTOR", str(path))
+
+    entries, dirs, refused = adapters.discover_adapters(None, "python")
+    assert entries == [] and dirs == []
+    assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
+
+
+def test_same_key_with_different_package_root_cannot_borrow_authority(
+    tmp_path, monkeypatch
+):
+    _setup(tmp_path, monkeypatch)
+    authorization_root = f"sha256:{'4' * 64}"
+    _write_descriptor(tmp_path, monkeypatch, "external-b", authorization_root)
+    adapter = (
+        tmp_path
+        / "extensions"
+        / "external-b"
+        / "src"
+        / "adapter"
+        / "python"
+        / "index.py"
+    )
+    adapter.write_text("# different adapter source\n", encoding="utf-8")
 
     entries, dirs, refused = adapters.discover_adapters(None, "python")
     assert entries == [] and dirs == []

--- a/tests/fixtures/_harness.mjs
+++ b/tests/fixtures/_harness.mjs
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   qualificationAuthority,
+  qualificationHostDescriptor,
   removalAuthority,
 } from './_kfx-authority.mjs';
 
@@ -185,6 +186,34 @@ export function kfxQualificationAuthorityFile(
       repoDir,
       inspected.package.packageRoot,
       inspected.package.declaredCapabilities,
+    ),
+  );
+}
+
+/** Build a qualification-only host descriptor bound to one exact package closure. */
+export function kfxQualificationHostDescriptorFile(
+  coreDir,
+  home,
+  sourceRoot,
+  packageKey,
+  runtime,
+) {
+  const inspected = json(
+    kfc(coreDir, home, [
+      'kfx',
+      'native',
+      'inspect',
+      packageKey,
+      '--root',
+      `workspace=${sourceRoot}`,
+    ]),
+  );
+  return writeFixtureJson(
+    'kfx-qualification-host-',
+    qualificationHostDescriptor(
+      packageKey,
+      inspected.package.packageRoot,
+      runtime,
     ),
   );
 }

--- a/tests/fixtures/_kfx-authority.mjs
+++ b/tests/fixtures/_kfx-authority.mjs
@@ -6,6 +6,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import crypto from 'node:crypto';
 
 const APPROVAL_ROOT = `sha256:${'a'.repeat(64)}`;
 const HIGH_CONSEQUENCE_CAPABILITIES = new Set([
@@ -17,6 +18,19 @@ const HIGH_CONSEQUENCE_CAPABILITIES = new Set([
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+function qualificationRoot(label, packageRoot) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify({
+        schema: 'kungfu.kfx-qualification-root/v1',
+        label,
+        packageRoot,
+      }),
+    )
+    .digest('hex')}`;
 }
 
 export function qualificationAuthority(
@@ -85,5 +99,78 @@ export function removalAuthority(packageRoot, status, nonce) {
       expiresAt: authorizationTime + 100,
       nonce,
     },
+  };
+}
+
+export function qualificationHostDescriptor(packageKey, packageRoot, runtime) {
+  const root = (label) => qualificationRoot(label, packageRoot);
+  const cutRoot = root('cut');
+  const generationRoot = root('generation');
+  const authorizationRoot = root(`adapter-${runtime}-authorization`);
+  const authorization = {
+    schema: 'kungfu.kfx.host-authorization/v2',
+    packageKey,
+    packageRoot,
+    manifestRoot: root('manifest'),
+    ownerProviderRoot: root('owner-provider'),
+    trustRoot: root('trust'),
+    runtimeTier: 'integrated-explicit',
+    admissionGrade: 'kfd-attested',
+    placement: 'co-resident',
+    requiredCapabilities: [],
+    grantedCapabilities: [],
+    reportRoot: root('report'),
+    admissionPlanRoot: root('admission-plan'),
+    corePolicyRoot: root('core-policy'),
+    requestedPolicyRoot: root('requested-policy'),
+    policyRoot: root('policy'),
+    authorizationPlanRoot: root('authorization-plan'),
+    capabilityDeclarationRoot: root('capability-declaration'),
+    capabilityGrantRoot: root('capability-grant'),
+    warrantRoot: root('warrant'),
+    cutRoot,
+    revision: 1,
+    generationRoot,
+    executionAllowed: true,
+    authorizationRoot,
+    host: `adapter-${runtime}`,
+  };
+  const registryRoot = root('registry');
+  const graphRoot = root('graph');
+  return {
+    schema: 'kungfu.kfx.experience-flow-host/v3',
+    descriptorRoot: root('descriptor'),
+    registryRoot,
+    graphRoot,
+    planRoot: root('plan'),
+    receiptDependencyRoot: root('receipt-dependency'),
+    cutRoot,
+    revision: 1,
+    generation: {
+      schema: 'kungfu.kfx.host-generation/v2',
+      registryRoot,
+      graphRoot,
+      cutRoot,
+      revision: 1,
+    },
+    generationRoot,
+    admission: {
+      schema: 'kungfu.kfx.host-admission/v2',
+      state: 'admitted',
+      exactRootRequired: true,
+      registryRoot,
+      graphRoot,
+      planRoot: root('plan'),
+      cutRoot,
+      revision: 1,
+      generationRoot,
+      contributionRoots: [],
+      facetRoots: [],
+      capabilityRoots: [],
+      authorizationRoots: [],
+      runtimeAuthorizationRoots: [authorizationRoot],
+    },
+    runtimeAuthorizations: [authorization],
+    contributions: [],
   };
 }

--- a/tests/fixtures/rewind-demo-langchain/run.mjs
+++ b/tests/fixtures/rewind-demo-langchain/run.mjs
@@ -29,10 +29,13 @@ import {
   uvPython,
   run,
   fail,
+  extractPackedKfx,
+  kfxQualificationHostDescriptorFile,
 } from '../_harness.mjs';
 
 const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
+const repoDir = path.resolve(coreDir, '..', '..');
 
 // ── provision the real framework (cached across runs) ────────────────
 const venv = path.join(fixtureDir, '.venv-langchain');
@@ -61,6 +64,25 @@ if (!hasLangchain()) {
 const home = tmpDir('rewind-langchain-');
 const runId = `fixturelangchain${Date.now()}`;
 
+// Adapter injection is an in-process host launch, so a workspace directory or
+// package name grants no authority. Exercise the same pack, exact-root
+// qualification and Core registry path a real installation uses, then bind the
+// trace to the resulting current host descriptor.
+const packdir = tmpDir('rewind-langchain-pack-');
+const extDir = path.join(repoDir, 'extensions', 'langchain-adapter');
+const packed = run('npm', ['pack', '--pack-destination', packdir], { cwd: extDir });
+const tgzName = packed.stdout.trim().split(/\r?\n/).pop();
+const tgz = path.join(packdir, tgzName);
+if (!fs.existsSync(tgz)) fail('npm pack produced no LangChain adapter tgz');
+const packedRoot = extractPackedKfx(coreDir, tgz);
+const hostDescriptor = kfxQualificationHostDescriptorFile(
+  coreDir,
+  home,
+  packedRoot,
+  'langchain-adapter',
+  'python',
+);
+
 // deterministic model upstream: the mock (stdlib only, system python3) binds an
 // ephemeral port and reports it; the supervisor picks it up as the openai
 // forward target and points the child's ChatOpenAI at its own proxy.
@@ -69,11 +91,11 @@ background(PY, [path.join(fixtureDir, 'mock_model.py'), portFile]);
 const port = waitForFile(portFile);
 const openaiBaseUrl = `http://127.0.0.1:${port}/v1`;
 
-// The LangChain adapter is NOT in core — it is the kfx package under
-// extensions/langchain-adapter. Point the extension root at the workspace
-// extensions tree so the supervisor discovers and injects it; capture of an
-// unmodified langchain run therefore comes from the package, not the kernel.
-const extRoot = path.resolve(coreDir, '..', '..', 'extensions');
+// The adapter remains product-disabled without an explicit runtime grant. This
+// qualification-only descriptor proves the authorized capture path while the
+// exact package-root check prevents a same-key workspace package from borrowing
+// authority issued to different bytes.
+const extRoot = path.resolve(repoDir, 'extensions');
 const kfExtensionPath = process.env.KF_EXTENSION_PATH
   ? `${extRoot}${path.delimiter}${process.env.KF_EXTENSION_PATH}`
   : extRoot;
@@ -88,6 +110,7 @@ kfc(
       // the openai SDK refuses to construct a client without a key; the proxy
       // never forwards request headers, so this dummy never leaves the machine
       OPENAI_API_KEY: 'sk-langchain-fixture',
+      KF_KFX_HOST_DESCRIPTOR: hostDescriptor,
       KF_EXTENSION_PATH: kfExtensionPath,
     },
   },


### PR DESCRIPTION
Atlas goal 2026-07-26-kungfu-kfd-support-governance. Fixes #1761 by binding qualification-only LangChain adapter injection to the exact package closure while keeping product execution fail-closed without explicit Core authority.


## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the qualification fixture under the already accepted exact-root Core host authority and closes a same-key package-root borrowing gap; it does not widen product adapter execution authority or change architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI2LWt1bmdmdS1rZmQtc3VwcG9ydC1nb3Zlcm5hbmNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiI5MDRjM2M5YzFhNmMzNjAwZDQ0N2YwNDM4NzZiZWY0YTRiN2MxN2RmIiwicHVsbFJlcXVlc3RIZWFkIjoiNDVkZTJmZGFjNDc5NTE3ZDU5YTc1Zjk1YjU1NGM1NDc2YjBhNDY4MiIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMjdlMTMzYTk5N2E1ZjBmNjg0YTliNGE1YjJlOTFlYmU1NDhhYzc2YyIsInJlcGxheWVkVHJlZSI6ImE0MmE1MTYyODcwOWY4MjcxMDlhYmU0OGMzMzJjMDc1ZDI0M2VhYTEiLCJxdWV1ZUF0dGVtcHQiOiI0NWRlMmZkYWM0Nzk1MTdkNTlhNzVmOTViNTU0YzU0NzZiMGE0NjgyQDkwNGMzYzljMWE2YzM2MDBkNDQ3ZjA0Mzg3NmJlZjRhNGI3YzE3ZGYiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6ZTU5MzY3ZjBkN2YwN2IzYzA4ZDk0YmMwNjk3NmU5NzAzMDFmMjhmNWYwNmIzMjQ0MjFjZjU3ZDMyNTM0NjhlYSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjJmMTIxMjlhMTM5MWIzMjQxYzM3Y2NkOTRlMDQ2ODcwZTAyOTMyZjlhNzZhOTBmZjQyODY1OTFmYmU3ODdhMjIiLCJzaGEyNTY6ZTU5MzY3ZjBkN2YwN2IzYzA4ZDk0YmMwNjk3NmU5NzAzMDFmMjhmNWYwNmIzMjQ0MjFjZjU3ZDMyNTM0NjhlYSJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6ZjhiZmU2ZDhjMTY0MTUxZWY4NDljMTQ4ZGJmMTZhNWI0ODJmNTg5YzU0M2Q1YTEyNWFhNTI1MDVkZmM3ZmEwYiJ9 -->