### PR TITLE
fix(maintainability): preserve rename budget lineage

### DIFF
--- a/scripts/code-complexity-budget.mjs
+++ b/scripts/code-complexity-budget.mjs
@@ -689,7 +689,34 @@ function softBudgetWarnings(files, baseline, renamedFrom = new Map()) {
   return warnings;
 }
 
+export function renameHistoryMap(output) {
+  const renamedFrom = new Map();
+  for (const line of String(output).split('\n').filter(Boolean)) {
+    const [status, previous, current] = line.split('\t');
+    if (!/^R\d{3}$/u.test(status || '') || !previous || !current) continue;
+    const baselinePath = renamedFrom.get(previous) || previous;
+    renamedFrom.delete(previous);
+    renamedFrom.set(current, baselinePath);
+  }
+  return renamedFrom;
+}
+
 function currentRenameMap(policy) {
+  const history = spawnSync(
+    'git',
+    [
+      'log',
+      '--reverse',
+      '--format=',
+      '--name-status',
+      '--diff-filter=R',
+      '--find-renames=50%',
+      `${policy.baselineRef}..HEAD`,
+    ],
+    { cwd: ROOT, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+  );
+  const renamedFrom =
+    history.status === 0 ? renameHistoryMap(history.stdout) : new Map();
   for (const candidate of protectedBaselineCandidates(policy)) {
     const mergeBase = spawnSync('git', ['merge-base', candidate, 'HEAD'], {
       cwd: ROOT,
@@ -709,19 +736,11 @@ function currentRenameMap(policy) {
       { cwd: ROOT, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
     );
     if (result.status !== 0) continue;
-    return new Map(
-      String(result.stdout || '')
-        .split('\n')
-        .filter(Boolean)
-        .flatMap((line) => {
-          const [status, previous, current] = line.split('\t');
-          return /^R\d{3}$/u.test(status || '') && previous && current
-            ? [[current, previous]]
-            : [];
-        }),
-    );
+    for (const [current, previous] of renameHistoryMap(result.stdout))
+      if (!renamedFrom.has(current)) renamedFrom.set(current, previous);
+    break;
   }
-  return new Map();
+  return renamedFrom;
 }
 
 function checkCurrent(policy, layers, baseline) {

--- a/scripts/code-complexity-budget.test.mjs
+++ b/scripts/code-complexity-budget.test.mjs
@@ -21,6 +21,7 @@ import {
   percentile,
   protectedBaselineCandidates,
   regressionIssues,
+  renameHistoryMap,
   validWaiverFor,
   validateMeasured,
   waiverIssues,
@@ -261,6 +262,20 @@ test('one-to-one Git renames preserve the old budget without becoming helper spl
     'scripts/legacy-lab.mjs',
     'scripts/current-lab.mjs',
   ]);
+});
+
+test('rename history keeps the baseline identity after the protected head advances', () => {
+  assert.deepEqual(
+    [
+      ...renameHistoryMap(
+        [
+          'R100\tscripts/qualification-lab.mjs\tscripts/agent-work-lab.mjs',
+          'R100\tscripts/agent-work-lab.mjs\tscripts/work-lab.mjs',
+        ].join('\n'),
+      ),
+    ],
+    [['scripts/work-lab.mjs', 'scripts/qualification-lab.mjs']],
+  );
 });
 
 test('unknown classification or owner fails closed', () => {


### PR DESCRIPTION
## Summary

Preserve code-complexity budget lineage across a protected-head advance. The previous rename bridge derived only from the candidate versus the then-current protected branch; after that candidate became `dev`, the merge base collapsed to `HEAD` and the protected branch failed its own source gate.

This bugfix reconstructs committed rename chains from the governed baseline ref and retains the existing candidate aggregate-diff fallback. It does not refresh, waive, or widen any complexity budget.

## Verification

- repository staged gate: passed
- complexity ratchet on current protected `dev`: passed
- rename-chain regression test: passed
- `./shifu check:source`: 722 pass, 10 skip, 1 local environment failure because `pytest` was absent from the new worktree PATH; required GitHub CI is authoritative for the complete environment

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore persistent rename lineage in the existing complexity source gate without changing an architecture decision or budget."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression test added

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LWdvLWZhbWlseS1jb250aW51b3VzLWRlbGl2ZXJ5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOC1rdW5nZnUtZ28tZmFtaWx5LXBvc3QtbWVyZ2UtY29tcGxleGl0eS1yZW5hbWUtY29udGludWl0eSIsImRlbGl2ZXJ5Q2xhc3MiOiJzb3VyY2Utb25seSIsImRldkhlYWQiOiI5NzA0MWMyNGU3M2ZlMjBhZTgxNDJmZjJkODdlNzA1NzJjMjRhNzNiIiwicHVsbFJlcXVlc3RIZWFkIjoiMDgwMzA2NGE3Yzk5NjRiMTMyNDI3ZWZiMDAxOTBiODcxZmE1NGMyOSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiZWU0MjkwYzZmZjI4M2UxNWU0OGQ1NWY3NzNlZjMxODMzZWFhYTEzYyIsInJlcGxheWVkVHJlZSI6IjVjZGQ1ZDEzNDJmZTlmOTdkYTJhOTkwMWVlODJlNjNlN2M2NGQwYWMiLCJxdWV1ZUF0dGVtcHQiOiIxNzgyQDk3MDQxYzI0ZTczZmUyMGFlODE0MmZmMmQ4N2U3MDU3MmMyNGE3M2IiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6YTliZWU4YjZjNTQ4NDg1MTEyZWU0NTNkYzlhNTE0ZDQ4Y2UyZWM5Mjk4NmViOWI4ODJjNGVlOGRmZjM5NmZmZCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OmE5YmVlOGI2YzU0ODQ4NTExMmVlNDUzZGM5YTUxNGQ0OGNlMmVjOTI5ODZlYjliODgyYzRlZThkZmYzOTZmZmQiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9lY2FjNjdiY2ViZmFlM2JmIiwibGVhc2VSb290Ijoic2hhMjU2OjBiNGJjMzUwZjY1MWI1ZjVjNTQyMDkyYTBiMWVlYWZhMDk4ZWJmZGQ3NmEyYTliOTY2YjgzMTQxNTUyMjM0MmMifQ -->