### PR TITLE
feat(ci): qualify Windows EC2 JIT burst runners

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: AWS US Windows Burst Qualification
+
+on:
+  workflow_dispatch:
+    inputs:
+      qualification-id:
+        description: "One bounded Windows JIT qualification slot"
+        required: true
+        type: choice
+        options:
+          - win-smoke
+          - win-full-01
+          - win-full-02
+          - win-full-03
+          - win-cancel
+          - win-timeout
+      mode:
+        description: "Qualification exercise selected by the operator"
+        required: true
+        type: choice
+        options:
+          - smoke
+          - full
+          - cancellation
+          - timeout
+      runner-label:
+        description: "Exact unique JIT label created for this run"
+        required: true
+      buildchain-ref:
+        description: "Exact reviewed Buildchain train for this campaign"
+        required: true
+        default: "train/v2/v2.3/aws-us-elastic-runner-burst-plane"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: aws-us-windows-burst-${{ inputs.qualification-id }}
+  cancel-in-progress: false
+
+jobs:
+  trust:
+    name: Reject non-canonical or untrusted dispatch
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Require canonical repository, mode, label, and reviewed train
+        shell: bash
+        env:
+          EXPECTED_REPOSITORY: kungfu-systems/kungfu
+          EXPECTED_BUILDCHAIN_REF: train/v2/v2.3/aws-us-elastic-runner-burst-plane
+          REQUESTED_BUILDCHAIN_REF: ${{ inputs.buildchain-ref }}
+          QUALIFICATION_ID: ${{ inputs.qualification-id }}
+          MODE: ${{ inputs.mode }}
+          RUNNER_LABEL: ${{ inputs.runner-label }}
+        run: |
+          set -euo pipefail
+          test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+          test "${GITHUB_REPOSITORY}" = "${EXPECTED_REPOSITORY}"
+          test "${REQUESTED_BUILDCHAIN_REF}" = "${EXPECTED_BUILDCHAIN_REF}"
+          case "${QUALIFICATION_ID}:${MODE}" in
+            win-smoke:smoke|win-full-0[1-3]:full|win-cancel:cancellation|win-timeout:timeout) ;;
+            *) exit 1 ;;
+          esac
+          test "${RUNNER_LABEL}" = "aws-us-ec2-windows-jit-${QUALIFICATION_ID}"
+
+      - name: Require write-capable actor
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const permission = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            if (!["admin", "maintain", "write"].includes(permission.data.permission || "")) {
+              core.setFailed(`actor permission ${permission.data.permission || "none"} cannot allocate a burst runner`);
+            }
+
+  smoke:
+    name: Windows JIT runner profile smoke
+    needs: trust
+    if: ${{ inputs.mode == 'smoke' }}
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane
+    with:
+      buildchain-ref: train/v2/v2.3/aws-us-elastic-runner-burst-plane
+      runner-preset: aws-us-ec2-windows-jit
+      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
+      artifact-paths: |
+        product/release/qualification/aws-windows-jit-smoke.json
+      expected-artifacts-json: >-
+        {"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-windows-jit-smoke.json"]}
+      require-install: false
+      require-build: true
+      build-command: node scripts/probe-release-platform.mjs --aws-windows-jit
+      require-verify: false
+      lifecycle-timeout-minutes: 30
+      requested-parallelism: 1
+      artifact-transfer-mode: github-artifacts
+      artifact-retention-days: 14
+      checkout-cache-mode: off
+      checkout-cache-fallback: github
+      checkout-cache-github-timeout-seconds: 1200
+      publish-channel: none
+      release-candidate: false
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-compatibility-policy: allow-additive
+      buildchain-contract-drift-issue-mode: off
+
+  full:
+    name: Trusted exact-source full Windows qualification
+    needs: trust
+    if: ${{ inputs.mode == 'full' }}
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane
+    with:
+      buildchain-ref: train/v2/v2.3/aws-us-elastic-runner-burst-plane
+      runner-preset: aws-us-ec2-windows-jit
+      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
+      artifact-paths: |
+        product/release
+      expected-artifacts-json: >-
+        {"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}
+      require-install: true
+      require-build: true
+      require-verify: true
+      verify-command: node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip
+      lifecycle-timeout-minutes: 150
+      requested-parallelism: 8
+      artifact-transfer-mode: github-artifacts
+      artifact-retention-days: 14
+      checkout-cache-mode: off
+      checkout-cache-fallback: github
+      checkout-cache-github-timeout-seconds: 1200
+      shifu-cache-profile-ref: docs/shifu/qualification-portable-off.cache-profile.json
+      shifu-cache-profile-digest: sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c
+      publish-channel: none
+      release-candidate: false
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-compatibility-policy: allow-additive
+      buildchain-contract-drift-issue-mode: off
+
+  cleanup-exercise:
+    name: ${{ inputs.mode == 'cancellation' && 'Cancellation cleanup exercise' || 'Timeout cleanup exercise' }}
+    needs: trust
+    if: ${{ inputs.mode == 'cancellation' || inputs.mode == 'timeout' }}
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+      - ${{ inputs.runner-label }}
+    timeout-minutes: ${{ inputs.mode == 'timeout' && 5 || 45 }}
+    steps:
+      - name: Confirm exact JIT runner identity
+        shell: pwsh
+        env:
+          EXPECTED_LABEL: ${{ inputs.runner-label }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:AWS_EC2_INSTANCE_ID -notmatch '^i-[0-9a-f]+$') {
+            throw "missing EC2 instance identity"
+          }
+          $labels = $env:BUILDCHAIN_RUNNER_LABELS_JSON | ConvertFrom-Json
+          if ($EXPECTED_LABEL -notin $labels) {
+            throw "JIT label mismatch"
+          }
+          "instance=$($env:AWS_EC2_INSTANCE_ID)"
+          "mode=${{ inputs.mode }}"
+
+      - name: Hold until the declared cleanup trigger
+        shell: pwsh
+        run: Start-Sleep -Seconds 1200

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -732,6 +732,75 @@
       ]
     },
     {
+      "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:e925eda66d0b6255f16b916e107957e9fb52ad56794bb4b4c196746426ab79ab",
+      "jobs": [
+        {
+          "id": "cleanup-exercise",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:88da612bd391529048ff81f3f1bc00d1beceed86b770b78de0557fef2b890b0d",
+          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": [],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Confirm exact JIT runner identity",
+              "definitionDigest": "sha256:115bfd9234736a1da607e61a0bb1be98a191d35f0da57ad4bb419a447069b9d2"
+            },
+            {
+              "index": 2,
+              "label": "name:Hold until the declared cleanup trigger",
+              "definitionDigest": "sha256:ebc15529c500b6f0e216a2a2ede2ade66d1f685f9b824e67cf3a5382af07cf84"
+            }
+          ]
+        },
+        {
+          "id": "full",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:692b6f39dfd98c7343f8ca18c14a67458a910cc762693c9b016cc9c1155d1627",
+          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
+          "steps": []
+        },
+        {
+          "id": "smoke",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:5b3675b305cc27790052577719d9dbef5acd621412a447b23be2cc4f0983a186",
+          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
+          "steps": []
+        },
+        {
+          "id": "trust",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:0ab3755153f464566cfd91816f58d3abb1bbd9d2ea4a45ea6e328bebcc70020f",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
+          "steps": [
+            {
+              "index": 1,
+              "label": "name:Require canonical repository, mode, label, and reviewed train",
+              "definitionDigest": "sha256:4e46e0fffd538e23ae01e63788a115e079e81318b2ce724060155d77a2012d70"
+            },
+            {
+              "index": 2,
+              "label": "name:Require write-capable actor",
+              "definitionDigest": "sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "path": ".github/workflows/build.yml",
       "authority": "product-publication",
       "definitionDigest": "sha256:aadbb97771ffd89eaec3f3ed67ef3925e1730472a5a722c1a8b956c8ee71b6c1",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -55,6 +55,10 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:write | none | 0 |
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `cleanup-exercise` | qualification | none | diagnostic | token:write | none | 2 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `full` | qualification | none | diagnostic | token:write | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `smoke` | qualification | none | diagnostic | token:write | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-passport` | qualification | none | qualifying | token:read | none | 4 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -99,6 +99,13 @@
           "sourceRoot": "sha256:67b6fac7c86c473ce4cc96ba35536f53273715806af60e9663bbb09b33a00ef4"
         },
         {
+          "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
+          "classification": "non-publication",
+          "owner": "kungfu-ci",
+          "surfaceIds": [],
+          "sourceRoot": "sha256:97f62f0547dd06e7e8dded565f8c5653fac27c7beec788ccf06bb11bc57b4700"
+        },
+        {
           "path": ".github/workflows/build.yml",
           "classification": "qualification",
           "owner": "kungfu-release",
@@ -799,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:c745769069e23d09ed8723229c63841fa41a4ed9a022b3864a2f4a2add9f6be9"
+  "registryRoot": "sha256:da00a9d9273080438ed1864ee16e92214999a271479cc265b68f40ea44159704"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -230,3 +230,22 @@ test('AWS Linux burst workflow is trusted exact-train qualification only', () =>
     /secrets:|notar|signing|npm-publish|release-new-version|deploy/,
   );
 });
+
+test('AWS Windows JIT qualification is trusted, exact-label, and non-publication', () => {
+  const workflow = fs.readFileSync(
+    path.join(
+      repositoryRoot,
+      '.github/workflows/aws-us-windows-burst-qualification.yml',
+    ),
+    'utf8',
+  );
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
+  assert.match(workflow, /needs: trust/);
+  assert.match(workflow, /aws-us-ec2-windows-jit-\$\{QUALIFICATION_ID\}/);
+  assert.match(workflow, /runner-preset: aws-us-ec2-windows-jit/);
+  assert.match(workflow, /publish-channel: none/);
+  assert.match(workflow, /release-candidate: false/);
+  assert.match(workflow, /win-cancel:cancellation\|win-timeout:timeout/);
+  assert.doesNotMatch(workflow, /\b(?:id-token|packages):\s*write/);
+});

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -235,7 +235,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 10);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 28);
+  assert.equal(result.workflowAuthority.workflows.length, 29);
   const agentPatrol = result.workflowAuthority.workflows.find(
     (workflow) => workflow.path === '.github/workflows/kungfu-agent-patrol.yml',
   );

--- a/scripts/probe-release-platform.mjs
+++ b/scripts/probe-release-platform.mjs
@@ -3,6 +3,7 @@
 // @ts-check
 
 import childProcess from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -38,6 +39,114 @@ function run(command, args, root = ROOT) {
       ).trim()}`,
     );
   }
+}
+
+function capture(command, args) {
+  const result = childProcess.spawnSync(command, args, {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.error || result.status !== 0) {
+    fail(
+      `${command} ${args.join(' ')} failed: ${String(
+        result.stderr || result.stdout || result.error?.message || '',
+      ).trim()}`,
+    );
+  }
+  return String(result.stdout || '').trim();
+}
+
+function exact(value, pattern, label) {
+  const normalized = String(value || '').trim();
+  if (!pattern.test(normalized)) fail(`${label} is invalid or missing`);
+  return normalized;
+}
+
+export function probeAwsWindowsJitRunner({
+  root = ROOT,
+  platform = process.platform,
+  env = process.env,
+  runCommand = capture,
+}) {
+  if (platform !== 'win32')
+    fail('AWS Windows JIT runner profile requires Windows');
+
+  const labels = JSON.parse(env.BUILDCHAIN_RUNNER_LABELS_JSON || '[]');
+  for (const required of ['self-hosted', 'Windows', 'X64']) {
+    if (!labels.includes(required))
+      fail(`runner labels are missing ${required}`);
+  }
+  const runnerLabel = labels.find((label) =>
+    String(label).startsWith('aws-us-ec2-windows-jit-'),
+  );
+  exact(
+    runnerLabel,
+    /^aws-us-ec2-windows-jit-[a-z0-9][a-z0-9-]{0,31}$/,
+    'runner label',
+  );
+
+  const vcvars = 'C:\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat';
+  if (!fs.existsSync(vcvars))
+    fail(`MSVC environment entrypoint is missing: ${vcvars}`);
+
+  const report = {
+    schemaVersion: 1,
+    contract: 'kungfu.aws-windows-jit-runner-profile/v1',
+    provider: 'aws-ec2',
+    sourceSha: exact(env.GITHUB_SHA, /^[0-9a-f]{40}$/, 'source SHA'),
+    githubRunId: exact(env.GITHUB_RUN_ID, /^\d+$/, 'GitHub run id'),
+    githubRunAttempt: exact(
+      env.GITHUB_RUN_ATTEMPT,
+      /^\d+$/,
+      'GitHub run attempt',
+    ),
+    runner: {
+      name: String(env.RUNNER_NAME || ''),
+      os: platform,
+      architecture: process.arch,
+      labels: [...labels].sort(),
+    },
+    aws: {
+      instanceId: exact(
+        env.AWS_EC2_INSTANCE_ID,
+        /^i-[0-9a-f]+$/,
+        'instance id',
+      ),
+      instanceType: exact(
+        env.AWS_EC2_INSTANCE_TYPE,
+        /^[a-z0-9.]+$/,
+        'instance type',
+      ),
+      amiId: exact(env.AWS_EC2_AMI_ID, /^ami-[0-9a-f]+$/, 'AMI id'),
+      amiName: String(env.AWS_EC2_AMI_NAME || ''),
+      availabilityZone: String(env.AWS_EC2_AVAILABILITY_ZONE || ''),
+      launchedAt: String(env.AWS_EC2_LAUNCHED_AT || ''),
+    },
+    toolchain: {
+      git: runCommand('git.exe', ['--version']),
+      node: runCommand('node.exe', ['--version']),
+      rustc: runCommand('rustc.exe', ['--version']),
+      cargo: runCommand('cargo.exe', ['--version']),
+      vcvars64: vcvars,
+    },
+    cacheMode: 'off',
+    observedAt: new Date().toISOString(),
+  };
+  report.digest = `sha256:${crypto
+    .createHash('sha256')
+    .update(JSON.stringify(report))
+    .digest('hex')}`;
+
+  const output = path.join(
+    root,
+    'product',
+    'release',
+    'qualification',
+    'aws-windows-jit-smoke.json',
+  );
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
+  return { report, output };
 }
 
 function findApplications(root) {
@@ -157,6 +266,11 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
+  if (process.argv.includes('--aws-windows-jit')) {
+    const { output } = probeAwsWindowsJitRunner({});
+    process.stdout.write(`${path.relative(ROOT, output)}\n`);
+    process.exit(0);
+  }
   const report = probeReleasePlatform({});
   process.stdout.write(`${JSON.stringify(report)}\n`);
 }

--- a/scripts/readonly-agent-bootstrap.test.mjs
+++ b/scripts/readonly-agent-bootstrap.test.mjs
@@ -178,6 +178,7 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
     'docs/qualification/kfd-support-matrix.md',
     '.github/workflows/affected-native-pr.yml',
     '.github/workflows/aws-us-linux-burst-qualification.yml',
+    '.github/workflows/aws-us-windows-burst-qualification.yml',
     '.github/workflows/cancel-dequeued-merge-group.yml',
     '.github/workflows/core-build-profiles.yml',
     '.github/workflows/kungfu-agent-patrol.yml',


### PR DESCRIPTION
## Summary

Add the trusted-only consumer workflow and exact Windows runner-profile witness for the AWS US overflow plane. The workflow accepts six bounded operator slots (smoke, three full exact-source runs, cancellation cleanup, and timeout cleanup), requires a unique card-scoped JIT label, uses the reviewed Buildchain train, and carries no release, signing, publication, or deployment authority.

The new workflow is registered as a non-publication qualification surface in both closed-world authorities. The existing release-platform probe owns the Windows JIT profile witness so the source-tooling file budget remains closed.

## Verification

- staged repository gate: passed
- `node --test scripts/buildchain-install.test.mjs scripts/check-kungfu-gate-catalog.test.mjs`: 33/33 passed
- `node --test scripts/readonly-agent-bootstrap.test.mjs`: passed cold read-only discovery fixture
- AWS CloudFormation stack: `CREATE_COMPLETE`
- security group ingress: empty
- reaper: enabled at `rate(5 minutes)` and dry invocation returned zero victims
- repository self-hosted runners: 0 before qualification
- Windows EC2 instances owned by this provider: 0 before qualification

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Implement the already-governed AWS US overflow qualification campaign without changing product architecture or release authority."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression tests added
- [x] No release credentials or publication authority
- [x] Exact-source and zero-idle cleanup boundaries retained
