### PR TITLE
fix(release): align GitHub attestation signer digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       artifact-paths: |
         product/release
       github-artifact-attestation-subject-path: product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz
-      github-artifact-attestation-signer-sha: ad57ae0fee5072a1de7a0b0182f70c0c41e45abb
+      github-artifact-attestation-signer-sha: 375b2d4b8a904776453773a33b4c4e4556c8c999
       github-artifact-attestation-platform-id: linux-x64
       credential-island-macos-app-path: product/dist/desktop/mac-arm64/Kungfu Episodes.app
       credential-island-caller-owned: true

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -920,7 +920,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:2e2784811c52b855886178e167372a9669ee42ce7dfae6f973fac5bae75c3f31",
+          "definitionDigest": "sha256:c4910c077460721daec067765aabd394217e2b0c50caf4c98e6f3184fef3b114",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@4716fc9d963f73c890f04cd3b91e59569de4fc38"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -479,7 +479,7 @@
         "with": {
           "runner-preset": "${{ inputs.platforms-json && 'custom' || 'kungfu-v4-native' }}",
           "github-artifact-attestation-subject-path": "product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz",
-          "github-artifact-attestation-signer-sha": "ad57ae0fee5072a1de7a0b0182f70c0c41e45abb",
+          "github-artifact-attestation-signer-sha": "375b2d4b8a904776453773a33b4c4e4556c8c999",
           "github-artifact-attestation-platform-id": "linux-x64",
           "credential-island-macos-app-path": "product/dist/desktop/mac-arm64/Kungfu Episodes.app",
           "credential-island-caller-owned": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -23,7 +23,7 @@
     "required_artifact_count": 5,
     "artifact_attestation": {
       "subject_path": "product/release/cli/kungfu-episodes-cli-linux-x64.tar.gz",
-      "signer_sha": "ad57ae0fee5072a1de7a0b0182f70c0c41e45abb",
+      "signer_sha": "375b2d4b8a904776453773a33b4c4e4556c8c999",
       "platform_id": "linux-x64",
       "policy_json": "auto",
       "environment": "buildchain-artifact-attestation"

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b947a743b8b8b286f60f4e0e0a30040c6da2d5faed36e6bdd0adf3efb336aca5",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:6e2ccbbbd69af611a46d7c8111d4851473c522c72b4cd56729bc38946f9e9c0e",
+  "sourceRoot": "sha256:38370bd7d070bc37df1e79a9fcc2dbae6c52c2ff88365ed6ea8388b7332173be",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1111,7 +1111,7 @@
           "path": "docs/qualification/gates/workflow-bindings.json",
           "currentLines": 650,
           "baselineLines": 580,
-          "currentRoot": "sha256:b89206e5a9a5d77d792c48b40485f15fadf181cb4e4d740a38b2a8724a6a5a62",
+          "currentRoot": "sha256:aef7f6b5f2e43d97487b720876a5121508bceda827b162f870ad6375a0c41752",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -114,7 +114,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:dc1c29228d181a3b377f305c0723ca633e17efd455234e2c2c8f58fade67fd8f"
+          "sourceRoot": "sha256:cc5f4b2e8c94c6a66a957b5e926ddf2845566c7ca76b2b3c8adc5e20c7042d9c"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4012b9c25394f9cab9a2b7e705e0741d6831284c1e6a592a5ec82d735256731f"
+  "registryRoot": "sha256:5743401db519c9c22f55108c3acc222d88fef1ebc26561ccc1fa2fc10ba67e84"
 }


### PR DESCRIPTION
## Summary

Align the Kungfu release-candidate attestation policy with the exact immutable Buildchain reusable signer workflow, replayed on the current protected dev head. This supersedes #1856 and #1859.

## Changes

- replace stale signer-bootstrap digest `ad57ae0f` with immutable workflow commit `375b2d4b`
- refresh the promotion rehearsal contract, Gate workflow binding, and closed-world workflow authority digest
- regenerate both source-bound semantic-amplification and release-publication projections on `7e0b6e5ee8`
- preserve the distinct Buildchain runtime SHA and original Linux build-runner evidence

## Verification

- `node --test scripts/release-promotion-rehearsal.test.mjs scripts/alpha-promotion-preflight.test.mjs scripts/check-kungfu-gate-catalog.test.mjs` — 47/47 passed
- `./shifu maintainability:amplification --check` — passed
- `./shifu check:release-publication-control-plane` — qualifying, 29 workflows / 10 surfaces
- `./shifu gate run governance.promotion-rehearsal` — passed with no tracked-file, ref, credential, or remote side effects
- exact protected replay `7e0b6e5ee8..51d366cac7` — qualified; two commits; no composition change

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair aligns an existing GitHub attestation policy digest with the already protected immutable signer workflow and refreshes its generated source-bound projections; it does not change architecture, permissions, artifact bytes, or release authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [x] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

No credential or permission is added. The change narrows verification to the exact GitHub-hosted reusable workflow commit already invoked by Buildchain.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Focused regression coverage and both generated authority projections updated

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI0LWJ1aWxkY2hhaW4tbGludXgtZ2l0aHViLWF0dGVzdGF0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiI3ZTBiNmU1ZWU4ZTRlYjE2ZTM4ZjlkZGQxZDE5MTFjYWFhZDFhMjEyIiwicHVsbFJlcXVlc3RIZWFkIjoiNTFkMzY2Y2FjN2ExZmY0MTIwNGM3MzA0ZTU2Yjc4NjFhY2MyNzViNiIsInJlcGxheWVkQ2FuZGlkYXRlIjoiNjFlNDlkYmNlODI4MzNhM2ZmZTBjNWFlMWZjZDBmZWQxOThlZmE0ZiIsInJlcGxheWVkVHJlZSI6Ijc1NGUwYmNmNzQ4ZmY5MmIyZDNmMTZlZmY2MzAzYjRmOWY0NTU0ZDgiLCJxdWV1ZUF0dGVtcHQiOiI1MWQzNjZjYWM3YTFmZjQxMjA0YzczMDRlNTZiNzg2MWFjYzI3NWI2QDdlMGI2ZTVlZThlNGViMTZlMzhmOWRkZDFkMTkxMWNhYWFkMWEyMTIiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6NjMzMzFiZDE1N2RkODk0ZjI4MjM1Njk3Nzk0OGRhNjliYzRlOTQ1ZmE0ODJiYWIxYzkxZWM4YTk0YjUxZGQ4NiIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjM5NTJhNzBlNDkzMzM2Njg5ZTk4NTVjZjgzMjU3NDIzYjQxMTg3NWFhYzJhMWRiYjNmMjQ0MDliMTQ3NDIyYWUiLCJzaGEyNTY6NjMzMzFiZDE1N2RkODk0ZjI4MjM1Njk3Nzk0OGRhNjliYzRlOTQ1ZmE0ODJiYWIxYzkxZWM4YTk0YjUxZGQ4NiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6NjY5M2YzYTI2YjhiNjliNWIwNzQxNmQwNmJjMmQwOTM2ZjUwMDZhNTQ3NTBlMGY1MDJkYzViYmMzMjZkZmM3MiJ9 -->