### PR TITLE
fix(ci): install CodeBuild platform optionals

### DIFF
--- a/scripts/buildchain-install.mjs
+++ b/scripts/buildchain-install.mjs
@@ -35,6 +35,15 @@ const FORBIDDEN_CODEBUILD_CREDENTIAL_ENV = [
 /** @param {NodeJS.ProcessEnv} env */
 export function installPlan(env = process.env) {
   if (env.BUILDCHAIN_CHECK_MODE !== 'source') {
+    const installArgs = [
+      LIFECYCLE_DISPATCHER,
+      'cache-apply',
+      'install',
+      '--frozen-lockfile',
+    ];
+    if (!(env.CODEBUILD_BUILD_ID && env.RUNNER_OS === 'Linux')) {
+      installArgs.push('--no-optional');
+    }
     return [
       {
         command: process.execPath,
@@ -42,13 +51,7 @@ export function installPlan(env = process.env) {
       },
       {
         command: process.execPath,
-        args: [
-          LIFECYCLE_DISPATCHER,
-          'cache-apply',
-          'install',
-          '--frozen-lockfile',
-          '--no-optional',
-        ],
+        args: installArgs,
       },
     ];
   }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -74,6 +74,17 @@ test('verify install preserves the existing Shifu lifecycle', () => {
   }
 });
 
+test('AWS CodeBuild installs the matching platform optional packages', () => {
+  const plan = installPlan({
+    BUILDCHAIN_CHECK_MODE: 'verify',
+    CODEBUILD_BUILD_ID: 'kungfu-buildchain-linux-burst-poc:build-id',
+    RUNNER_OS: 'Linux',
+  });
+  const text = JSON.stringify(plan);
+  assert.match(text, /cache-apply[^}]*install[^}]*--frozen-lockfile/);
+  assert.doesNotMatch(text, /--no-optional/);
+});
+
 test('GitHub-hosted Linux product qualification binds the admitted GCC toolchain', () => {
   assert.deepEqual(
     productToolchainBindings({


### PR DESCRIPTION
## Summary

- let real AWS CodeBuild Linux qualification install the matching platform optional packages
- keep `--no-optional` unchanged for every other runner and lifecycle
- add a focused contract test for the clean-runner libnode dependency path

## Verification

- `node --test scripts/buildchain-install.test.mjs` (8/8)
- `./shifu check:source` (721 tests: 711 passed, 10 skipped)
- `git diff --check origin/dev/v4/v4.0...HEAD`

## Delivery boundary

Trusted exact-source qualification only. No release credentials or static cloud credentials are admitted.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Cloud qualification dependency provisioning does not alter an architecture contract"
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoibm9uLW5hdGl2ZS1mYXN0IiwiZGV2SGVhZCI6ImNhMzcyZDFlNWM0ZTk3MjE5NjYzYTU3MmJkNjU3ZGU3ODBiN2JmYzYiLCJwdWxsUmVxdWVzdEhlYWQiOiIwM2JlMmQ5NGExMjhkYWYwYmQ4NzU2YzRjOGIzNmFkZmE4NzJkZTFhIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJlYzJkYTQyYmE3OGM2YmIzNWNlZTdiODFmYjA5MzQ3OTEyNzI3M2I4IiwicmVwbGF5ZWRUcmVlIjoiMTkwOGU0ODliMTgwNzM4MGE2MWUxYjA4NWFiNzBiMjMzNmY5YTBjYSIsInF1ZXVlQXR0ZW1wdCI6IjAzYmUyZDk0YTEyOGRhZjBiZDg3NTZjNGM4YjM2YWRmYTg3MmRlMWFAY2EzNzJkMWU1YzRlOTcyMTk2NjNhNTcyYmQ2NTdkZTc4MGI3YmZjNiIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjoxNDlmOWQ5MTQ3MjdkZDI2NGIxZWRkZmM5YzM3ZGRhYTdhY2RiZTBjMjQ4NDRiMjBkOTJkNTZiNjY1ZTQwNzhmIiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6MTQ5ZjlkOTE0NzI3ZGQyNjRiMWVkZGZjOWMzN2RkYWE3YWNkYmUwYzI0ODQ0YjIwZDkyZDU2YjY2NWU0MDc4ZiIsInNoYTI1Njo1Y2QyMmFkODFhN2E3NzhmMmU1YmZhZjI5Y2VlOTViNWFlNzliODI0MDRmZGRkM2ViMGI1ZTFhODgwYWNmMmVkIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1Njo1ZDI4NzcyMDViMDEyMmE0MDBlYzZmOTE3NzgzMTQ1ZjkyMDAyZmEwM2I4OTAyY2UyNWFjYTJiM2NkNDA5M2FhIn0 -->