### PR TITLE
fix(ci): run qualified Core producer

### DIFF
--- a/.github/workflows/affected-native-cache-promote.yml
+++ b/.github/workflows/affected-native-cache-promote.yml
@@ -386,6 +386,8 @@ jobs:
           attempt=1
           while [ "$attempt" -le 180 ]; do
             authorities=""
+            observed_run=false
+            pending_run=false
             runs="$(
               gh api --method GET \
                 "repos/${GITHUB_REPOSITORY}/actions/workflows/affected-native-pr.yml/runs" \
@@ -395,6 +397,12 @@ jobs:
                 --jq '.workflow_runs | sort_by(.created_at) | reverse | .[].id'
             )"
             for run_id in $runs; do
+              observed_run=true
+              run_status="$(
+                gh api --method GET \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+                  --jq '.status'
+              )"
               gate_count="$(
                 gh api --method GET \
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
@@ -406,13 +414,17 @@ jobs:
               artifact_state="$(
                 gh api \
                   "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
-                  --jq "[.artifacts[] | select(.expired == false and (.name == \"qualified-assignment-core-candidate-${TARGET_SHA}\" or .name == \"core-affected-native-delivery-attempt-${TARGET_SHA}\")) | .name] | sort | if length == 2 and .[0] != .[1] then \"complete\" elif length == 0 then \"absent\" else \"ambiguous\" end"
+                  --jq "[.artifacts[] | select(.expired == false and (.name == \"qualified-assignment-core-candidate-${TARGET_SHA}\" or .name == \"core-affected-native-delivery-attempt-${TARGET_SHA}\")) | .name] | sort | if length == 2 and (unique | length) == 2 then \"complete\" elif length <= 1 then \"incomplete\" else \"ambiguous\" end"
               )"
               if [ "$artifact_state" = complete ]; then
                 authorities="${authorities}${run_id}"$'\n'
               elif [ "$artifact_state" = ambiguous ]; then
                 echo "Qualified Core transport is ambiguous in run ${run_id}." >&2
                 exit 1
+              elif [ "$run_status" != completed ]; then
+                pending_run=true
+              else
+                echo "Completed producer run ${run_id} has no complete Qualified Core transport; source build remains authoritative."
               fi
             done
             authorities="$(printf '%s' "$authorities" | sed '/^$/d')"
@@ -424,6 +436,11 @@ jobs:
             if [ "$authority_count" -eq 1 ]; then
               producer_run="$authorities"
               break
+            fi
+            if [ "$observed_run" = true ] && [ "$pending_run" = false ]; then
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              echo "No exact Qualified Core producer became available; source build remains authoritative."
+              exit 0
             fi
             sleep 30
             attempt=$((attempt + 1))

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -1075,7 +1075,7 @@ jobs:
         github.event_name == 'merge_group' &&
         needs.candidate_preflight.result == 'success' &&
         needs.candidate_preflight.outputs.native-required == 'true' &&
-        needs.affected-native.result == 'success'
+        needs['affected-native'].result == 'success'
       }}
     continue-on-error: true
     runs-on: macos-15

--- a/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
+++ b/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1808, https://github.com/kungfu-systems/kungfu/pull/1835]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1808, https://github.com/kungfu-systems/kungfu/pull/1836, https://github.com/kungfu-systems/kungfu/pull/1840]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1808
 qualification_refs: [scripts/check-shifu-cache-contract.mjs, scripts/check-shifu-cache-contract.test.mjs, scripts/qualified-assignment-core-artifact.test.mjs, framework/release/qualified-assignment-core-artifact.mjs, docs/shifu/schema/qualified-assignment-core-artifact-v1.schema.json, docs/shifu/schema/qualified-assignment-core-qualification-v1.schema.json, docs/shifu/artifact-contract.json, docs/shifu/cache-contract.json, .github/workflows/affected-native-pr.yml, .github/workflows/affected-native-cache-promote.yml]
 review_state: maintainer-reviewed
@@ -20,7 +20,7 @@ ai_provenance: GPT-5 via Codex on 2026-07-29; based on repository contracts, sou
 
 # SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa: Qualified Assignment Core artifacts bind identity, qualification, and promotion authority
 
-- Status: accepted; contract merged in PR #1808 and exact producer/promotion delivery implemented and independently reviewed in PR #1835
+- Status: accepted; contract merged in PR #1808, exact producer/promotion delivery merged in PR #1836, and hosted runtime activation independently reviewed in PR #1840
 - Date: 2026-07-29
 
 ## Context
@@ -89,3 +89,9 @@ Its workflow artifact remains replaceable transport, and rejection or absence
 continues to select the current-source build. This delivery still does not
 claim a CAS materializer, cross-platform qualification, stable compatibility
 line, or authority to make reuse a blocking build path.
+
+The hosted runtime activation resolves the hyphenated aggregate job through
+expression-safe bracket notation so the exact merge-group macOS ARM64 producer
+is actually scheduled. A completed run with fewer than both required transport
+artifacts remains an unavailable producer and selects the source-build fallback;
+multiple candidate or delivery artifacts remain ambiguous and fail closed.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -40,7 +40,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:bde5b125a4ec6e8f721df048a091373172f21017c87a965f97af6da9cf3dfbf3",
+          "definitionDigest": "sha256:f4dc36dc0d177a54ac9b50ac6067d126460603ea0d498a1aaba15edb0eb2bdc4",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@v6.4.0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830","actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
@@ -138,7 +138,7 @@
             {
               "index": 18,
               "label": "id:qualified_core_producer",
-              "definitionDigest": "sha256:b4467dd4ef0e9fe9183ce0cd164fa028531a3917e9b68cfb43e776e4384c44df"
+              "definitionDigest": "sha256:d5a04bcebf2539305e92f44a81b5dad6084132fe4f269b758ec0264bccc391bd"
             },
             {
               "index": 19,
@@ -591,7 +591,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:7d0a48b72551589d234dd50002a8d9414b6c9a3dd8b5b2e3aed4472ce407d8a2",
+          "definitionDigest": "sha256:ef18ddd171d545cf5801ae15fce672fe146df67df7ebea3ca29db6af36417806",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -68,7 +68,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:21a2d28d1289233cc7e7a446460d8e822d8f6e67506c4898133b4231cf0a4502"
+          "sourceRoot": "sha256:490d40fa0ab6adaf75981e6288df09a916e224d40be3b79a98f1517d93ce03a2"
         },
         {
           "path": ".github/workflows/affected-native-pr.yml",
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:9f9def5fbb287f2743312a13eab62447ff895817fb03cd6df464162755648094"
+          "sourceRoot": "sha256:8e46975be43d1879bea841b135cf3cfbde03823f79fabff47e0ec598b70af9d0"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:f18a99698e86d839904ac38108ccdef9e83e020be1280b4ca01b58f466acddbd"
+  "registryRoot": "sha256:79430e24c2095d269d6d48f8f5997f0aaab9a68493660bb43745fd77fabb3865"
 }

--- a/scripts/qualified-assignment-core-artifact.test.mjs
+++ b/scripts/qualified-assignment-core-artifact.test.mjs
@@ -364,7 +364,7 @@ test('workflows keep candidate and promotion outside untrusted PR authority', ()
   );
   assert.match(
     candidateJob,
-    /github\.event_name == 'merge_group'[\s\S]*native-required == 'true'[\s\S]*continue-on-error: true[\s\S]*runs-on: macos-15/u,
+    /github\.event_name == 'merge_group'[\s\S]*native-required == 'true'[\s\S]*needs\['affected-native'\]\.result == 'success'[\s\S]*continue-on-error: true[\s\S]*runs-on: macos-15/u,
   );
   assert.match(
     candidateJob,
@@ -384,5 +384,9 @@ test('workflows keep candidate and promotion outside untrusted PR authority', ()
   assert.match(
     promotionWorkflow,
     /No exact Qualified Core producer became available; source build remains authoritative/u,
+  );
+  assert.match(
+    promotionWorkflow,
+    /run_status[\s\S]*length <= 1 then \\"incomplete\\"[\s\S]*pending_run=true[\s\S]*Completed producer run[\s\S]*observed_run[\s\S]*pending_run/u,
   );
 });


### PR DESCRIPTION
## Summary

Ensure the qualified Assignment Core path actually schedules its exact merge-group macOS ARM64 producer, while keeping an incomplete producer transport visible without turning the protected-dev source fallback into a failed promotion.

## Related issue

Kungfu Assignment `2026-07-28-kungfu-qualified-core-producer-promotion`.

## Changes

- Resolve the hyphenated aggregate job through the expression-safe bracket form so the merge-group macOS producer is scheduled after an exact successful Gate.
- Distinguish an incomplete completed producer transport from duplicate or ambiguous authority while retaining exact-root and exact-run rejection.
- Refresh the closed-world workflow authority and publication-surface roots.

## Verification

- `actionlint .github/workflows/affected-native-pr.yml .github/workflows/affected-native-cache-promote.yml`
- `node --test scripts/qualified-assignment-core-artifact.test.mjs`
- `KUNGFU_READONLY_PYTEST="$PWD/framework/core/.venv/bin/pytest" ./shifu check:source`
- Commit-time staged Gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa"],
  "summary": "Activate the exact merge-group producer and preserve non-blocking source fallback for incomplete qualified Core transport",
  "verification": ["Full source acceptance", "Exact artifact contract tests", "Closed-world workflow authority", "Commit-time staged Gate"]
}
-->

## Evolution Map impact

Evolution impact: extends

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change corrects qualifying artifact evidence and protected promotion control flow. It adds no release credentials, package publication, or deployment action; closed-world workflow authority and exact-root contract tests cover this boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LXF1YWxpZmllZC1hc3NpZ25tZW50LWNvcmUtY2FjaGUtZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOC1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtcHJvZHVjZXItcHJvbW90aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJmYTk3MDg4MWRiYTI0MWU5YzY0YWZhMzAyZjhmMjBmYTgwNDE1ODY3IiwicHVsbFJlcXVlc3RIZWFkIjoiNjgxYzQ3NTdiZTliZDQ2MWQ5NDgyMjQ4MTE0MmZlZTUxZGFjMjgwMyIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMjkyZGI0ZjYwNmVhNWY4MWNlNmJhYjBlZWYzNzA0N2YyNDEwOWNlZiIsInJlcGxheWVkVHJlZSI6IjA4OGI4ZDk1ODRlNDAyYzMxZmZlMGE0YmY2MmY5MzAxNWIwZDgwYTgiLCJxdWV1ZUF0dGVtcHQiOiI2ODFjNDc1N2JlOWJkNDYxZDk0ODIyNDgxMTQyZmVlNTFkYWMyODAzQGZhOTcwODgxZGJhMjQxZTljNjRhZmEzMDJmOGYyMGZhODA0MTU4NjciLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6OGQ4MGYwOWMwMjI4ODcyN2MzZTkxMTlhYTdlNjZjMWNhMzk3OGQ1MDU2OGNmODVhY2Q3MjBmNmQzOGM5NjEwMCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjhkODBmMDljMDIyODg3MjdjM2U5MTE5YWE3ZTY2YzFjYTM5NzhkNTA1NjhjZjg1YWNkNzIwZjZkMzhjOTYxMDAiLCJzaGEyNTY6ZDk3ZWI4MzI0ODQ4MjI1MDRkMmJiMGMyNTZlM2E4OThlZDYzOGFjNWNhNjRhZDIwNTgyMTc3NjdiNzllZDg2YyJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzIyYzg0YjMxNzAxMDc5ZTIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6ZGEwZTFhZmU3YTQ0ZWY3M2U0ZGE4YjZlZjlkYWRkMzNmZDZkZjRhOTg5ODZjMzJhNWIxMzI5YzMyODQxMDVlZiJ9 -->