### PR TITLE
perf(ci): classify SDK-neutral workflow changes

### DIFF
--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -228,6 +228,14 @@ Each section is bound to the registry id by the catalog meta gate.
   run to completion. A non-empty, source-bound native plan enters the
   registered action; a tier-none plan writes the same receipt directly without
   installing Buildchain, Conan, or the workspace.
+- **SDK workflow impact:** the build-free planner compares a bounded semantic
+  projection of the candidate planner and affected-native shard through the
+  installed four-language SDK qualification step. The shard's
+  `source_acceptance` dependency and unrelated jobs are scheduling-only, so
+  changing only those fields does not rebuild the SDK. Changes to any other
+  dependency, runner, permissions, environment, matrix, timeout, planner
+  wiring, SDK preparation/build/pack/qualification step, or an unreadable or
+  incomplete workflow projection require SDK qualification.
 - **Retirement:** remove only with a replacement that consumes the same
   architecture authority and preserves changed-path completeness, raw native
   evidence and the alpha/release responsibility split.

--- a/scripts/candidate-timeline-events.test.mjs
+++ b/scripts/candidate-timeline-events.test.mjs
@@ -312,7 +312,7 @@ function deliveryAttempt(overrides = {}) {
       pullRequest: 1262,
       pullRequestHead,
       devHead: 'c'.repeat(40),
-      replayedCandidate: 'd'.repeat(40),
+      replayedCandidate: mergeGroupHead,
       replayedTree: 'e'.repeat(40),
       mergeGroupHead,
       checkout: mergeGroupHead,

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -11,6 +11,7 @@ import { pathToFileURL } from 'node:url';
 import { observeNativeToolchain } from './affected-native-proof.mjs';
 import telemetry from './candidate-timeline-events.cjs';
 import { devMergeBaseCandidates } from './candidate-timeline-events.cjs';
+import { parseDocument } from './readonly-source-toolchain.mjs';
 import { writeShifuGateEvidence } from './shifu-gate-evidence.mjs';
 
 const { measureCandidateStage } = telemetry;
@@ -68,9 +69,13 @@ const sdkRootScriptKeys = [
   'sdk:layered:check',
   'sdk:layered:generate',
 ];
+const affectedNativeWorkflow = '.github/workflows/affected-native-pr.yml';
+const affectedNativeSdkTerminalStep =
+  'Qualify installed four-language SDK wire contract';
+const affectedNativePlanStep = 'Plan exact dev candidate qualification';
 const sdkQualificationPaths = [
   '.github/workflows/affected-native-cache-promote.yml',
-  '.github/workflows/affected-native-pr.yml',
+  affectedNativeWorkflow,
   'crates/Cargo.lock',
   'crates/Cargo.toml',
   'crates/kungfu-sdk/',
@@ -171,6 +176,119 @@ function readJsonAtRevision(revision, file) {
   return JSON.parse(result.stdout);
 }
 
+function readWorkflowAtRevision(revision, file) {
+  const result = spawnSync('git', ['show', `${revision}:${file}`], {
+    cwd: root,
+    encoding: 'utf8',
+    shell: false,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr.trim() || `cannot read ${file} at ${revision}`,
+    );
+  }
+  const document = parseDocument(result.stdout);
+  if (document.errors.length) throw document.errors[0];
+  return document.toJS();
+}
+
+function requiredObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function uniqueNamedStep(job, name, label) {
+  const steps = Array.isArray(job.steps) ? job.steps : [];
+  const matches = steps
+    .map((step, index) => ({ step, index }))
+    .filter(({ step }) => step?.name === name);
+  if (matches.length !== 1) {
+    throw new Error(`${label} must contain exactly one '${name}' step`);
+  }
+  return matches[0];
+}
+
+function semanticNeeds(value, ignored, label) {
+  const needs =
+    value === undefined
+      ? []
+      : typeof value === 'string'
+        ? [value]
+        : Array.isArray(value) &&
+            value.every((item) => typeof item === 'string')
+          ? value
+          : null;
+  if (!needs)
+    throw new Error(`${label} needs must be a string or string array`);
+  return unique(needs.filter((item) => !ignored.includes(item)));
+}
+
+function semanticShardCondition(value) {
+  if (typeof value !== 'string') {
+    throw new Error('affected_native_shards job if must be a string');
+  }
+  const sourceGuard =
+    /needs\.source_acceptance\.result\s*==\s*'success'\s*&&\s*/gu;
+  const matches = value.match(sourceGuard) || [];
+  if (matches.length > 1) {
+    throw new Error(
+      'affected_native_shards job has duplicate source acceptance guards',
+    );
+  }
+  return value.replace(sourceGuard, '').replace(/\s+/gu, ' ').trim();
+}
+
+export function affectedNativeWorkflowSdkProjection(document) {
+  const workflow = requiredObject(document, 'affected-native workflow');
+  const jobs = requiredObject(workflow.jobs, 'affected-native workflow jobs');
+  const candidate = requiredObject(
+    jobs.candidate_preflight,
+    'candidate_preflight job',
+  );
+  const shard = requiredObject(
+    jobs.affected_native_shards,
+    'affected_native_shards job',
+  );
+  if (!Array.isArray(shard.steps)) {
+    throw new Error('affected_native_shards steps must be an array');
+  }
+  const terminal = uniqueNamedStep(
+    shard,
+    affectedNativeSdkTerminalStep,
+    'affected_native_shards job',
+  );
+  const candidatePlan = uniqueNamedStep(
+    candidate,
+    affectedNativePlanStep,
+    'candidate_preflight job',
+  );
+  const { steps: _candidateSteps, ...candidateJob } = candidate;
+  const { steps: _shardSteps, ...shardJob } = shard;
+  shardJob.needs = semanticNeeds(
+    shard.needs,
+    ['source_acceptance'],
+    'affected_native_shards job',
+  );
+  shardJob.if = semanticShardCondition(shard.if);
+  return {
+    workflow: {
+      permissions: workflow.permissions || null,
+      env: workflow.env || null,
+      defaults: workflow.defaults || null,
+    },
+    candidatePreflight: {
+      job: candidateJob,
+      plan: candidatePlan.step,
+    },
+    affectedNativeShards: {
+      job: shardJob,
+      stepsThroughSdkQualification: shard.steps.slice(0, terminal.index + 1),
+    },
+  };
+}
+
 export function rootPackageSdkProjection(document) {
   if (!document || typeof document !== 'object' || Array.isArray(document)) {
     throw new Error('root package document must be an object');
@@ -235,7 +353,10 @@ export function sdkQualificationImpact(
   changedFiles,
   base,
   head,
-  { packageAtRevision = readJsonAtRevision } = {},
+  {
+    packageAtRevision = readJsonAtRevision,
+    workflowAtRevision = readWorkflowAtRevision,
+  } = {},
 ) {
   let required = false;
   const reasons = [];
@@ -257,6 +378,31 @@ export function sdkQualificationImpact(
         reasons.push({
           path: file,
           kind: 'root-package-sdk-impact-unknown',
+        });
+      }
+      continue;
+    }
+    if (file === affectedNativeWorkflow) {
+      try {
+        const before = affectedNativeWorkflowSdkProjection(
+          workflowAtRevision(base, file),
+        );
+        const after = affectedNativeWorkflowSdkProjection(
+          workflowAtRevision(head, file),
+        );
+        const changed = stableJson(before) !== stableJson(after);
+        required ||= changed;
+        reasons.push({
+          path: file,
+          kind: changed
+            ? 'affected-native-workflow-sdk-projection'
+            : 'affected-native-workflow-sdk-neutral',
+        });
+      } catch {
+        required = true;
+        reasons.push({
+          path: file,
+          kind: 'affected-native-workflow-sdk-impact-unknown',
         });
       }
       continue;

--- a/scripts/run-core-affected-native.test.mjs
+++ b/scripts/run-core-affected-native.test.mjs
@@ -3,7 +3,65 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { devQueueQualificationImpact } from './run-core-affected-native.mjs';
+import {
+  affectedNativeWorkflowSdkProjection,
+  devQueueQualificationImpact,
+  sdkQualificationImpact,
+} from './run-core-affected-native.mjs';
+
+const workflowPath = '.github/workflows/affected-native-pr.yml';
+
+function affectedNativeWorkflowFixture() {
+  return {
+    permissions: { contents: 'read', actions: 'read' },
+    jobs: {
+      candidate_preflight: {
+        'runs-on': 'ubuntu-24.04',
+        'timeout-minutes': 10,
+        needs: 'candidate_buildchain_config',
+        outputs: {
+          'sdk-required': '${{ steps.plan.outputs.sdk-required }}',
+        },
+        steps: [
+          {
+            name: 'Plan exact dev candidate qualification',
+            id: 'plan',
+            run: 'node scripts/run-core-affected-native.mjs --json',
+          },
+          { name: 'Upload candidate preflight plan', uses: 'actions/upload' },
+        ],
+      },
+      affected_native_shards: {
+        needs: ['candidate_preflight', 'proof_probe'],
+        if: '${{ needs.candidate_preflight.outputs.sdk-required }}',
+        'runs-on': 'ubuntu-24.04',
+        'timeout-minutes': 75,
+        strategy: { matrix: { partition: [0, 1] } },
+        env: { CC: 'gcc-14', CXX: 'g++-14' },
+        steps: [
+          { uses: 'actions/checkout@v4' },
+          { name: 'Build Core SDK artifacts', run: './shifu build:core:sdk' },
+          {
+            name: 'Qualify installed four-language SDK wire contract',
+            run: './shifu layers:qualify:sdk',
+          },
+          { name: 'Run affected native closure', run: './shifu gate run' },
+        ],
+      },
+    },
+  };
+}
+
+function workflowImpact(before, after) {
+  return sdkQualificationImpact(
+    ['.github/workflows/affected-native-pr.yml'],
+    'base',
+    'head',
+    {
+      workflowAtRevision: (revision) => (revision === 'base' ? before : after),
+    },
+  );
+}
 
 test('dev queue impact keeps unrelated source changes out of optional heavy gates', () => {
   assert.deepEqual(devQueueQualificationImpact(['framework/gui/src/app.ts']), {
@@ -43,4 +101,83 @@ test('the staged workflow remains self-qualifying under both moved gates', () =>
       '.github/workflows/affected-native-pr.yml',
     ],
   );
+});
+
+test('affected-native SDK projection excludes scheduling needs and unrelated jobs', () => {
+  const before = affectedNativeWorkflowFixture();
+  const after = structuredClone(before);
+  after.jobs.affected_native_shards.needs.push('source_acceptance');
+  after.jobs.affected_native_shards.if =
+    "${{ needs.source_acceptance.result == 'success' && needs.candidate_preflight.outputs.sdk-required }}";
+  after.jobs.cancel_after_source_failure = {
+    needs: 'source_acceptance',
+    'runs-on': 'ubuntu-24.04',
+    steps: [{ run: 'gh api --method POST /cancel' }],
+  };
+
+  assert.deepEqual(
+    affectedNativeWorkflowSdkProjection(before),
+    affectedNativeWorkflowSdkProjection(after),
+  );
+  assert.deepEqual(workflowImpact(before, after), {
+    required: false,
+    reasons: [
+      {
+        path: workflowPath,
+        kind: 'affected-native-workflow-sdk-neutral',
+      },
+    ],
+  });
+});
+
+test('affected-native SDK projection preserves execution and qualification changes', () => {
+  const mutations = [
+    (workflow) => {
+      workflow.jobs.candidate_preflight.steps[0].run += ' --changed';
+    },
+    (workflow) => {
+      workflow.jobs.candidate_preflight.needs = 'another_preflight';
+    },
+    (workflow) => {
+      workflow.jobs.affected_native_shards.needs = ['candidate_preflight'];
+    },
+    (workflow) => {
+      workflow.jobs.affected_native_shards.if =
+        '${{ needs.candidate_preflight.outputs.native-required }}';
+    },
+    (workflow) => {
+      workflow.jobs.affected_native_shards['runs-on'] = 'ubuntu-22.04';
+    },
+    (workflow) => {
+      workflow.jobs.affected_native_shards.steps[1].run += ' --changed';
+    },
+    (workflow) => {
+      workflow.jobs.affected_native_shards.steps[2].run += ' --changed';
+    },
+  ];
+  for (const mutate of mutations) {
+    const before = affectedNativeWorkflowFixture();
+    const after = structuredClone(before);
+    mutate(after);
+    assert.equal(workflowImpact(before, after).required, true);
+    assert.equal(
+      workflowImpact(before, after).reasons[0].kind,
+      'affected-native-workflow-sdk-projection',
+    );
+  }
+});
+
+test('affected-native SDK projection fails closed when its boundary is missing', () => {
+  const before = affectedNativeWorkflowFixture();
+  const after = structuredClone(before);
+  after.jobs.affected_native_shards.steps.splice(2, 1);
+  assert.deepEqual(workflowImpact(before, after), {
+    required: true,
+    reasons: [
+      {
+        path: workflowPath,
+        kind: 'affected-native-workflow-sdk-impact-unknown',
+      },
+    ],
+  });
 });


### PR DESCRIPTION
## Summary

Avoid rebuilding the four-language SDK when an affected-native workflow edit changes only source-acceptance scheduling or unrelated jobs. Preserve fail-closed qualification for every execution, planner, runner, dependency, and SDK-boundary change.

## Related issue

Dev required Gate latency SLO closure.

## Changes

- compare a build-free semantic projection of the affected-native workflow at base and head
- exclude only the source-acceptance scheduling edge and unrelated jobs from SDK impact
- retain all candidate planning and affected-native execution fields through SDK qualification
- fail closed when the workflow or qualification boundary cannot be parsed
- repair the delivery-attempt fixture so replay identity matches the merge-group head

## Verification

- `./shifu check`
- `node --test scripts/run-core-affected-native.test.mjs scripts/candidate-timeline-events.test.mjs`
- `./shifu core:affected -- --self-test`
- historical replay of `bd5c1316e5`: SDK neutral while preserving 12 native closure components and the `embedded-sqlite` profile
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded CI planner optimization preserves the existing qualification authority and fail-closed SDK boundary."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
