### PR TITLE
fix(ci): bind recovery attempt artifact to target

### DIFF
--- a/.github/workflows/affected-native-cache-promote.yml
+++ b/.github/workflows/affected-native-cache-promote.yml
@@ -112,7 +112,7 @@ jobs:
               attempt_count="$(
                 gh api \
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
-                  --jq "[.artifacts[] | select(.expired == false and .name == \"core-affected-native-delivery-attempt-${GITHUB_SHA}\")] | length"
+                  --jq "[.artifacts[] | select(.expired == false and .name == \"core-affected-native-delivery-attempt-${TARGET_SHA}\")] | length"
               )"
               if [ "$direct_state" = "complete" ] &&
                 [ "$authority_count" -eq 0 ]; then

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -40,7 +40,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0b1d0393206b95172bb59f4949caf303c12069688ef49b036264dfb8df15a4f6",
+          "definitionDigest": "sha256:afc19b5fbe4b8d991055b71989046a0bf778a801e78c0e505852e9e08508bb03",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@v6.4.0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830"],
           "steps": [
@@ -63,7 +63,7 @@
               "index": 4,
               "label": "id:producer",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:19dd6c9ae287d19063b19c045c0535d8c9abc3e83b3aaf77d47370ffd0227cac"
+              "definitionDigest": "sha256:cf2d3ce8db1c8facbe697f6dbef707973eeee2e1eff25b12d7bdf3954f1514b3"
             },
             {
               "index": 5,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -68,7 +68,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:ceb9079f407ceecc7770ce2c5fba0601abec61fe546b97b28193d2666c997e37"
+          "sourceRoot": "sha256:243a9111bd8a5e9c26172a8a318d8fd58b401cafece80c2a35e7dda6fbc468ac"
         },
         {
           "path": ".github/workflows/affected-native-pr.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4489c233586262a7dc20a9a74652488d054682aaae9376f69c00757d43ef1eee"
+  "registryRoot": "sha256:d39bafaf7cc5ca5cd72785f37133d5afcc10f5693eebbc3cfe5194a2b9dfdf0c"
 }

--- a/scripts/affected-native-cache-payload.test.mjs
+++ b/scripts/affected-native-cache-payload.test.mjs
@@ -306,6 +306,14 @@ test('push promotion waits for the exact required Gate instead of whole-run comp
   );
   assert.match(workflow, /actions\/runs\/\$\{run_id\}\/jobs/u);
   assert.match(workflow, /\.name == "affected-native \/ linux"/u);
+  assert.match(
+    workflow,
+    /core-affected-native-delivery-attempt-\$\{TARGET_SHA\}/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /core-affected-native-delivery-attempt-\$\{GITHUB_SHA\}/u,
+  );
   assert.match(workflow, /direct_state.*complete/su);
   assert.match(workflow, /authority_count.*reused-proof/su);
   assert.match(workflow, /attempt_count.*delivery-attempt/su);


### PR DESCRIPTION
修复历史 cache promotion 恢复时 delivery-attempt artifact 仍误绑当前 dev GITHUB_SHA，导致旧 target 永远匹配不到并轮询 10 分钟。现在该 artifact 与其余 authority 一样精确绑定 TARGET_SHA。

验证：cache/proof、workflow authority、Gate catalog、actionlint、YAML、Biome、复杂度预算与 staged gate 通过。

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This CI recovery fix completes exact target binding for an immutable delivery-attempt artifact and does not change product architecture or release semantics."
}
-->