### PR TITLE
fix(release): align GitHub attestation signer digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       artifact-paths: |
         product/release
       github-artifact-attestation-subject-path: product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz
-      github-artifact-attestation-signer-sha: ad57ae0fee5072a1de7a0b0182f70c0c41e45abb
+      github-artifact-attestation-signer-sha: 375b2d4b8a904776453773a33b4c4e4556c8c999
       github-artifact-attestation-platform-id: linux-x64
       credential-island-macos-app-path: product/dist/desktop/mac-arm64/Kungfu Episodes.app
       credential-island-caller-owned: true

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -920,7 +920,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:2e2784811c52b855886178e167372a9669ee42ce7dfae6f973fac5bae75c3f31",
+          "definitionDigest": "sha256:c4910c077460721daec067765aabd394217e2b0c50caf4c98e6f3184fef3b114",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@4716fc9d963f73c890f04cd3b91e59569de4fc38"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -479,7 +479,7 @@
         "with": {
           "runner-preset": "${{ inputs.platforms-json && 'custom' || 'kungfu-v4-native' }}",
           "github-artifact-attestation-subject-path": "product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz",
-          "github-artifact-attestation-signer-sha": "ad57ae0fee5072a1de7a0b0182f70c0c41e45abb",
+          "github-artifact-attestation-signer-sha": "375b2d4b8a904776453773a33b4c4e4556c8c999",
           "github-artifact-attestation-platform-id": "linux-x64",
           "credential-island-macos-app-path": "product/dist/desktop/mac-arm64/Kungfu Episodes.app",
           "credential-island-caller-owned": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -23,7 +23,7 @@
     "required_artifact_count": 5,
     "artifact_attestation": {
       "subject_path": "product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz",
-      "signer_sha": "ad57ae0fee5072a1de7a0b0182f70c0c41e45abb",
+      "signer_sha": "375b2d4b8a904776453773a33b4c4e4556c8c999",
       "platform_id": "linux-x64",
       "policy_json": "auto",
       "environment": "buildchain-artifact-attestation"

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b947a743b8b8b286f60f4e0e0a30040c6da2d5faed36e6bdd0adf3efb336aca5",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:5f9051593c766de889330dc1d81f2fa9c004ea7b317df2ee592c911d9d606284",
+  "sourceRoot": "sha256:7cdcf605542c70f85065784ec3d9307fee3abfe1da1d54de08a6fd5beeb82354",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1111,7 +1111,7 @@
           "path": "docs/qualification/gates/workflow-bindings.json",
           "currentLines": 650,
           "baselineLines": 580,
-          "currentRoot": "sha256:b89206e5a9a5d77d792c48b40485f15fadf181cb4e4d740a38b2a8724a6a5a62",
+          "currentRoot": "sha256:aef7f6b5f2e43d97487b720876a5121508bceda827b162f870ad6375a0c41752",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },


### PR DESCRIPTION
## Summary

Replays the GitHub attestation signer alignment on the current protected head and retains the regenerated semantic-amplification report required by source acceptance. This supersedes #1856 without rewriting its branch.

## Changes

- replace the stale signer-bootstrap digest `ad57ae0f` with immutable workflow commit `375b2d4b`
- refresh the promotion rehearsal contract, Gate workflow binding, and closed-world workflow authority digest
- regenerate the source-bound semantic-amplification report on `aab113f3d3`
- preserve the distinct Buildchain runtime SHA and original Linux build-runner evidence

## Verification

- `node --test scripts/release-promotion-rehearsal.test.mjs scripts/alpha-promotion-preflight.test.mjs scripts/check-kungfu-gate-catalog.test.mjs` — 47/47 passed
- `./shifu gate run governance.promotion-rehearsal` — passed with no tracked-file, ref, credential, or remote side effects
- `./shifu maintainability:amplification --check` — passed
- commit-time staged Gate — passed, including documentation, Gate catalog, KFD evidence, support matrix, and negative fixtures

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair aligns an existing GitHub attestation policy digest with the already protected immutable signer workflow and refreshes its generated source-bound report; it does not change architecture, permissions, artifact bytes, or release authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [x] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No credential or permission is added. The change narrows verification to the exact GitHub-hosted reusable workflow commit already invoked by Buildchain.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Focused regression coverage and generated authority projections updated