### PR TITLE
fix(project-cut): repair settlement and queue identities

### DIFF
--- a/framework/project-cut/src/publication.mjs
+++ b/framework/project-cut/src/publication.mjs
@@ -540,12 +540,12 @@ export function planSettlementPublication(
   const projectCuts = normalized.projectCuts.map((cutRoot) =>
     inspectProjectCut(root, sourceCommit, cutRoot),
   );
-  const selectedEpisodeRoots = new Set(
-    episodes.map((episode) => episode.semanticRoot),
+  const selectedEpisodeProviderRoots = new Set(
+    episodes.map((episode) => episode.providerRoot),
   );
   const missingEpisodeRoots = projectCuts
     .flatMap((cut) => cut.episodeRoots)
-    .filter((episodeRoot) => !selectedEpisodeRoots.has(episodeRoot))
+    .filter((episodeRoot) => !selectedEpisodeProviderRoots.has(episodeRoot))
     .sort(utf8Compare);
   if (missingEpisodeRoots.length > 0)
     throw failure(

--- a/scripts/affected-native-proof.mjs
+++ b/scripts/affected-native-proof.mjs
@@ -799,7 +799,10 @@ export function createDeliveryAttempt(descriptor, proof, decision, producer) {
     producer.triggerHeadSha,
     'delivery merge-group head',
   );
-  if (binding.source.replayedCandidate !== mergeGroupHead) {
+  if (
+    binding.family === null &&
+    binding.source.replayedCandidate !== mergeGroupHead
+  ) {
     throw new Error('delivery merge-group candidate drift');
   }
   const body = {
@@ -853,7 +856,8 @@ export function validateDeliveryAttempt(attempt) {
   requireSha(body.source?.checkout, 'delivery checkout');
   if (
     body.source.checkout !== body.source.mergeGroupHead ||
-    body.source.replayedCandidate !== body.source.mergeGroupHead
+    (body.family === null &&
+      body.source.replayedCandidate !== body.source.mergeGroupHead)
   ) {
     throw new Error('affected-native delivery checkout drift');
   }

--- a/scripts/affected-native-proof.mjs
+++ b/scripts/affected-native-proof.mjs
@@ -222,10 +222,11 @@ export function createDeliveryBinding({
     };
     return { ...body, bindingRoot: digest(body) };
   }
+  // Admission creates a synthetic replay commit before enqueue. GitHub later
+  // authors a different merge-group commit, so only their trees can be equal.
   if (
     lease.pullRequestHead !== source.pullRequestHead ||
     lease.devHead !== exactDevHead ||
-    lease.replayedCandidate !== exactCandidateHead ||
     lease.replayedTree !== exactCandidateTree
   ) {
     throw new Error('family delivery source or latest-dev replay drift');

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -262,7 +262,7 @@ test('descriptor binds the exact tree, base, plan projection, and toolchain', ()
 });
 
 test('family delivery binding is separate from reusable qualification identity', () => {
-  const { values } = deliveryFixture();
+  const { values } = deliveryFixture({ values: { candidateHead: OTHER_HEAD } });
   const binding = createDeliveryBinding(values);
   const first = createProofDescriptor(
     plan(QUEUE_HEAD),

--- a/scripts/affected-native-proof.test.mjs
+++ b/scripts/affected-native-proof.test.mjs
@@ -493,9 +493,10 @@ test('exact pull-request qualification proof is reusable by bound delivery', () 
   );
   fs.rmSync(value.root, { recursive: true, force: true });
 });
-
 test('delivery attempt seals the exact family, source, proof decision, and run', () => {
-  const binding = createDeliveryBinding(deliveryFixture().values);
+  const binding = createDeliveryBinding(
+    deliveryFixture({ values: { candidateHead: OTHER_HEAD } }).values,
+  );
   const descriptor = createProofDescriptor(
     plan(QUEUE_HEAD),
     TREE,
@@ -518,13 +519,13 @@ test('delivery attempt seals the exact family, source, proof decision, and run',
     'reused',
     producer({
       runId: 42,
-      triggerHeadSha: QUEUE_HEAD,
-      checkoutSha: QUEUE_HEAD,
+      triggerHeadSha: OTHER_HEAD,
+      checkoutSha: OTHER_HEAD,
     }),
   );
   assert.equal(validateDeliveryAttempt(attempt), attempt);
   assert.equal(attempt.source.pullRequestHead, HEAD);
-  assert.equal(attempt.source.mergeGroupHead, QUEUE_HEAD);
+  assert.equal(attempt.source.mergeGroupHead, OTHER_HEAD);
   assert.equal(attempt.proof.decision, 'reused');
   assert.equal(attempt.workflow.runId, 42);
   assert.throws(
@@ -536,7 +537,6 @@ test('delivery attempt seals the exact family, source, proof decision, and run',
     /root drift/u,
   );
 });
-
 test('effective rules normalize the exact required-check set', () => {
   assert.deepEqual(
     requiredContextsFromRules([

--- a/scripts/check-project-cut-publication.test.mjs
+++ b/scripts/check-project-cut-publication.test.mjs
@@ -153,22 +153,20 @@ function workspace(t) {
 
   const firstEpisode = episodeBundle(7, 'first');
   const secondEpisode = episodeBundle(8, 'second');
-  for (const entry of [firstEpisode, secondEpisode]) {
-    sealGitEpisode(
-      root,
-      buildGitEpisodeSegment(entry.bundle, entry.qualification),
-      { writerId: 'publication-test' },
-    );
-  }
-  const firstCut = projectCut('first', firstEpisode.root);
-  const secondCut = projectCut('second', secondEpisode.root);
+  const sealedEpisodes = [firstEpisode, secondEpisode].map((entry) => {
+    const segment = buildGitEpisodeSegment(entry.bundle, entry.qualification);
+    sealGitEpisode(root, segment, { writerId: 'publication-test' });
+    return segment;
+  });
+  const firstCut = projectCut('first', sealedEpisodes[0].providerRoot);
+  const secondCut = projectCut('second', sealedEpisodes[1].providerRoot);
   addProjectCut(root, firstCut);
   addProjectCut(root, secondCut);
   git(root, 'add', '--all');
   git(root, 'commit', '-qm', 'test: seed sealed settlement material');
   return {
     root,
-    episodes: [firstEpisode.root, secondEpisode.root].sort(),
+    episodes: sealedEpisodes.map((episode) => episode.semanticRoot).sort(),
     cuts: [firstCut.cutRoot, secondCut.cutRoot].sort(),
   };
 }
@@ -265,6 +263,19 @@ test('planner is deterministic, order-independent, bounded, and root-sensitive',
   assert.equal(
     first.manifest.runtimeContinuation.publicationIsAuthority,
     false,
+  );
+  assert.ok(
+    first.manifest.selection.episodes.every(
+      (episode) => episode.semanticRoot !== episode.providerRoot,
+    ),
+  );
+  const selectedProviderRoots = new Set(
+    first.manifest.selection.episodes.map((episode) => episode.providerRoot),
+  );
+  assert.ok(
+    first.manifest.selection.projectCuts
+      .flatMap((cut) => cut.episodeRoots)
+      .every((episodeRoot) => selectedProviderRoots.has(episodeRoot)),
   );
   assert.equal(first.manifest.files.length, 10);
 


### PR DESCRIPTION
Supersedes #1791. Rebuilt from live `dev/v4/v4.0` after deterministic admission returned `repair-required` for the obsolete merge-bearing branch history.

## Summary

- match Project Cut `episodeDelta.nativeRoots` against sealed Episode provider roots
- keep request and tracked Episode paths keyed by the existing semantic root
- make the publication fixture exercise distinct semantic and provider roots\n- accept a provider-authored merge-group commit when its deterministic replay tree, live base, and PR head remain exact

## Verification\n\n- affected-native proof/workflow contracts — 21/21 passed\n- `./shifu check:source` — 733 tests (723 passed, 10 skipped, 0 failed) after the live queue repair\n
- `./shifu test:project-cut-publication` — 10/10 passed
- real Wave publication dry-run — 1 sealed Episode and 2 settled Project Cuts planned as batch `sha256:a74ce92fb5c388d874d2875433ae63cd1ca8c128a05fe4e389f5a6de2bc2025f`
- `./shifu check:source` — 733 tests (723 passed, 10 skipped, 0 failed); build-free source gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the existing settlement-publication contract across the already distinct Episode semantic and provider identities without changing either root algorithm or authority boundary."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change only repairs identity matching inside the existing protected settlement projection.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed\n

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LWdvLWZhbWlseS1jb250aW51b3VzLWRlbGl2ZXJ5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOC1rdW5nZnUtZ28tZmFtaWx5LWdpdC1zZXR0bGVtZW50LXB1YmxpY2F0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJiOTRlMDAxNWE4M2EzOGQ5ZTZiN2Q3NzU4NTY2Y2NjMDgyNDFjODk2IiwicHVsbFJlcXVlc3RIZWFkIjoiMmQyZmU4ZmMwYmJhNzkyYzRmMDI4N2Q2NmI3ZTAyMjFiYzlhMmMwZiIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMjAwNTRmNTIxMmE4MTM2NmQyMTg4MDgyOTYzM2I5MDEwNWZmNWE0NCIsInJlcGxheWVkVHJlZSI6IjZkYjIwZDQ1YmEwNTNjYzdkYWUzNWZmMjQ3YTI3ZjFiY2FlOTk4MTkiLCJxdWV1ZUF0dGVtcHQiOiIxNzk3QGI5NGUwMDE1YTgzYTM4ZDllNmI3ZDc3NTg1NjZjY2MwODI0MWM4OTYiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6Zjk0MWE0NTJmYjNkOTI4ZDljMmVlYzFkNzY1NWJiOThjM2MzYTI1OGZjYmJlNmYxODE0MjIzMGE4MTUxNTg3MCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OmExNTY4ZWMzNDcyOGNmMDEwNWVkYzFkOTY0Y2M5YzEyYjMxYWQ5NTI3MThlOGUyNzU1OGVlNGUwZjZkMWI5NzAiLCJzaGEyNTY6ZDI3NmI0ZWZkYmJjYWE4ZTViMzViMTRmNDg0OTg4NGM2ZjNmOGQ5ZjQwYjFhYWFhODRiNTE3NGQ1YWFmZDYxNSIsInNoYTI1NjpmOTQxYTQ1MmZiM2Q5MjhkOWMyZWVjMWQ3NjU1YmI5OGMzYzNhMjU4ZmNiYmU2ZjE4MTQyMjMwYTgxNTE1ODcwIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZWNhYzY3YmNlYmZhZTNiZiIsImxlYXNlUm9vdCI6InNoYTI1NjphMTcxYjg2ZDRjN2E0OWI1ODZjYjBkZDMwNTE0YWMyNTM0OTEwYjc1ODIxMDI2OGUzNjAxZDY4ZTEzYWQ4YjkwIn0 -->