### PR TITLE
fix(ci): use public Cargo index for CodeBuild

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -67,7 +67,7 @@ jobs:
       rust-toolchain: "1.96.0"
       rustup-dist-server: https://rsproxy.cn
       rustup-update-root: https://rsproxy.cn/rustup
-      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
+      cargo-registry-index: sparse+https://index.crates.io/
       artifact-name: kungfu-aws-linux-burst-${{ inputs.qualification-id }}
       artifact-paths: |
         product/release/qualification/aws-codebuild-linux.json

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -687,7 +687,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:ddb830fef0e931abd526e3f7d0a268aee2b41eec607c2a6f5ee4a57435158919",
+          "definitionDigest": "sha256:3cb40b01b4d8c808f57679f528d62ef30e921124499b1a0c457962efef53fac6",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,7 +96,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:7aa718bad3854524f225c7df59059e7f027d6c33adba9d04afaa6d067aa89af2"
+          "sourceRoot": "sha256:2b03a46bb83a1470e6e9be8d427bef54fe0cd6f64e42c7087645b17a069cbe90"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:cefffa850f6bf513a9e5cb7858720419f0e188be79b62cfee82b3e874cf2fe9a"
+  "registryRoot": "sha256:be60b83ee8ce1610f0657705f0f9ef9acbea8dd2a3e5b7e1ddfa7cbd225a4a7d"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -204,6 +204,11 @@ test('AWS Linux burst workflow is trusted exact-train qualification only', () =>
   assert.match(workflow, /artifact-transfer-mode: github-artifacts/);
   assert.match(workflow, /checkout-cache-mode: off/);
   assert.doesNotMatch(workflow, /checkout-cache-mode: (?:auto|require|github)/);
+  assert.match(
+    workflow,
+    /cargo-registry-index: sparse\+https:\/\/index\.crates\.io\//,
+  );
+  assert.doesNotMatch(workflow, /BUILDCHAIN_CARGO_REGISTRY_INDEX/);
   assert.doesNotMatch(
     workflow,
     /secrets:|notar|signing|npm-publish|release-new-version|deploy/,


### PR DESCRIPTION
## Summary

- bind the AWS CodeBuild Linux burst qualification to the public crates.io sparse index
- keep office-only Cargo mirror configuration out of the cloud runner contract
- refresh governed workflow and publication projections

## Verification

- `node --test scripts/buildchain-install.test.mjs` (7/7)
- `./shifu check:source` (passed)
- staged pre-commit gate (passed)
- workflow authority closed-world verification (passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Cloud qualification transport configuration does not alter an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This touches a provider qualification boundary but adds no credentials, publication, or release authority. Validation is listed above.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoibm9uLW5hdGl2ZS1mYXN0IiwiZGV2SGVhZCI6IjJiZDQzNzc3ZTYxYmY3MjcyNTIyNWE4NWJmOTZiYWRhMDI0YjUwYWEiLCJwdWxsUmVxdWVzdEhlYWQiOiIwYzY4NDFhOWQxMmEyM2NkZDEzZDMyMmIxZWRmNmZkYjk1YjIwZWUyIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiIyZTgyOTZjYmM5ZGE3NmIxMmU0ODAyZmMyMDA5ZjM4YTkyMTUwNGJlIiwicmVwbGF5ZWRUcmVlIjoiODg3OWM0MTg4ZTRiMjhmYjk1ZGZjNmNhN2UxY2QwZTU4NjViODE2YSIsInF1ZXVlQXR0ZW1wdCI6IjBjNjg0MWE5ZDEyYTIzY2RkMTNkMzIyYjFlZGY2ZmRiOTViMjBlZTJAMmJkNDM3NzdlNjFiZjcyNzI1MjI1YTg1YmY5NmJhZGEwMjRiNTBhYSIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1Njo2NTU2NGQ2MDc4YmFiZDk2NjVkMDVlZmU0NDgyMzcyOWY5MzlmY2QwYmEyNmJlNDk3M2IyOTQ1ZDVkZDFjNDM5IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6NWNkMjJhZDgxYTdhNzc4ZjJlNWJmYWYyOWNlZTk1YjVhZTc5YjgyNDA0ZmRkZDNlYjBiNWUxYTg4MGFjZjJlZCIsInNoYTI1Njo2NTU2NGQ2MDc4YmFiZDk2NjVkMDVlZmU0NDgyMzcyOWY5MzlmY2QwYmEyNmJlNDk3M2IyOTQ1ZDVkZDFjNDM5Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1NjpkZTA4M2Q5ZTM2MzA5MGIwN2VmMGVjMTFiNTMxYWI1ZTMwODMzNGNmMTBhN2E0YmExODYzYmQ0Y2EyODA0MjgzIn0 -->