### PR TITLE
fix(ci): accept prefixed runtime recovery command

### DIFF
--- a/scripts/check-runtime-surface-integration.mjs
+++ b/scripts/check-runtime-surface-integration.mjs
@@ -78,7 +78,10 @@ assert.match(guiMain, /stopRuntimeForRecovery/);
 
 const guiRecovery = read('framework/gui/src/main/runtime-recovery.ts');
 assert.match(guiRecovery, /shared public CLI/);
-assert.match(guiRecovery, /\['runtime', 'stop'\]/);
+assert.match(
+  guiRecovery,
+  /\[\.\.\.\(options\.argsPrefix \?\? \[\]\), 'runtime', 'stop'\]/,
+);
 for (const command of fixture.ordinaryLifecycleCommands.filter(
   (item) => item !== 'stop',
 )) {


### PR DESCRIPTION
## Summary

- keep the runtime surface qualification bound to the GUI recovery path through the shared public CLI
- admit the existing optional `argsPrefix` before the literal `runtime stop` command
- preserve the prohibition on ordinary lifecycle ownership in GUI recovery

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This qualification bugfix updates a stale source assertion to the existing prefixed public CLI invocation without changing runtime authority or behavior."
}
-->

## Failure evidence

Final Build run 30446260284 attempt 2, Linux x64 job 90566601803, passed the native build and 72/72 build-chain verification before `runtime-surface-parity` rejected `[...(options.argsPrefix ?? []), 'runtime', 'stop']` with the obsolete exact-array regex.

## Validation

- `node scripts/check-runtime-surface-integration.mjs`: passed, 7 surfaces and 14 KFX actions
- `node --check scripts/check-runtime-surface-integration.mjs`: passed
- `git diff --check`: passed
- pre-commit staged gate: passed, including 53 dev-required latency tests, 17 invariant tests, 118 documentation tests, deterministic docs gate, and Biome