### PR TITLE
fix(ci): bound CodeBuild native parallelism

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -76,7 +76,8 @@ jobs:
       require-install: true
       install-command: node scripts/buildchain-install.mjs
       require-build: true
-      build-command: ./shifu build:core && node scripts/buildchain-install.mjs qualify-codebuild record
+      build-command: KUNGFU_BUILD_JOBS=4 ./shifu build:core && node scripts/buildchain-install.mjs qualify-codebuild record
+      requested-parallelism: 4
       require-verify: true
       verify-command: node scripts/buildchain-install.mjs qualify-codebuild verify
       lifecycle-timeout-minutes: 105

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -687,7 +687,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:3cb40b01b4d8c808f57679f528d62ef30e921124499b1a0c457962efef53fac6",
+          "definitionDigest": "sha256:644f282b34d334d136bfd353a94686c857493b811636ef045ec6290151ac66bb",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,7 +96,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:2b03a46bb83a1470e6e9be8d427bef54fe0cd6f64e42c7087645b17a069cbe90"
+          "sourceRoot": "sha256:67b6fac7c86c473ce4cc96ba35536f53273715806af60e9663bbb09b33a00ef4"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:be60b83ee8ce1610f0657705f0f9ef9acbea8dd2a3e5b7e1ddfa7cbd225a4a7d"
+  "registryRoot": "sha256:48197126a0093c8fc6d441a2b446bef017968ba0f2ce78cd71a8fa72379eb138"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -208,6 +208,11 @@ test('AWS Linux burst workflow is trusted exact-train qualification only', () =>
     workflow,
     /aws-codebuild-project: kungfu-buildchain-linux-burst-poc/,
   );
+  assert.match(
+    workflow,
+    /build-command: KUNGFU_BUILD_JOBS=4 \.\/shifu build:core/,
+  );
+  assert.match(workflow, /requested-parallelism: 4/);
   assert.match(workflow, /permissions:\n {2}contents: read/);
   assert.doesNotMatch(workflow, /\b(?:id-token|packages):\s*write/);
   assert.match(workflow, /publish-channel: none/);


### PR DESCRIPTION
## Summary

- cap AWS CodeBuild Linux core builds at four native compile jobs through the existing `KUNGFU_BUILD_JOBS` contract
- record the same requested parallelism in retained Buildchain process diagnostics
- refresh the closed-world workflow authority and non-publication source roots

## Evidence

`poc-03` completed install and reached 365/578 native objects, then `cc1plus` was killed while CMake used 8 jobs and Buildchain observed 20 concurrent processes. This change is scoped only to the AWS qualification workflow; local runners keep their existing host policy.

## Verification

- `node --test scripts/buildchain-install.test.mjs` (8/8)
- `./shifu check:source` (721 tests: 711 passed, 10 skipped)
- workflow authority and publication control-plane checks

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Cloud qualification resource parallelism does not alter an architecture contract"
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoibm9uLW5hdGl2ZS1mYXN0IiwiZGV2SGVhZCI6ImE3ODZjMTVmODNlNjM1NDI5ZmY2OGFmMGI0MGFhNDYxY2U0ZGVkNGYiLCJwdWxsUmVxdWVzdEhlYWQiOiI2NDA2MjRlZjU5YmU4ZTJmNzQzZDhjZjQyNTNlMTUwY2ZjMWMzMjA2IiwicmVwbGF5ZWRDYW5kaWRhdGUiOiIwZWNmOTcyZjA4MTExYmY3M2EyYjczMzNhOTdhOGM4MjFkOTU4YjEyIiwicmVwbGF5ZWRUcmVlIjoiMDIxZjZkODY3NGE2M2Y3ZTUzN2IzNTNhMDYxMzBlNjczOWM3YzE1YiIsInF1ZXVlQXR0ZW1wdCI6IjY0MDYyNGVmNTliZThlMmY3NDNkOGNmNDI1M2UxNTBjZmMxYzMyMDZAYTc4NmMxNWY4M2U2MzU0MjlmZjY4YWYwYjQwYWE0NjFjZTRkZWQ0ZiIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjpkYjZiMjkyNDQ2MWM1MzkyMzMzNjM3ODQyMGE2ZDJlZGM5NDkzMTU0ZGFjMDQ0MzcyOTAyNDAyMWZhY2EyNDY5IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6NWNkMjJhZDgxYTdhNzc4ZjJlNWJmYWYyOWNlZTk1YjVhZTc5YjgyNDA0ZmRkZDNlYjBiNWUxYTg4MGFjZjJlZCIsInNoYTI1NjpkYjZiMjkyNDQ2MWM1MzkyMzMzNjM3ODQyMGE2ZDJlZGM5NDkzMTU0ZGFjMDQ0MzcyOTAyNDAyMWZhY2EyNDY5Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1NjpkZTYxYjhiYTYwNTYzNGE0ODc3N2EwNjFhN2RjY2ZmYzVjOGI0NjkyODc3NmMwZGE2YzY4NmIyOTQzNmIzYjhjIn0 -->