### PR TITLE
fix(ci): cancel doomed parallel gate runs

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,6 +76,23 @@ jobs:
       mode: source
       upload-artifacts: true
 
+  cancel_after_source_failure:
+    name: Stop selected lanes after source failure
+    needs: source_acceptance
+    if: ${{ always() && needs.source_acceptance.result != 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Cancel this failed source workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh api --method POST
+          "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/cancel"
+
   candidate_buildchain_config:
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -405,12 +405,10 @@ jobs:
   affected_native_shards:
     name: affected-native shard ${{ matrix.partition }} of 2 / linux
     needs:
-      - source_acceptance
       - candidate_preflight
       - proof_probe
     if: >-
       ${{
-        needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
         needs.proof_probe.result == 'success' &&
         needs.proof_probe.outputs.reuse != 'true' &&
@@ -705,12 +703,10 @@ jobs:
   shifu_workspace:
     name: Shifu workspace / linux
     needs:
-      - source_acceptance
       - candidate_preflight
       - proof_probe
     if: >-
       ${{
-        needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
         needs.proof_probe.result == 'success' &&
         needs.proof_probe.outputs.reuse != 'true' &&
@@ -733,12 +729,10 @@ jobs:
   kfd_verifier:
     name: KFD verifier / linux
     needs:
-      - source_acceptance
       - candidate_preflight
       - proof_probe
     if: >-
       ${{
-        needs.source_acceptance.result == 'success' &&
         needs.candidate_preflight.result == 'success' &&
         needs.proof_probe.result == 'success' &&
         needs.proof_probe.outputs.reuse != 'true' &&

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -214,16 +214,17 @@ Each section is bound to the registry id by the catalog meta gate.
   <base> --head <head> --json`; run mutation fixtures with `./shifu
   core:affected -- --self-test`.
 - **Cost:** heavy; timeout 1500 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (affected_native_shards; two deterministic GitHub-hosted Linux partitions on the first exact merge-group execution after source and governance preflight, or after any reuse mismatch; the stable affected-native aggregator reports fast PR admission and admits either the complete impact-selected queue set or one verified exact same-SHA queue proof)
-- **Source-first orchestration:** the workflow first runs the build-free source
-  planner with `node scripts/run-core-affected-native.mjs --plan-out <path>
-  --json`. Pull requests stop after source/governance admission and this exact
-  impact plan. A merge group starts native/SDK, three-platform Shifu, and KFD
-  jobs in parallel only after both preflight jobs pass; every optional skip is
-  justified by a `required: false` decision retained in the plan. A non-empty,
-  source-bound native plan enters the registered action; a tier-none plan
-  writes the same receipt directly without installing Buildchain, Conan, or
-  the workspace.
+- **Current source:** .github/workflows/affected-native-pr.yml (affected_native_shards; two deterministic GitHub-hosted Linux partitions on the first exact merge-group execution after governance planning and proof probing, or after any reuse mismatch; the stable affected-native aggregator reports fast PR admission and admits either the complete impact-selected queue set or one verified exact same-SHA queue proof)
+- **Parallel source orchestration:** the workflow runs authoritative Buildchain
+  source acceptance concurrently with the impact-selected native/SDK, Shifu,
+  and KFD lanes. Those execution lanes start only after the build-free
+  governance planner and proof probe pass; every optional skip is justified by
+  a `required: false` decision retained in the plan. The stable aggregate still
+  waits for and requires successful source acceptance together with every
+  selected lane, so concurrency shortens the healthy critical path without
+  admitting a source failure. A non-empty, source-bound native plan enters the
+  registered action; a tier-none plan writes the same receipt directly without
+  installing Buildchain, Conan, or the workspace.
 - **Retirement:** remove only with a replacement that consumes the same
   architecture authority and preserves changed-path completeness, raw native
   evidence and the alpha/release responsibility split.

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -219,10 +219,13 @@ Each section is bound to the registry id by the catalog meta gate.
   source acceptance concurrently with the impact-selected native/SDK, Shifu,
   and KFD lanes. Those execution lanes start only after the build-free
   governance planner and proof probe pass; every optional skip is justified by
-  a `required: false` decision retained in the plan. The stable aggregate still
-  waits for and requires successful source acceptance together with every
-  selected lane, so concurrency shortens the healthy critical path without
-  admitting a source failure. A non-empty, source-bound native plan enters the
+  a `required: false` decision retained in the plan. A source failure invokes
+  an `actions: write`-scoped controller that cancels the current workflow and
+  its in-flight selected lanes; it cannot cancel another run. The stable
+  aggregate still waits for and requires successful source acceptance together
+  with every selected lane, so concurrency shortens the healthy critical path
+  without admitting a source failure or letting an already-doomed SDK shard
+  run to completion. A non-empty, source-bound native plan enters the
   registered action; a tier-none plan writes the same receipt directly without
   installing Buildchain, Conan, or the workspace.
 - **Retirement:** remove only with a replacement that consumes the same

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -142,7 +142,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:3d9e020c9bdcd477b68354a5c8aa85a4de697638efb9515576d57c053e39b263",
+          "definitionDigest": "sha256:2024ae7be92a8b9a1bc627249d323e1d8c3c2c480fdb07f45aea8f01b7b7ce2f",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0","actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
@@ -446,7 +446,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:821e24c0aa6bd63f10be13721771a550035c3c50283d65e1913143e040f0cf89",
+          "definitionDigest": "sha256:c8797849fa3d0a626284cefcccf6ed67c7557e06ca27fa94e4133b0ea533f6aa",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"],
           "steps": [
@@ -542,7 +542,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e9bdb64f8a73c24f5e38c878adddc267b7a42caf7d6f22f0516e2789ea65e72e",
+          "definitionDigest": "sha256:208cdc05e520df6e9b412325af8fc6d91104c07c3014888d150c6debbaedb3cf",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@v4","actions/setup-node@v6.4.0"],
           "steps": [

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -351,6 +351,22 @@
           ]
         },
         {
+          "id": "cancel_after_source_failure",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:57208c6a1444ec98972a55d0daf6f4598399329fc5d887ff28794b310fa8ba86",
+          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": [],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Cancel this failed source workflow",
+              "definitionDigest": "sha256:67176f1a3882b1d671cce858a073b08fd093cfd45c4af8eac49e2687ccfcf062"
+            }
+          ]
+        },
+        {
           "id": "candidate_buildchain_config",
           "authority": "qualification",
           "publication": "none",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -43,6 +43,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/affected-native-cache-promote.yml` | `promote` | qualification | none | diagnostic | token:write | none | 16 |
 | `.github/workflows/affected-native-pr.yml` | `affected_native_shards` | qualification | none | diagnostic | token:read | none | 23 |
 | `.github/workflows/affected-native-pr.yml` | `affected-native` | qualification | none | diagnostic | token:read | none | 13 |
+| `.github/workflows/affected-native-pr.yml` | `cancel_after_source_failure` | qualification | none | diagnostic | token:write | none | 1 |
 | `.github/workflows/affected-native-pr.yml` | `candidate_buildchain_config` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/affected-native-pr.yml` | `candidate_preflight` | qualification | none | diagnostic | token:read | none | 7 |
 | `.github/workflows/affected-native-pr.yml` | `dco` | qualification | none | diagnostic | token:read | none | 2 |

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -39,7 +39,7 @@
       "gates": [
         "source.changed-scope"
       ],
-      "activation": "two deterministic GitHub-hosted Linux partitions on the first exact merge-group execution after source and governance preflight, or after any reuse mismatch; the stable affected-native aggregator reports fast PR admission and admits either the complete impact-selected queue set or one verified exact same-SHA queue proof",
+      "activation": "two deterministic GitHub-hosted Linux partitions on the first exact merge-group execution after governance planning and proof probing, or after any reuse mismatch; the stable affected-native aggregator reports fast PR admission and admits either the complete impact-selected queue set or one verified exact same-SHA queue proof",
       "invocation": {
         "args": [
           "--omit-dependency",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:97786bb5dc87b07c0308f1b77543a3b0d6fcaa8867e9500704d1c7d4d5f99548",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:1302555b1e90d3de3ed1a8120d7b2a4db7eb0c1d7ef24ee40479dc9e04185a13",
+  "sourceRoot": "sha256:117d55c82264a31eea08ea4e9183f430ea98d91612b316783c429f4a32ccbc0b",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1111,7 +1111,7 @@
           "path": "docs/qualification/gates/workflow-bindings.json",
           "currentLines": 649,
           "baselineLines": 580,
-          "currentRoot": "sha256:941304ace4037c3cce54fca7a41f75c81ce317ab50c56f1f5a34d91d1e728e6b",
+          "currentRoot": "sha256:e4d0c7728d55186910c7724c0e6be0021770516263ef385abf1f89e0b2196680",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:0f5b48a442c4be58c43b64434ffc7180b8bf18786f044fa21343a35c2447eeb2"
+          "sourceRoot": "sha256:2bb649b129cdc97160f3a6fb9c70dbe3322c53eff1a7a7bfc049d98e6e80c8dc"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:10a1f3de29f2363d29862be2234a88c2944b12b6e3fd686b5e1ef947529a0399"
+  "registryRoot": "sha256:abdb31db7648a3b4558e2db55e50abd5d6e194bbd53220382ebba237ec2a40be"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:b63858718028af011d01fc21bacf949de805d10c49c3ea63313df0ac6c801a18"
+          "sourceRoot": "sha256:0f5b48a442c4be58c43b64434ffc7180b8bf18786f044fa21343a35c2447eeb2"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -799,5 +799,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:6fb3e9b6ba583e6dfbbbf6e9b438d4546235fe3319e043cd4a6d78e908f6d8be"
+  "registryRoot": "sha256:10a1f3de29f2363d29862be2234a88c2944b12b6e3fd686b5e1ef947529a0399"
 }

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -1106,7 +1106,7 @@ test('workflow keeps one context while PR proof replaces duplicate queue builds'
   );
   assert.match(
     workflow,
-    /affected_native_shards:[\s\S]*- source_acceptance[\s\S]*- candidate_preflight[\s\S]*needs\.proof_probe\.outputs\.reuse != 'true'/u,
+    /affected_native_shards:[\s\S]*- candidate_preflight[\s\S]*- proof_probe[\s\S]*needs\.proof_probe\.outputs\.reuse != 'true'/u,
   );
   assert.match(
     workflow,

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -118,6 +118,15 @@ test('PR proof overlaps source acceptance with heavy gates before exact queue re
   assert.match(native, /needs\.proof_probe\.outputs\.reuse != 'true'/);
   assert.doesNotMatch(native, /if:.*merge_group.*runs-on:/su);
   const aggregate = source.slice(source.indexOf('  affected-native:\n'));
+  const cancellation = source.slice(
+    source.indexOf('  cancel_after_source_failure:\n'),
+    source.indexOf('  candidate_buildchain_config:\n'),
+  );
+  assert.match(
+    cancellation,
+    /needs: source_acceptance[\s\S]*needs\.source_acceptance\.result != 'success'[\s\S]*permissions:\n {6}actions: write[\s\S]*repos\/\$GITHUB_REPOSITORY\/actions\/runs\/\$GITHUB_RUN_ID\/cancel/,
+  );
+  assert.doesNotMatch(cancellation, /run_id|head_sha|workflow_id/);
   assert.match(aggregate, /- source_acceptance/);
   assert.match(
     aggregate,

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -103,7 +103,7 @@ test('the single required dev workflow is merge-queue compatible', () => {
   }
 });
 
-test('PR proof closes heavy gates before exact queue reuse', () => {
+test('PR proof overlaps source acceptance with heavy gates before exact queue reuse', () => {
   const source = fs.readFileSync(
     path.join(ROOT, '.github/workflows/affected-native-pr.yml'),
     'utf8',
@@ -112,10 +112,18 @@ test('PR proof closes heavy gates before exact queue reuse', () => {
     source.indexOf('  affected_native_shards:\n'),
     source.indexOf('  shifu_workspace:\n'),
   );
-  assert.match(native, /- source_acceptance[\s\S]*- candidate_preflight/);
+  assert.doesNotMatch(native, /- source_acceptance/);
+  assert.doesNotMatch(native, /needs\.source_acceptance/);
+  assert.match(native, /- candidate_preflight[\s\S]*- proof_probe/);
   assert.match(native, /needs\.proof_probe\.outputs\.reuse != 'true'/);
   assert.doesNotMatch(native, /if:.*merge_group.*runs-on:/su);
-  assert.match(source, /require_optional_gate "PR affected-native"/);
+  const aggregate = source.slice(source.indexOf('  affected-native:\n'));
+  assert.match(aggregate, /- source_acceptance/);
+  assert.match(
+    aggregate,
+    /SOURCE_RESULT:[\s\S]*require_result "source acceptance" success "\$SOURCE_RESULT"/,
+  );
+  assert.match(aggregate, /require_optional_gate "PR affected-native"/);
   assert.match(source, /producer-event[\s\S]*producer-head-sha/);
   assert.match(source, /Upload authoritative producer proof/);
 });


### PR DESCRIPTION
## Summary

Overlap dev source acceptance with native qualification lanes and cancel the current workflow run when source acceptance fails.

## Verification

- `./shifu check:source`
- `node --test scripts/affected-native-proof.test.mjs scripts/check-kungfu-gate-catalog.test.mjs`
- workflow authority, publication, semantic amplification, complexity, and diff checks

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded CI scheduling change preserves existing gate authority and does not alter an architecture contract"
}
-->