### PR TITLE
perf(ci): skip unused SDK module scans

### DIFF
--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -119,9 +119,10 @@ Each section is bound to the registry id by the catalog meta gate.
   Exact or compatible restores still run the current configure/build/CTest
   closure. Misses run and record the cold path; per-run ccache statistics are
   retained beside the provider receipts so an exact restore cannot be confused
-  with effective compiler hits. The dev-only affected-native configure disables
-  C++ module dependency scanning because the current closure declares no module
-  sources; this avoids uncached scan work without changing alpha/release build
+  with effective compiler hits. The dev-only affected-native native closure and
+  SDK build plan disable C++ module dependency scanning because the current
+  closure declares no module sources; this avoids uncached scan and compile work
+  without weakening installed SDK qualification or changing alpha/release build
   semantics. Contradictory or foreign-key evidence fails closed. Successful
   queue candidates may restore a compatible base-branch baseline while
   retaining source-bound exact keys and always rerunning configure/build/CTest.

--- a/framework/core/architecture/sdk-build-plan.json
+++ b/framework/core/architecture/sdk-build-plan.json
@@ -4,6 +4,7 @@
   "runtime": "node",
   "target": "kungfu_node",
   "cmake_definitions": {
+    "CMAKE_CXX_SCAN_FOR_MODULES": "OFF",
     "KUNGFU_WITH_CORE_TESTS": "OFF"
   },
   "required_artifacts": {
@@ -32,6 +33,7 @@
     "node-runtime-host",
     "production-libwasm-dual-engine-build",
     "pykungfu-binding-stubs-and-wheel",
-    "public-header-self-compilation"
+    "public-header-self-compilation",
+    "unused-cxx-module-dependency-scans"
   ]
 }

--- a/framework/core/tests/sdk-core-build.test.js
+++ b/framework/core/tests/sdk-core-build.test.js
@@ -25,6 +25,7 @@ test('SDK Core build freezes the minimum installed-artifact target closure', () 
   assert.equal(plan.runtime, 'node');
   assert.equal(plan.target, 'kungfu_node');
   assert.deepEqual(plan.cmake_definitions, {
+    CMAKE_CXX_SCAN_FOR_MODULES: 'OFF',
     KUNGFU_WITH_CORE_TESTS: 'OFF',
   });
   assert.deepEqual(plan.required_artifacts.common, [
@@ -50,6 +51,7 @@ test('SDK Core build freezes the minimum installed-artifact target closure', () 
     'production-libwasm-dual-engine-build',
     'pykungfu-binding-stubs-and-wheel',
     'public-header-self-compilation',
+    'unused-cxx-module-dependency-scans',
   ]);
 });
 

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -85,6 +85,7 @@ const sdkQualificationPaths = [
   'framework/core/architecture/build-capabilities.json',
   'framework/core/architecture/layered-api-encoding-boundary.contract.json',
   'framework/core/architecture/layers.json',
+  'framework/core/architecture/sdk-build-plan.json',
   'framework/core/cmake/',
   'framework/core/conanfile.py',
   'framework/core/package.json',
@@ -1421,6 +1422,7 @@ function selfTest(authority, buildAuthority) {
   expect('public ABI and gate authority schedule SDK qualification', () => {
     for (const file of [
       'framework/core/src/libkungfu/include/kungfu/api.h',
+      'framework/core/architecture/sdk-build-plan.json',
       '.github/workflows/affected-native-pr.yml',
       'tests/qualification/layers/sdk/run.mjs',
     ]) {

--- a/scripts/run-core-affected-native.test.mjs
+++ b/scripts/run-core-affected-native.test.mjs
@@ -87,6 +87,25 @@ test('dev queue impact selects Shifu and KFD from their declared source surfaces
   );
 });
 
+test('the SDK build plan is a self-qualifying SDK authority input', () => {
+  assert.deepEqual(
+    sdkQualificationImpact(
+      ['framework/core/architecture/sdk-build-plan.json'],
+      'base',
+      'head',
+    ),
+    {
+      required: true,
+      reasons: [
+        {
+          path: 'framework/core/architecture/sdk-build-plan.json',
+          kind: 'sdk-authority-or-input',
+        },
+      ],
+    },
+  );
+});
+
 test('the staged workflow remains self-qualifying under both moved gates', () => {
   const impact = devQueueQualificationImpact([
     '.github/workflows/affected-native-cache-promote.yml',


### PR DESCRIPTION
## Summary

- disable unused C++ module dependency scanning in the dev SDK build plan
- keep the installed four-language SDK qualification and exact artifact closure unchanged
- freeze the optimization in the SDK build-plan contract and gate documentation

## Validation

- `./shifu check`
- `node --test framework/core/tests/sdk-core-build.test.js`
- `node --test scripts/run-core-affected-native.test.mjs scripts/affected-native-proof.test.mjs`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This dev CI optimization skips dependency scanning only where the governed Core closure declares no C++ module sources; it preserves installed SDK qualification, artifact authority, and release semantics."
}
-->