### PR TITLE
fix(ci): stabilize Agent Patrol checkout transport

### DIFF
--- a/.github/workflows/kungfu-agent-patrol.yml
+++ b/.github/workflows/kungfu-agent-patrol.yml
@@ -45,6 +45,10 @@ jobs:
     steps:
       - name: Check out exact protected source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: http.version
+          GIT_CONFIG_VALUE_0: HTTP/1.1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1

--- a/docs/qualification/agent-patrol-agent-121.md
+++ b/docs/qualification/agent-patrol-agent-121.md
@@ -26,6 +26,11 @@ off agent-120, which remains the Dev build primary.
   rootless daemon uses container `0:0`, which maps back to the unprivileged
   runner account and preserves writable bind-mount ownership. Rootful daemons
   continue to use the invoking host UID/GID.
+- Checkout transport: the exact protected-source checkout forces Git HTTP/1.1
+  through step-scoped environment configuration. This avoids reproducible
+  HTTP/2 stream cancellation and early-EOF failures observed on agent-121
+  without changing the source ref, credentials, runner-global Git config, or
+  any later Patrol step.
 - Concurrency: one Patrol run at a time
 - Credentials: none admitted to the model or Dogfood payload
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1777,14 +1777,14 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5b6183fa0007097274fadcbf8fa4097fbc83b89135c53aedcfd9e2acea7f5f3b",
+          "definitionDigest": "sha256:eb88c534da283957e4f74a932ac9177884d3870272b7b135e52c56d6023e77ad",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
           "steps": [
             {
               "index": 1,
               "label": "name:Check out exact protected source",
-              "definitionDigest": "sha256:c29587b518fd5f52b5410a7d54bffb493087c11abc943c5aa5e31ea62b3ad212"
+              "definitionDigest": "sha256:f59a8bf2f2ec268be4a505dfc794e8872e7f5173cd61e8c1f5b5a0cfcd84cabe"
             },
             {
               "index": 2,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -240,7 +240,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:b99fd90ecdf14068e7dc4391d37209e862048ec85dc3a5bb977a3c83714e6601"
+          "sourceRoot": "sha256:e6ceee0413754541cd3ca63f12838edc2989e75c4b5e52a5c531feac82f39a03"
         },
         {
           "path": ".github/workflows/opencode-agent-repository-work.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:dc72293400e59e180bd8491ef23eeb19a95706f534509684c581fdf9580c1033"
+  "registryRoot": "sha256:369c9106f2c56d0cb21d19e1590d6ef62c20d4208e9f674c69ccf608ecba4629"
 }

--- a/scripts/agent-patrol-workflow.test.mjs
+++ b/scripts/agent-patrol-workflow.test.mjs
@@ -40,6 +40,17 @@ test('Agent Patrol is isolated to the dedicated agent-121 runner', () => {
   assert.match(workflow, /timeout-minutes: 90/);
 });
 
+test('Agent Patrol bounds the protected-source checkout transport', () => {
+  assert.match(
+    workflow,
+    /- name: Check out exact protected source\n {8}uses: actions\/checkout@[0-9a-f]{40}[^\n]*\n {8}env:\n {10}GIT_CONFIG_COUNT: "1"\n {10}GIT_CONFIG_KEY_0: http\.version\n {10}GIT_CONFIG_VALUE_0: HTTP\/1\.1\n {8}with:/,
+  );
+  assert.match(workflow, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /fetch-depth: 1/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.doesNotMatch(workflow, /git config --global/u);
+});
+
 test('Agent Patrol pins its local-model runtime and retains bounded evidence', () => {
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

Stabilize the protected-source checkout used by the dedicated agent-121 Patrol after repeated HTTP/2 stream cancellation and early-EOF failures. The change is scoped to the checkout step and preserves the exact source, runner, credential, model, evidence, and concurrency boundaries.

## Related issue

Kungfu Assignment 2026-07-29-kungfu-agent-patrol-cadence.

## Changes

- force Git HTTP/1.1 only for the pinned actions/checkout step through GIT_CONFIG_COUNT;
- preserve github.sha, fetch-depth 1, and persist-credentials false;
- add a workflow contract that rejects transport, ref, credential, or runner-global config drift;
- document the bounded transport fallback;
- refresh the closed-world workflow authority and release publication source roots.

## Verification

- node --test scripts/agent-patrol-workflow.test.mjs (6 passing)
- Git configuration environment readback returned HTTP/1.1
- git diff --check
- staged commit Gate passed, including Gate catalog, documentation, KFD, and workflow authority checks
- ./shifu check:source passed the changed workflow authority, Gate catalog, publication control, documentation, and 755 contract tests; the only local failure was the unrelated cold-fixture pytest executable prerequisite missing from PATH

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This reliability fix changes only the transport used by the existing exact protected-source checkout; it does not alter Patrol authority, architecture, evidence, or model contracts"
}
-->

## Evolution Map impact

Evolution impact: none

This is a bounded CI transport reliability fix with no authority transition.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow remains non-publication. Generated authority and publication-control roots are refreshed only to bind the modified workflow bytes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed