### PR TITLE
fix(ci): bootstrap producer conan profile

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -1085,6 +1085,7 @@ jobs:
       actions: read
       contents: read
     env:
+      KUNGFU_BUILDCHAIN_SOURCE_BUILD: "1"
       KUNGFU_BUILD_PROFILE: full
     steps:
       - name: Check out exact merge-group source

--- a/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
+++ b/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
@@ -99,4 +99,7 @@ identifier is therefore `affected_native`, while its human-visible required
 context remains `affected-native / linux`; downstream `needs` expressions use
 the identifier-safe machine name. The producer condition begins with
 `always()` so exact proof reuse may skip heavy indirect prerequisites without
-preventing evaluation of the successful direct aggregate dependency.
+preventing evaluation of the successful direct aggregate dependency. The
+hosted producer also declares the bounded Buildchain source-build environment,
+which uses the existing Conan bootstrap contract to detect a default profile
+only when a fresh runner does not already have one.

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -587,7 +587,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:bb015648cc59bbcbba8c03bc2284f76e31ec1699d3eb4f64b4c6e68e96e6ea6b",
+          "definitionDigest": "sha256:95fb4fe1ca3779245386eba26dad91d3911aaa5f9fe3bb59f7da66168b54bb3c",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -79,7 +79,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:ad4cddef1611a96e383efc7a16a2c09e8f7f18a830e5242245c7f0e887274433"
+          "sourceRoot": "sha256:32c64460a994dcc872c9257b03b885ebb838992e0ea485eb7ad220940c9fdaeb"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:2d3febb5824968475597d3cd132db3bfc96b690fb70d50647abf68aaab9f33ad"
+  "registryRoot": "sha256:7e79b009491fd09fbcc4e77a8e16746c9f40944ce06e88d0bab89349cd534f32"
 }

--- a/scripts/qualified-assignment-core-artifact.test.mjs
+++ b/scripts/qualified-assignment-core-artifact.test.mjs
@@ -368,7 +368,7 @@ test('workflows keep candidate and promotion outside untrusted PR authority', ()
   );
   assert.match(
     candidateJob,
-    /Build and seal minimum relocatable Assignment Core candidate[\s\S]*RUNNER_OS[\s\S]*RUNNER_ARCH[\s\S]*rebuild:core[\s\S]*framework\/release\/qualified-assignment-core-artifact\.mjs seal/u,
+    /KUNGFU_BUILDCHAIN_SOURCE_BUILD: "1"[\s\S]*Build and seal minimum relocatable Assignment Core candidate[\s\S]*RUNNER_OS[\s\S]*RUNNER_ARCH[\s\S]*rebuild:core[\s\S]*framework\/release\/qualified-assignment-core-artifact\.mjs seal/u,
   );
   assert.doesNotMatch(candidateJob, /pull_request/);
 


### PR DESCRIPTION
## Summary

Bind the hosted qualified Core producer to the existing bounded Buildchain source-build bootstrap so a fresh macOS runner receives a default Conan profile before rebuilding Core.

## Related issue

Kungfu Assignment `2026-07-28-kungfu-qualified-core-producer-promotion`.

## Changes

- Declare `KUNGFU_BUILDCHAIN_SOURCE_BUILD=1` only on the trusted merge-group producer job.
- Reuse `run-conan.js`'s existing profile-exists probe and missing-only `conan profile detect --force` path.
- Strengthen the workflow artifact contract test.
- Refresh closed-world workflow authority and publication-surface roots.
- Record the fresh-runner bootstrap invariant in the accepted ADR.

## Verification

- `actionlint .github/workflows/affected-native-pr.yml`
- `node --test scripts/qualified-assignment-core-artifact.test.mjs scripts/check-kungfu-gate-catalog.test.mjs scripts/affected-native-proof.test.mjs scripts/adr-release-gate.test.mjs`
- `node scripts/kungfu-workflow-authority.mjs`
- `node framework/release/publication-control-plane.mjs check`
- Commit-time staged Gate
- Runtime evidence: merge-group run `30436997924`, job `90527714348`, failed because the fresh hosted macOS ARM64 runner had no default Conan profile

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa"],
  "summary": "Bootstrap the trusted hosted producer through the existing missing-only Conan profile contract",
  "verification": ["Hosted macOS ARM64 failure evidence", "Exact artifact contract tests", "Closed-world workflow authority", "Commit-time staged Gate"]
}
-->

## Evolution Map impact

Evolution impact: extends

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change enables only the existing source-build bootstrap on the already trusted, read-only merge-group producer. It adds no credential or publication authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LXF1YWxpZmllZC1hc3NpZ25tZW50LWNvcmUtY2FjaGUtZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOC1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtcHJvZHVjZXItcHJvbW90aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiI3MjU1NTIwY2E1MTI2OWIzNGJlN2VjOTU5NGU5ZDZiNjc3MzEwYjQ5IiwicHVsbFJlcXVlc3RIZWFkIjoiNzcyMDRmODBlNjExYjBkNmRlZWQ1OTZhYWY3OWEyOThhMjUyZWQyZSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMWZmZTE1MWQxMTM1YjEwODNiMTZlZWNkM2ZjMGYyNTY3ZGYxYWMxZiIsInJlcGxheWVkVHJlZSI6IjQyZGVmZDM3MmZlMGM5YjI4ZDUxYWE5MWExYTAxMmY0NGNjNDgwN2EiLCJxdWV1ZUF0dGVtcHQiOiI3NzIwNGY4MGU2MTFiMGQ2ZGVlZDU5NmFhZjc5YTI5OGEyNTJlZDJlQDcyNTU1MjBjYTUxMjY5YjM0YmU3ZWM5NTk0ZTlkNmI2NzczMTBiNDkiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6N2RmODAyMDZmNmIyNjAyOWQ5NjVjYmVjYTY2NDYyZDczNzcwODRhY2RjZGMwZGViNzhiZjRlY2NiZGRmZjZlNCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjdkZjgwMjA2ZjZiMjYwMjlkOTY1Y2JlY2E2NjQ2MmQ3Mzc3MDg0YWNkY2RjMGRlYjc4YmY0ZWNjYmRkZmY2ZTQiLCJzaGEyNTY6ZDk3ZWI4MzI0ODQ4MjI1MDRkMmJiMGMyNTZlM2E4OThlZDYzOGFjNWNhNjRhZDIwNTgyMTc3NjdiNzllZDg2YyJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzIyYzg0YjMxNzAxMDc5ZTIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6YTRkNmM1NWMwMzUzYmNkM2I3MjM2NTgyZGRhMzVjNDJjODI0YjU2N2RiNTBiMzNlZjk2OWIwODU3NzM0ZjI4ZCJ9 -->