### PR TITLE
fix(ci): execute dequeue from current protected base

### DIFF
--- a/.github/workflows/cancel-dequeued-merge-group.yml
+++ b/.github/workflows/cancel-dequeued-merge-group.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout trusted base revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: refs/heads/${{ github.event.pull_request.base.ref }}
           persist-credentials: false
       - name: Cancel active merge-group runs for the dequeued pull request
         env:

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -210,12 +210,14 @@ PRs to have a non-merged exit and at least 20 completed delivery samples.
 
 `.github/workflows/cancel-dequeued-merge-group.yml` bounds waste after an
 authoritative dequeue. Its `pull_request_target: dequeued` job checks out only
-the event's trusted base SHA, does not execute pull-request code, and grants
-only the scoped permissions required to cancel Actions runs and maintain the
-PR repair marker. The controller selects active `affected-native-pr.yml`
-merge-group runs whose queue branch ends in the exact PR number and cancels
-each run once. A `409` terminal race is idempotent; unexpected API or
-permission failures remain fatal and visible. A `failed_checks`,
+the current protected base ref selected by the event's `dev/v*/v*` target,
+never the pull-request head. This avoids executing a stale controller when the
+event's immutable base SHA predates a recently merged terminal-state fix. The
+job grants only the scoped permissions required to cancel Actions runs and
+maintain the PR repair marker. The controller selects active
+`affected-native-pr.yml` merge-group runs whose queue branch ends in the exact
+PR number and cancels each run once. A `409` terminal race is idempotent;
+unexpected API or permission failures remain fatal and visible. A `failed_checks`,
 `merge_conflict`, or `invalid_merge_commit` removal also upserts one marker
 bound to the event's exact PR head. Atlas admission refuses that same head in a
 later thread; a corrected head is eligible for a fresh admission. Manual

--- a/docs/qualification/gates/dev-queue-admission.contract.json
+++ b/docs/qualification/gates/dev-queue-admission.contract.json
@@ -17,7 +17,8 @@
   "authority": {
     "pullRequestHead": "atlas-serialized-wrapper",
     "mergeGroup": ".github/workflows/queue-admission-lease.yml",
-    "dequeueRevocation": ".github/workflows/cancel-dequeued-merge-group.yml"
+    "dequeueRevocation": ".github/workflows/cancel-dequeued-merge-group.yml",
+    "dequeueControllerSource": "current-protected-pull-request-base-ref"
   },
   "admission": {
     "queueMustBeEmpty": true,

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -199,10 +199,12 @@ Each section is bound to the registry id by the catalog meta gate.
   inadvertent direct position-two entry from changing the proof base and turning
   an exact PR proof into a full native queue rebuild; it does not weaken proof
   verification when source, plan, or toolchain identity changes.
-- **Dequeue repair admission:** the trusted-base dequeue controller cancels
-  active work and writes one PR marker for deterministic `failed_checks`,
-  `merge_conflict`, or `invalid_merge_commit` exits. The marker binds the exact
-  pull-request head SHA. Atlas merge orchestration rejects a later enqueue of
+- **Dequeue repair admission:** the dequeue controller executes from the
+  event-selected current protected `dev/v*/v*` base ref, never from the
+  pull-request head or a stale event base SHA. It cancels active work and writes
+  one PR marker for deterministic `failed_checks`, `merge_conflict`, or
+  `invalid_merge_commit` exits. The marker binds the exact pull-request head
+  SHA. Atlas merge orchestration rejects a later enqueue of
   that same head, including from another account or thread, and observes a new
   source SHA as the only ordinary unlock. Manual dequeues remain unmarked so
   position-one serialization can yield without manufacturing a repair debt.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1088,14 +1088,14 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:deee23b837ae71601ee117fdb3d9d28068aa6cdf849d23fae0cc19183ae24795",
+          "definitionDigest": "sha256:b258883a39928a2d88dee675843a638dc06eab66361ba6bfd44455f787f45acf",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
               "label": "name:Checkout trusted base revision",
-              "definitionDigest": "sha256:f499afb8b18fa1dcfbfb2c8d639e727e932faecd84acb0b87f6f5900318a0ebe"
+              "definitionDigest": "sha256:edfa0850c9158080010fad307856d6c6bc5934d1d6aa06d032751e4288e7dcb5"
             },
             {
               "index": 2,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -131,7 +131,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:724cda588f962bdd2744f1b3d9031269e38c835d2fe74e06e9a2f905619f0745"
+          "sourceRoot": "sha256:fd383d7aec3c23cdcc590f5139d37a1f483fe14e715c65f63201f4400deedd43"
         },
         {
           "path": ".github/workflows/queue-admission-lease.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:da00a9d9273080438ed1864ee16e92214999a271479cc265b68f40ea44159704"
+  "registryRoot": "sha256:a924ca4f110be471199b73b0123f0c8108f08851b3c14548652aa1119e671551"
 }

--- a/scripts/cancel-dequeued-merge-group-runs.test.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.test.mjs
@@ -62,6 +62,7 @@ test('dequeue workflow executes only the trusted base with least privilege', () 
     'utf8',
   );
   assert.match(workflow, /pull_request_target:\n\s+types: \[dequeued\]/u);
+  assert.match(workflow, /branches:\n\s+- dev\/v\*\/v\*/u);
   assert.match(workflow, /permissions:\n\s+actions: write\n\s+contents: read/u);
   assert.match(workflow, /\s+pull-requests: write/u);
   assert.match(workflow, /\s+statuses: write/u);
@@ -76,8 +77,9 @@ test('dequeue workflow executes only the trusted base with least privilege', () 
   );
   assert.match(
     workflow,
-    /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/u,
+    /ref: refs\/heads\/\$\{\{ github\.event\.pull_request\.base\.ref \}\}/u,
   );
+  assert.doesNotMatch(workflow, /pull_request\.base\.sha/u);
   assert.match(workflow, /persist-credentials: false/u);
   assert.doesNotMatch(
     workflow,

--- a/scripts/queue-admission-lease.test.mjs
+++ b/scripts/queue-admission-lease.test.mjs
@@ -44,6 +44,10 @@ test('queue admission lease has distinct PR-head and merge-group authorities', (
     CONTRACT.revocation.merged,
     'preserve-success-status-on-exact-pr-head',
   );
+  assert.equal(
+    CONTRACT.authority.dequeueControllerSource,
+    'current-protected-pull-request-base-ref',
+  );
   assert.equal(CONTRACT.revocation.sameHeadRetry, 'forbidden-after-revocation');
   assert.equal(CONTRACT.admittedFamily.minimumMajor, 4);
   assert.deepEqual(CONTRACT.admittedFamily.include, ['refs/heads/dev/v*/v*']);


### PR DESCRIPTION
## Summary

- execute the dequeue controller from the current protected dev/v*/v* base ref
- never execute pull-request head code
- prevent stale pull_request.base.sha from reverting terminal queue-admission semantics

## Live evidence

- PR #1811 dequeue run 30414552175 checked out stale base 66f4318 after the terminal-preservation fix had merged
- PR #1812 dequeue run 30414782541 repeated the same stale checkout even though its merge group was based on 4bf3344
- both observations wrote a failure lease after a successful merged exit

## Validation

- targeted dequeue tests: 17/17
- dev required Gate latency suite: 92/92
- Gate catalog: passed
- full ./shifu check: passed
- pre-commit staged gate: passed
- post-rebase targeted dequeue tests: 17/17

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This CI control-plane fix changes trusted controller source selection without altering an architecture contract"
}
-->