### PR TITLE
fix(work-control): clean up portfolio state projection

### DIFF
--- a/docs/profiles/work-control.md
+++ b/docs/profiles/work-control.md
@@ -23,6 +23,25 @@ a continuation decision remain separate facts. Portfolio reports completion
 only when the accepted decision and applicable Project Cut settlement are both
 present.
 
+Portfolio keeps three state coordinates separate: the source record's
+`source_status`, the native Assignment `orchestration_phase`, and the derived
+`portfolio_state`. The default active-and-attention view treats compatibility
+statuses `complete`, `completed`, `merged`, `archived`, and `closed` as
+terminal; `--include-settled` retains their exact canonical rows. A
+`stage-ready` Assignment is therefore visible as unfinished until review,
+continuation decision, and Project Cut settlement actually complete it.
+
+Repeated Initiative subjects are rendered as one deterministic presentation
+group. An authority-distinct group lists every canonical root and workspace
+authority root; it is a readability projection only and never asserts replica
+equivalence or discards an exact WorkRef.
+
+Disposable probe processes that intentionally share the machine Catalog must
+set `KF_WORKSPACE_CATALOG_LIFECYCLE=test-only` before their first workspace
+write. The initial observation is then retained with the `test-only` lifecycle
+and excluded from the default Portfolio. Existing active entries are changed
+only through the dry-run-bound `workspace catalog-maintain` transition.
+
 ## Assignment Family typed envelope
 
 `kungfu.work-control.initiative-family-state/v1` remains the immutable Wave 0

--- a/framework/core/src/python/kungfu/cli/commands/workspace.py
+++ b/framework/core/src/python/kungfu/cli/commands/workspace.py
@@ -48,12 +48,34 @@ def _json(payload):
 def _human_work_line(row, width):
     display = row["display"]
     state = display.get("portfolio_state") or display.get("status") or "unknown"
+    phase = display.get("orchestration_phase")
+    source_status = display.get("source_status") or display.get("status")
+    state_detail = str(state)
+    if phase:
+        state_detail += f" phase={phase}"
+    if source_status:
+        state_detail += f" src={source_status}"
     conflict = " !conflict" if row["conflict"] else ""
     replicas = f" x{row['replica_count'] + 1}" if row["replica_count"] else ""
-    suffix = f" [{state}]{conflict}{replicas} {row['canonical_root'][7:15]}"
+    suffix = f" [{state_detail}]{conflict}{replicas} {row['canonical_root'][7:15]}"
     prefix = f"{row['object_kind']} "
     available = max(8, width - len(prefix) - len(suffix))
     title = str(display["title"])
+    if len(title) > available:
+        title = title[: max(1, available - 1)] + "…"
+    return f"{prefix}{title}{suffix}"
+
+
+def _human_initiative_group_line(group, width):
+    state = group["display"].get("portfolio_state") or "unknown"
+    authority = group["authority_state"]
+    suffix = (
+        f" [{state} {authority} authorities={group['authority_count']}] "
+        f"{group['group_root'][7:15]}"
+    )
+    prefix = "initiative "
+    available = max(1, width - len(prefix) - len(suffix))
+    title = str(group["display"]["title"])
     if len(title) > available:
         title = title[: max(1, available - 1)] + "…"
     return f"{prefix}{title}{suffix}"
@@ -600,8 +622,12 @@ def work(
             f"unresolved={aggregate['unresolved_reference_count']}",
             err=True,
         )
+    width = max(40, click.get_current_context().terminal_width or 80)
+    for group in projection["visible_initiative_groups"]:
+        click.echo(_human_initiative_group_line(group, width))
     for row in projection["visible_work"]:
-        width = max(40, click.get_current_context().terminal_width or 80)
+        if row["object_kind"] == "initiative":
+            continue
         click.echo(_human_work_line(row, width))
     if details == "components":
         for component in payload["components"]:

--- a/framework/core/src/python/kungfu/workspace.py
+++ b/framework/core/src/python/kungfu/workspace.py
@@ -10,7 +10,7 @@ import tempfile
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal, Mapping
+from typing import Any, Literal, Mapping, cast
 from uuid import uuid4
 
 from kungfu.config import (
@@ -583,10 +583,21 @@ def load_workspace_catalog(
 def observe_workspace_locator(
     identity: WorkspaceIdentity,
     *,
+    lifecycle: CatalogLifecycleState = "active",
+    lifecycle_reason: str | None = None,
     config_home: str | None = None,
     env: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     """Record one explicitly selected or successfully written locator."""
+
+    if lifecycle not in {"active", "test-only"}:
+        raise ValueError(
+            "initial Catalog observation supports only active or test-only; "
+            "use catalog-maintain for other lifecycle states"
+        )
+    lifecycle_reason = str(lifecycle_reason or "").strip()
+    if lifecycle != "active" and not lifecycle_reason:
+        raise ValueError("non-active Catalog observation requires a reason")
 
     catalog = load_workspace_catalog(config_home, env=env)
     if catalog["issues"]:
@@ -602,6 +613,17 @@ def observe_workspace_locator(
             "registration_reason": identity.resolution_reason,
         },
     )
+    if lifecycle != "active":
+        entry["provenance"] = {
+            "source": "explicit-disposable-observation",
+            "registration_reason": lifecycle_reason,
+        }
+        entry["lifecycle"] = {
+            "state": lifecycle,
+            "reason": lifecycle_reason,
+            "transitioned_at": observed_at,
+            "previous_state": None,
+        }
     existing = next(
         (
             row
@@ -611,6 +633,10 @@ def observe_workspace_locator(
         None,
     )
     if existing is not None:
+        if lifecycle != _catalog_lifecycle(existing)["state"]:
+            raise ValueError(
+                "existing Catalog lifecycle must change through catalog-maintain"
+            )
         entry["lifecycle"] = _catalog_lifecycle(existing)
         entry["provenance"] = _catalog_provenance(existing)
         unchanged_entry = {
@@ -1232,10 +1258,22 @@ def select_workspace(
 def ensure_workspace_data_home(
     identity: WorkspaceIdentity,
     reason: str,
+    *,
+    catalog_lifecycle: CatalogLifecycleState | None = None,
 ) -> dict[str, Any]:
     reason = reason.strip()
     if not reason:
         raise ValueError("workspace initialization requires a non-empty write intent")
+    requested_catalog_lifecycle = str(
+        catalog_lifecycle
+        or os.environ.get("KF_WORKSPACE_CATALOG_LIFECYCLE")
+        or "active"
+    )
+    if requested_catalog_lifecycle not in {"active", "test-only"}:
+        raise ValueError(
+            "initial Catalog observation supports only active or test-only; "
+            "use catalog-maintain for other lifecycle states"
+        )
     continuation = inspect_workspace_continuation(identity)
     previous_state = continuation["state"]
     if previous_state == "evidence-degraded":
@@ -1261,11 +1299,16 @@ def ensure_workspace_data_home(
     try:
         catalog_observation = observe_workspace_locator(
             qualified,
+            lifecycle=cast(CatalogLifecycleState, requested_catalog_lifecycle),
+            lifecycle_reason=(
+                reason if requested_catalog_lifecycle != "active" else None
+            ),
             config_home=qualified.config_home,
         )
         catalog_status = {
             "status": "observed",
             "catalog_path": catalog_observation["catalog_path"],
+            "lifecycle": requested_catalog_lifecycle,
         }
     except (OSError, ValueError) as error:
         catalog_status = {

--- a/framework/core/src/python/kungfu/workspace_federation.py
+++ b/framework/core/src/python/kungfu/workspace_federation.py
@@ -38,6 +38,7 @@ QUERY_PROOF_SCHEMA = "kungfu.workspace-federation.query-proof/v1"
 QUERY_VERIFICATION_SCHEMA = "kungfu.workspace-federation.query-verification/v1"
 GLOBAL_WORK_PROJECTION_SCHEMA = "kungfu.workspace-federation.global-work/v1"
 CANONICAL_WORK_SCHEMA = "kungfu.workspace-federation.canonical-work/v1"
+INITIATIVE_GROUP_SCHEMA = "kungfu.workspace-federation.initiative-group/v1"
 CANONICAL_WORK_IDENTITY_SCHEMA = (
     "kungfu.workspace-federation.canonical-work-identity/v1"
 )
@@ -48,6 +49,10 @@ DOGFOOD_GATE_VERIFICATION_SCHEMA = (
     "kungfu.workspace-federation.dogfood-gate-verification/v1"
 )
 TRAVERSAL_SCHEMA = "kungfu.assignment-graph.traversal/v1"
+
+TERMINAL_SOURCE_STATUSES = frozenset(
+    {"archived", "closed", "complete", "completed", "merged"}
+)
 
 _ROOT = re.compile(r"^sha256:[0-9a-f]{64}$")
 _SUBJECT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$")
@@ -744,6 +749,10 @@ def _compose_global_work(
                         or reference.subject
                     ),
                     "status": str(record.get("status") or ""),
+                    "source_status": str(record.get("status") or ""),
+                    "orchestration_phase": str(
+                        (record.get("lifecycle") or {}).get("orchestration_phase") or ""
+                    ),
                     "portfolio_state": str(
                         (record.get("lifecycle") or {}).get("portfolio_state") or ""
                     ),
@@ -1051,14 +1060,93 @@ def _compose_global_work(
         if include_settled
         or (
             str(row["display"].get("portfolio_state") or "") != "completed"
-            and str(row["display"].get("status") or "").lower()
-            not in {"completed", "archived", "closed"}
+            and str(row["display"].get("source_status") or "").strip().lower()
+            not in TERMINAL_SOURCE_STATUSES
         )
+    ]
+    visible_roots = {str(row["canonical_root"]) for row in visible_work}
+    initiative_groups: list[dict[str, Any]] = []
+    for (object_kind, subject), _rows in sorted(by_label.items()):
+        if object_kind != "initiative":
+            continue
+        initiative_rows = [
+            row
+            for row in canonical_rows
+            if row["object_kind"] == "initiative" and row["subject"] == subject
+        ]
+        if not initiative_rows:
+            continue
+        canonical_roots = sorted(str(row["canonical_root"]) for row in initiative_rows)
+        authority_roots = sorted(
+            {str(root) for row in initiative_rows for root in row["authority_roots"]}
+        )
+        statuses = sorted(
+            {
+                str(row["display"].get("source_status") or "")
+                for row in initiative_rows
+                if row["display"].get("source_status")
+            }
+        )
+        phases = sorted(
+            {
+                str(row["display"].get("orchestration_phase") or "")
+                for row in initiative_rows
+                if row["display"].get("orchestration_phase")
+            }
+        )
+        portfolio_states = sorted(
+            {
+                str(row["display"].get("portfolio_state") or "")
+                for row in initiative_rows
+                if row["display"].get("portfolio_state")
+            }
+        )
+        titles = sorted(
+            {str(row["display"].get("title") or subject) for row in initiative_rows}
+        )
+        group_body = {
+            "schema": INITIATIVE_GROUP_SCHEMA,
+            "object_kind": "initiative",
+            "subject": subject,
+            "authority_state": (
+                "authority-distinct" if len(canonical_roots) > 1 else "single-authority"
+            ),
+            "canonical_roots": canonical_roots,
+            "authority_roots": authority_roots,
+            "canonical_count": len(canonical_roots),
+            "authority_count": len(authority_roots),
+            "observation_count": sum(
+                int(row["observation_count"]) for row in initiative_rows
+            ),
+            "display": {
+                "title": titles[0],
+                "source_status": (
+                    statuses[0] if len(statuses) == 1 else ("mixed" if statuses else "")
+                ),
+                "orchestration_phase": (
+                    phases[0] if len(phases) == 1 else ("mixed" if phases else "")
+                ),
+                "portfolio_state": (
+                    portfolio_states[0]
+                    if len(portfolio_states) == 1
+                    else ("mixed" if portfolio_states else "")
+                ),
+            },
+        }
+        initiative_groups.append(
+            {**group_body, "group_root": semantic_root(group_body)}
+        )
+    visible_initiative_groups = [
+        group
+        for group in initiative_groups
+        if any(root in visible_roots for root in group["canonical_roots"])
     ]
     body = {
         "schema": GLOBAL_WORK_PROJECTION_SCHEMA,
         "canonical_work": canonical_rows,
         "label_collisions": label_collisions,
+        "initiative_groups": initiative_groups,
+        "visible_initiative_groups": visible_initiative_groups,
         "retained_assignment_states": [
             retained_states[root] for root in sorted(retained_states)
         ],
@@ -1074,6 +1162,7 @@ def _compose_global_work(
         "reference_resolution": reference_resolution,
         "canonical_work_count": len(canonical_rows),
         "visible_work_count": len(visible_work),
+        "visible_initiative_group_count": len(visible_initiative_groups),
         "initiative_count": sum(
             row["object_kind"] == "initiative" for row in canonical_rows
         ),

--- a/framework/core/tests/python/test_workspace.py
+++ b/framework/core/tests/python/test_workspace.py
@@ -386,6 +386,40 @@ def test_catalog_lifecycle_expected_plan_mismatch_is_write_free(tmp_path):
     assert not (config_home / "workspaces" / "receipts").exists()
 
 
+def test_disposable_course_probe_is_test_only_from_first_catalog_observation(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("KF_WORKSPACE_CATALOG_LIFECYCLE", "test-only")
+    repo = tmp_path / "kungfu-course-control-probe"
+    repo.mkdir()
+    env = {"HOME": str(tmp_path)}
+    candidate = inspect_workspace(str(repo), env=env)
+    assert candidate is not None
+
+    receipt = ensure_workspace_data_home(candidate, "course-control probe fixture")
+    catalog = load_workspace_catalog(candidate.config_home, env=env)
+
+    assert receipt["catalog_observation"]["lifecycle"] == "test-only"
+    assert catalog["entries"][0]["lifecycle"]["state"] == "test-only"
+    assert catalog["entries"][0]["required"] is False
+    assert catalog["entries"][0]["retained"] is True
+    assert catalog["entries"][0]["exclusion_policy"] == "isolated-test-fixture"
+
+
+def test_initial_catalog_observation_rejects_maintenance_only_lifecycle(tmp_path):
+    repo = tmp_path / "retired-probe"
+    repo.mkdir()
+    candidate = inspect_workspace(str(repo), env={"HOME": str(tmp_path)})
+    assert candidate is not None
+
+    with pytest.raises(ValueError, match="use catalog-maintain"):
+        ensure_workspace_data_home(
+            candidate,
+            "invalid direct retirement",
+            catalog_lifecycle="retired",
+        )
+
+
 def test_tracked_settled_shadow_is_readable_without_runtime_initialization(tmp_path):
     repo = tmp_path / "repo"
     manifest_dir = (

--- a/framework/core/tests/python/test_workspace_federation.py
+++ b/framework/core/tests/python/test_workspace_federation.py
@@ -28,7 +28,10 @@ from kungfu.workspace_federation import (
     verify_dogfood_gate_receipt,
 )
 from kungfu.workspace_federation_observer import _runtime_signal
-from kungfu.cli.commands.workspace import _human_work_line
+from kungfu.cli.commands.workspace import (
+    _human_initiative_group_line,
+    _human_work_line,
+)
 
 
 ROOT_A = "sha256:" + "a" * 64
@@ -131,6 +134,27 @@ def test_human_projection_is_stable_at_realistic_scale_and_narrow_width():
     assert len(set(snapshot)) == 35
     assert any("!conflict" in line for line in snapshot)
     assert sum(" x2 " in line for line in snapshot) == 2
+
+
+def test_human_assignment_projection_keeps_phase_and_source_status_separate():
+    row = {
+        "object_kind": "assignment",
+        "display": {
+            "title": "Ready for independent review",
+            "portfolio_state": "awaiting-review",
+            "orchestration_phase": "stage-ready",
+            "source_status": "active",
+        },
+        "conflict": False,
+        "replica_count": 0,
+        "canonical_root": ROOT_A,
+    }
+
+    rendered = _human_work_line(row, 100)
+
+    assert "awaiting-review" in rendered
+    assert "phase=stage-ready" in rendered
+    assert "src=active" in rendered
 
 
 def test_work_ref_requires_qualified_workspace_and_contains_no_locator(tmp_path):
@@ -507,6 +531,118 @@ def test_same_label_divergent_roots_remain_distinct_without_unsafe_collapse(tmp_
     collision = result["global_work"]["label_collisions"][0]
     assert collision["state"] == "authority-distinct"
     assert len(collision["canonical_roots"]) == 2
+
+
+def test_initiative_group_preserves_authority_distinct_canonical_roots(tmp_path):
+    config_home = tmp_path / "config"
+    left = _qualified_project(tmp_path, "initiative-left")
+    right = _qualified_project(tmp_path, "initiative-right")
+    for identity in (left, right):
+        observe_workspace_locator(
+            identity,
+            config_home=str(config_home),
+            env={"HOME": str(tmp_path)},
+        )
+
+    def loader(identity):
+        component = _component_fixture(identity, {})
+        version_root = ROOT_A if identity == left else ROOT_B
+        component["initiatives"] = [
+            {
+                "title": "Technical stewardship",
+                "status": "active",
+                "lifecycle": {
+                    "portfolio_state": "open",
+                    "orchestration_phase": "executing",
+                },
+                "work_ref": build_work_ref(
+                    identity,
+                    object_kind="initiative",
+                    subject="kungfu:technical-stewardship",
+                    version_root=version_root,
+                    cut_root=ROOT_D,
+                ).as_dict(),
+            }
+        ]
+        return component
+
+    result = query_federation(
+        left,
+        scope="all",
+        config_home=str(config_home),
+        env={"HOME": str(tmp_path)},
+        loader=loader,
+    )
+
+    projection = result["global_work"]
+    assert len(projection["initiative_groups"]) == 1
+    group = projection["initiative_groups"][0]
+    raw_roots = sorted(
+        row["canonical_root"]
+        for row in projection["canonical_work"]
+        if row["object_kind"] == "initiative"
+    )
+    assert group["authority_state"] == "authority-distinct"
+    assert group["canonical_roots"] == raw_roots
+    expected_authority_roots = sorted(
+        {
+            root
+            for row in projection["canonical_work"]
+            if row["object_kind"] == "initiative"
+            for root in row["authority_roots"]
+        }
+    )
+    assert group["authority_roots"] == expected_authority_roots
+    assert {left.identity_root, right.identity_root}.issubset(group["authority_roots"])
+    assert projection["visible_initiative_groups"] == [group]
+    rendered = _human_initiative_group_line(group, 100)
+    assert "authority-distinct" in rendered
+    assert f"authorities={len(expected_authority_roots)}" in rendered
+
+
+@pytest.mark.parametrize("terminal_status", ["complete", "merged"])
+def test_default_portfolio_filter_normalizes_legacy_terminal_statuses(
+    tmp_path, terminal_status
+):
+    identity = _qualified_project(tmp_path, terminal_status)
+    assignments = {
+        identity.identity_root: [
+            {
+                "title": f"Legacy {terminal_status}",
+                "status": terminal_status,
+                "lifecycle": {
+                    "portfolio_state": "open",
+                    "orchestration_phase": "stage-ready",
+                },
+                "work_ref": _ref(
+                    identity, f"kungfu:legacy-{terminal_status}"
+                ).as_dict(),
+            }
+        ]
+    }
+
+    default = query_federation(
+        identity,
+        scope="local",
+        config_home=str(tmp_path / "config"),
+        env={"HOME": str(tmp_path)},
+        loader=lambda current: _component_fixture(current, assignments),
+    )
+    settled = query_federation(
+        identity,
+        scope="local",
+        config_home=str(tmp_path / "config"),
+        env={"HOME": str(tmp_path)},
+        loader=lambda current: _component_fixture(current, assignments),
+        include_settled=True,
+    )
+
+    assert default["global_work"]["visible_work"] == []
+    assert len(settled["global_work"]["visible_work"]) == 1
+    display = settled["global_work"]["visible_work"][0]["display"]
+    assert display["source_status"] == terminal_status
+    assert display["orchestration_phase"] == "stage-ready"
+    assert display["portfolio_state"] == "open"
 
 
 def test_same_authority_divergent_versions_are_a_strict_conflict(tmp_path):


### PR DESCRIPTION
## Summary

- normalize terminal compatibility status without conflating native Assignment phase
- group authority-distinct Initiative labels while preserving every canonical root
- keep disposable course probes test-only from first Catalog observation

## Verification

- `./shifu test:workspace-continuation` (121 passed)
- `./shifu check:workspace-continuation`
- `./shifu check:source`
- Catalog maintenance exact plan `sha256:5b8b6cbf4d90b85d13ee04ee5dc9732e7abccca4fd11dfa36eb4e241ab6ae7cf`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bugfix corrects Work Portfolio status projection and disposable Catalog lifecycle handling without changing an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none
