### PR TITLE
fix(ci): separate qualification proof identity

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -282,6 +282,7 @@ jobs:
             --pull-request "$pr_number" \
             --pull-request-head "$pr_head" \
             --dev-head "$GITHUB_BASE_SHA" \
+            --candidate-head "$GITHUB_HEAD_SHA" \
             --candidate-tree "$candidate_tree" \
             --pr-body "$RUNNER_TEMP/family-pr-body.txt" \
             --status-file "$RUNNER_TEMP/family-status.json" \

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -242,6 +242,11 @@ but historical conflict and retry gaps remain part of the measured tail.
 These measurements do not relax affected-native proof identity. Reuse remains
 bound to the exact base, candidate source tree, plan projection, partitions,
 tier, receipt, hosted-runner image, and observed compiler/CMake/Ninja evidence.
+A reusable qualification id excludes the transient family lease, required
+status snapshot, and queue-attempt binding. Those delivery facts remain
+fail-closed in the descriptor and are sealed independently into the
+merge-group delivery attempt and cache-promotion authority; they cannot
+authorize a different source, plan, toolchain, or SDK obligation.
 A successful PR run may publish proof only after its complete required native,
 SDK, Shifu, and KFD dependency graph passes. The matching merge-group may
 consume that proof, and a serialized repeat may consume a same-SHA queue proof,

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -170,6 +170,11 @@ Each section is bound to the registry id by the catalog meta gate.
   compiler/CMake/Ninja facts. Moved bases, changed trees/toolchains, expired or
   untrusted evidence, and every lookup/download/verification failure run the
   full required set.
+  The reusable qualification id intentionally excludes the transient family
+  lease, required-status snapshot, and queue-attempt binding. The current
+  merge-group descriptor must still validate those facts, and its delivery
+  attempt and cache-promotion authority seal their exact binding root
+  independently before admission.
   The producer workflow must itself be completed-success, so the source-bound
   plan also proves that its SDK, Shifu, and KFD obligations passed before a
   repeated run can skip them. The probe descriptor is handed unchanged to the

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -477,7 +477,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5b5b215982086bb9ae947aa28749bd2b329431871d57add56a7eeb869c876e0e",
+          "definitionDigest": "sha256:9561cd41d2b32fd3002ae936789654c3160fb330af8eb5b12878f111b42ba780",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"],
           "steps": [
@@ -499,7 +499,7 @@
             {
               "index": 4,
               "label": "id:delivery",
-              "definitionDigest": "sha256:8cd648d1975633976c118d51b2f201e51b73a241b6611005719d976c33f4754e"
+              "definitionDigest": "sha256:5add98bf62d272dc66b4c5a051d990364e979b3f38bae42ef14083a60648104f"
             },
             {
               "index": 5,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:b1087073ae2f8599fd54e25933cbec0dda0f48b0ff6f934352c11fa27e6dd613"
+          "sourceRoot": "sha256:b63858718028af011d01fc21bacf949de805d10c49c3ea63313df0ac6c801a18"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:870bc55d5f178a6b5afe002fbd44b2e171e6a2b987d076adaeade281feaf8f00"
+  "registryRoot": "sha256:6fb3e9b6ba583e6dfbbbf6e9b438d4546235fe3319e043cd4a6d78e908f6d8be"
 }

--- a/scripts/affected-native-proof.mjs
+++ b/scripts/affected-native-proof.mjs
@@ -14,9 +14,11 @@ import { parseFamilyQueueLeaseMarker } from './project-cut-merge-queue-admission
 const LEGACY_IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v3';
 const LEGACY_PROOF_SCHEMA = 'kungfu.affected-native-proof/v3';
 const LEGACY_DESCRIPTOR_SCHEMA = 'kungfu.affected-native-proof-descriptor/v1';
-export const IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v4';
-export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v4';
-export const DESCRIPTOR_SCHEMA = 'kungfu.affected-native-proof-descriptor/v2';
+export const IDENTITY_SCHEMA = 'kungfu.affected-native-proof-identity/v5';
+export const QUALIFICATION_IDENTITY_SCHEMA =
+  'kungfu.affected-native-qualification-identity/v1';
+export const PROOF_SCHEMA = 'kungfu.affected-native-proof/v5';
+export const DESCRIPTOR_SCHEMA = 'kungfu.affected-native-proof-descriptor/v3';
 export const DELIVERY_BINDING_SCHEMA =
   'kungfu.affected-native-delivery-binding/v1';
 export const DELIVERY_ATTEMPT_SCHEMA =
@@ -141,6 +143,7 @@ export function createDeliveryBinding({
   pullRequest,
   pullRequestHead,
   devHead,
+  candidateHead,
   candidateTree,
   pullRequestBody = '',
   combinedStatus = {},
@@ -177,28 +180,59 @@ export function createDeliveryBinding({
     return { ...body, bindingRoot: digest(body) };
   }
   const lease = parseFamilyQueueLeaseMarker(pullRequestBody);
-  if (lease === null) {
-    throw new Error('merge-group delivery binding requires a family lease');
-  }
   const exactDevHead = requireSha(devHead, 'delivery dev head');
+  const exactCandidateHead = requireSha(
+    candidateHead,
+    'delivery candidate head',
+  );
   const exactCandidateTree = requireSha(
     candidateTree,
     'delivery candidate tree',
   );
+  const queueStatus = latestStatus(combinedStatus, queueContext);
+  if (queueStatus?.state !== 'success') {
+    throw new Error('queue admission lease is not successful');
+  }
+  if (lease === null) {
+    const body = {
+      schema: DELIVERY_BINDING_SCHEMA,
+      state: 'bound',
+      source: {
+        ...source,
+        devHead: exactDevHead,
+        replayedCandidate: exactCandidateHead,
+        replayedTree: exactCandidateTree,
+      },
+      family: null,
+      requiredChecks: {
+        contexts,
+        root: digest({ contexts }),
+      },
+      queueAdmission: {
+        context: queueContext,
+        state: queueStatus.state,
+        familyLeaseState: 'not-applicable',
+        root: digest({
+          context: queueContext,
+          state: queueStatus.state,
+          familyLeaseState: 'not-applicable',
+        }),
+      },
+      reason: 'exact-queue-admission-without-family-lease',
+    };
+    return { ...body, bindingRoot: digest(body) };
+  }
   if (
     lease.pullRequestHead !== source.pullRequestHead ||
     lease.devHead !== exactDevHead ||
+    lease.replayedCandidate !== exactCandidateHead ||
     lease.replayedTree !== exactCandidateTree
   ) {
     throw new Error('family delivery source or latest-dev replay drift');
   }
   const familyStatus = latestStatus(combinedStatus, lease.statusContext);
-  const queueStatus = latestStatus(combinedStatus, queueContext);
   if (familyStatus?.state !== 'pending') {
     throw new Error('family delivery lease is not active');
-  }
-  if (queueStatus?.state !== 'success') {
-    throw new Error('queue admission lease is not successful');
   }
   const admissionProofRoots = [
     ...new Set((lease.admissionProofRoots || []).map(String)),
@@ -282,24 +316,33 @@ export function validateDeliveryBinding(binding) {
     requireSha(body.source?.devHead, 'delivery dev head');
     requireSha(body.source?.replayedCandidate, 'delivery replayed candidate');
     requireSha(body.source?.replayedTree, 'delivery replayed tree');
-    requireIdentifier(body.family?.initiativeId, 'family initiative id');
-    requireIdentifier(body.family?.assignmentId, 'family assignment id');
-    requireIdentifier(body.family?.deliveryClass, 'family delivery class');
-    requireQueueAttempt(body.family?.queueAttempt);
-    requireRoot(body.family?.leaseRoot, 'family lease root');
-    requireRoot(
-      body.family?.admissionProofRoot,
-      'family replay admission proof root',
-    );
-    for (const root of body.family?.admissionProofRoots || []) {
-      requireRoot(root, 'family admission proof root');
-    }
-    requireContext(body.family?.statusContext, 'family status context');
-    if (
-      body.queueAdmission?.state !== 'success' ||
-      body.queueAdmission?.familyLeaseState !== 'pending'
-    ) {
+    if (body.queueAdmission?.state !== 'success') {
       throw new Error('affected-native delivery admission state drift');
+    }
+    if (body.family === null) {
+      if (
+        body.queueAdmission?.familyLeaseState !== 'not-applicable' ||
+        body.reason !== 'exact-queue-admission-without-family-lease'
+      ) {
+        throw new Error('affected-native non-family delivery state drift');
+      }
+    } else {
+      requireIdentifier(body.family?.initiativeId, 'family initiative id');
+      requireIdentifier(body.family?.assignmentId, 'family assignment id');
+      requireIdentifier(body.family?.deliveryClass, 'family delivery class');
+      requireQueueAttempt(body.family?.queueAttempt);
+      requireRoot(body.family?.leaseRoot, 'family lease root');
+      requireRoot(
+        body.family?.admissionProofRoot,
+        'family replay admission proof root',
+      );
+      for (const root of body.family?.admissionProofRoots || []) {
+        requireRoot(root, 'family admission proof root');
+      }
+      requireContext(body.family?.statusContext, 'family status context');
+      if (body.queueAdmission?.familyLeaseState !== 'pending') {
+        throw new Error('affected-native delivery admission state drift');
+      }
     }
     requireRoot(body.queueAdmission?.root, 'queue admission root');
   } else if (
@@ -392,6 +435,57 @@ export function planProjection(plan) {
   return projection;
 }
 
+function qualificationIdentityFromIdentity(identity) {
+  if (identity?.schema !== IDENTITY_SCHEMA) {
+    throw new Error('affected-native qualification identity schema drift');
+  }
+  return {
+    schema: QUALIFICATION_IDENTITY_SCHEMA,
+    base: identity.base,
+    sourceTree: identity.sourceTree,
+    planProjectionDigest: identity.planProjectionDigest,
+    partitionCount: identity.partitionCount,
+    platformTier: identity.platformTier,
+    toolchain: identity.toolchain,
+    dependencyRoot: identity.dependencyRoot,
+    closureRoot: identity.closureRoot,
+  };
+}
+
+function validateCurrentDescriptor(descriptor) {
+  if (
+    descriptor?.schema !== DESCRIPTOR_SCHEMA ||
+    descriptor.identity?.schema !== IDENTITY_SCHEMA
+  ) {
+    throw new Error('affected-native proof descriptor schema drift');
+  }
+  const binding = validateDeliveryBinding(descriptor.identity.deliveryBinding);
+  if (
+    binding.state === 'bound' &&
+    (binding.source.devHead !== descriptor.identity.base ||
+      binding.source.replayedTree !== descriptor.identity.sourceTree)
+  ) {
+    throw new Error('affected-native descriptor delivery source drift');
+  }
+  const qualificationIdentity = qualificationIdentityFromIdentity(
+    descriptor.identity,
+  );
+  if (
+    stableJson(descriptor.qualificationIdentity) !==
+    stableJson(qualificationIdentity)
+  ) {
+    throw new Error('affected-native qualification identity projection drift');
+  }
+  const proofId = digest(qualificationIdentity).slice('sha256:'.length);
+  if (
+    descriptor.proofId !== proofId ||
+    descriptor.artifactName !== `core-affected-native-proof-${proofId}`
+  ) {
+    throw new Error('affected-native qualification proof id drift');
+  }
+  return qualificationIdentity;
+}
+
 export function createProofDescriptor(
   plan,
   sourceTree,
@@ -421,31 +515,43 @@ export function createProofDescriptor(
     targets: projection.targets,
     tests: projection.tests,
   });
-  const identity = {
-    schema: deliveryBinding ? IDENTITY_SCHEMA : LEGACY_IDENTITY_SCHEMA,
+  const sharedIdentity = {
     base: plan.base,
     sourceTree,
     planProjectionDigest: digest(projection),
     partitionCount,
     platformTier: plan.platformTier,
     toolchain: nativeToolchainIdentity(toolchain, nativeRequired),
-    ...(deliveryBinding
-      ? {
-          dependencyRoot,
-          closureRoot,
-          deliveryBinding: validateDeliveryBinding(deliveryBinding),
-        }
-      : {}),
   };
-  const proofId = digest(identity).slice('sha256:'.length);
-  return {
+  const identity = deliveryBinding
+    ? {
+        schema: IDENTITY_SCHEMA,
+        ...sharedIdentity,
+        dependencyRoot,
+        closureRoot,
+        deliveryBinding: validateDeliveryBinding(deliveryBinding),
+      }
+    : {
+        schema: LEGACY_IDENTITY_SCHEMA,
+        ...sharedIdentity,
+      };
+  const qualificationIdentity = deliveryBinding
+    ? qualificationIdentityFromIdentity(identity)
+    : null;
+  const proofId = digest(qualificationIdentity || identity).slice(
+    'sha256:'.length,
+  );
+  const descriptor = {
     schema: deliveryBinding ? DESCRIPTOR_SCHEMA : LEGACY_DESCRIPTOR_SCHEMA,
     identity,
+    ...(qualificationIdentity ? { qualificationIdentity } : {}),
     proofId,
     artifactName: `core-affected-native-proof-${proofId}`,
     nativeRequired,
     sdkRequired: plan.sdkQualification?.required === true,
   };
+  if (deliveryBinding) validateCurrentDescriptor(descriptor);
+  return descriptor;
 }
 
 function expectedPartition(plan, count, index) {
@@ -590,12 +696,15 @@ export function sealProof(descriptor, inputDir, producer) {
   if (checkoutHeads.size !== 1 || !checkoutHeads.has(producer.checkoutSha)) {
     throw new Error('affected-native proof producer checkout drift');
   }
+  const current = descriptor.identity?.schema === IDENTITY_SCHEMA;
+  const proofIdentity = current
+    ? validateCurrentDescriptor(descriptor)
+    : descriptor.identity;
   const proof = {
-    schema:
-      descriptor.identity?.schema === IDENTITY_SCHEMA
-        ? PROOF_SCHEMA
-        : LEGACY_PROOF_SCHEMA,
-    identity: descriptor.identity,
+    schema: current ? PROOF_SCHEMA : LEGACY_PROOF_SCHEMA,
+    ...(current
+      ? { qualificationIdentity: proofIdentity }
+      : { identity: proofIdentity }),
     proofId: descriptor.proofId,
     artifactName: descriptor.artifactName,
     producer: {
@@ -641,15 +750,22 @@ function validateProducer(producer, options) {
 export function verifyProofBundle(descriptor, bundleDir, options) {
   const proof = readJson(path.join(bundleDir, 'proof.json'));
   const { proofRoot, ...body } = proof;
-  const expectedProofSchema =
-    descriptor.identity?.schema === IDENTITY_SCHEMA
-      ? PROOF_SCHEMA
-      : LEGACY_PROOF_SCHEMA;
+  const current = descriptor.identity?.schema === IDENTITY_SCHEMA;
+  const expectedIdentity = current
+    ? validateCurrentDescriptor(descriptor)
+    : descriptor.identity;
+  const expectedProofSchema = current ? PROOF_SCHEMA : LEGACY_PROOF_SCHEMA;
   if (proof.schema !== expectedProofSchema || proofRoot !== digest(body)) {
     throw new Error('affected-native proof root drift');
   }
   if (
-    stableJson(proof.identity) !== stableJson(descriptor.identity) ||
+    (current &&
+      (proof.identity !== undefined ||
+        stableJson(proof.qualificationIdentity) !==
+          stableJson(expectedIdentity))) ||
+    (!current &&
+      (proof.qualificationIdentity !== undefined ||
+        stableJson(proof.identity) !== stableJson(expectedIdentity))) ||
     proof.proofId !== descriptor.proofId ||
     proof.artifactName !== descriptor.artifactName
   ) {
@@ -676,17 +792,21 @@ export function createDeliveryAttempt(descriptor, proof, decision, producer) {
   }
   const binding = validateDeliveryBinding(descriptor.identity?.deliveryBinding);
   if (binding.state !== 'bound') {
-    throw new Error('delivery attempt requires a bound family delivery');
+    throw new Error('delivery attempt requires a bound delivery');
+  }
+  const mergeGroupHead = requireSha(
+    producer.triggerHeadSha,
+    'delivery merge-group head',
+  );
+  if (binding.source.replayedCandidate !== mergeGroupHead) {
+    throw new Error('delivery merge-group candidate drift');
   }
   const body = {
     schema: DELIVERY_ATTEMPT_SCHEMA,
     deliveryBindingRoot: binding.bindingRoot,
     source: {
       ...binding.source,
-      mergeGroupHead: requireSha(
-        producer.triggerHeadSha,
-        'delivery merge-group head',
-      ),
+      mergeGroupHead,
       checkout: requireSha(producer.checkoutSha, 'delivery checkout'),
     },
     family: binding.family,
@@ -725,35 +845,49 @@ export function validateDeliveryAttempt(attempt) {
     throw new Error('affected-native delivery attempt authority drift');
   }
   requireSha(body.source?.pullRequestHead, 'delivery pull request head');
+  requireSha(body.source?.devHead, 'delivery dev head');
+  requireSha(body.source?.replayedCandidate, 'delivery replayed candidate');
+  requireSha(body.source?.replayedTree, 'delivery replayed tree');
   requireSha(body.source?.mergeGroupHead, 'delivery merge-group head');
   requireSha(body.source?.checkout, 'delivery checkout');
-  if (body.source.checkout !== body.source.mergeGroupHead) {
+  if (
+    body.source.checkout !== body.source.mergeGroupHead ||
+    body.source.replayedCandidate !== body.source.mergeGroupHead
+  ) {
     throw new Error('affected-native delivery checkout drift');
   }
   requireRoot(
     body.deliveryBindingRoot,
     'affected-native delivery binding root',
   );
-  requireIdentifier(body.family?.initiativeId, 'family initiative id');
-  requireIdentifier(body.family?.assignmentId, 'family assignment id');
-  requireIdentifier(body.family?.deliveryClass, 'family delivery class');
-  requireQueueAttempt(body.family?.queueAttempt);
-  requireRoot(body.family?.leaseRoot, 'family lease root');
-  requireRoot(
-    body.family?.admissionProofRoot,
-    'family replay admission proof root',
-  );
-  for (const root of body.family?.admissionProofRoots || []) {
-    requireRoot(root, 'family admission proof root');
-  }
-  requireContext(body.family?.statusContext, 'family status context');
   const contexts = normalizedContexts(body.requiredChecks?.contexts);
   if (
     body.requiredChecks?.root !== digest({ contexts }) ||
-    body.queueAdmission?.state !== 'success' ||
-    body.queueAdmission?.familyLeaseState !== 'pending'
+    body.queueAdmission?.state !== 'success'
   ) {
     throw new Error('affected-native delivery admission binding drift');
+  }
+  if (body.family === null) {
+    if (body.queueAdmission?.familyLeaseState !== 'not-applicable') {
+      throw new Error('affected-native non-family delivery binding drift');
+    }
+  } else {
+    requireIdentifier(body.family?.initiativeId, 'family initiative id');
+    requireIdentifier(body.family?.assignmentId, 'family assignment id');
+    requireIdentifier(body.family?.deliveryClass, 'family delivery class');
+    requireQueueAttempt(body.family?.queueAttempt);
+    requireRoot(body.family?.leaseRoot, 'family lease root');
+    requireRoot(
+      body.family?.admissionProofRoot,
+      'family replay admission proof root',
+    );
+    for (const root of body.family?.admissionProofRoots || []) {
+      requireRoot(root, 'family admission proof root');
+    }
+    requireContext(body.family?.statusContext, 'family status context');
+    if (body.queueAdmission?.familyLeaseState !== 'pending') {
+      throw new Error('affected-native delivery admission binding drift');
+    }
   }
   requireContext(body.queueAdmission?.context, 'queue admission context');
   requireRoot(body.queueAdmission?.root, 'queue admission root');
@@ -1108,6 +1242,7 @@ async function main() {
       pullRequest: options['pull-request'],
       pullRequestHead: options['pull-request-head'],
       devHead: options['dev-head'],
+      candidateHead: options['candidate-head'],
       candidateTree: options['candidate-tree'],
       pullRequestBody: fs.readFileSync(
         path.resolve(options['pr-body']),

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -158,6 +158,7 @@ function deliveryFixture(overrides = {}) {
       compositionChanged: false,
       compositionRoot: null,
       reasonCodes: [],
+      ...(overrides.cut || {}),
     },
     {
       initiativeId: 'go-family-native-state-contract',
@@ -179,6 +180,7 @@ function deliveryFixture(overrides = {}) {
       pullRequest: 1728,
       pullRequestHead: HEAD,
       devHead: BASE,
+      candidateHead: QUEUE_HEAD,
       candidateTree: TREE,
       pullRequestBody: lease.marker,
       combinedStatus: {
@@ -259,7 +261,7 @@ test('descriptor binds the exact tree, base, plan projection, and toolchain', ()
   );
 });
 
-test('family delivery binding enters proof identity and preserves same-attempt reuse', () => {
+test('family delivery binding is separate from reusable qualification identity', () => {
   const { values } = deliveryFixture();
   const binding = createDeliveryBinding(values);
   const first = createProofDescriptor(
@@ -277,36 +279,79 @@ test('family delivery binding enters proof identity and preserves same-attempt r
     createDeliveryBinding(values),
   );
   assert.equal(binding.state, 'bound');
-  assert.equal(first.schema, 'kungfu.affected-native-proof-descriptor/v2');
+  assert.equal(first.schema, 'kungfu.affected-native-proof-descriptor/v3');
   assert.match(first.identity.dependencyRoot, /^sha256:[0-9a-f]{64}$/u);
   assert.match(first.identity.closureRoot, /^sha256:[0-9a-f]{64}$/u);
   assert.equal(first.proofId, repeated.proofId);
+  const reclassified = createProofDescriptor(
+    plan(QUEUE_HEAD),
+    TREE,
+    2,
+    TOOLCHAIN,
+    createDeliveryBinding(
+      deliveryFixture({
+        family: { deliveryClass: 'native-proof-reclassified' },
+      }).values,
+    ),
+  );
+  const expandedChecks = createProofDescriptor(
+    plan(QUEUE_HEAD),
+    TREE,
+    2,
+    TOOLCHAIN,
+    createDeliveryBinding({
+      ...values,
+      requiredContexts: [...values.requiredContexts, 'source / acceptance'],
+    }),
+  );
+  assert.equal(first.proofId, reclassified.proofId);
+  assert.equal(first.proofId, expandedChecks.proofId);
+  assert.deepEqual(
+    first.qualificationIdentity,
+    reclassified.qualificationIdentity,
+  );
+  assert.deepEqual(
+    first.qualificationIdentity,
+    expandedChecks.qualificationIdentity,
+  );
+  assert.notEqual(
+    first.identity.deliveryBinding.bindingRoot,
+    reclassified.identity.deliveryBinding.bindingRoot,
+  );
+  assert.notEqual(
+    first.identity.deliveryBinding.bindingRoot,
+    expandedChecks.identity.deliveryBinding.bindingRoot,
+  );
   assert.notEqual(
     first.proofId,
     createProofDescriptor(
-      plan(QUEUE_HEAD),
+      plan(QUEUE_HEAD, { base: '6'.repeat(40) }),
       TREE,
       2,
       TOOLCHAIN,
       createDeliveryBinding(
         deliveryFixture({
-          family: { deliveryClass: 'native-proof-reclassified' },
+          cut: { baseCommitOid: '6'.repeat(40) },
+          values: { devHead: '6'.repeat(40) },
         }).values,
       ),
     ).proofId,
   );
-  assert.notEqual(
-    first.proofId,
-    createProofDescriptor(
-      plan(QUEUE_HEAD),
-      TREE,
-      2,
-      TOOLCHAIN,
-      createDeliveryBinding({
-        ...values,
-        requiredContexts: [...values.requiredContexts, 'source / acceptance'],
-      }),
-    ).proofId,
+  assert.throws(
+    () =>
+      createProofDescriptor(
+        plan(QUEUE_HEAD),
+        TREE,
+        2,
+        TOOLCHAIN,
+        createDeliveryBinding(
+          deliveryFixture({
+            cut: { candidateTreeOid: '6'.repeat(40) },
+            values: { candidateTree: '6'.repeat(40) },
+          }).values,
+        ),
+      ),
+    /descriptor delivery source drift/u,
   );
   assert.throws(
     () =>
@@ -318,7 +363,8 @@ test('family delivery binding enters proof identity and preserves same-attempt r
   );
 });
 
-test('pull-request proof is explicitly unbound from later family delivery', () => {
+test('exact pull-request qualification proof is reusable by bound delivery', () => {
+  const value = fixture();
   const { values } = deliveryFixture();
   const unbound = createDeliveryBinding({
     ...values,
@@ -327,20 +373,108 @@ test('pull-request proof is explicitly unbound from later family delivery', () =
     combinedStatus: {},
   });
   const bound = createDeliveryBinding(values);
+  const pullDescriptor = createProofDescriptor(
+    value.value,
+    TREE,
+    2,
+    TOOLCHAIN,
+    unbound,
+  );
+  const queueDescriptor = createProofDescriptor(
+    plan(QUEUE_HEAD),
+    TREE,
+    2,
+    TOOLCHAIN,
+    bound,
+  );
   assert.equal(unbound.state, 'unbound');
   assert.equal(unbound.queueAdmission.state, 'not-issued');
-  assert.notEqual(
-    createProofDescriptor(plan(QUEUE_HEAD), TREE, 2, TOOLCHAIN, unbound)
-      .proofId,
-    createProofDescriptor(plan(QUEUE_HEAD), TREE, 2, TOOLCHAIN, bound).proofId,
+  assert.equal(pullDescriptor.proofId, queueDescriptor.proofId);
+  assert.deepEqual(
+    pullDescriptor.qualificationIdentity,
+    queueDescriptor.qualificationIdentity,
   );
+  assert.notEqual(
+    pullDescriptor.identity.deliveryBinding.bindingRoot,
+    queueDescriptor.identity.deliveryBinding.bindingRoot,
+  );
+  writeBundle(
+    pullDescriptor,
+    value,
+    producer({
+      event: 'pull_request',
+      triggerHeadSha: OTHER_HEAD,
+      checkoutSha: HEAD,
+    }),
+  );
+  const proof = verifyProofBundle(queueDescriptor, value.bundle, {
+    repository: 'kungfu-systems/kungfu',
+    producerRunId: 42,
+    producerEvent: 'pull_request',
+    producerHeadSha: OTHER_HEAD,
+    maxAgeSeconds: 6 * 60 * 60,
+    now: '2026-07-22T01:00:00Z',
+  });
+  const projectedDrift = structuredClone(queueDescriptor);
+  projectedDrift.qualificationIdentity.sourceTree = '6'.repeat(40);
+  assert.throws(
+    () =>
+      verifyProofBundle(projectedDrift, value.bundle, {
+        repository: 'kungfu-systems/kungfu',
+        producerRunId: 42,
+        producerEvent: 'pull_request',
+        producerHeadSha: OTHER_HEAD,
+        maxAgeSeconds: 6 * 60 * 60,
+        now: '2026-07-22T01:00:00Z',
+      }),
+    /qualification identity projection drift/u,
+  );
+  const attempt = createDeliveryAttempt(
+    queueDescriptor,
+    proof,
+    'reused',
+    producer({
+      runId: 84,
+      triggerHeadSha: QUEUE_HEAD,
+      checkoutSha: QUEUE_HEAD,
+    }),
+  );
+  assert.equal(attempt.deliveryBindingRoot, bound.bindingRoot);
+  assert.equal(validateDeliveryAttempt(attempt), attempt);
+  const ordinary = createDeliveryBinding({
+    ...values,
+    pullRequestBody: '',
+    combinedStatus: {
+      statuses: [{ context: values.queueAdmissionContext, state: 'success' }],
+    },
+  });
+  const ordinaryDescriptor = createProofDescriptor(
+    plan(QUEUE_HEAD),
+    TREE,
+    2,
+    TOOLCHAIN,
+    ordinary,
+  );
+  const ordinaryAttempt = createDeliveryAttempt(
+    ordinaryDescriptor,
+    proof,
+    'reused',
+    producer({
+      runId: 84,
+      triggerHeadSha: QUEUE_HEAD,
+      checkoutSha: QUEUE_HEAD,
+    }),
+  );
+  assert.equal(ordinaryDescriptor.proofId, pullDescriptor.proofId);
+  assert.equal(validateDeliveryAttempt(ordinaryAttempt), ordinaryAttempt);
   assert.throws(
     () =>
       createDeliveryBinding({
         ...values,
         pullRequestBody: '',
+        combinedStatus: {},
       }),
-    /requires a family lease/u,
+    /queue admission lease is not successful/u,
   );
   assert.throws(
     () =>
@@ -357,6 +491,7 @@ test('pull-request proof is explicitly unbound from later family delivery', () =
       }),
     /family delivery lease is not active/u,
   );
+  fs.rmSync(value.root, { recursive: true, force: true });
 });
 
 test('delivery attempt seals the exact family, source, proof decision, and run', () => {


### PR DESCRIPTION
## Summary

Make the documented exact pull-request affected-native proof reuse path reachable by separating reusable qualification identity from transient delivery-attempt identity. Exact source, plan, hosted toolchain, partition, closure, and SDK obligations remain fail-closed; family lease and queue admission facts remain independently sealed for the current merge-group delivery.

## Related issue

Atlas Assignment `2026-07-17-kungfu-dev-gate-latency-slo`.

## Changes

- derive proof ids and artifact names from a dedicated qualification identity
- keep family lease, required-status snapshot, and queue-attempt binding in the current descriptor, delivery attempt, and cache-promotion authority
- reject descriptor base/tree drift against the bound delivery source
- add exact PR-to-merge-group reuse and projection-tamper fail-closed coverage
- document the qualification/delivery identity boundary in the Gate qualification docs

## Verification

- `node --test` dev latency contract suite (87/87)
- proof, Gate catalog, workflow authority, ARM64, and Shifu entry suites (65/65)
- rebase-after-current-head focused proof/Gate/workflow suite (42/42)
- staged pre-commit gate passed, including latency, invariant, documentation, schema, KFD, and Biome checks
- `./shifu check:source` ran 720 tests: 709 passed, 10 declared skips, and one unrelated local environment failure because `pytest` is not on this Mac PATH; GitHub source install remains authoritative for that lane

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes the affected-native proof implementation to match the existing exact PR proof reuse contract without changing source, SDK, queue-admission, or release architecture semantics"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The affected-native qualification proof is provenance-bearing CI evidence. The new schema invalidates older proof artifact names and preserves exact source/plan/toolchain/SDK checks plus an independently sealed family delivery binding. No publication credential or release workflow changes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed