### PR TITLE
fix(product): snapshot runtime pins before assembly

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b947a743b8b8b286f60f4e0e0a30040c6da2d5faed36e6bdd0adf3efb336aca5",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:b49872e595fc21a6bb6f139afbf6ca5c12d99898a41b8d8b8762a64aecdff621",
+  "sourceRoot": "sha256:807d35ba6a372a39b54b1f267ebde01f661804ce1c236f4bae4eb28cceb9200f",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -608,9 +608,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 2530,
+          "currentLines": 2528,
           "baselineLines": 2514,
-          "currentRoot": "sha256:98ff068752c5bb9bc31715d438143038d2a089912ebc6cd3a1da0ea0fcdad353",
+          "currentRoot": "sha256:f3b127c03229d82c868ebfcb9ba363232d1dd361e295df3bfc518e22a23a4526",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -26,6 +26,7 @@ import {
 } from './libwasm-artifact.mjs';
 import { normalizeCopiedSymlinks } from './portable-symlinks.mjs';
 import { productReleaseChannelConfig } from './release-channel-trust.mjs';
+import { readTrunkRuntimePinSnapshot } from './runtime-pin-snapshot.mjs';
 import {
   buildBundledUpgradeManifest,
   finalizeCliUpgradeManifest,
@@ -876,7 +877,7 @@ function assertCoreFrozen() {
 // env/package surface) ships next to the frozen binary, together with its
 // runtime-pins manifest. UV_VERSION in the manifest must equal the repo's
 // .uv-version so the product and the dev launcher pull the same pinned uv.
-function stageTrunk() {
+function stageTrunk(runtimePinSnapshot) {
   // KF-ADR-019f86da-4f90-73ff-9543-f0a4f0beef05 stage 3 productionization: link the embedding membrane and ship the
   // real embedding-backed doctor on every platform. POSIX links the SHARED
   // libkungfu from build/<type>; Windows links the single-export
@@ -914,19 +915,12 @@ function stageTrunk() {
   if (!fs.existsSync(trunkBin)) {
     throw new Error(`cargo did not produce ${rel(trunkBin)}`);
   }
-  const uvPin = (fs
-    .readFileSync(RUNTIME_PINS, 'utf8')
-    .match(/^UV_VERSION=(.+)$/m) || [])[1]?.trim();
-  const repoPin = fs
-    .readFileSync(path.join(ROOT, '.uv-version'), 'utf8')
-    .trim();
-  if (uvPin !== repoPin) {
-    throw new Error(
-      `runtime-pins.env pins uv ${uvPin} but .uv-version pins ${repoPin}; update product/runtime-pins.env (version and checksums) alongside .uv-version`,
-    );
-  }
   fs.copyFileSync(trunkBin, path.join(CORE_DIST, path.basename(trunkBin)));
-  fs.copyFileSync(RUNTIME_PINS, path.join(CORE_DIST, 'runtime-pins.env'));
+  fs.writeFileSync(
+    path.join(CORE_DIST, 'runtime-pins.env'),
+    runtimePinSnapshot.runtimePins,
+    'utf8',
+  );
   console.log(
     '[product] kungfu-trunk + runtime-pins.env staged into core dist',
   );
@@ -2301,6 +2295,10 @@ function buildCliProduct(esbuildRuntime) {
 }
 
 function main() {
+  const trunkRuntimePinSnapshot = readTrunkRuntimePinSnapshot({
+    runtimePinsPath: RUNTIME_PINS,
+    repoPinPath: path.join(ROOT, '.uv-version'),
+  });
   buildchainLogger.spanSync(
     'product.dist',
     {
@@ -2369,7 +2367,7 @@ function main() {
         },
       );
       assertCoreFrozen();
-      stageTrunk();
+      stageTrunk(trunkRuntimePinSnapshot);
       runPnpm(
         'pack core npm artifacts',
         ['--filter', '@kungfu-tech/core', 'run', 'pack-platform'],

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -29,6 +29,7 @@ import {
   productReleaseChannelConfig,
   releaseChannelKeyId,
 } from './release-channel-trust.mjs';
+import { readTrunkRuntimePinSnapshot } from './runtime-pin-snapshot.mjs';
 
 const require = createRequire(import.meta.url);
 const workDashboardPackage = require('../../extensions/work-dashboard/kungfu.kfx.json');
@@ -38,6 +39,55 @@ const {
   esmEntrypointArgs,
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
+
+test('trunk staging retains one source-authoritative runtime pin snapshot', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-pin-test-'));
+  const runtimePinsPath = path.join(root, 'runtime-pins.env');
+  const repoPinPath = path.join(root, '.uv-version');
+  try {
+    fs.writeFileSync(
+      runtimePinsPath,
+      '# source pin\nUV_VERSION=0.11.23\n',
+      'utf8',
+    );
+    fs.writeFileSync(repoPinPath, '0.11.23\n', 'utf8');
+    const snapshot = readTrunkRuntimePinSnapshot({
+      runtimePinsPath,
+      repoPinPath,
+    });
+
+    fs.rmSync(runtimePinsPath);
+    fs.rmSync(repoPinPath);
+    assert.deepEqual(snapshot, {
+      runtimePins: '# source pin\nUV_VERSION=0.11.23\n',
+      uvPin: '0.11.23',
+      repoPin: '0.11.23',
+    });
+    assert.equal(Object.isFrozen(snapshot), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('trunk runtime pin snapshot rejects source drift', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-pin-test-'));
+  const runtimePinsPath = path.join(root, 'runtime-pins.env');
+  const repoPinPath = path.join(root, '.uv-version');
+  try {
+    fs.writeFileSync(runtimePinsPath, 'UV_VERSION=0.11.24\n', 'utf8');
+    fs.writeFileSync(repoPinPath, '0.11.23\n', 'utf8');
+    assert.throws(
+      () =>
+        readTrunkRuntimePinSnapshot({
+          runtimePinsPath,
+          repoPinPath,
+        }),
+      /runtime-pins\.env pins uv 0\.11\.24 but \.uv-version pins 0\.11\.23/u,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test('installed KFD smoke accepts only release-qualified shipped support', () => {
   assert.equal(isShippedKfdSupport({ status: 'supported' }), true);

--- a/product/scripts/runtime-pin-snapshot.mjs
+++ b/product/scripts/runtime-pin-snapshot.mjs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+
+export function readTrunkRuntimePinSnapshot({ runtimePinsPath, repoPinPath }) {
+  const runtimePins = fs.readFileSync(runtimePinsPath, 'utf8');
+  const uvPin = (runtimePins.match(/^UV_VERSION=(.+)$/m) || [])[1]?.trim();
+  const repoPin = fs.readFileSync(repoPinPath, 'utf8').trim();
+  if (!uvPin || uvPin !== repoPin) {
+    throw new Error(
+      `runtime-pins.env pins uv ${uvPin} but .uv-version pins ${repoPin}; update product/runtime-pins.env (version and checksums) alongside .uv-version`,
+    );
+  }
+  return Object.freeze({ runtimePins, uvPin, repoPin });
+}


### PR DESCRIPTION
## Summary

- capture the source-authoritative `.uv-version` and `runtime-pins.env` before product assembly mutates the checkout
- stage the exact captured runtime pin bytes after Core freeze
- retain fail-closed pin mismatch checks and add regression coverage

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix preserves the existing runtime pin authority and only snapshots its exact source bytes before mutable product assembly."
}
-->

## Failure evidence

Build run 30442629961 failed on macOS ARM64 after Core freeze because `.uv-version` was no longer present when `stageTrunk` read it late.

## Validation

- focused runtime pin snapshot tests: 2 passed
- Biome: passed
- code complexity ratchet: passed (`dist.mjs` 2528 lines, below current 2530)
- semantic amplification projection: current
- source acceptance: 745 passed, 10 environment skips, with the sole local pytest-path failure rerun successfully after creating the pinned Core venv
- pre-commit staged gate: passed