### PR TITLE
fix(ci): verify Windows JIT smoke explicitly

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -100,7 +100,8 @@ jobs:
       require-install: false
       require-build: true
       build-command: node scripts/probe-release-platform.mjs --aws-windows-jit
-      require-verify: false
+      require-verify: true
+      verify-command: node scripts/probe-release-platform.mjs --aws-windows-jit
       lifecycle-timeout-minutes: 30
       requested-parallelism: 1
       artifact-transfer-mode: github-artifacts

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -772,7 +772,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5b3675b305cc27790052577719d9dbef5acd621412a447b23be2cc4f0983a186",
+          "definitionDigest": "sha256:59e0cef37723c0658648a83e8e7b7b9facf3117fad6c4ef8d3eebcc008ce4165",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -103,7 +103,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:97f62f0547dd06e7e8dded565f8c5653fac27c7beec788ccf06bb11bc57b4700"
+          "sourceRoot": "sha256:cb2e7b9c9d569b1795ff8e3b41130b596056ca3826458d324e0a940c2b09ec29"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:a924ca4f110be471199b73b0123f0c8108f08851b3c14548652aa1119e671551"
+  "registryRoot": "sha256:a4de98d8854ae6cbd9a8a8780e5bf71e0953995cf863936b4cb3040c762084c6"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -244,6 +244,10 @@ test('AWS Windows JIT qualification is trusted, exact-label, and non-publication
   assert.match(workflow, /needs: trust/);
   assert.match(workflow, /aws-us-ec2-windows-jit-\$\{QUALIFICATION_ID\}/);
   assert.match(workflow, /runner-preset: aws-us-ec2-windows-jit/);
+  assert.match(
+    workflow,
+    /require-verify: true\n {6}verify-command: node scripts\/probe-release-platform\.mjs --aws-windows-jit/,
+  );
   assert.match(workflow, /publish-channel: none/);
   assert.match(workflow, /release-candidate: false/);
   assert.match(workflow, /win-cancel:cancellation\|win-timeout:timeout/);


### PR DESCRIPTION
## Summary

- make the Windows JIT smoke use an explicit platform probe for both build and verify
- prevent the optional default Kungfu lifecycle from demanding full native artifacts in the bounded smoke
- refresh the closed-world workflow authority and release-surface roots

## Verification

- `node --test scripts/buildchain-install.test.mjs`
- repository staged gate (pre-commit)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct the already-governed AWS US Windows qualification smoke lifecycle without changing product architecture or release authority."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression test added
- [x] No release credentials or publication authority
- [x] Exact-source and zero-idle cleanup boundaries retained