### PR TITLE
fix(action): refresh package manifest digest

### DIFF
--- a/framework/action/action.test.mjs
+++ b/framework/action/action.test.mjs
@@ -14,6 +14,7 @@ import {
   canonicalJson,
   contractResponse,
   parseSingleJsonDocument,
+  verifyPackage,
 } from './action.mjs';
 
 const ACTION_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -31,6 +32,14 @@ function runAction(args, env = {}) {
 function digest(file) {
   return `sha256:${createHash('sha256').update(fs.readFileSync(file)).digest('hex')}`;
 }
+
+test('source Action package manifest matches tracked bytes', () => {
+  const manifest = verifyPackage(ACTION_DIR);
+  assert.equal(manifest.schema, 'kungfu.action.package-manifest/v1');
+  assert.ok(
+    manifest.files.some((entry) => entry.path === 'action-loop.contract.json'),
+  );
+});
 
 test('development Node and embedded libnode hosts retain one semantic root', () => {
   const request = JSON.stringify({

--- a/framework/action/manifest.json
+++ b/framework/action/manifest.json
@@ -28,7 +28,7 @@
     },
     {
       "path": "action-loop.contract.json",
-      "sha256": "sha256:279abe91d7aca1fc095f8e169f4ba727112aadabc54a82f4894b579b68d717cd"
+      "sha256": "sha256:f4327c98ee30b4f04ad65ef1939069dc10580c180b908de1aceaa7aaf2dde506"
     },
     {
       "path": "action-loop-fixtures.json",


### PR DESCRIPTION
## Summary

- refresh the Action package manifest digest for the renamed work-control contract bytes
- add a direct source-package verification regression so tracked byte drift fails locally
- preserve the existing Action authority and installed package verification behavior

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the existing Action package integrity invariant after a contract vocabulary rename without changing Action authority, authorization, or runtime behavior."
}
-->

## Failure evidence

Final auditable-demo Build run 30462994266 failed on Linux x64 job 90614161860 and macOS ARM64 job 90614161886 with package-tampered because action-loop.contract.json had digest sha256:f4327c98ee30b4f04ad65ef1939069dc10580c180b908de1aceaa7aaf2dde506 while framework/action/manifest.json retained the pre-rename digest.

## Validation

- node --test framework/action/action.test.mjs: 9 passed
- ./shifu test:action-kernel: 36 passed, 2 native-binding skips; Python 5 passed
- staged pre-commit gate: passed, including test manifest, 53 latency tests, 17 invariant tests, 131 documentation tests, deterministic docs gate, and Biome
- git diff --check: passed
