### PR TITLE
fix(ci): preserve merged queue admission lease

### DIFF
--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -220,7 +220,10 @@ permission failures remain fatal and visible. A `failed_checks`,
 bound to the event's exact PR head. Atlas admission refuses that same head in a
 later thread; a corrected head is eligible for a fresh admission. Manual
 dequeues do not mint the marker, so a serialized position race can safely
-yield and retry.
+yield and retry. Every non-merged removal revokes the exact-head queue
+admission lease. A normal `merged` removal still releases any family lease and
+bounds leftover work, but preserves the successful terminal queue-admission
+status instead of manufacturing a post-merge failure.
 
 Before expensive pull-request qualification starts, candidate preflight also
 replays the pull request's first-parent commit series onto the exact protected

--- a/docs/qualification/gates/dev-queue-admission.contract.json
+++ b/docs/qualification/gates/dev-queue-admission.contract.json
@@ -26,7 +26,8 @@
     "leaseAfterReplay": true
   },
   "revocation": {
-    "dequeue": "failure-status-on-exact-pr-head",
+    "dequeue": "failure-status-on-exact-pr-head-for-non-merged-removal",
+    "merged": "preserve-success-status-on-exact-pr-head",
     "headChange": "lease-does-not-transfer",
     "sameHeadRetry": "forbidden-after-revocation"
   },

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -190,13 +190,15 @@ Each section is bound to the registry id by the catalog meta gate.
   wrapper issues that status after observing an empty queue and replaying the
   Project Cut against the latest base; it then accepts only position one. A
   merge-group-only workflow continues the same required context on the exact
-  synthetic SHA without satisfying it on ordinary PR events. Every dequeue
-  revokes the exact-head lease and forbids retrying that head; a new head
-  cannot inherit an older status. The bounded contract is
-  `docs/qualification/gates/dev-queue-admission.contract.json`. This prevents
-  an inadvertent direct position-two entry from changing the proof base and
-  turning an exact PR proof into a full native queue rebuild; it does not
-  weaken proof verification when source, plan, or toolchain identity changes.
+  synthetic SHA without satisfying it on ordinary PR events. Every non-merged
+  dequeue revokes the exact-head lease and forbids retrying that head; a normal
+  `merged` removal preserves the successful terminal lease instead of replacing
+  it with a misleading failure. A new head cannot inherit an older status. The
+  bounded contract is
+  `docs/qualification/gates/dev-queue-admission.contract.json`. This prevents an
+  inadvertent direct position-two entry from changing the proof base and turning
+  an exact PR proof into a full native queue rebuild; it does not weaken proof
+  verification when source, plan, or toolchain identity changes.
 - **Dequeue repair admission:** the trusted-base dequeue controller cancels
   active work and writes one PR marker for deterministic `failed_checks`,
   `merge_conflict`, or `invalid_merge_commit` exits. The marker binds the exact

--- a/scripts/cancel-dequeued-merge-group-runs.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.mjs
@@ -411,6 +411,19 @@ export async function revokeQueueAdmissionLease({
   return { headSha, context, state: 'failure' };
 }
 
+export function preserveQueueAdmissionLease({ headSha, context, reason }) {
+  required(headSha, 'head sha', /^[0-9a-f]{40}$/u);
+  required(
+    context,
+    'queue admission context',
+    /^[A-Za-z0-9][A-Za-z0-9 ._/-]{0,99}$/u,
+  );
+  if (reason !== 'merged') {
+    throw new Error('queue admission lease can be preserved only after merge');
+  }
+  return { headSha, context, state: 'preserved', reason };
+}
+
 export async function releaseDequeuedFamilyQueueLease({
   repository,
   pullRequest,
@@ -494,6 +507,12 @@ export async function settleDequeuedMergeGroup({
   token,
   request = fetch,
 }) {
+  const removalPromise = latestMergeQueueRemoval({
+    repository,
+    pullRequest,
+    token,
+    request,
+  });
   const results = await Promise.allSettled([
     cancelDequeuedMergeGroupRuns({
       repository,
@@ -502,29 +521,62 @@ export async function settleDequeuedMergeGroup({
       token,
       request,
     }),
-    recordDequeuedRepairMarker({
-      repository,
-      pullRequest,
-      headSha,
-      token,
-      request,
-    }),
-    revokeQueueAdmissionLease({
-      repository,
-      headSha,
-      context,
-      token,
-      request,
-    }),
-    releaseDequeuedFamilyQueueLease({
-      repository,
-      pullRequest,
-      headSha,
-      body: pullRequestBody,
-      reason: '',
-      token,
-      request,
-    }),
+    removalPromise.then((observedRemoval) =>
+      recordDequeuedRepairMarker({
+        repository,
+        pullRequest,
+        headSha,
+        removal: observedRemoval,
+        token,
+        request,
+      }),
+    ),
+    removalPromise.then(
+      (observedRemoval) =>
+        observedRemoval.reason === 'merged'
+          ? preserveQueueAdmissionLease({
+              headSha,
+              context,
+              reason: observedRemoval.reason,
+            })
+          : revokeQueueAdmissionLease({
+              repository,
+              headSha,
+              context,
+              token,
+              request,
+            }),
+      () =>
+        revokeQueueAdmissionLease({
+          repository,
+          headSha,
+          context,
+          token,
+          request,
+        }),
+    ),
+    removalPromise.then(
+      (observedRemoval) =>
+        releaseDequeuedFamilyQueueLease({
+          repository,
+          pullRequest,
+          headSha,
+          body: pullRequestBody,
+          reason: observedRemoval.reason,
+          token,
+          request,
+        }),
+      () =>
+        releaseDequeuedFamilyQueueLease({
+          repository,
+          pullRequest,
+          headSha,
+          body: pullRequestBody,
+          reason: '',
+          token,
+          request,
+        }),
+    ),
   ]);
   const failures = results
     .map((result, index) =>

--- a/scripts/cancel-dequeued-merge-group-runs.test.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.test.mjs
@@ -279,6 +279,129 @@ test('dequeue settlement still revokes the lease when other cleanup fails', asyn
   ]);
 });
 
+test('merged dequeue preserves the successful exact-head queue admission lease', async () => {
+  const headSha = 'e'.repeat(40);
+  const requests = [];
+  const request = async (url, init = {}) => {
+    requests.push({
+      url,
+      method: init.method || 'GET',
+      body: init.body ? JSON.parse(init.body) : null,
+    });
+    if (url.endsWith('/graphql')) {
+      return response(200, {
+        data: {
+          repository: {
+            pullRequest: {
+              timelineItems: {
+                nodes: [
+                  {
+                    createdAt: '2026-07-29T00:26:29Z',
+                    reason: 'MERGED',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    }
+    if (url.includes('/actions/workflows/affected-native-pr.yml/runs?')) {
+      return response(200, { workflow_runs: [] });
+    }
+    throw new Error(`merged dequeue must not write status: ${url}`);
+  };
+  const settlement = await settleDequeuedMergeGroup({
+    repository: 'kungfu-systems/kungfu',
+    pullRequest: 1798,
+    headSha,
+    workflow: 'affected-native-pr.yml',
+    context: 'Queue admission lease',
+    token: 'test-token',
+    request,
+  });
+  assert.deepEqual(settlement.queueAdmissionLease, {
+    headSha,
+    context: 'Queue admission lease',
+    state: 'preserved',
+    reason: 'merged',
+  });
+  assert.equal(settlement.repairMarker.repairRequired, false);
+  assert.equal(settlement.evidence.dequeue.reason, 'merged');
+  assert.equal(
+    requests.filter(({ url }) => url.endsWith(`/statuses/${headSha}`)).length,
+    0,
+  );
+});
+
+test('non-merged dequeue still revokes the exact-head queue admission lease', async () => {
+  const headSha = 'f'.repeat(40);
+  const requests = [];
+  const request = async (url, init = {}) => {
+    requests.push({
+      url,
+      method: init.method || 'GET',
+      body: init.body ? JSON.parse(init.body) : null,
+    });
+    if (url.endsWith('/graphql')) {
+      return response(200, {
+        data: {
+          repository: {
+            pullRequest: {
+              timelineItems: {
+                nodes: [
+                  {
+                    createdAt: '2026-07-29T00:30:00Z',
+                    reason: 'MANUAL',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    }
+    if (url.includes('/actions/workflows/affected-native-pr.yml/runs?')) {
+      return response(200, { workflow_runs: [] });
+    }
+    if (url.endsWith(`/statuses/${headSha}`)) return response(201);
+    throw new Error(`unexpected request ${url}`);
+  };
+  const settlement = await settleDequeuedMergeGroup({
+    repository: 'kungfu-systems/kungfu',
+    pullRequest: 1799,
+    headSha,
+    workflow: 'affected-native-pr.yml',
+    context: 'Queue admission lease',
+    token: 'test-token',
+    request,
+  });
+  assert.deepEqual(settlement.queueAdmissionLease, {
+    headSha,
+    context: 'Queue admission lease',
+    state: 'failure',
+  });
+  assert.equal(settlement.repairMarker.repairRequired, false);
+  assert.equal(settlement.evidence.dequeue.reason, 'manual');
+  assert.equal(
+    requests.filter(({ url }) => url.endsWith('/graphql')).length,
+    1,
+  );
+  assert.deepEqual(
+    requests
+      .filter(({ url }) => url.endsWith(`/statuses/${headSha}`))
+      .map(({ body }) => body),
+    [
+      {
+        state: 'failure',
+        context: 'Queue admission lease',
+        description:
+          'Lease revoked after merge-queue dequeue; use the serialized wrapper',
+      },
+    ],
+  );
+});
+
 test('failed or conflicting dequeue records one exact-head repair marker', async () => {
   const requests = [];
   const headSha = 'a'.repeat(40);

--- a/scripts/queue-admission-lease.test.mjs
+++ b/scripts/queue-admission-lease.test.mjs
@@ -36,6 +36,14 @@ test('queue admission lease has distinct PR-head and merge-group authorities', (
   assert.equal(CONTRACT.admission.queueMustBeEmpty, true);
   assert.equal(CONTRACT.admission.requiredPosition, 1);
   assert.equal(CONTRACT.admission.freshProjectCutReplay, true);
+  assert.equal(
+    CONTRACT.revocation.dequeue,
+    'failure-status-on-exact-pr-head-for-non-merged-removal',
+  );
+  assert.equal(
+    CONTRACT.revocation.merged,
+    'preserve-success-status-on-exact-pr-head',
+  );
   assert.equal(CONTRACT.revocation.sameHeadRetry, 'forbidden-after-revocation');
   assert.equal(CONTRACT.admittedFamily.minimumMajor, 4);
   assert.deepEqual(CONTRACT.admittedFamily.include, ['refs/heads/dev/v*/v*']);


### PR DESCRIPTION
Preserve the successful exact-head Queue admission lease after a normal merged dequeue, while retaining fail-closed revocation for every non-merged removal. Reuse one authoritative merge-queue removal observation across repair-marker, lease, and family settlement.

Validation:
- ./shifu exec node --test scripts/cancel-dequeued-merge-group-runs.test.mjs scripts/queue-admission-lease.test.mjs
- ./shifu test:gate-latency
- ./shifu check:gate-catalog
- ./shifu check

Live acceptance: the PR's post-merge dequeue run must report queueAdmissionLease.state=preserved and must not write a failure status to the exact PR head.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves terminal merge-queue status semantics without changing an architecture contract"
}
-->