### PR TITLE
fix(ci): evaluate producer after proof reuse

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -1072,6 +1072,7 @@ jobs:
       - affected_native
     if: >-
       ${{
+        always() &&
         github.event_name == 'merge_group' &&
         needs.candidate_preflight.result == 'success' &&
         needs.candidate_preflight.outputs.native-required == 'true' &&

--- a/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
+++ b/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
@@ -97,4 +97,6 @@ remains an unavailable producer and selects the source-build fallback; multiple
 candidate or delivery artifacts remain ambiguous and fail closed. The machine
 identifier is therefore `affected_native`, while its human-visible required
 context remains `affected-native / linux`; downstream `needs` expressions use
-the identifier-safe machine name.
+the identifier-safe machine name. The producer condition begins with
+`always()` so exact proof reuse may skip heavy indirect prerequisites without
+preventing evaluation of the successful direct aggregate dependency.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -587,7 +587,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:83bbc30cba3edf537d35fa769510804d4e08b16f65789f6ad5b35c82f7756ad4",
+          "definitionDigest": "sha256:bb015648cc59bbcbba8c03bc2284f76e31ec1699d3eb4f64b4c6e68e96e6ea6b",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:f8b2778135b2d71927c7e6476e0d98139523aff4e6f0fada2bb59995cf921999"
+          "sourceRoot": "sha256:ad4cddef1611a96e383efc7a16a2c09e8f7f18a830e5242245c7f0e887274433"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:a7496616966433d82d6352e35dff8fb3ff5a949ad1c9dccc81bdaf333c5180f8"
+  "registryRoot": "sha256:2d3febb5824968475597d3cd132db3bfc96b690fb70d50647abf68aaab9f33ad"
 }

--- a/scripts/qualified-assignment-core-artifact.test.mjs
+++ b/scripts/qualified-assignment-core-artifact.test.mjs
@@ -364,7 +364,7 @@ test('workflows keep candidate and promotion outside untrusted PR authority', ()
   );
   assert.match(
     candidateJob,
-    /github\.event_name == 'merge_group'[\s\S]*native-required == 'true'[\s\S]*needs\.affected_native\.result == 'success'[\s\S]*continue-on-error: true[\s\S]*runs-on: macos-15/u,
+    /always\(\)[\s\S]*github\.event_name == 'merge_group'[\s\S]*native-required == 'true'[\s\S]*needs\.affected_native\.result == 'success'[\s\S]*continue-on-error: true[\s\S]*runs-on: macos-15/u,
   );
   assert.match(
     candidateJob,


### PR DESCRIPTION
## Summary

Force the merge-group qualified Core producer condition to be evaluated after exact PR-proof reuse skips heavy indirect prerequisite jobs.

## Related issue

Kungfu Assignment `2026-07-28-kungfu-qualified-core-producer-promotion`.

## Changes

- Add `always()` to the producer job-level condition.
- Preserve all exact direct-result, event, source, and affected-native gates.
- Strengthen the artifact contract test to freeze the scheduling invariant.
- Refresh closed-world workflow authority and publication-surface roots.
- Record the hosted dependency-propagation invariant in the accepted ADR.

## Verification

- `actionlint .github/workflows/affected-native-pr.yml`
- `node --test scripts/qualified-assignment-core-artifact.test.mjs scripts/check-kungfu-gate-catalog.test.mjs scripts/affected-native-proof.test.mjs scripts/adr-release-gate.test.mjs`
- `node scripts/kungfu-workflow-authority.mjs`
- `node framework/release/publication-control-plane.mjs check`
- Commit-time staged Gate
- Runtime evidence: merge-group run `30435705508` reused exact proof, skipped indirect heavy prerequisites, and GitHub skipped the producer before evaluating its otherwise true direct gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa"],
  "summary": "Evaluate the exact merge-group qualified Core producer after skipped indirect proof-reuse prerequisites",
  "verification": ["Hosted merge-group evidence", "Exact artifact contract tests", "Closed-world workflow authority", "Commit-time staged Gate"]
}
-->

## Evolution Map impact

Evolution impact: extends

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only trusted workflow scheduling and evidence projections. It adds no credential or publication authority and preserves every exact producer gate.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LXF1YWxpZmllZC1hc3NpZ25tZW50LWNvcmUtY2FjaGUtZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOC1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtcHJvZHVjZXItcHJvbW90aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJlMGE5NzVkYjgxNTg4ZDI2NjczMjBkMDM1MmY1ZDUwYzFkNjhhZjdhIiwicHVsbFJlcXVlc3RIZWFkIjoiZTBkMjQ1M2YyZTY3N2RiM2U3NTM4NDg2NzJhOWY3NDA0NjA4ZDU0OSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiN2FhODU5NTkzNzViM2I2ZTdmZmFmMTc4NWQ3MzYxZWUxMmE0YTZiMyIsInJlcGxheWVkVHJlZSI6ImU1YWY2OWYyZjJmZDFkZGQzYzAzNTM2MGUyZDFkOWVhNThmNjlhZmIiLCJxdWV1ZUF0dGVtcHQiOiJlMGQyNDUzZjJlNjc3ZGIzZTc1Mzg0ODY3MmE5Zjc0MDQ2MDhkNTQ5QGUwYTk3NWRiODE1ODhkMjY2NzMyMGQwMzUyZjVkNTBjMWQ2OGFmN2EiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6MTcyYTY3MGUyOTg5NmEwMTNkZGY3MjFjYzgwYzM2NmQ4YzE1NmUwNzhlYmEwYjg2OTUzMjg3ZDFkMWY1MGYyYyIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjE3MmE2NzBlMjk4OTZhMDEzZGRmNzIxY2M4MGMzNjZkOGMxNTZlMDc4ZWJhMGI4Njk1MzI4N2QxZDFmNTBmMmMiLCJzaGEyNTY6ZDk3ZWI4MzI0ODQ4MjI1MDRkMmJiMGMyNTZlM2E4OThlZDYzOGFjNWNhNjRhZDIwNTgyMTc3NjdiNzllZDg2YyJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzIyYzg0YjMxNzAxMDc5ZTIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6ZTkwZmQyODQ0ZDRjNWE3Mzc0MzAzMTU5ZTg2NmVmZDg1ODBmYWZjM2YyZDE5ZGNjNjcyMDUxYzQwNTI2MTcwZCJ9 -->