### PR TITLE
fix(project-cut): match published episode provider roots

### DIFF
--- a/framework/project-cut/src/publication.mjs
+++ b/framework/project-cut/src/publication.mjs
@@ -540,12 +540,12 @@ export function planSettlementPublication(
   const projectCuts = normalized.projectCuts.map((cutRoot) =>
     inspectProjectCut(root, sourceCommit, cutRoot),
   );
-  const selectedEpisodeRoots = new Set(
-    episodes.map((episode) => episode.semanticRoot),
+  const selectedEpisodeProviderRoots = new Set(
+    episodes.map((episode) => episode.providerRoot),
   );
   const missingEpisodeRoots = projectCuts
     .flatMap((cut) => cut.episodeRoots)
-    .filter((episodeRoot) => !selectedEpisodeRoots.has(episodeRoot))
+    .filter((episodeRoot) => !selectedEpisodeProviderRoots.has(episodeRoot))
     .sort(utf8Compare);
   if (missingEpisodeRoots.length > 0)
     throw failure(

--- a/scripts/check-project-cut-publication.test.mjs
+++ b/scripts/check-project-cut-publication.test.mjs
@@ -153,22 +153,20 @@ function workspace(t) {
 
   const firstEpisode = episodeBundle(7, 'first');
   const secondEpisode = episodeBundle(8, 'second');
-  for (const entry of [firstEpisode, secondEpisode]) {
-    sealGitEpisode(
-      root,
-      buildGitEpisodeSegment(entry.bundle, entry.qualification),
-      { writerId: 'publication-test' },
-    );
-  }
-  const firstCut = projectCut('first', firstEpisode.root);
-  const secondCut = projectCut('second', secondEpisode.root);
+  const sealedEpisodes = [firstEpisode, secondEpisode].map((entry) => {
+    const segment = buildGitEpisodeSegment(entry.bundle, entry.qualification);
+    sealGitEpisode(root, segment, { writerId: 'publication-test' });
+    return segment;
+  });
+  const firstCut = projectCut('first', sealedEpisodes[0].providerRoot);
+  const secondCut = projectCut('second', sealedEpisodes[1].providerRoot);
   addProjectCut(root, firstCut);
   addProjectCut(root, secondCut);
   git(root, 'add', '--all');
   git(root, 'commit', '-qm', 'test: seed sealed settlement material');
   return {
     root,
-    episodes: [firstEpisode.root, secondEpisode.root].sort(),
+    episodes: sealedEpisodes.map((episode) => episode.semanticRoot).sort(),
     cuts: [firstCut.cutRoot, secondCut.cutRoot].sort(),
   };
 }
@@ -265,6 +263,19 @@ test('planner is deterministic, order-independent, bounded, and root-sensitive',
   assert.equal(
     first.manifest.runtimeContinuation.publicationIsAuthority,
     false,
+  );
+  assert.ok(
+    first.manifest.selection.episodes.every(
+      (episode) => episode.semanticRoot !== episode.providerRoot,
+    ),
+  );
+  const selectedProviderRoots = new Set(
+    first.manifest.selection.episodes.map((episode) => episode.providerRoot),
+  );
+  assert.ok(
+    first.manifest.selection.projectCuts
+      .flatMap((cut) => cut.episodeRoots)
+      .every((episodeRoot) => selectedProviderRoots.has(episodeRoot)),
   );
   assert.equal(first.manifest.files.length, 10);
 


### PR DESCRIPTION
## Summary

- match Project Cut `episodeDelta.nativeRoots` against sealed Episode provider roots
- keep request and tracked Episode paths keyed by the existing semantic root
- make the publication fixture exercise distinct semantic and provider roots

## Verification

- `./shifu test:project-cut-publication` — 10/10 passed
- real Wave publication dry-run — 1 sealed Episode and 2 settled Project Cuts planned as batch `sha256:a74ce92fb5c388d874d2875433ae63cd1ca8c128a05fe4e389f5a6de2bc2025f`
- `./shifu check:source` — 733 tests (723 passed, 10 skipped, 0 failed); build-free source gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the existing settlement-publication contract across the already distinct Episode semantic and provider identities without changing either root algorithm or authority boundary."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change only repairs identity matching inside the existing protected settlement projection.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
