### PR TITLE
fix(ci): harden merged rename evidence

### DIFF
--- a/scripts/code-complexity-budget.mjs
+++ b/scripts/code-complexity-budget.mjs
@@ -689,58 +689,48 @@ function softBudgetWarnings(files, baseline, renamedFrom = new Map()) {
   return warnings;
 }
 
-export function renameHistoryMap(output) {
+export function renameEvidenceBase(policy) {
+  const baselineRef = String(policy?.baselineRef || '').trim();
+  if (!/^[0-9a-f]{40}$/u.test(baselineRef)) {
+    throw new Error(
+      'complexity rename evidence requires an exact baseline ref',
+    );
+  }
+  return baselineRef;
+}
+
+export function composeRenameEvidence(statusLines) {
   const renamedFrom = new Map();
-  for (const line of String(output).split('\n').filter(Boolean)) {
+  for (const line of String(statusLines || '').split('\n')) {
     const [status, previous, current] = line.split('\t');
-    if (!/^R\d{3}$/u.test(status || '') || !previous || !current) continue;
-    const baselinePath = renamedFrom.get(previous) || previous;
-    renamedFrom.delete(previous);
-    renamedFrom.set(current, baselinePath);
+    if (/^R\d{3}$/u.test(status || '') && previous && current) {
+      const baselinePath = renamedFrom.get(previous) || previous;
+      renamedFrom.delete(previous);
+      renamedFrom.set(current, baselinePath);
+      continue;
+    }
+    if (/^[AD]$/u.test(status || '') && previous) renamedFrom.delete(previous);
   }
   return renamedFrom;
 }
 
 function currentRenameMap(policy) {
-  const history = spawnSync(
+  const result = spawnSync(
     'git',
     [
       'log',
       '--reverse',
+      '--topo-order',
       '--format=',
       '--name-status',
-      '--diff-filter=R',
       '--find-renames=50%',
-      `${policy.baselineRef}..HEAD`,
+      `${renameEvidenceBase(policy)}..HEAD`,
+      '--',
     ],
     { cwd: ROOT, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
   );
-  const renamedFrom =
-    history.status === 0 ? renameHistoryMap(history.stdout) : new Map();
-  for (const candidate of protectedBaselineCandidates(policy)) {
-    const mergeBase = spawnSync('git', ['merge-base', candidate, 'HEAD'], {
-      cwd: ROOT,
-      encoding: 'utf8',
-    });
-    if (mergeBase.status !== 0 || !String(mergeBase.stdout || '').trim())
-      continue;
-    const result = spawnSync(
-      'git',
-      [
-        'diff',
-        '--find-renames=50%',
-        '--diff-filter=R',
-        '--name-status',
-        `${String(mergeBase.stdout).trim()}..HEAD`,
-      ],
-      { cwd: ROOT, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
-    );
-    if (result.status !== 0) continue;
-    for (const [current, previous] of renameHistoryMap(result.stdout))
-      if (!renamedFrom.has(current)) renamedFrom.set(current, previous);
-    break;
-  }
-  return renamedFrom;
+  if (result.status !== 0) return new Map();
+  return composeRenameEvidence(result.stdout);
 }
 
 function checkCurrent(policy, layers, baseline) {

--- a/scripts/code-complexity-budget.test.mjs
+++ b/scripts/code-complexity-budget.test.mjs
@@ -16,12 +16,13 @@ import {
 } from '../framework/maintainability/complexity-governance.mjs';
 import {
   classify,
+  composeRenameEvidence,
   hasGeneratedProvenance,
   ownerFor,
   percentile,
   protectedBaselineCandidates,
   regressionIssues,
-  renameHistoryMap,
+  renameEvidenceBase,
   validWaiverFor,
   validateMeasured,
   waiverIssues,
@@ -264,18 +265,34 @@ test('one-to-one Git renames preserve the old budget without becoming helper spl
   ]);
 });
 
-test('rename history keeps the baseline identity after the protected head advances', () => {
+test('rename evidence remains anchored to the measured baseline after a refactor merges', () => {
+  const baselineRef = 'a'.repeat(40);
+  assert.equal(
+    renameEvidenceBase({
+      baselineRef,
+      baselineGovernance: { protectedRef: 'origin/HEAD' },
+    }),
+    baselineRef,
+  );
+  assert.throws(
+    () => renameEvidenceBase({ baselineRef: 'origin/HEAD' }),
+    /exact baseline ref/u,
+  );
   assert.deepEqual(
     [
-      ...renameHistoryMap(
-        [
-          'R100\tscripts/qualification' +
-            '-lab.mjs\tscripts/agent-work-lab.mjs',
-          'R100\tscripts/agent-work-lab.mjs\tscripts/work-lab.mjs',
-        ].join('\n'),
+      ...composeRenameEvidence(
+        'R100\told.ts\tmiddle.ts\nR060\tmiddle.ts\tnew.ts',
       ),
     ],
-    [['scripts/work-lab.mjs', 'scripts/qualification' + '-lab.mjs']],
+    [['new.ts', 'old.ts']],
+  );
+  assert.deepEqual(
+    [
+      ...composeRenameEvidence(
+        'R100\told.ts\tcurrent.ts\nD\tcurrent.ts\nA\tcurrent.ts',
+      ),
+    ],
+    [],
   );
 });
 


### PR DESCRIPTION
## Summary

Harden the rename-lineage repair merged in #1782 so complexity evidence remains fail-closed across the full history from the exact measured baseline.

#1782 fixed the immediate #1771 post-merge regression, but its history scan retained two bypass edges: it still supplemented evidence from the mutable `origin/HEAD` merge base, and it filtered out delete/add records. A renamed hotspot could therefore be deleted and recreated at the same path while still inheriting the old grandfathered budget.

## Related issue

Atlas Assignment `2026-07-17-kungfu-dev-gate-latency-slo`.

## Changes

- require the rename-evidence base to be the exact 40-hex complexity baseline ref
- remove the mutable protected-head supplement now that merged history is reconstructed from the baseline
- compose per-commit Git rename records in topological order
- include deletion and addition records and invalidate inherited lineage on delete or same-path re-add
- retain fail-closed treatment for one-to-many splits, new helpers, threshold crossings, and malformed baseline authority
- extend regression coverage for chained renames, mutable protected refs, and delete/re-add invalidation

## Verification

- `node --test scripts/code-complexity-budget.test.mjs` (14/14)
- `node scripts/code-complexity-budget.mjs` (`pass: kungfu.code-complexity-budget-report/v1` against current dev including #1782)
- `npx --no-install biome check scripts/code-complexity-budget.mjs scripts/code-complexity-budget.test.mjs`
- `git diff --check`
- repository staged pre-commit gate passed on the original patch, including latency, invariant, documentation, schema, KFD, and Biome checks
- `./shifu check:source` reached 723 tests: 712 passed, 10 declared skips, and one local environment failure because `pytest` is not on this Mac PATH; the code-complexity gate itself passed and GitHub source install is authoritative for that lane

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This closes fail-open edges in the merged complexity rename-lineage repair without changing architecture semantics, budget thresholds, waivers, classifications, or release intent"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change hardens source-acceptance provenance for refactored files. It does not change credentials, publishing, deployment, budgets, waivers, or protected baseline authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed