### PR TITLE
fix(core): qualify Core artifact authority changes

### DIFF
--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -628,6 +628,13 @@ export function planFromChanged(
     'scripts/affected-native-proof.mjs',
     '.github/workflows/affected-native-cache-promote.yml',
     '.github/workflows/affected-native-pr.yml',
+    'framework/release/qualified-assignment-core-artifact.mjs',
+    'framework/assignment-capture/qualified-assignment-core-consumer.mjs',
+    'scripts/check-shifu-cache-contract.mjs',
+    'docs/shifu/artifact-contract.json',
+    'docs/shifu/cache-contract.json',
+    'docs/shifu/schema/qualified-assignment-core-artifact-v1.schema.json',
+    'docs/shifu/schema/qualified-assignment-core-qualification-v1.schema.json',
     'shifu.gates.json',
     'docs/qualification/gates/',
     'package.json',
@@ -1738,15 +1745,27 @@ function selfTest(authority, buildAuthority) {
     }
   });
   expect('authority dependency change expands globally', () => {
-    const plan = planFromChanged(
-      ['framework/core/architecture/layers.json'],
-      authority,
-      buildAuthority,
-      'base',
-      'head',
-    );
-    if (plan.closureComponents.length !== authority.components.length)
-      throw new Error('closure incomplete');
+    for (const file of [
+      'framework/core/architecture/layers.json',
+      'framework/release/qualified-assignment-core-artifact.mjs',
+      'framework/assignment-capture/qualified-assignment-core-consumer.mjs',
+      'scripts/check-shifu-cache-contract.mjs',
+      'docs/shifu/artifact-contract.json',
+      'docs/shifu/cache-contract.json',
+      'docs/shifu/schema/qualified-assignment-core-artifact-v1.schema.json',
+      'docs/shifu/schema/qualified-assignment-core-qualification-v1.schema.json',
+    ]) {
+      const plan = planFromChanged(
+        [file],
+        authority,
+        buildAuthority,
+        'base',
+        'head',
+      );
+      if (plan.closureComponents.length !== authority.components.length)
+        throw new Error(`${file}: closure incomplete`);
+      if (!plan.profile) throw new Error(`${file}: native profile missing`);
+    }
   });
   expect('Core native build support changes expand globally', () => {
     const plan = planFromChanged(


### PR DESCRIPTION
## Summary

Make every Qualified Assignment Core producer, consumer, contract, and qualification-authority change schedule the complete native Core qualification closure. This closes the post-merge gap where a successful source-only merge produced no protected macOS ARM64 artifact.

## Related issue

Kungfu Assignment `2026-07-29-kungfu-qualified-core-consumer-materialization`.

## Changes

- Classify the Qualified Core producer, consumer, cache contract, artifact contract, and both schemas as global native-impact authority paths.
- Require every authority path fixture to select all 12 Core components and a native build profile.
- Preserve the existing affected-native planner, branch policy, and artifact contract.

## Verification

- `./shifu core:affected -- --self-test`: 31 negative and determinism fixtures passed.
- Direct planner readback for `framework/release/qualified-assignment-core-artifact.mjs`: all 12 components, `embedded-sqlite`, `architecture-or-gate-authority`.
- `node --test scripts/qualified-assignment-core-artifact.test.mjs`: 7 passed.
- `./shifu check:source`: 761 passed, 10 platform skips, 0 failed; Agent Work Python 40, runtime upgrade 116, desktop update 69, docs 131.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the existing Qualified Assignment Core artifact qualification path without changing its architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The patch changes only the source-bound native-impact planner. It does not broaden workflow permissions, change transport authority, or mutate installed product state.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LXF1YWxpZmllZC1hc3NpZ25tZW50LWNvcmUtY2FjaGUtZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOS1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtY29uc3VtZXItbWF0ZXJpYWxpemF0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiI5MTQ4OWU4MDE1YTg4ZmQyZThiYjcwYTkwNDkyOGY5NmE3OGJiM2U0IiwicHVsbFJlcXVlc3RIZWFkIjoiM2M0MmZmNGYzMzJjNGE2YzhhMDI2Mjc4OWYwYzJmNmZjMmQ2MmJjYSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiNmY5NWU5MWYzZDY5NzdjYTg5ZmI4ZmZjODNkNzczMTI3Mzc1YmVhZiIsInJlcGxheWVkVHJlZSI6IjgxNGNkMGFlZGRlZjNiMDJhYjJlOGE0M2Y4N2NhMjc4YzA0M2FlNTIiLCJxdWV1ZUF0dGVtcHQiOiIzYzQyZmY0ZjMzMmM0YTZjOGEwMjYyNzg5ZjBjMmY2ZmMyZDYyYmNhQDkxNDg5ZTgwMTVhODhmZDJlOGJiNzBhOTA0OTI4Zjk2YTc4YmIzZTQiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6YzViODJjMTUzNDMxMWU3ZjkzNDc5YWEzMGVlNmE1YWIwZjYzNzY1ZDZmMDZiMzFlNDRjNzMyNGU4MDBmZDUxMiIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjQwNTRhYWU5OTQxNWEyYjM0N2I4NjZkNzIzNTRmYzUxZjQyNjQ0NWNjZjgxYjE1ZTQxYWZkZmU2NzJmNzNhZmQiLCJzaGEyNTY6YzViODJjMTUzNDMxMWU3ZjkzNDc5YWEzMGVlNmE1YWIwZjYzNzY1ZDZmMDZiMzFlNDRjNzMyNGU4MDBmZDUxMiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzIyYzg0YjMxNzAxMDc5ZTIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6ZjVmNDA4MjJkYjBjM2IyNTEwZjA2MjMyM2RiMTNlNjgxNDE3YWZjNzEwMGQwMTdmY2I5OTJlMGZhYzBlNDQxZSJ9 -->