### PR TITLE
fix(kfx): enforce native adapter host authority

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
@@ -642,6 +642,7 @@ snapshot build_snapshot(const json &request) {
       keys[key] = package_path;
       const auto closure = package_closure(package_path);
       const auto native_contract = native_kfx_contract();
+      const auto hosts = host_placements(manifest);
       json package = {{"key", key},
                       {"name", manifest.value("name", "")},
                       {"version", manifest.value("version", "")},
@@ -661,7 +662,7 @@ snapshot build_snapshot(const json &request) {
                       {"admissionGrade", "unverified"},
                       {"supplyChainGrade", "unverified"},
                       {"grantedCapabilities", json::array()},
-                      {"hosts", host_placements(manifest)},
+                      {"hosts", hosts},
                       {"semantic", object_or_empty(manifest.at("kungfuConfig"), "registry")},
                       {"candidate", true},
                       {"installed", false},
@@ -977,7 +978,7 @@ std::string runtime_placement(const std::string &host) {
   if (host.starts_with("service-"))
     return "process-isolated";
   if (host.starts_with("adapter-"))
-    return "integrated-disabled";
+    return "integrated-explicit";
   if (host == "profile")
     return "metadata-only";
   refuse("KF_KFX_HOST_UNKNOWN", "Core cannot derive a physical placement for host " + host);

--- a/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
@@ -261,7 +261,7 @@ public:
                                                object_or_empty(options.operation_options, "document"));
     }
     if (action == "list" || action == "inspect" || action == "resolve" || action == "plan" || action == "status" ||
-        action == "assess" || action == "apply" || action == "history") {
+        action == "assess" || action == "apply" || action == "authorize-host" || action == "history") {
       return kfx::query_native_kfx_registry(action, object_or_empty(options.operation_options, "request"),
                                             options.runtime_dir);
     }

--- a/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
@@ -991,6 +991,64 @@ void test_native_lifecycle_uses_fact_work_and_named_cut_authority() {
   fs::remove_all(home);
 }
 
+void test_native_adapter_authority_requires_the_current_fact_cut() {
+  const auto home = temp_root("adapter-authority");
+  const auto source_root = home / "sources";
+  const auto package_source = source_root / "trace-adapter";
+  const auto runtime_dir = home / "runtime";
+  fs::create_directories(package_source);
+  auto manifest = nlohmann::json::object();
+  manifest["schema"] = "kungfu.kfx.manifest/v1";
+  manifest["name"] = "@kungfu-test/trace-adapter";
+  manifest["version"] = "1.0.0";
+  manifest["kungfuConfig"]["key"] = "trace-adapter";
+  manifest["kungfuConfig"]["config"]["adapter"]["runtimes"] = nlohmann::json::array({"python"});
+  manifest["kungfuConfig"]["config"]["adapter"]["entry"] = {{"python", "index.py"}};
+  manifest["kungfuConfig"]["config"]["adapter"]["capabilities"] = nlohmann::json::array();
+  write_json(package_source / "kungfu.kfx.json", manifest);
+  std::ofstream(package_source / "index.py") << "# qualification adapter\n";
+
+  const auto source_request = passport_authorized_request(
+      {{"roots", nlohmann::json::array({{{"kind", "workspace"}, {"path", source_root.string()}}})}}, "trace-adapter",
+      "install", runtime_dir.string());
+  const auto preview = kfx::query_native_kfx_registry("plan", source_request, runtime_dir.string());
+  const auto &preview_authorization = preview.at("hostContract").at("runtimeAuthorizations").front();
+  require(preview.at("packages").front().at("runtimeTier") == "isolated" &&
+              preview_authorization.at("placement") == "integrated-explicit" &&
+              !preview_authorization.at("executionAllowed").get<bool>(),
+          "adapter preview either gained authority or lost its Core-derived integrated placement");
+
+  const auto installed = kfx::query_native_kfx_registry(
+      "apply", mutation_request(source_request, preview, "trace-adapter", "install"), runtime_dir.string());
+  const auto admitted = kfx::query_native_kfx_registry("plan", nlohmann::json::object(), runtime_dir.string());
+  const auto &descriptor = admitted.at("hostContract");
+  const auto &authorization = descriptor.at("runtimeAuthorizations").front();
+  require(installed.at("receipt").at("outcome") == "applied" && authorization.at("host") == "adapter-python" &&
+              authorization.at("runtimeTier") == "isolated" && authorization.at("placement") == "integrated-explicit" &&
+              authorization.at("executionAllowed").get<bool>(),
+          "settled adapter did not receive one exact native integrated authorization");
+
+  const nlohmann::json launch_request = {{"packageKey", "trace-adapter"},
+                                         {"host", "adapter-python"},
+                                         {"expectedCutRoot", descriptor.at("cutRoot")},
+                                         {"expectedRevision", descriptor.at("revision")},
+                                         {"expectedGenerationRoot", descriptor.at("generationRoot")},
+                                         {"expectedPackageRoot", authorization.at("packageRoot")},
+                                         {"expectedCapabilityGrantRoot", authorization.at("capabilityGrantRoot")},
+                                         {"expectedAuthorizationRoot", authorization.at("authorizationRoot")},
+                                         {"expectedGrantedCapabilities", authorization.at("grantedCapabilities")}};
+  const auto launch = kfx::query_native_kfx_registry("authorize-host", launch_request, runtime_dir.string());
+  require(launch.at("executionAllowed").get<bool>() &&
+              launch.at("authorization").at("authorizationRoot") == authorization.at("authorizationRoot"),
+          "native adapter launch did not revalidate the current Fact Cut authorization");
+
+  auto replayed = launch_request;
+  replayed["expectedAuthorizationRoot"] = fixture_root('f');
+  require_refusal("KF_KFX_AUTHORIZATION_STALE",
+                  [&] { (void)kfx::query_native_kfx_registry("authorize-host", replayed, runtime_dir.string()); });
+  fs::remove_all(home);
+}
+
 void test_control_suite_recursively_dogfoods_public_fact_work() {
   const auto home = temp_root("control-suite");
   const auto runtime_dir = home / "runtime";
@@ -1106,6 +1164,7 @@ int main() {
     test_exact_buildchain_attestation_and_operation_admission();
     test_semantic_graph_and_host_contract_are_canonical();
     test_native_lifecycle_uses_fact_work_and_named_cut_authority();
+    test_native_adapter_authority_requires_the_current_fact_cut();
     test_control_suite_recursively_dogfoods_public_fact_work();
     std::cout << "native KFX contract tests passed\n";
     return 0;

--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -19,13 +19,12 @@
 from __future__ import annotations
 
 import os
-import json
 from collections.abc import Iterator
 
-from kungfu import kfx_contract, kfx_host, profile_sdk
+from kungfu import kfx_contract
+from kungfu.storage import service as storage_service
 
 ENV_EXTENSION_PATH = "KF_EXTENSION_PATH"
-ENV_HOST_DESCRIPTOR = "KF_KFX_HOST_DESCRIPTOR"
 # shared contract strings with the child hooks (per runtime): the python hook
 # reads ENV_PLUGIN_ADAPTERS, the node hook reads ENV_NODE_ADAPTERS.
 ENV_PLUGIN_ADAPTERS = "KUNGFU_REWIND_ADAPTERS"
@@ -69,16 +68,18 @@ def discover_adapters(
     package path wins; missing entry files are skipped.
 
     An adapter runs in-process inside the traced program and cannot be sandboxed,
-    so injection requires the exact Core host authorization for this package and
-    adapter runtime. Discovery origin and package identity carry no authority.
+    so injection requires the exact native host authorization from the current
+    KFX Fact Cut. The discovered closure must match that authorization before
+    native ``authorize-host`` revalidates its generation and roots. Discovery
+    origin, caller-provided descriptors, and package identity carry no authority.
     """
     descriptor = None
-    descriptor_path = os.environ.get(ENV_HOST_DESCRIPTOR)
-    if descriptor_path:
+    if runtime_dir:
         try:
-            with open(descriptor_path, encoding="utf-8") as descriptor_file:
-                descriptor = json.load(descriptor_file)
-        except (OSError, ValueError):
+            descriptor = storage_service.kfx_registry("plan", {}, runtime_dir).get(
+                "hostContract"
+            )
+        except (OSError, RuntimeError, ValueError):
             descriptor = None
     entries: list[str] = []
     dirs: list[str] = []
@@ -102,30 +103,62 @@ def discover_adapters(
                 continue
             seen.add(path)
             key = kfx.get("key")
-            try:
-                package_root = profile_sdk.package_content_root(pkg)
-            except (OSError, ValueError):
-                package_root = None
             authorization = None
             if descriptor is not None and key:
+                observed = None
+                try:
+                    observed = storage_service.kfx_registry(
+                        "inspect",
+                        {
+                            "roots": [{"kind": "workspace", "path": pkg}],
+                            "packageKey": key,
+                        },
+                        "",
+                    ).get("package")
+                except (OSError, RuntimeError, ValueError):
+                    observed = None
                 for candidate in descriptor.get("runtimeAuthorizations", []):
                     if (
                         candidate.get("packageKey") == key
                         and candidate.get("host") == f"adapter-{runtime}"
+                        and isinstance(observed, dict)
+                        and observed.get("packageRoot") == candidate.get("packageRoot")
+                        and observed.get("manifestRoot")
+                        == candidate.get("manifestRoot")
                     ):
                         try:
-                            authorization = kfx_host.authorize_host_launch(
-                                descriptor,
-                                key,
-                                f"adapter-{runtime}",
-                                candidate.get("authorizationRoot", ""),
+                            launch = storage_service.kfx_registry(
+                                "authorize-host",
+                                {
+                                    "packageKey": key,
+                                    "host": f"adapter-{runtime}",
+                                    "expectedCutRoot": descriptor.get("cutRoot"),
+                                    "expectedRevision": descriptor.get("revision"),
+                                    "expectedGenerationRoot": descriptor.get(
+                                        "generationRoot"
+                                    ),
+                                    "expectedPackageRoot": candidate.get("packageRoot"),
+                                    "expectedCapabilityGrantRoot": candidate.get(
+                                        "capabilityGrantRoot"
+                                    ),
+                                    "expectedAuthorizationRoot": candidate.get(
+                                        "authorizationRoot"
+                                    ),
+                                    "expectedGrantedCapabilities": candidate.get(
+                                        "grantedCapabilities", []
+                                    ),
+                                },
+                                runtime_dir,
                             )
-                        except ValueError:
-                            authorization = None
-                        if (
-                            authorization is not None
-                            and authorization.get("packageRoot") != package_root
-                        ):
+                            authorization = launch.get("authorization")
+                            if (
+                                launch.get("executionAllowed") is not True
+                                or not isinstance(authorization, dict)
+                                or authorization.get("authorizationRoot")
+                                != candidate.get("authorizationRoot")
+                            ):
+                                authorization = None
+                        except (OSError, RuntimeError, ValueError):
                             authorization = None
                         break
             if authorization is None:

--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -148,7 +148,7 @@ def discover_adapters(
                                         "grantedCapabilities", []
                                     ),
                                 },
-                                runtime_dir,
+                                runtime_dir or "",
                             )
                             authorization = launch.get("authorization")
                             if (

--- a/framework/core/src/python/kungfu/storage/service.py
+++ b/framework/core/src/python/kungfu/storage/service.py
@@ -909,6 +909,7 @@ def kfx_registry(
         "assess",
         "apply",
         "history",
+        "authorize-host",
     }:
         raise ValueError(f"unsupported KFX registry action: {action}")
     return dict(

--- a/framework/core/tests/python/test_adapter_trust.py
+++ b/framework/core/tests/python/test_adapter_trust.py
@@ -7,7 +7,6 @@
 import json
 import os
 
-from kungfu import profile_sdk
 from kungfu.rewind import adapters
 
 
@@ -39,7 +38,7 @@ def _write_adapter(root, key, runtime="python"):
     return pkg
 
 
-def _host_descriptor(package_key, package_root, authorization_root):
+def _host_descriptor(package_key, authorization_root):
     roots = {
         name: f"sha256:{character * 64}"
         for name, character in {
@@ -68,7 +67,7 @@ def _host_descriptor(package_key, package_root, authorization_root):
     authorization = {
         "schema": "kungfu.kfx.host-authorization/v2",
         "packageKey": package_key,
-        "packageRoot": package_root,
+        "packageRoot": roots["package"],
         "manifestRoot": roots["manifest"],
         "ownerProviderRoot": roots["provider"],
         "trustRoot": roots["trust"],
@@ -131,19 +130,63 @@ def _host_descriptor(package_key, package_root, authorization_root):
     }
 
 
-def _write_descriptor(tmp_path, monkeypatch, package_key, authorization_root):
-    path = tmp_path / "host-descriptor.json"
-    path.write_text(
-        json.dumps(
-            _host_descriptor(
-                package_key,
-                profile_sdk.package_content_root(tmp_path / "extensions" / package_key),
-                authorization_root,
+def _mock_native_authority(
+    monkeypatch, descriptor, allowed_key=None, *, observed_matches=True
+):
+    calls = []
+
+    def kfx_registry(action, request, runtime_dir):
+        calls.append((action, request, runtime_dir))
+        if action == "plan":
+            if descriptor is None:
+                raise ValueError("KF_KFX_CUT_MISSING")
+            return {"hostContract": descriptor}
+        if action == "inspect":
+            candidate = next(
+                (
+                    item
+                    for item in descriptor["runtimeAuthorizations"]
+                    if item["packageKey"] == request["packageKey"]
+                ),
+                None,
             )
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("KF_KFX_HOST_DESCRIPTOR", str(path))
+            if candidate is None or not observed_matches:
+                return {
+                    "package": {
+                        "packageRoot": f"sha256:{'e' * 64}",
+                        "manifestRoot": f"sha256:{'e' * 64}",
+                    }
+                }
+            return {
+                "package": {
+                    "packageRoot": candidate["packageRoot"],
+                    "manifestRoot": candidate["manifestRoot"],
+                }
+            }
+        if action != "authorize-host":
+            raise AssertionError(f"unexpected native KFX action: {action}")
+        candidate = next(
+            (
+                item
+                for item in descriptor["runtimeAuthorizations"]
+                if item["packageKey"] == request["packageKey"]
+                and item["host"] == request["host"]
+            ),
+            None,
+        )
+        if (
+            candidate is None
+            or request["packageKey"] != allowed_key
+            or request["expectedAuthorizationRoot"] != candidate["authorizationRoot"]
+        ):
+            raise ValueError("KF_KFX_AUTHORIZATION_STALE")
+        return {
+            "executionAllowed": True,
+            "authorization": candidate,
+        }
+
+    monkeypatch.setattr(adapters.storage_service, "kfx_registry", kfx_registry)
+    return calls
 
 
 def _setup(tmp_path, monkeypatch):
@@ -155,7 +198,10 @@ def _setup(tmp_path, monkeypatch):
 
 def test_discovery_origin_and_package_name_confer_zero_authority(tmp_path, monkeypatch):
     _setup(tmp_path, monkeypatch)
-    entries, dirs, refused = adapters.discover_adapters(None, "python")
+    _mock_native_authority(monkeypatch, None)
+    entries, dirs, refused = adapters.discover_adapters(
+        str(tmp_path / "runtime"), "python"
+    )
     assert entries == [] and dirs == []
     assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
 
@@ -165,48 +211,46 @@ def test_only_the_exact_core_authorization_allows_in_process_injection(
 ):
     _setup(tmp_path, monkeypatch)
     authorization_root = f"sha256:{'4' * 64}"
-    _write_descriptor(tmp_path, monkeypatch, "external-b", authorization_root)
+    descriptor = _host_descriptor("external-b", authorization_root)
+    calls = _mock_native_authority(monkeypatch, descriptor, "external-b")
 
-    entries, dirs, refused = adapters.discover_adapters(None, "python")
+    entries, dirs, refused = adapters.discover_adapters(
+        str(tmp_path / "runtime"), "python"
+    )
     assert len(entries) == 1
     assert {os.path.basename(path) for path in dirs} == {"external-b"}
     assert {row["key"] for row in refused} == {"bundled-a"}
+    launch = next(request for action, request, _ in calls if action == "authorize-host")
+    assert launch["expectedCutRoot"] == descriptor["cutRoot"]
+    assert launch["expectedGenerationRoot"] == descriptor["generationRoot"]
+    assert launch["expectedAuthorizationRoot"] == authorization_root
 
 
-def test_mismatched_authorization_root_fails_closed(tmp_path, monkeypatch):
+def test_caller_supplied_descriptor_conveys_zero_authority(tmp_path, monkeypatch):
     _setup(tmp_path, monkeypatch)
-    descriptor = _host_descriptor(
-        "bundled-a",
-        profile_sdk.package_content_root(tmp_path / "extensions" / "bundled-a"),
-        f"sha256:{'4' * 64}",
-    )
-    descriptor["admission"]["runtimeAuthorizationRoots"][0] = f"sha256:{'5' * 64}"
+    descriptor = _host_descriptor("bundled-a", f"sha256:{'4' * 64}")
     path = tmp_path / "host-descriptor.json"
     path.write_text(json.dumps(descriptor), encoding="utf-8")
     monkeypatch.setenv("KF_KFX_HOST_DESCRIPTOR", str(path))
+    _mock_native_authority(monkeypatch, None)
 
-    entries, dirs, refused = adapters.discover_adapters(None, "python")
-    assert entries == [] and dirs == []
-    assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
-
-
-def test_same_key_with_different_package_root_cannot_borrow_authority(
-    tmp_path, monkeypatch
-):
-    _setup(tmp_path, monkeypatch)
-    authorization_root = f"sha256:{'4' * 64}"
-    _write_descriptor(tmp_path, monkeypatch, "external-b", authorization_root)
-    adapter = (
-        tmp_path
-        / "extensions"
-        / "external-b"
-        / "src"
-        / "adapter"
-        / "python"
-        / "index.py"
+    entries, dirs, refused = adapters.discover_adapters(
+        str(tmp_path / "runtime"), "python"
     )
-    adapter.write_text("# different adapter source\n", encoding="utf-8")
-
-    entries, dirs, refused = adapters.discover_adapters(None, "python")
     assert entries == [] and dirs == []
     assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
+
+
+def test_same_key_shadow_with_different_closure_is_refused(tmp_path, monkeypatch):
+    _setup(tmp_path, monkeypatch)
+    descriptor = _host_descriptor("external-b", f"sha256:{'4' * 64}")
+    calls = _mock_native_authority(
+        monkeypatch, descriptor, "external-b", observed_matches=False
+    )
+
+    entries, dirs, refused = adapters.discover_adapters(
+        str(tmp_path / "runtime"), "python"
+    )
+    assert entries == [] and dirs == []
+    assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
+    assert not any(action == "authorize-host" for action, _, _ in calls)

--- a/framework/core/tests/python/test_native_kfx_contract.py
+++ b/framework/core/tests/python/test_native_kfx_contract.py
@@ -106,6 +106,48 @@ def test_native_kfx_python_binding_is_a_thin_core_edge(tmp_path):
         )
 
 
+def test_native_kfx_registry_python_edge_forwards_host_authorization(
+    tmp_path, monkeypatch
+):
+    calls = []
+
+    class Runtime:
+        def run_storage_service_operation(self, operation, runtime_dir, options):
+            calls.append((operation, runtime_dir, options))
+            return {"executionAllowed": False}
+
+    runtime = Runtime()
+    monkeypatch.setattr(storage_service, "_runtime", lambda: runtime)
+    request = {
+        "packageKey": "langchain-adapter",
+        "host": "adapter-python",
+        "expectedAuthorizationRoot": f"sha256:{'a' * 64}",
+    }
+
+    assert storage_service.kfx_registry("authorize-host", request, tmp_path) == {
+        "executionAllowed": False
+    }
+    assert calls == [
+        (
+            "kfx_runtime",
+            str(tmp_path),
+            {"action": "authorize-host", "request": request},
+        )
+    ]
+
+
+def test_native_kfx_registry_binding_reaches_host_authorization(tmp_path):
+    with pytest.raises(ValueError, match="KF_KFX_CUT_MISSING"):
+        storage_service.kfx_registry(
+            "authorize-host",
+            {
+                "packageKey": "langchain-adapter",
+                "host": "adapter-python",
+            },
+            tmp_path / "runtime",
+        )
+
+
 def test_native_kfx_registry_python_projection_matches_core_roots(tmp_path):
     request = _registry_request()
     plan = storage_service.kfx_registry("plan", request, tmp_path)

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:97786bb5dc87b07c0308f1b77543a3b0d6fcaa8867e9500704d1c7d4d5f99548",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:3c0ee2d0d27e39102982318767829d8c5e51c9bd91bd9bb63946731fa54bb1ad",
+  "sourceRoot": "sha256:3dbb2d08179429178d05f814d2a3781a0e7503bcf5ab500527b46cd4d0157a57",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -528,9 +528,9 @@
         },
         {
           "path": "framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp",
-          "currentLines": 2432,
+          "currentLines": 2433,
           "baselineLines": 912,
-          "currentRoot": "sha256:995abbdb23299df59066cf3503afa9f5fdb823ef0455ec5277f9f7b49d11f478",
+          "currentRoot": "sha256:98881b2110239f54706b05da88d8a847442b82782a32805aaa6d65faa9b21808",
           "baselineRoot": "sha256:9d1ca07b479450341e5c33d4740cea0835257e0b73991faf166bfc54d77ccb68",
           "changedSinceBaseline": true
         },
@@ -890,9 +890,9 @@
         },
         {
           "path": "framework/core/src/python/kungfu/storage/service.py",
-          "currentLines": 1746,
+          "currentLines": 1747,
           "baselineLines": 1737,
-          "currentRoot": "sha256:a17a43af34f898a14f69f6aab2fdea355dbe6d213fe5cc10180c598edb18e487",
+          "currentRoot": "sha256:0dd3ceeb5e6aef4dcd72e793df8e8384ca6a3159aa9eee2ec1d86429bce0e1a1",
           "baselineRoot": "sha256:41cf5713cf4db1b65cdb192bf2b34160fe1e981aa2fd52833eed3cc9f76797a7",
           "changedSinceBaseline": true
         },

--- a/tests/fixtures/rewind-demo-langchain/run.mjs
+++ b/tests/fixtures/rewind-demo-langchain/run.mjs
@@ -30,7 +30,7 @@ import {
   run,
   fail,
   extractPackedKfx,
-  kfxQualificationHostDescriptorFile,
+  kfxQualificationAuthorityFile,
 } from '../_harness.mjs';
 
 const PY = process.platform === 'win32' ? 'python' : 'python3';
@@ -64,25 +64,6 @@ if (!hasLangchain()) {
 const home = tmpDir('rewind-langchain-');
 const runId = `fixturelangchain${Date.now()}`;
 
-// Adapter injection is an in-process host launch, so a workspace directory or
-// package name grants no authority. Exercise the same pack, exact-root
-// qualification and Core registry path a real installation uses, then bind the
-// trace to the resulting current host descriptor.
-const packdir = tmpDir('rewind-langchain-pack-');
-const extDir = path.join(repoDir, 'extensions', 'langchain-adapter');
-const packed = run('npm', ['pack', '--pack-destination', packdir], { cwd: extDir });
-const tgzName = packed.stdout.trim().split(/\r?\n/).pop();
-const tgz = path.join(packdir, tgzName);
-if (!fs.existsSync(tgz)) fail('npm pack produced no LangChain adapter tgz');
-const packedRoot = extractPackedKfx(coreDir, tgz);
-const hostDescriptor = kfxQualificationHostDescriptorFile(
-  coreDir,
-  home,
-  packedRoot,
-  'langchain-adapter',
-  'python',
-);
-
 // deterministic model upstream: the mock (stdlib only, system python3) binds an
 // ephemeral port and reports it; the supervisor picks it up as the openai
 // forward target and points the child's ChatOpenAI at its own proxy.
@@ -91,14 +72,25 @@ background(PY, [path.join(fixtureDir, 'mock_model.py'), portFile]);
 const port = waitForFile(portFile);
 const openaiBaseUrl = `http://127.0.0.1:${port}/v1`;
 
-// The adapter remains product-disabled without an explicit runtime grant. This
-// qualification-only descriptor proves the authorized capture path while the
-// exact package-root check prevents a same-key workspace package from borrowing
-// authority issued to different bytes.
-const extRoot = path.resolve(repoDir, 'extensions');
-const kfExtensionPath = process.env.KF_EXTENSION_PATH
-  ? `${extRoot}${path.delimiter}${process.env.KF_EXTENSION_PATH}`
-  : extRoot;
+// The LangChain adapter is NOT in core. Pack and extract it exactly as a
+// distributable KFX, then admit those bytes into this qualification home's
+// native Fact Cut before tracing. Capture of an unmodified LangChain run
+// therefore comes from the installed, authorized package rather than the
+// kernel, a workspace identity shortcut, or a caller-provided descriptor.
+const packDir = tmpDir('rewind-langchain-pack-');
+const adapterSource = path.join(repoDir, 'extensions', 'langchain-adapter');
+const packed = run('npm', ['pack', '--pack-destination', packDir], { cwd: adapterSource });
+const tgzName = packed.stdout.trim().split(/\r?\n/).pop();
+const tgz = path.join(packDir, tgzName);
+if (!fs.existsSync(tgz)) fail('npm pack produced no LangChain adapter tgz');
+const packedRoot = extractPackedKfx(coreDir, tgz);
+const authorityFile = kfxQualificationAuthorityFile(
+  coreDir,
+  home,
+  packedRoot,
+  'langchain-adapter',
+);
+kfc(coreDir, home, ['kfx', 'install', packedRoot, '--authority-file', authorityFile]);
 
 kfc(
   coreDir,
@@ -110,8 +102,10 @@ kfc(
       // the openai SDK refuses to construct a client without a key; the proxy
       // never forwards request headers, so this dummy never leaves the machine
       OPENAI_API_KEY: 'sk-langchain-fixture',
-      KF_KFX_HOST_DESCRIPTOR: hostDescriptor,
-      KF_EXTENSION_PATH: kfExtensionPath,
+      // The qualification installs one exact admitted package into this
+      // temporary home. A workspace discovery path conveys no runtime
+      // authority and must not participate in this proof.
+      KF_EXTENSION_PATH: '',
     },
   },
 );


### PR DESCRIPTION
## Summary

Bind Rewind in-process adapter injection to the current Core-native KFX Fact Cut. Package names, discovery paths, caller environment, and stale descriptors no longer confer execution authority; the exact installed closure must match a current native host authorization.

## Related assignment

Kungfu Assignment: `2026-07-24-buildchain-linux-github-attestation`

## Changes

- derive adapter host placement and authorization only in native Core
- require exact cut, generation, package, manifest, capability-grant, and authorization roots before Python or Node adapter injection
- ignore caller-provided host descriptors and reject same-key closure shadows
- route `authorize-host` through the Python storage-service binding into native Core
- install the packed LangChain KFX into a qualification Fact Cut before the real capture fixture runs
- preserve the previously published KFX assessment and contract roots

## Verification

- repository staged gate passed, including 50/50 latency contract tests, 17/17 invariant tests, and 112/112 documentation/promotion tests
- Linux GCC 14 affected-native qualification passed 21/21 native tests on the pre-merge feature head
- Linux full Core build passed on the pre-merge feature head
- exact merged-head Linux build and runtime fixture sequence are being recorded as protected-controller evidence

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix closes an adapter authority membrane and dispatcher wiring gap under the already accepted Core-native KFX lifecycle and exact-root authority; it does not change an accepted architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change narrows in-process execution authority and retains fail-closed behavior when a current native Fact Cut or exact closure match is absent.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Focused regression coverage added

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI0LWJ1aWxkY2hhaW4tbGludXgtZ2l0aHViLWF0dGVzdGF0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiIxMjk2OWZjYzRmMzMzMzE2ODAyNDE5ZGY5YzRiZTYwNDI2OWYxZjEzIiwicHVsbFJlcXVlc3RIZWFkIjoiN2JkZTBjN2NkN2JhODZmMzM0Yzc0OTllNWQyYjUyMmExYmY5MDk4MyIsInJlcGxheWVkQ2FuZGlkYXRlIjoiZGQwNWVmNmRiYTgxYjU5MmNmNjhmZjU3ZjFlNzhlY2YxMzljY2QyYiIsInJlcGxheWVkVHJlZSI6IjYxZTI5NmNjYTRiYzg0ZmRhZTc5MjdlMTRjMjRhODJjOWViZmU1ZDgiLCJxdWV1ZUF0dGVtcHQiOiI3YmRlMGM3Y2Q3YmE4NmYzMzRjNzQ5OWU1ZDJiNTIyYTFiZjkwOTgzQDEyOTY5ZmNjNGYzMzMzMTY4MDI0MTlkZjljNGJlNjA0MjY5ZjFmMTMiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6ZTYwMGMwNmUwMjA1ODc1MGNkZDE1YjQyYmU3YTdlYTkxYmU5MDgzNmZmMjI0MGIzNGFjOTMxZGNmMDQ0ZThkOCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjM5NTJhNzBlNDkzMzM2Njg5ZTk4NTVjZjgzMjU3NDIzYjQxMTg3NWFhYzJhMWRiYjNmMjQ0MDliMTQ3NDIyYWUiLCJzaGEyNTY6ZTYwMGMwNmUwMjA1ODc1MGNkZDE1YjQyYmU3YTdlYTkxYmU5MDgzNmZmMjI0MGIzNGFjOTMxZGNmMDQ0ZThkOCJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6NmUyZTM0ZWUwNmU5M2RiZjM3Y2YxOTEwNjYyZDU0NGQ3ZmVkZDY5NDM2MTg5NWM3NmRhZGMzMTBmMDgwYWQ5OSJ9 -->