### PR TITLE
fix(project-cut): match settlement provider roots

### DIFF
--- a/framework/project-cut/src/publication.mjs
+++ b/framework/project-cut/src/publication.mjs
@@ -540,12 +540,12 @@ export function planSettlementPublication(
   const projectCuts = normalized.projectCuts.map((cutRoot) =>
     inspectProjectCut(root, sourceCommit, cutRoot),
   );
-  const selectedEpisodeRoots = new Set(
-    episodes.map((episode) => episode.semanticRoot),
+  const selectedEpisodeProviderRoots = new Set(
+    episodes.map((episode) => episode.providerRoot),
   );
   const missingEpisodeRoots = projectCuts
     .flatMap((cut) => cut.episodeRoots)
-    .filter((episodeRoot) => !selectedEpisodeRoots.has(episodeRoot))
+    .filter((episodeRoot) => !selectedEpisodeProviderRoots.has(episodeRoot))
     .sort(utf8Compare);
   if (missingEpisodeRoots.length > 0)
     throw failure(

--- a/scripts/check-project-cut-publication.test.mjs
+++ b/scripts/check-project-cut-publication.test.mjs
@@ -153,22 +153,20 @@ function workspace(t) {
 
   const firstEpisode = episodeBundle(7, 'first');
   const secondEpisode = episodeBundle(8, 'second');
-  for (const entry of [firstEpisode, secondEpisode]) {
-    sealGitEpisode(
-      root,
-      buildGitEpisodeSegment(entry.bundle, entry.qualification),
-      { writerId: 'publication-test' },
-    );
-  }
-  const firstCut = projectCut('first', firstEpisode.root);
-  const secondCut = projectCut('second', secondEpisode.root);
+  const sealedEpisodes = [firstEpisode, secondEpisode].map((entry) => {
+    const segment = buildGitEpisodeSegment(entry.bundle, entry.qualification);
+    sealGitEpisode(root, segment, { writerId: 'publication-test' });
+    return segment;
+  });
+  const firstCut = projectCut('first', sealedEpisodes[0].providerRoot);
+  const secondCut = projectCut('second', sealedEpisodes[1].providerRoot);
   addProjectCut(root, firstCut);
   addProjectCut(root, secondCut);
   git(root, 'add', '--all');
   git(root, 'commit', '-qm', 'test: seed sealed settlement material');
   return {
     root,
-    episodes: [firstEpisode.root, secondEpisode.root].sort(),
+    episodes: sealedEpisodes.map((episode) => episode.semanticRoot).sort(),
     cuts: [firstCut.cutRoot, secondCut.cutRoot].sort(),
   };
 }
@@ -265,6 +263,19 @@ test('planner is deterministic, order-independent, bounded, and root-sensitive',
   assert.equal(
     first.manifest.runtimeContinuation.publicationIsAuthority,
     false,
+  );
+  assert.ok(
+    first.manifest.selection.episodes.every(
+      (episode) => episode.semanticRoot !== episode.providerRoot,
+    ),
+  );
+  const selectedProviderRoots = new Set(
+    first.manifest.selection.episodes.map((episode) => episode.providerRoot),
+  );
+  assert.ok(
+    first.manifest.selection.projectCuts
+      .flatMap((cut) => cut.episodeRoots)
+      .every((episodeRoot) => selectedProviderRoots.has(episodeRoot)),
   );
   assert.equal(first.manifest.files.length, 10);
 


### PR DESCRIPTION
Supersedes #1797. Live `dev/v4/v4.0` advanced with the overlapping affected-native provider-head repair, so this successor is rebuilt linearly from `223592b190578e3ed19d12f2df4ef36bc3887bf7` and retains only the unsettled publication fix.

## Summary

- match Project Cut `episodeDelta.nativeRoots` against sealed Episode provider roots
- keep request and tracked Episode paths keyed by the existing semantic root
- make the publication fixture exercise distinct semantic and provider roots
- preserve the already-merged affected-native provider-head authority unchanged

## Verification

- focused publication/affected-native/queue contracts: 34/34 passed
- complexity budget: `verdict=pass`, `blocking=[]`
- `./shifu check:source`: 733 tests (723 passed, 10 skipped, 0 failed)
- Python agent state: 40/40; runtime upgrade: 116/116; desktop update: 69/69
- staged pre-commit gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the existing settlement-publication contract across the already distinct Episode semantic and provider identities without changing either root algorithm or authority boundary."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change only repairs identity matching inside the existing protected settlement projection.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LWdvLWZhbWlseS1jb250aW51b3VzLWRlbGl2ZXJ5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOC1rdW5nZnUtZ28tZmFtaWx5LWdpdC1zZXR0bGVtZW50LXB1YmxpY2F0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiIyMjM1OTJiMTkwNTc4ZTNlZDE5ZDEyZjJkZjRlZjM2YmMzODg3YmY3IiwicHVsbFJlcXVlc3RIZWFkIjoiZTQzMmZjMDJkZWRmZmYwN2VkOWEwMjFjNmYwZGMyNjE0NjYwMWZiMiIsInJlcGxheWVkQ2FuZGlkYXRlIjoiOGI2NWY1MTNjMWFhNjE1OGRhODNjYWRjNjYwOGI4OWFmMThjZjVlYiIsInJlcGxheWVkVHJlZSI6IjFkMGFjNzhjOTFkMWU1MjQ1NjNiNDQ0OWY0NjQwZTgzZTUyNmEyNDAiLCJxdWV1ZUF0dGVtcHQiOiIxODAxQDIyMzU5MmIxOTA1NzhlM2VkMTlkMTJmMmRmNGVmMzZiYzM4ODdiZjciLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6N2VlNzJiYmMzYTlhMDg3NjU4OTM3NDRlY2Y0YmJlOGRlNGUzMDk3N2Q5NjU5OTQxNTg0ZjM4MGRmNTJlZDI5MSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjdlZTcyYmJjM2E5YTA4NzY1ODkzNzQ0ZWNmNGJiZThkZTRlMzA5NzdkOTY1OTk0MTU4NGYzODBkZjUyZWQyOTEiLCJzaGEyNTY6YTE1NjhlYzM0NzI4Y2YwMTA1ZWRjMWQ5NjRjYzljMTJiMzFhZDk1MjcxOGU4ZTI3NTU4ZWU0ZTBmNmQxYjk3MCIsInNoYTI1NjpkMjc2YjRlZmRiYmNhYThlNWIzNWIxNGY0ODQ5ODg0YzZmM2Y4ZDlmNDBiMWFhYWE4NGI1MTc0ZDVhYWZkNjE1Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZWNhYzY3YmNlYmZhZTNiZiIsImxlYXNlUm9vdCI6InNoYTI1NjoyYTAwNDk0MWUxNTVhZmZkMDZiNTQzMTE0MDUzODliMTEzZGM3ZGZhZmI3ODc2OWEzMjhmYjVjNTMzODQyNmU3In0 -->