### PR TITLE
feat(ci): expand local agent patrol cadence

### DIFF
--- a/.github/workflows/kungfu-agent-patrol.yml
+++ b/.github/workflows/kungfu-agent-patrol.yml
@@ -3,10 +3,20 @@
 name: Kungfu Agent Patrol
 
 on:
-  # Monday 02:00 Asia/Shanghai. Scheduled workflows run from the default branch.
+  # One run at 02:00 Asia/Shanghai every day. Monday is the deeper weekly slot.
   schedule:
+    - cron: "0 18 * * 1-6"
     - cron: "0 18 * * 0"
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Bounded Patrol mode
+        required: true
+        type: choice
+        default: light
+        options:
+          - light
+          - deep
 
 permissions:
   contents: read
@@ -26,7 +36,7 @@ jobs:
     runs-on:
       - agent-121
       - kungfu-agent-patrol
-    timeout-minutes: 75
+    timeout-minutes: 90
     env:
       OPENCODE_IMAGE: ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3
       OPENCODE_MODEL: qwen3-coder:30b-opencode-64k
@@ -61,54 +71,92 @@ jobs:
           ./shifu build:core
           ./shifu test:agent-patrol
 
-      - name: Run bounded repository-work experiment
+      - name: Select bounded Patrol plan
         shell: bash
+        env:
+          PATROL_EVENT_NAME: ${{ github.event_name }}
+          PATROL_SCHEDULE: ${{ github.event.schedule || '' }}
+          PATROL_MANUAL_MODE: ${{ inputs.mode || 'light' }}
+          PATROL_ROTATION_KEY: ${{ github.run_number }}
         run: |
           set -euo pipefail
           evidence_dir="$RUNNER_TEMP/kungfu-agent-patrol-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
           mkdir -p "$evidence_dir"
           printf 'KUNGFU_AGENT_PATROL_EVIDENCE=%s\n' "$evidence_dir" >>"$GITHUB_ENV"
-          runner_exit=0
-          ./shifu qualify:agent-repository-work -- \
-            --output "$evidence_dir/repository-work" \
-            --image "$OPENCODE_IMAGE" \
-            --model "$OPENCODE_MODEL" \
-            --base-url "$OPENCODE_BASE_URL" \
-            --source-head "$GITHUB_SHA" \
-            --timeout-seconds 900 || runner_exit=$?
-          printf '%s\n' "$runner_exit" >"$evidence_dir/runner-exit"
+          ./shifu agent-patrol:select -- \
+            --event-name "$PATROL_EVENT_NAME" \
+            --schedule "$PATROL_SCHEDULE" \
+            --manual-mode "$PATROL_MANUAL_MODE" \
+            --rotation-key "$PATROL_ROTATION_KEY" \
+            --output "$evidence_dir/plan.json"
 
-      - name: Classify bounded outcome
+      - name: Run bounded repository-work experiments
         shell: bash
         run: |
           set -euo pipefail
-          ./shifu agent-patrol:classify -- \
-            --report "$KUNGFU_AGENT_PATROL_EVIDENCE/repository-work/agent-repository-work-report.json" \
-            --output "$KUNGFU_AGENT_PATROL_EVIDENCE/classification.json" \
-            --runner-exit "$(cat "$KUNGFU_AGENT_PATROL_EVIDENCE/runner-exit")" \
-            --source-head "$GITHUB_SHA" \
-            --model "$OPENCODE_MODEL" \
-            --image "$OPENCODE_IMAGE" \
-            --runner "$RUNNER_NAME"
+          timeout_seconds="$(jq -r '.timeoutSeconds' \
+            "$KUNGFU_AGENT_PATROL_EVIDENCE/plan.json")"
+          while IFS= read -r fixture; do
+            fixture_dir="$KUNGFU_AGENT_PATROL_EVIDENCE/repository-work/$fixture"
+            mkdir -p "$fixture_dir"
+            runner_exit=0
+            ./shifu qualify:agent-repository-work -- \
+              --output "$fixture_dir/evidence" \
+              --image "$OPENCODE_IMAGE" \
+              --model "$OPENCODE_MODEL" \
+              --base-url "$OPENCODE_BASE_URL" \
+              --source-head "$GITHUB_SHA" \
+              --fixture "$fixture" \
+              --timeout-seconds "$timeout_seconds" || runner_exit=$?
+            printf '%s\n' "$runner_exit" >"$fixture_dir/runner-exit"
+          done < <(jq -r '.fixtures[]' \
+            "$KUNGFU_AGENT_PATROL_EVIDENCE/plan.json")
 
-      - name: Capture or deduplicate native Dogfood Finding
+      - name: Classify bounded outcomes
         shell: bash
         run: |
           set -euo pipefail
-          ./shifu agent-patrol:dogfood-capture -- \
-            --classification "$KUNGFU_AGENT_PATROL_EVIDENCE/classification.json" \
-            --intent "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-finding-intent.json" \
-            --output "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-capture-receipt.json" \
-            --workspace "$HOME/.local/state/kungfu-agent-patrol"
+          mkdir -p "$KUNGFU_AGENT_PATROL_EVIDENCE/classification"
+          while IFS= read -r fixture; do
+            fixture_dir="$KUNGFU_AGENT_PATROL_EVIDENCE/repository-work/$fixture"
+            ./shifu agent-patrol:classify -- \
+              --report "$fixture_dir/evidence/agent-repository-work-report.json" \
+              --output "$KUNGFU_AGENT_PATROL_EVIDENCE/classification/$fixture.json" \
+              --runner-exit "$(cat "$fixture_dir/runner-exit")" \
+              --source-head "$GITHUB_SHA" \
+              --model "$OPENCODE_MODEL" \
+              --image "$OPENCODE_IMAGE" \
+              --runner "$RUNNER_NAME"
+          done < <(jq -r '.fixtures[]' \
+            "$KUNGFU_AGENT_PATROL_EVIDENCE/plan.json")
+
+      - name: Capture or deduplicate native Dogfood Findings
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p \
+            "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-intent" \
+            "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-receipt"
+          while IFS= read -r fixture; do
+            ./shifu agent-patrol:dogfood-capture -- \
+              --classification "$KUNGFU_AGENT_PATROL_EVIDENCE/classification/$fixture.json" \
+              --intent "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-intent/$fixture.json" \
+              --output "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-receipt/$fixture.json" \
+              --workspace "$HOME/.local/state/kungfu-agent-patrol"
+          done < <(jq -r '.fixtures[]' \
+            "$KUNGFU_AGENT_PATROL_EVIDENCE/plan.json")
 
       - name: Enforce infrastructure and evidence integrity
         shell: bash
         run: |
           set -euo pipefail
-          jq -e '.issueAdmitted == false' \
-            "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-capture-receipt.json" >/dev/null
-          test "$(jq -r '.blocking' \
-            "$KUNGFU_AGENT_PATROL_EVIDENCE/classification.json")" = "false"
+          while IFS= read -r fixture; do
+            jq -e '.issueAdmitted == false' \
+              "$KUNGFU_AGENT_PATROL_EVIDENCE/dogfood-receipt/$fixture.json" >/dev/null
+            test "$(jq -r '.blocking' \
+              "$KUNGFU_AGENT_PATROL_EVIDENCE/classification/$fixture.json")" = "false"
+          done < <(jq -r '.fixtures[]' \
+            "$KUNGFU_AGENT_PATROL_EVIDENCE/plan.json")
 
       - name: Upload bounded Patrol evidence
         if: ${{ always() }}
@@ -116,8 +164,9 @@ jobs:
         with:
           name: kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            ${{ runner.temp }}/kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}/repository-work/agent-repository-work-report.json
-            ${{ runner.temp }}/kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}/classification.json
-            ${{ runner.temp }}/kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}/dogfood-capture-receipt.json
+            ${{ runner.temp }}/kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}/plan.json
+            ${{ runner.temp }}/kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}/repository-work/*/evidence/agent-repository-work-report.json
+            ${{ runner.temp }}/kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}/classification/*.json
+            ${{ runner.temp }}/kungfu-agent-patrol-${{ github.run_id }}-${{ github.run_attempt }}/dogfood-receipt/*.json
           if-no-files-found: warn
           retention-days: 14

--- a/docs/qualification/agent-patrol-agent-121.md
+++ b/docs/qualification/agent-patrol-agent-121.md
@@ -7,8 +7,13 @@ off agent-120, which remains the Dev build primary.
 ## Execution contract
 
 - Workflow: `.github/workflows/kungfu-agent-patrol.yml`
-- Schedule: Monday 02:00 Asia/Shanghai (`0 18 * * 0` UTC)
-- Manual trigger: `workflow_dispatch` on the protected default branch only
+- Schedule: one run at 02:00 Asia/Shanghai every day
+- Daily lightweight slot: Tuesday through Sunday
+  (`0 18 * * 1-6` UTC), one fixed fixture
+- Weekly deeper slot: Monday (`0 18 * * 0` UTC), two fixtures selected from
+  the three-fixture catalog
+- Manual trigger: `workflow_dispatch` with an explicit `light` or `deep` mode
+  on the protected default branch only
 - Runner: `agent-121-kungfu-systems`
 - Required labels: `agent-121`, `kungfu-agent-patrol`
 - Image:
@@ -23,6 +28,22 @@ off agent-120, which remains the Dev build primary.
   continue to use the invoking host UID/GID.
 - Concurrency: one Patrol run at a time
 - Credentials: none admitted to the model or Dogfood payload
+
+`framework/agent-patrol/select.mjs` owns the trigger-to-plan contract. The
+lightweight mode always runs `incident-board-lease-v1` with a 600-second
+per-session timeout. The deeper mode runs two fixtures with a 900-second
+per-session timeout and rotates the starting fixture from the stable GitHub
+workflow run number:
+
+```text
+lease + recovery
+recovery + combined replay
+combined replay + lease
+```
+
+Rerunning one workflow attempt preserves the same rotation key and suite. The
+shared non-cancelling concurrency group serializes scheduled and manual runs,
+so the two modes cannot contend for agent-121.
 
 The workflow is classified as `qualification` authority with a `diagnostic`
 receipt. It cannot publish a product, move a release channel, become a required
@@ -62,10 +83,10 @@ The owning authority is the persistent project workspace:
 $HOME/.local/state/kungfu-agent-patrol/.kungfu
 ```
 
-The workflow uploads only the bounded repository-work report, classification,
-and capture receipt. It does not upload provider transcripts, raw prompts,
-credentials, signed URLs, the native Fact store, or the generated capture
-intent.
+The workflow uploads only the bounded Patrol plan, per-fixture repository-work
+reports, classifications, and capture receipts. It does not upload provider
+transcripts, raw prompts, credentials, signed URLs, the native Fact store, or
+generated capture intents.
 
 The native Dogfood Inbox is a federated projection, not one atomic global
 database. A consumer that needs to inspect this runner-owned Finding must
@@ -104,10 +125,12 @@ Local deterministic and native temporary-workspace coverage:
 
 After activation, dispatch the protected-branch workflow and verify:
 
-1. the job ran on `agent-121-kungfu-systems`;
-2. the exact image, model, source commit, and endpoint were bound;
-3. a passing report produced `not-required`;
-4. a controlled failure produced `captured`;
-5. replaying that failure produced `deduplicated` with the same Finding root;
-6. `issueAdmitted` remained `false`; and
-7. a controlled runner-integrity failure left the job red.
+1. a manual `light` dispatch ran only `incident-board-lease-v1`;
+2. a manual `deep` dispatch ran the exact two-fixture suite in `plan.json`;
+3. both jobs ran on `agent-121-kungfu-systems`;
+4. the exact image, model, source commit, endpoint, and fixture IDs were bound;
+5. a passing report produced `not-required`;
+6. a controlled failure produced `captured`;
+7. replaying that failure produced `deduplicated` with the same Finding root;
+8. every receipt retained `issueAdmitted: false`; and
+9. a controlled runner-integrity failure left the job red.

--- a/docs/qualification/agent-repository-work-experiment.md
+++ b/docs/qualification/agent-repository-work-experiment.md
@@ -6,7 +6,7 @@ repository repair. It is deliberately separate from Auditable Demo,
 Qualification Lab, release Gates, public capability claims, and model ranking.
 
 ```text
-49-file / 2433-line Python fixture with a seeded defect
+49-file Python fixture selected from a three-entry seeded-defect catalog
 -> fresh Agent A investigates under a read-only Warrant
 -> deterministic assessment accepts only a bounded partial Claim
 -> Kungfu admits a content-rooted continuation envelope
@@ -18,6 +18,19 @@ Qualification Lab, release Gates, public capability claims, and model ranking.
 The fixture implements an append-only incident board. Its seeded defect permits
 an expired lease to complete work and counts historical retry completions more
 than once after restart. The repository uses only the Python standard library.
+
+The catalog derives three byte-bounded fixtures from that repository:
+
+| Fixture | Seeded boundary | Writable Warrant |
+| --- | --- | --- |
+| `incident-board-lease-v1` | expired-lease completion authorization | `incident_board/lease.py` |
+| `incident-board-recovery-v1` | duplicate-completion restart replay | `incident_board/replay.py` |
+| `incident-board-replay-v1` | combined lease, command, and replay repair | three production modules |
+
+Each derived fixture pre-applies the independent reference repair outside its
+seeded boundary. The visible and hidden external oracle still checks the full
+repository behavior, so a focused repair cannot pass by regressing another
+boundary.
 
 ## Trust boundaries
 
@@ -74,7 +87,8 @@ For a direct trusted-host invocation:
   --output /tmp/kungfu-agent-repository-work \
   --image ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3 \
   --model qwen3-coder:30b-opencode-64k \
-  --base-url http://host.docker.internal:11435/v1
+  --base-url http://host.docker.internal:11435/v1 \
+  --fixture incident-board-lease-v1
 ```
 
 The resulting `agent-repository-work-report.json` records execution,
@@ -101,5 +115,5 @@ privacy, deduplication, authority, and activation boundaries.
 This experiment does not establish multi-day durability, concurrent editing,
 arbitrary repository competence, provider superiority, production safety,
 GUI/TUI parity, cross-machine Dogfood replication, or release readiness. A
-single passing run is evidence that the tested path bore this workload; it is
-not a generalized product claim.
+passing run is evidence that the selected fixture, runtime, and runner bore that
+workload; it is not a generalized product claim.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1770,14 +1770,14 @@
     {
       "path": ".github/workflows/kungfu-agent-patrol.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:383a26ee97c69c803d51d77dd709d7e45711a30148a0f7af6801043a9a9bc1fc",
+      "definitionDigest": "sha256:3c50b45eb56f34f88eb3f1407b4cf469224894f5a7726e5003ce26db2dd4ab5e",
       "jobs": [
         {
           "id": "patrol",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:d20bbcfb8bc6fa41e3d00274537abdfa16b181376bb1b3ed3b325609113fca32",
+          "definitionDigest": "sha256:5b6183fa0007097274fadcbf8fa4097fbc83b89135c53aedcfd9e2acea7f5f3b",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
@@ -1798,29 +1798,35 @@
             },
             {
               "index": 4,
-              "label": "name:Run bounded repository-work experiment",
-              "definitionDigest": "sha256:bc41e7329ddf176b5b55b7e81e8f30efedabdc34f4f7dadd8d5f67b83e99d994"
+              "label": "name:Select bounded Patrol plan",
+              "definitionDigest": "sha256:07e94217d605a7ea42dd95af957ad859d101f727067cb4e9fcc713ed03068f1e"
             },
             {
               "index": 5,
-              "label": "name:Classify bounded outcome",
-              "definitionDigest": "sha256:1e998c6fd0b3d9b8caed2d54fe19ee1a8e1beabd56771eca31f6aa20d4299772"
+              "label": "name:Run bounded repository-work experiments",
+              "definitionDigest": "sha256:9f6798817fa55908789d5c938c30db7842c6ee936ee249439c7fcbd1de28fdd9"
             },
             {
               "index": 6,
-              "label": "name:Capture or deduplicate native Dogfood Finding",
-              "definitionDigest": "sha256:653ed067fd57cff2c6f6ea66463209cec472d8483448ebf68d4f8c80baed06c0"
+              "label": "name:Classify bounded outcomes",
+              "definitionDigest": "sha256:b50b4f1fcf14af84df58711e0f730e04cecd7e95dd457d21cb1438be3d761071"
             },
             {
               "index": 7,
-              "label": "name:Enforce infrastructure and evidence integrity",
-              "definitionDigest": "sha256:532688cc7f28e3aaf4b41748496592f5becf691c6f1f3fdb6d062bfb48ac800a"
+              "label": "name:Capture or deduplicate native Dogfood Findings",
+              "definitionDigest": "sha256:ae11f433abbbf6093d7116802d4081db5db645fe3d0c12e36c1a4c62ceb8bc46"
             },
             {
               "index": 8,
+              "label": "name:Enforce infrastructure and evidence integrity",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:7b2371cde4bcdf1b0ee56a070ba790e9040e6bd2c49d7eea936cb25d4cf2c48f"
+            },
+            {
+              "index": 9,
               "label": "name:Upload bounded Patrol evidence",
               "authority": "evidence-publication",
-              "definitionDigest": "sha256:0d703a621007119b0b6e0f92b4edb4d4b3b57f1d289ec98144ba2b1721e4944f"
+              "definitionDigest": "sha256:bc1d87aaecf76f845b0739fd113342e55f501c6f0a01cc61622910b048c1444e"
             }
           ]
         }

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -87,7 +87,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/gate-measurement.yml` | `focused` | qualification | none | diagnostic | token:read | none | 7 |
 | `.github/workflows/gate-measurement.yml` | `measure` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/kfd-verifier-drift.yml` | `verify-owned-fixtures` | qualification | none | qualifying | token:read | none | 4 |
-| `.github/workflows/kungfu-agent-patrol.yml` | `patrol` | qualification | none | diagnostic | token:read | none | 8 |
+| `.github/workflows/kungfu-agent-patrol.yml` | `patrol` | qualification | none | diagnostic | token:read | none | 9 |
 | `.github/workflows/linux-arm64-alpha-qualification.yml` | `artifact` | qualification | none | diagnostic | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN | none | 0 |
 | `.github/workflows/linux-arm64-alpha-qualification.yml` | `preflight` | qualification | none | diagnostic | token:write, oidc | none | 2 |
 | `.github/workflows/opencode-agent-repository-work.yml` | `experiment` | qualification | none | diagnostic | token:read | none | 5 |

--- a/framework/agent-patrol/classify.mjs
+++ b/framework/agent-patrol/classify.mjs
@@ -179,7 +179,12 @@ export function classifyReport(
         error: [category, `fingerprint:${fingerprintRoot.slice(7, 23)}`],
         build: [`source:${report.sourceHead}`],
         platform: ['linux-x64', 'agent-121'],
-        tag: ['opencode', 'qwen3-coder', blocking ? 'blocking' : 'advisory'],
+        tag: [
+          'opencode',
+          'qwen3-coder',
+          `fixture:${report.fixture.id}`,
+          blocking ? 'blocking' : 'advisory',
+        ],
         evidence: ['bounded-report'],
       },
       privacy: 'internal',

--- a/framework/agent-patrol/select.mjs
+++ b/framework/agent-patrol/select.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  LIGHT_REPOSITORY_WORK_FIXTURE_ID,
+  REPOSITORY_WORK_FIXTURES,
+} from '../../tests/qualification/agent-repository-work/fixture-catalog.mjs';
+
+export const DAILY_LIGHT_SCHEDULE = '0 18 * * 1-6';
+export const WEEKLY_DEEP_SCHEDULE = '0 18 * * 0';
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object')
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonical(value[key])]),
+    );
+  return value;
+}
+
+function jsonRoot(value) {
+  return `sha256:${crypto
+    .createHash('sha256')
+    .update(JSON.stringify(canonical(value)))
+    .digest('hex')}`;
+}
+
+function deepFixtures(rotationKey) {
+  const ids = REPOSITORY_WORK_FIXTURES.map(({ id }) => id);
+  const start = (rotationKey - 1) % ids.length;
+  return [ids[start], ids[(start + 1) % ids.length]];
+}
+
+export function selectPatrolPlan({
+  eventName,
+  schedule = '',
+  manualMode = '',
+  rotationKey,
+}) {
+  if (!Number.isInteger(rotationKey) || rotationKey < 1)
+    throw new Error('rotation key must be a positive integer');
+  let mode;
+  if (eventName === 'schedule') {
+    if (schedule === DAILY_LIGHT_SCHEDULE) mode = 'light';
+    else if (schedule === WEEKLY_DEEP_SCHEDULE) mode = 'deep';
+    else throw new Error(`unrecognized protected schedule: ${schedule}`);
+  } else if (eventName === 'workflow_dispatch') {
+    if (!['light', 'deep'].includes(manualMode))
+      throw new Error('manual mode must be light or deep');
+    mode = manualMode;
+  } else {
+    throw new Error(`untrusted Patrol event: ${eventName}`);
+  }
+
+  const body = {
+    schema: 'kungfu.agent-patrol.plan/v1',
+    evidenceClass: 'bounded-experiment',
+    mode,
+    trigger: eventName,
+    schedule: eventName === 'schedule' ? schedule : null,
+    rotationKey,
+    fixtures:
+      mode === 'light'
+        ? [LIGHT_REPOSITORY_WORK_FIXTURE_ID]
+        : deepFixtures(rotationKey),
+    timeoutSeconds: mode === 'light' ? 600 : 900,
+    issueAdmission: 'prohibited',
+    requiredGate: false,
+  };
+  return { ...body, planRoot: jsonRoot(body) };
+}
+
+export function parseArgs(argv) {
+  const result = {
+    eventName: '',
+    schedule: '',
+    manualMode: '',
+    rotationKey: null,
+    output: '',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue;
+    if (arg === '--event-name') result.eventName = argv[++index] || '';
+    else if (arg === '--schedule') result.schedule = argv[++index] || '';
+    else if (arg === '--manual-mode') result.manualMode = argv[++index] || '';
+    else if (arg === '--rotation-key')
+      result.rotationKey = Number.parseInt(argv[++index] || '', 10);
+    else if (arg === '--output') result.output = argv[++index] || '';
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!result.eventName) throw new Error('--event-name is required');
+  if (!result.output) throw new Error('--output is required');
+  return result;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const plan = selectPatrolPlan(options);
+    const output = path.resolve(options.output);
+    fs.mkdirSync(path.dirname(output), { recursive: true });
+    fs.writeFileSync(output, `${JSON.stringify(plan, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify({
+        mode: plan.mode,
+        fixtures: plan.fixtures,
+        timeoutSeconds: plan.timeoutSeconds,
+        planRoot: plan.planRoot,
+      })}\n`,
+    );
+  } catch (error) {
+    process.stderr.write(`${error.stack || error}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/framework/agent-repository-work/run.mjs
+++ b/framework/agent-repository-work/run.mjs
@@ -10,11 +10,14 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import {
+  DEFAULT_REPOSITORY_WORK_FIXTURE_ID,
+  getRepositoryWorkFixture,
+} from '../../tests/qualification/agent-repository-work/fixture-catalog.mjs';
+import {
   materializeIncidentBoardFixture,
   qualifySeededIncidentBoardFixture,
   verifyIncidentBoardWorkspace,
 } from '../../tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs';
-import { INCIDENT_BOARD_FIXTURE } from '../../tests/qualification/agent-repository-work/incident-board-replay-v1.mjs';
 
 const ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -66,7 +69,7 @@ function writeJson(file, value) {
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const result = {
     output: '',
     image: DEFAULT_IMAGE,
@@ -75,6 +78,7 @@ function parseArgs(argv) {
     opencode: '',
     sourceHead: '',
     timeoutSeconds: 900,
+    fixture: DEFAULT_REPOSITORY_WORK_FIXTURE_ID,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -85,6 +89,7 @@ function parseArgs(argv) {
     else if (arg === '--base-url') result.baseUrl = argv[++index] || '';
     else if (arg === '--opencode') result.opencode = argv[++index] || '';
     else if (arg === '--source-head') result.sourceHead = argv[++index] || '';
+    else if (arg === '--fixture') result.fixture = argv[++index] || '';
     else if (arg === '--timeout-seconds')
       result.timeoutSeconds = Number.parseInt(argv[++index] || '', 10);
     else throw new Error(`unknown argument: ${arg}`);
@@ -93,6 +98,7 @@ function parseArgs(argv) {
     throw new Error('--timeout-seconds must be an integer of at least 60');
   if (!result.opencode && !result.image.includes('@sha256:'))
     throw new Error('--image must be pinned by digest');
+  getRepositoryWorkFixture(result.fixture);
   return result;
 }
 
@@ -277,20 +283,18 @@ function providerSessionId(run, label) {
   return values[0];
 }
 
-export function parseInvestigationClaim(text) {
+export function parseInvestigationClaim(
+  text,
+  fixture = getRepositoryWorkFixture('incident-board-replay-v1'),
+) {
   if (typeof text !== 'string' || !text.trim())
     throw new Error('Agent A returned no investigation claim');
   const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/iu);
   const source =
     fenced?.[1] || text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1);
   const value = JSON.parse(source);
-  const expectedFailures = [
-    'test_expired_lease_cannot_complete',
-    'test_legacy_duplicate_log_has_stable_restart_summary',
-  ];
-  const expectedPaths = [
-    ...INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths,
-  ].sort();
+  const expectedFailures = [...fixture.investigation.expectedFailures].sort();
+  const expectedPaths = [...fixture.warrants.agentB.writablePaths].sort();
   if (
     value?.schema !== 'kungfu.agent-repository-work.investigation-claim/v1' ||
     value.investigationComplete !== true ||
@@ -298,8 +302,8 @@ export function parseInvestigationClaim(text) {
       JSON.stringify(expectedFailures) ||
     JSON.stringify([...(value.repairPaths || [])].sort()) !==
       JSON.stringify(expectedPaths) ||
-    value.remainingObligation !== 'implement-and-verify-bounded-repair' ||
-    value.nextAction !== 'repair-seeded-completion-idempotency'
+    value.remainingObligation !== fixture.investigation.remainingObligation ||
+    value.nextAction !== fixture.investigation.nextAction
   )
     throw new Error(
       'Agent A investigation claim failed deterministic assessment',
@@ -362,16 +366,16 @@ export function validateExperimentReport(report) {
   return true;
 }
 
-function buildBaseReport(options, sourceHead) {
+function buildBaseReport(options, sourceHead, fixture) {
   return {
     schema: REPORT_SCHEMA,
     evidenceClass: 'bounded-experiment',
     passed: false,
     sourceHead,
     fixture: {
-      id: INCIDENT_BOARD_FIXTURE.id,
-      fileCount: Object.keys(INCIDENT_BOARD_FIXTURE.files).length,
-      lineCount: Object.values(INCIDENT_BOARD_FIXTURE.files).reduce(
+      id: fixture.id,
+      fileCount: Object.keys(fixture.files).length,
+      lineCount: Object.values(fixture.files).reduce(
         (count, content) => count + content.split('\n').length,
         0,
       ),
@@ -392,7 +396,7 @@ function buildBaseReport(options, sourceHead) {
     warrant: {
       agentA: 'investigation-only',
       agentB: 'bounded-repair',
-      writablePaths: [...INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths],
+      writablePaths: [...fixture.warrants.agentB.writablePaths],
       verifierOutsideAgentWorkspace: true,
     },
     dimensions: {
@@ -426,14 +430,16 @@ export function runExperiment(options = {}) {
     opencode: options.opencode || '',
     sourceHead: options.sourceHead || '',
     timeoutSeconds: options.timeoutSeconds || 900,
+    fixture: options.fixture || DEFAULT_REPOSITORY_WORK_FIXTURE_ID,
   };
+  const fixture = getRepositoryWorkFixture(normalized.fixture);
   const output = path.resolve(normalized.output);
   if (fs.existsSync(output) && fs.readdirSync(output).length > 0)
     throw new Error('output directory must be new or empty');
   fs.mkdirSync(output, { recursive: true });
   const reportPath = path.join(output, 'agent-repository-work-report.json');
   const sourceHead = normalized.sourceHead || currentHead();
-  const report = buildBaseReport(normalized, sourceHead);
+  const report = buildBaseReport(normalized, sourceHead, fixture);
   const started = process.hrtime.bigint();
   try {
     if (!fs.existsSync(CONTRACT_PATH))
@@ -442,9 +448,9 @@ export function runExperiment(options = {}) {
     const workspace = path.join(output, 'workspace');
     const home = path.join(output, 'kf-home');
     const configHome = path.join(output, 'kf-config');
-    const initialTree = materializeIncidentBoardFixture(workspace);
+    const initialTree = materializeIncidentBoardFixture(workspace, fixture);
     const initialTreeRoot = jsonRoot(initialTree);
-    const seeded = qualifySeededIncidentBoardFixture();
+    const seeded = qualifySeededIncidentBoardFixture(fixture);
     if (!seeded.passed)
       throw new Error('seeded fixture did not expose the expected failures');
     const planProfile = runtimeProfile({
@@ -492,9 +498,9 @@ export function runExperiment(options = {}) {
     const workEntity = {
       schema: 'kungfu.agent-repository-work.entity/v1',
       contractRoot,
-      fixtureId: INCIDENT_BOARD_FIXTURE.id,
+      fixtureId: fixture.id,
       initialTreeRoot,
-      warrantRoot: jsonRoot(INCIDENT_BOARD_FIXTURE.warrants),
+      warrantRoot: jsonRoot(fixture.warrants),
     };
     const currentCutRoot = jsonRoot({
       schema: 'kungfu.agent-repository-work.cut/v1',
@@ -504,10 +510,10 @@ export function runExperiment(options = {}) {
     const workRef = {
       schema: 'kungfu.work-ref/v1',
       workspaceId: 'agent-repository-work-disposable',
-      profileId: 'incident-board-replay-v1',
+      profileId: fixture.id,
       profileRoot: jsonRoot(contract),
       entityType: 'work',
-      entityId: 'incident-board-replay-v1',
+      entityId: fixture.id,
       entityRoot: jsonRoot(workEntity),
       purpose: 'bounded-local-agent-repository-load-experiment',
       systemTimeCut: currentCutRoot,
@@ -517,10 +523,10 @@ export function runExperiment(options = {}) {
     const promptA = [
       'Investigate the repository defect without modifying any file.',
       'Run `python -m unittest discover -s tests -v`, inspect the lease, command, and replay boundaries, and identify the exact bounded repair paths.',
-      `The admitted investigation Warrant limits the candidate repair to exactly these repository-relative paths: ${INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths.join(', ')}.`,
+      `The admitted investigation Warrant limits the candidate repair to exactly these repository-relative paths: ${fixture.warrants.agentB.writablePaths.join(', ')}.`,
       'Confirm the seeded failures can be repaired within that Warrant; do not propose tests, service.py, or any other path.',
       'Return only one JSON object, with no prose or Markdown.',
-      'The object must contain schema "kungfu.agent-repository-work.investigation-claim/v1", investigationComplete true, failingTests containing exactly the two failing unittest method names, repairPaths containing exactly three repository-relative Python paths without leading slashes, line numbers, or fragments, remainingObligation "implement-and-verify-bounded-repair", and nextAction "repair-seeded-completion-idempotency".',
+      `The object must contain schema "kungfu.agent-repository-work.investigation-claim/v1", investigationComplete true, failingTests containing exactly ${JSON.stringify(fixture.investigation.expectedFailures)}, repairPaths containing exactly ${JSON.stringify(fixture.warrants.agentB.writablePaths)} without leading slashes, line numbers, or fragments, remainingObligation "${fixture.investigation.remainingObligation}", and nextAction "${fixture.investigation.nextAction}".`,
     ].join(' ');
     const sessionA = JSON.parse(
       pythonKungfu(
@@ -549,6 +555,7 @@ export function runExperiment(options = {}) {
       throw new Error('Agent A modified the investigation-only workspace');
     const investigation = parseInvestigationClaim(
       sessionA.providerObservation?.text,
+      fixture,
     );
     const claimBody = {
       schema: 'kungfu.agent-repository-work.claim/v1',
@@ -571,8 +578,7 @@ export function runExperiment(options = {}) {
       initialTreeRoot,
       seededDefectRoot: jsonRoot(seeded),
       outcome: 'partial',
-      remainingObligation:
-        'Repair expired-lease authorization, retry idempotency, and restart replay using only incident_board/commands.py, incident_board/lease.py, and incident_board/replay.py; run python -m unittest discover -s tests -v and leave the workspace for an external hidden verifier.',
+      remainingObligation: `Complete ${fixture.task.title.toLowerCase()} using only ${fixture.warrants.agentB.writablePaths.join(', ')}; run python -m unittest discover -s tests -v and leave the workspace for an external hidden verifier.`,
       nextAction: 'implement bounded repair and run visible tests',
     };
     const assessment = {
@@ -678,6 +684,7 @@ export function runExperiment(options = {}) {
     };
     report.episodeVerification = episodeVerification;
     const oracle = verifyIncidentBoardWorkspace(workspace, {
+      fixture,
       expectedInitialTree: initialTree,
     });
     report.oracle = oracle;
@@ -705,7 +712,7 @@ export function runExperiment(options = {}) {
         sessionBUsage: sessionB.providerObservation?.usage || null,
       },
       residuals: [
-        'single deterministic Python fixture',
+        `single deterministic Python fixture ${fixture.id}`,
         'single pinned local model and one trusted runner',
         'no multi-day durability or concurrent repository-edit claim',
       ],

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -240,7 +240,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:fb701486e6006ffc60567756d1bb11117fbb6a6c85abd1e8ed8581a516ac973d"
+          "sourceRoot": "sha256:b99fd90ecdf14068e7dc4391d37209e862048ec85dc3a5bb977a3c83714e6601"
         },
         {
           "path": ".github/workflows/opencode-agent-repository-work.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:a7496616966433d82d6352e35dff8fb3ff5a949ad1c9dccc81bdaf333c5180f8"
+  "registryRoot": "sha256:0f1b0bbfc938aa3fa2d8f3923d7388865e968eb7b49b2b5b993a37ab52b54602"
 }

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "test:agent-repository-work": "node scripts/require-shifu.mjs test:agent-repository-work && node --test scripts/run-agent-repository-work-experiment.test.mjs scripts/agent-repository-work-workflow.test.mjs",
     "test:agent-patrol": "node scripts/require-shifu.mjs test:agent-patrol && node --test scripts/run-agent-repository-work-experiment.test.mjs scripts/agent-patrol.test.mjs scripts/agent-patrol-workflow.test.mjs",
     "agent-patrol:classify": "node scripts/require-shifu.mjs agent-patrol:classify && node framework/agent-patrol/classify.mjs",
+    "agent-patrol:select": "node scripts/require-shifu.mjs agent-patrol:select && node framework/agent-patrol/select.mjs",
     "agent-patrol:dogfood-capture": "node scripts/require-shifu.mjs agent-patrol:dogfood-capture && node framework/agent-patrol/dogfood-capture.mjs",
     "qualify:agent-repository-work": "node scripts/require-shifu.mjs qualify:agent-repository-work && node framework/agent-repository-work/run.mjs",
     "check:agent-pack": "node scripts/require-shifu.mjs check:agent-pack && node scripts/verify-agent-pack.mjs",

--- a/scripts/agent-patrol-workflow.test.mjs
+++ b/scripts/agent-patrol-workflow.test.mjs
@@ -10,10 +10,13 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const workflowPath = '.github/workflows/kungfu-agent-patrol.yml';
 const workflow = fs.readFileSync(path.join(root, workflowPath), 'utf8');
 
-test('Agent Patrol is weekly or manual only on the protected default branch', () => {
+test('Agent Patrol is daily-light, weekly-deep, or trusted manual only', () => {
   assert.match(workflow, /^on:\n {2}[\s\S]*schedule:/m);
+  assert.match(workflow, /cron: "0 18 \* \* 1-6"/);
   assert.match(workflow, /cron: "0 18 \* \* 0"/);
-  assert.match(workflow, /^ {2}workflow_dispatch:\s*$/m);
+  assert.match(workflow, /^ {2}workflow_dispatch:\n {4}inputs:/m);
+  assert.match(workflow, /default: light/);
+  assert.match(workflow, /(?:\n {10}- light)(?:\n {10}- deep)/);
   assert.doesNotMatch(workflow, /^\s+(?:pull_request|push):/m);
   assert.match(workflow, /github\.repository == 'kungfu-systems\/kungfu'/);
   assert.match(
@@ -34,7 +37,7 @@ test('Agent Patrol is isolated to the dedicated agent-121 runner', () => {
   assert.match(workflow, /test "\$\(id -u\)" = "996"/);
   assert.match(workflow, /DOCKER_HOST=%s\\n' "\$docker_host" >>"\$GITHUB_ENV"/);
   assert.match(workflow, /group: kungfu-agent-patrol-agent-121/);
-  assert.match(workflow, /timeout-minutes: 75/);
+  assert.match(workflow, /timeout-minutes: 90/);
 });
 
 test('Agent Patrol pins its local-model runtime and retains bounded evidence', () => {
@@ -58,6 +61,17 @@ test('Agent Patrol pins its local-model runtime and retains bounded evidence', (
     /actions\/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02/,
   );
   assert.match(workflow, /retention-days: 14/);
+  assert.match(workflow, /\/plan\.json/);
+  assert.match(workflow, /repository-work\/\*\/evidence/);
+});
+
+test('Agent Patrol selects and serially executes bounded fixture suites', () => {
+  assert.match(workflow, /\.\/shifu agent-patrol:select --/);
+  assert.match(workflow, /--rotation-key "\$PATROL_ROTATION_KEY"/);
+  assert.match(workflow, /--fixture "\$fixture"/);
+  assert.match(workflow, /jq -r '\.fixtures\[\]'/);
+  assert.match(workflow, /group: kungfu-agent-patrol-agent-121/);
+  assert.match(workflow, /cancel-in-progress: false/);
 });
 
 test('Agent Patrol captures deduplicated Findings but can never admit Issues', () => {

--- a/scripts/agent-patrol.test.mjs
+++ b/scripts/agent-patrol.test.mjs
@@ -15,6 +15,12 @@ import {
   captureFinding,
   parseArgs as parseDogfoodCaptureArgs,
 } from '../framework/agent-patrol/dogfood-capture.mjs';
+import {
+  DAILY_LIGHT_SCHEDULE,
+  WEEKLY_DEEP_SCHEDULE,
+  parseArgs as parseSelectionArgs,
+  selectPatrolPlan,
+} from '../framework/agent-patrol/select.mjs';
 
 const IMAGE =
   'ghcr.io/kungfu-systems/build-images/opencode-ci@sha256:4083ee089fa9a419f4915505094a6c1bcce433ff77455605ce8993af3b684ed3';
@@ -24,6 +30,80 @@ const ROOT_A = `sha256:${'a'.repeat(64)}`;
 const ROOT_B = `sha256:${'b'.repeat(64)}`;
 const ROOT_C = `sha256:${'c'.repeat(64)}`;
 const ROOT_D = `sha256:${'d'.repeat(64)}`;
+
+test('Patrol selector maps the two protected schedules to bounded modes', () => {
+  const light = selectPatrolPlan({
+    eventName: 'schedule',
+    schedule: DAILY_LIGHT_SCHEDULE,
+    rotationKey: 1,
+  });
+  assert.equal(light.mode, 'light');
+  assert.deepEqual(light.fixtures, ['incident-board-lease-v1']);
+  assert.equal(light.timeoutSeconds, 600);
+  assert.match(light.planRoot, /^sha256:[0-9a-f]{64}$/u);
+
+  const deep = selectPatrolPlan({
+    eventName: 'schedule',
+    schedule: WEEKLY_DEEP_SCHEDULE,
+    rotationKey: 1,
+  });
+  assert.equal(deep.mode, 'deep');
+  assert.deepEqual(deep.fixtures, [
+    'incident-board-lease-v1',
+    'incident-board-recovery-v1',
+  ]);
+  assert.equal(deep.timeoutSeconds, 900);
+});
+
+test('weekly deep Patrol rotates two-fixture suites across the catalog', () => {
+  const suites = [1, 2, 3].map(
+    (rotationKey) =>
+      selectPatrolPlan({
+        eventName: 'workflow_dispatch',
+        manualMode: 'deep',
+        rotationKey,
+      }).fixtures,
+  );
+  assert.deepEqual(suites, [
+    ['incident-board-lease-v1', 'incident-board-recovery-v1'],
+    ['incident-board-recovery-v1', 'incident-board-replay-v1'],
+    ['incident-board-replay-v1', 'incident-board-lease-v1'],
+  ]);
+  assert.equal(new Set(suites.flat()).size, 3);
+});
+
+test('Patrol selector rejects undeclared schedules and untrusted events', () => {
+  assert.throws(
+    () =>
+      selectPatrolPlan({
+        eventName: 'schedule',
+        schedule: '0 0 * * *',
+        rotationKey: 1,
+      }),
+    /unrecognized protected schedule/u,
+  );
+  assert.throws(
+    () =>
+      selectPatrolPlan({
+        eventName: 'pull_request',
+        manualMode: 'light',
+        rotationKey: 1,
+      }),
+    /untrusted Patrol event/u,
+  );
+  const parsed = parseSelectionArgs([
+    '--',
+    '--event-name',
+    'workflow_dispatch',
+    '--manual-mode',
+    'light',
+    '--rotation-key',
+    '7',
+    '--output',
+    '/tmp/plan.json',
+  ]);
+  assert.equal(parsed.rotationKey, 7);
+});
 
 function baseReport() {
   return {

--- a/scripts/run-agent-repository-work-experiment.test.mjs
+++ b/scripts/run-agent-repository-work-experiment.test.mjs
@@ -15,10 +15,15 @@ import {
 } from '../framework/agent-repository-work/opencode-docker-proxy.mjs';
 import {
   parseInvestigationClaim,
+  parseArgs as parseRepositoryWorkArgs,
   runExperiment,
   runtimeProfile,
   validateExperimentReport,
 } from '../framework/agent-repository-work/run.mjs';
+import {
+  REPOSITORY_WORK_FIXTURES,
+  getRepositoryWorkFixture,
+} from '../tests/qualification/agent-repository-work/fixture-catalog.mjs';
 import {
   applyIncidentBoardReferenceRepair,
   materializeIncidentBoardFixture,
@@ -85,6 +90,58 @@ test('fixture contract pins a moderate deterministic repository', () => {
   assert.equal(contract.oracle.sourceRoot, fileRoot(oraclePath));
   assert.equal(contract.oracle.referenceRoot, fileRoot(referencePath));
   assert.equal(contract.oracle.mountedIntoAgentWorkspace, false);
+  assert.deepEqual(
+    contract.fixtureCatalog.entries.map(({ id }) => id).sort(),
+    REPOSITORY_WORK_FIXTURES.map(({ id }) => id).sort(),
+  );
+});
+
+test('fixture catalog exposes three independently seeded bounded repairs', () => {
+  assert.equal(REPOSITORY_WORK_FIXTURES.length, 3);
+  assert.equal(
+    new Set(REPOSITORY_WORK_FIXTURES.map(({ id }) => id)).size,
+    REPOSITORY_WORK_FIXTURES.length,
+  );
+  for (const fixture of REPOSITORY_WORK_FIXTURES) {
+    const seeded = qualifySeededIncidentBoardFixture(fixture);
+    assert.equal(seeded.passed, true, fixture.id);
+    assert.deepEqual(
+      seeded.expectedFailures,
+      fixture.investigation.expectedFailures,
+    );
+    const reference = qualifyReferenceIncidentBoardRepair(fixture);
+    assert.equal(reference.passed, true, fixture.id);
+    assert.deepEqual(
+      reference.changedPaths,
+      fixture.warrants.agentB.writablePaths.slice().sort(),
+    );
+  }
+});
+
+test('repository-work CLI selects one declared fixture explicitly', () => {
+  const parsed = parseRepositoryWorkArgs([
+    '--',
+    '--fixture',
+    'incident-board-lease-v1',
+    '--opencode',
+    mockOpenCodePath,
+  ]);
+  assert.equal(parsed.fixture, 'incident-board-lease-v1');
+  assert.equal(
+    getRepositoryWorkFixture(parsed.fixture).warrants.agentB.writablePaths
+      .length,
+    1,
+  );
+  assert.throws(
+    () =>
+      parseRepositoryWorkArgs([
+        '--fixture',
+        'unknown-fixture',
+        '--opencode',
+        mockOpenCodePath,
+      ]),
+    /unknown repository-work fixture/u,
+  );
 });
 
 test('seeded defect fails and independent reference repair passes', () => {

--- a/tests/qualification/agent-repository-work/contract.json
+++ b/tests/qualification/agent-repository-work/contract.json
@@ -14,6 +14,41 @@
       "test_legacy_duplicate_log_has_stable_restart_summary"
     ]
   },
+  "fixtureCatalog": {
+    "selection": "explicit-id",
+    "entries": [
+      {
+        "id": "incident-board-lease-v1",
+        "seededFailures": [
+          "test_expired_lease_cannot_complete"
+        ],
+        "writablePaths": [
+          "incident_board/lease.py"
+        ]
+      },
+      {
+        "id": "incident-board-recovery-v1",
+        "seededFailures": [
+          "test_legacy_duplicate_log_has_stable_restart_summary"
+        ],
+        "writablePaths": [
+          "incident_board/replay.py"
+        ]
+      },
+      {
+        "id": "incident-board-replay-v1",
+        "seededFailures": [
+          "test_expired_lease_cannot_complete",
+          "test_legacy_duplicate_log_has_stable_restart_summary"
+        ],
+        "writablePaths": [
+          "incident_board/commands.py",
+          "incident_board/lease.py",
+          "incident_board/replay.py"
+        ]
+      }
+    ]
+  },
   "sessions": {
     "count": 2,
     "agentA": {
@@ -36,7 +71,7 @@
     "externalVerifierAuthoritative": true
   },
   "oracle": {
-    "sourceRoot": "sha256:74b1ec3cd7dcd4f27e4db981fa7d869119b6fc208fd890547576ad00f524349f",
+    "sourceRoot": "sha256:56da03c640d1bc4c76f4f53b4e26c701bab079770a72f654ce282af236b71132",
     "referenceRoot": "sha256:9c55e48f2d0cbcc5fe88c8a0a8e1a0f9dd242bf12f955519e5738c1b7d6fd634",
     "mountedIntoAgentWorkspace": false,
     "visibleAndHiddenTestsRequired": true

--- a/tests/qualification/agent-repository-work/fixture-catalog.mjs
+++ b/tests/qualification/agent-repository-work/fixture-catalog.mjs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { INCIDENT_BOARD_REFERENCE_REPAIR } from './incident-board-replay-v1-reference.mjs';
+import { INCIDENT_BOARD_FIXTURE } from './incident-board-replay-v1.mjs';
+
+const FULL_FIXTURE_ID = 'incident-board-replay-v1';
+const LEASE_FIXTURE_ID = 'incident-board-lease-v1';
+const REPLAY_FIXTURE_ID = 'incident-board-recovery-v1';
+
+function subset(value, paths) {
+  return Object.freeze(
+    Object.fromEntries(paths.map((relative) => [relative, value[relative]])),
+  );
+}
+
+function derivedFixture({
+  id,
+  title,
+  defectId,
+  expectedFailures,
+  writablePaths,
+  preRepairedPaths = [],
+  remainingObligation,
+  nextAction,
+}) {
+  const files = {
+    ...INCIDENT_BOARD_FIXTURE.files,
+    ...Object.fromEntries(
+      preRepairedPaths.map((relative) => [
+        relative,
+        INCIDENT_BOARD_REFERENCE_REPAIR[relative],
+      ]),
+    ),
+  };
+  return Object.freeze({
+    ...INCIDENT_BOARD_FIXTURE,
+    id,
+    defect: {
+      ...INCIDENT_BOARD_FIXTURE.defect,
+      id: defectId,
+    },
+    task: {
+      ...INCIDENT_BOARD_FIXTURE.task,
+      title,
+    },
+    warrants: {
+      agentA: {
+        mode: 'investigation-only',
+        writablePaths: [],
+      },
+      agentB: {
+        mode: 'bounded-repair',
+        writablePaths: [...writablePaths],
+      },
+    },
+    investigation: {
+      expectedFailures: [...expectedFailures],
+      remainingObligation,
+      nextAction,
+    },
+    referenceRepair: subset(INCIDENT_BOARD_REFERENCE_REPAIR, writablePaths),
+    files: Object.freeze(files),
+  });
+}
+
+const combined = derivedFixture({
+  id: FULL_FIXTURE_ID,
+  title: INCIDENT_BOARD_FIXTURE.task.title,
+  defectId: INCIDENT_BOARD_FIXTURE.defect.id,
+  expectedFailures: [
+    'test_expired_lease_cannot_complete',
+    'test_legacy_duplicate_log_has_stable_restart_summary',
+  ],
+  writablePaths: INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths,
+  remainingObligation: 'implement-and-verify-bounded-repair',
+  nextAction: 'repair-seeded-completion-idempotency',
+});
+
+const lease = derivedFixture({
+  id: LEASE_FIXTURE_ID,
+  title: 'Repair expired-lease completion authorization',
+  defectId: 'expired-lease-completion-authorization',
+  expectedFailures: ['test_expired_lease_cannot_complete'],
+  writablePaths: ['incident_board/lease.py'],
+  preRepairedPaths: ['incident_board/commands.py', 'incident_board/replay.py'],
+  remainingObligation: 'implement-and-verify-expired-lease-authorization',
+  nextAction: 'repair-expired-lease-authorization',
+});
+
+const replay = derivedFixture({
+  id: REPLAY_FIXTURE_ID,
+  title: 'Repair duplicate-completion restart replay',
+  defectId: 'duplicate-completion-restart-replay-divergence',
+  expectedFailures: ['test_legacy_duplicate_log_has_stable_restart_summary'],
+  writablePaths: ['incident_board/replay.py'],
+  preRepairedPaths: ['incident_board/commands.py', 'incident_board/lease.py'],
+  remainingObligation: 'implement-and-verify-restart-replay-idempotency',
+  nextAction: 'repair-duplicate-completion-replay',
+});
+
+export const DEFAULT_REPOSITORY_WORK_FIXTURE_ID = FULL_FIXTURE_ID;
+export const LIGHT_REPOSITORY_WORK_FIXTURE_ID = LEASE_FIXTURE_ID;
+
+export const REPOSITORY_WORK_FIXTURES = Object.freeze([
+  lease,
+  replay,
+  combined,
+]);
+
+export function getRepositoryWorkFixture(id) {
+  const fixture = REPOSITORY_WORK_FIXTURES.find(
+    (candidate) => candidate.id === id,
+  );
+  if (!fixture)
+    throw new Error(
+      `unknown repository-work fixture: ${id}; expected one of ${REPOSITORY_WORK_FIXTURES.map(
+        (candidate) => candidate.id,
+      ).join(', ')}`,
+    );
+  return fixture;
+}

--- a/tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs
+++ b/tests/qualification/agent-repository-work/incident-board-replay-v1-oracle.mjs
@@ -6,11 +6,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { INCIDENT_BOARD_REFERENCE_REPAIR } from './incident-board-replay-v1-reference.mjs';
-import { INCIDENT_BOARD_FIXTURE } from './incident-board-replay-v1.mjs';
+import { getRepositoryWorkFixture } from './fixture-catalog.mjs';
 
 const REPORT_SCHEMA = 'kungfu.agent-repository-work.oracle-report/v1';
 const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const DEFAULT_FIXTURE = getRepositoryWorkFixture('incident-board-replay-v1');
 
 function root(value) {
   return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
@@ -43,8 +43,8 @@ function walkFiles(workspace) {
   return rows.sort((left, right) => left.path.localeCompare(right.path));
 }
 
-function expectedTree() {
-  return Object.entries(INCIDENT_BOARD_FIXTURE.files)
+function expectedTree(fixture) {
+  return Object.entries(fixture.files)
     .map(([relative, content]) => ({
       path: relative,
       bytes: Buffer.byteLength(content),
@@ -223,13 +223,14 @@ function diffTrees(initial, current) {
     .sort();
 }
 
-export function materializeIncidentBoardFixture(workspace) {
+export function materializeIncidentBoardFixture(
+  workspace,
+  fixture = DEFAULT_FIXTURE,
+) {
   if (fs.existsSync(workspace) && fs.readdirSync(workspace).length > 0)
     throw new Error('fixture workspace must be new or empty');
   fs.mkdirSync(workspace, { recursive: true });
-  for (const [relative, content] of Object.entries(
-    INCIDENT_BOARD_FIXTURE.files,
-  )) {
+  for (const [relative, content] of Object.entries(fixture.files)) {
     const target = path.resolve(workspace, relative);
     if (!target.startsWith(`${path.resolve(workspace)}${path.sep}`))
       throw new Error(`fixture path escapes workspace: ${relative}`);
@@ -239,17 +240,19 @@ export function materializeIncidentBoardFixture(workspace) {
   return walkFiles(workspace);
 }
 
-export function applyIncidentBoardReferenceRepair(workspace) {
-  for (const [relative, content] of Object.entries(
-    INCIDENT_BOARD_REFERENCE_REPAIR,
-  ))
+export function applyIncidentBoardReferenceRepair(
+  workspace,
+  fixture = DEFAULT_FIXTURE,
+) {
+  for (const [relative, content] of Object.entries(fixture.referenceRepair))
     fs.writeFileSync(path.join(workspace, relative), content);
 }
 
 export function verifyIncidentBoardWorkspace(
   workspace,
   {
-    expectedInitialTree = expectedTree(),
+    fixture = DEFAULT_FIXTURE,
+    expectedInitialTree = expectedTree(fixture),
     requireModification = true,
     runHidden = true,
   } = {},
@@ -257,7 +260,7 @@ export function verifyIncidentBoardWorkspace(
   const before = expectedInitialTree;
   const current = walkFiles(workspace);
   const changedPaths = diffTrees(before, current);
-  const allowed = new Set(INCIDENT_BOARD_FIXTURE.warrants.agentB.writablePaths);
+  const allowed = new Set(fixture.warrants.agentB.writablePaths);
   const scopeViolations = changedPaths.filter(
     (relative) => !allowed.has(relative),
   );
@@ -270,7 +273,7 @@ export function verifyIncidentBoardWorkspace(
     (!hidden || hidden.status === 0);
   const report = {
     schema: REPORT_SCHEMA,
-    fixtureId: INCIDENT_BOARD_FIXTURE.id,
+    fixtureId: fixture.id,
     passed,
     authoritative: true,
     verifierLocation: 'outside-agent-workspace',
@@ -306,18 +309,15 @@ export function verifyIncidentBoardWorkspace(
   return report;
 }
 
-export function qualifySeededIncidentBoardFixture() {
+export function qualifySeededIncidentBoardFixture(fixture = DEFAULT_FIXTURE) {
   const workspace = fs.mkdtempSync(
     path.join(os.tmpdir(), 'incident-board-seeded.'),
   );
   try {
-    materializeIncidentBoardFixture(workspace);
+    materializeIncidentBoardFixture(workspace, fixture);
     const visible = visibleSuite(workspace);
     const combined = `${visible.stdout}\n${visible.stderr}`;
-    const expectedFailures = [
-      'test_expired_lease_cannot_complete',
-      'test_legacy_duplicate_log_has_stable_restart_summary',
-    ];
+    const expectedFailures = fixture.investigation.expectedFailures;
     return {
       schema: 'kungfu.agent-repository-work.seeded-defect-report/v1',
       passed:
@@ -332,14 +332,15 @@ export function qualifySeededIncidentBoardFixture() {
   }
 }
 
-export function qualifyReferenceIncidentBoardRepair() {
+export function qualifyReferenceIncidentBoardRepair(fixture = DEFAULT_FIXTURE) {
   const workspace = fs.mkdtempSync(
     path.join(os.tmpdir(), 'incident-board-reference.'),
   );
   try {
-    const initialTree = materializeIncidentBoardFixture(workspace);
-    applyIncidentBoardReferenceRepair(workspace);
+    const initialTree = materializeIncidentBoardFixture(workspace, fixture);
+    applyIncidentBoardReferenceRepair(workspace, fixture);
     return verifyIncidentBoardWorkspace(workspace, {
+      fixture,
       expectedInitialTree: initialTree,
     });
   } finally {


### PR DESCRIPTION
## Summary

Run the isolated agent-121 local-model Patrol as a daily light signal and a weekly deep rotating-fixture qualification, while keeping model outcomes advisory and infrastructure, evidence, privacy, and deduplication gates fail-closed.

This linear delivery supersedes #1845 so the protected merge queue can replay one exact commit.

## Related issue

Kungfu Assignment `2026-07-29-kungfu-agent-patrol-cadence`.

## Changes

- schedule light Patrol runs Tuesday through Sunday and a deep Patrol run every Monday at 02:00 CST;
- add manual light/deep dispatch and one shared non-cancelling concurrency group;
- retain the exact agent-121 runner, local Qwen model, immutable OpenCode image, bounded timeouts, and sequential execution;
- rotate the deep run through two of three repository-work fixtures while the light run executes one fixture;
- keep model-oracle failures advisory while infrastructure, evidence, privacy, and Finding capture failures remain blocking;
- capture privacy-safe deduplicated Dogfood Findings without automatically admitting Issues;
- retain only bounded plan, report, classification, and receipt artifacts.

## Verification

- `./shifu test:agent-patrol` (27 passing)
- `./shifu check:gate-catalog`
- `./shifu docs validate --json`
- `node framework/release/publication-control-plane.mjs check`
- `./shifu check:source`
- staged commit Gate on the linear commit
- `./shifu project-cut:queue-admission -- --base origin/dev/v4/v4.0 --head HEAD` (`decision=qualified`, one replayed commit)
- `./shifu docs final-ready --since origin/dev/v4/v4.0 --budget 66560 --json` (three authored documents require PR review; no violations)
- native Dogfood Finding capture returned `already-present` on the second identical capture

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f86da-4f90-786d-aa24-a97705e13917"],
  "summary": "Complete the bounded recurring agent-121 Patrol feedback stage with rotating repository-work fixtures and privacy-safe deduplicated Findings",
  "verification": ["Full source acceptance", "Agent Patrol contract tests", "Closed-world workflow authority", "Publication control plane", "Independent PR review"]
}
-->

## Evolution Map impact

Evolution impact: extends

This PR extends the current Agent work stage with recurring operational evidence; it does not open or settle a new authority transition.

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The Patrol invokes only the office-local Ollama endpoint through the exact pinned OpenCode image and Qwen model. It receives no credentials, retains no prompts or transcripts, grants no publishing authority, and uploads only bounded privacy-safe evidence. Contract tests, workflow authority, publication control-plane checks, and live protected-branch runs cover this boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed