### PR TITLE
fix(assignment): retry qualified core transport

### DIFF
--- a/framework/assignment-capture/qualified-assignment-core-consumer.mjs
+++ b/framework/assignment-capture/qualified-assignment-core-consumer.mjs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-check
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -23,6 +23,7 @@ const RECEIPT = '.qualified-core-materialization.json';
 const MAX_ARCHIVE_BYTES = 512 * 1024 * 1024;
 const MAX_ENTRY_BYTES = 256 * 1024 * 1024;
 const MAX_ENTRIES = 32;
+const GITHUB_DOWNLOAD_ATTEMPTS = 3;
 const SHA = /^[0-9a-f]{40}$/u;
 const ROOT_HASH = /^sha256:[0-9a-f]{64}$/u;
 
@@ -455,7 +456,90 @@ function ghJson(endpoint) {
   );
 }
 
-function discoverGithubBundle(checkout, temporary) {
+function runBinaryToFile(command, args, destination, { maxBytes, reason }) {
+  return new Promise((resolve, reject) => {
+    let descriptor;
+    try {
+      descriptor = fs.openSync(destination, 'wx', 0o600);
+    } catch {
+      reject(new QualifiedCoreUnavailable(reason));
+      return;
+    }
+    let bytes = 0;
+    let failure = null;
+    let finished = false;
+    const child = spawn(command, args, {
+      env: process.env,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const complete = (error = null) => {
+      if (finished) return;
+      finished = true;
+      try {
+        fs.closeSync(descriptor);
+      } catch {
+        failure ||= new QualifiedCoreUnavailable(reason);
+      }
+      if (error || failure) reject(error || failure);
+      else resolve({ bytes });
+    };
+    child.stdout.on('data', (chunk) => {
+      if (finished || failure) return;
+      bytes += chunk.byteLength;
+      if (bytes > maxBytes) {
+        failure = new QualifiedCoreUnavailable('archive-too-large');
+        child.kill('SIGTERM');
+        return;
+      }
+      try {
+        fs.writeSync(descriptor, chunk);
+      } catch {
+        failure = new QualifiedCoreUnavailable(reason);
+        child.kill('SIGTERM');
+      }
+    });
+    // Provider errors can contain short-lived signed URLs. Drain but never retain
+    // or surface those bytes.
+    child.stderr.resume();
+    child.on('error', () => complete(new QualifiedCoreUnavailable(reason)));
+    child.on('close', (code) => {
+      if (code !== 0 || bytes === 0) {
+        failure ||= new QualifiedCoreUnavailable(reason);
+      }
+      complete();
+    });
+  });
+}
+
+export async function downloadGithubArtifact({
+  repository,
+  artifactId,
+  destination,
+  attempts = GITHUB_DOWNLOAD_ATTEMPTS,
+  runAttempt = runBinaryToFile,
+}) {
+  if (fs.existsSync(destination)) {
+    throw new QualifiedCoreUnavailable('github-download-target-dirty');
+  }
+  const endpoint = `repos/${repository}/actions/artifacts/${artifactId}/zip`;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const partial = `${destination}.attempt-${attempt}`;
+    try {
+      await runAttempt('gh', ['api', endpoint], partial, {
+        maxBytes: MAX_ARCHIVE_BYTES + 1024,
+        reason: 'github-artifact-download-failed',
+      });
+      fs.renameSync(partial, destination);
+      return destination;
+    } catch {
+      fs.rmSync(partial, { force: true });
+    }
+  }
+  throw new QualifiedCoreUnavailable('github-artifact-download-failed');
+}
+
+async function discoverGithubBundle(checkout, temporary) {
   const name = `qualified-assignment-core-${checkout.commit}`;
   const listing = ghJson(
     `repos/${checkout.repository}/actions/artifacts?name=${name}&per_page=100`,
@@ -487,20 +571,14 @@ function discoverGithubBundle(checkout, temporary) {
   ) {
     throw new QualifiedCoreUnavailable('untrusted-github-workflow');
   }
-  const zip = run(
-    'gh',
-    [
-      'api',
-      `repos/${checkout.repository}/actions/artifacts/${artifact.id}/zip`,
-    ],
-    {
-      binary: true,
-      maxBuffer: MAX_ARCHIVE_BYTES + 1024,
-      reason: 'github-artifact-download-failed',
-    },
-  );
+  const zip = path.join(temporary, 'artifact.zip');
+  await downloadGithubArtifact({
+    repository: checkout.repository,
+    artifactId: artifact.id,
+    destination: zip,
+  });
   const bundleRoot = path.join(temporary, 'bundle');
-  extractZip(Buffer.from(zip), bundleRoot);
+  extractZip(fs.readFileSync(zip), bundleRoot);
   return {
     bundleRoot,
     transport: {
@@ -700,7 +778,7 @@ export async function consumeQualifiedCoreForCheckout({
         };
       }
     } else if (process.env.KUNGFU_QUALIFIED_CORE_GITHUB !== '0') {
-      discovered = discoverGithubBundle(checkout, temporary);
+      discovered = await discoverGithubBundle(checkout, temporary);
     } else {
       throw new QualifiedCoreUnavailable('qualified-core-cache-miss');
     }

--- a/scripts/qualified-assignment-core-artifact.test.mjs
+++ b/scripts/qualified-assignment-core-artifact.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   consumeQualifiedCoreForCheckout,
+  downloadGithubArtifact,
   materializeQualifiedCoreBundle,
 } from '../framework/assignment-capture/qualified-assignment-core-consumer.mjs';
 import {
@@ -581,6 +582,60 @@ test('consumer CLI emits one source-build diagnosis when reuse is unavailable', 
   const output = JSON.parse(result.stdout);
   assert.equal(output.code, 'qualified-core-reuse-unavailable');
   assert.equal(output.next_actions[0].command, './shifu build:core');
+});
+
+test('consumer streams GitHub artifacts through bounded retries and removes partials', async (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'qualified-core-github-download-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+  const destination = path.join(temporary, 'artifact.zip');
+  let observedAttempts = 0;
+  await downloadGithubArtifact({
+    repository: 'kungfu-systems/kungfu',
+    artifactId: 42,
+    destination,
+    runAttempt: async (_command, _args, partial, options) => {
+      observedAttempts += 1;
+      assert.equal(options.maxBytes, 512 * 1024 * 1024 + 1024);
+      fs.writeFileSync(
+        partial,
+        observedAttempts < 3 ? 'incomplete' : 'complete',
+        { flag: 'wx' },
+      );
+      if (observedAttempts < 3) throw new Error('bounded transport failure');
+    },
+  });
+  assert.equal(observedAttempts, 3);
+  assert.equal(fs.readFileSync(destination, 'utf8'), 'complete');
+  assert.deepEqual(
+    fs.readdirSync(temporary).filter((name) => name.includes('.attempt-')),
+    [],
+  );
+});
+
+test('consumer leaves no GitHub artifact bytes after retry exhaustion', async (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'qualified-core-github-failure-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+  const destination = path.join(temporary, 'artifact.zip');
+  let observedAttempts = 0;
+  await assert.rejects(
+    downloadGithubArtifact({
+      repository: 'kungfu-systems/kungfu',
+      artifactId: 42,
+      destination,
+      runAttempt: async (_command, _args, partial) => {
+        observedAttempts += 1;
+        fs.writeFileSync(partial, 'incomplete', { flag: 'wx' });
+        throw new Error('bounded transport failure');
+      },
+    }),
+    /github-artifact-download-failed/u,
+  );
+  assert.equal(observedAttempts, 3);
+  assert.deepEqual(fs.readdirSync(temporary), []);
 });
 
 test('consumer rejects two locally retained authorities for one exact checkout', async (t) => {


### PR DESCRIPTION
## Summary

- stream Qualified Core GitHub artifact downloads into bounded mode-0600 temporary files
- retry transient transport failures three times without retaining partial bytes
- discard transport stderr so signed artifact URLs are never retained or surfaced
- preserve exact commit, tree, authority, and digest verification before publication

## Motivation

A real empty-cache source-thread materialization test reached the promoted exact artifact but failed during a transient TLS handshake after a partial download. The consumer correctly fell back without publishing bytes, but a single transport interruption made an otherwise valid promoted artifact unusable.

## Validation

- `node --check framework/assignment-capture/qualified-assignment-core-consumer.mjs`
- `node --test scripts/qualified-assignment-core-artifact.test.mjs scripts/run-core-affected-native.test.mjs` (16 passed)
- commit hook staged validation passed
- local source acceptance: 768 passed, 10 skipped; the sole failure was the host environment lacking `ruff` on PATH
- protected source acceptance: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Harden the existing Qualified Assignment Core transport without changing its architecture or authority contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The patch changes only the authenticated artifact transport implementation. It does not read or log credentials, broaden workflow permissions, alter qualification authority, or mutate installed product state.

## Version impact

Patch: this hardens transport behavior without changing the artifact contract or public command surface.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LXF1YWxpZmllZC1hc3NpZ25tZW50LWNvcmUtY2FjaGUtZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOS1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtY29uc3VtZXItbWF0ZXJpYWxpemF0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJlNmYzNmU5NDQxMWQ0MjA0ZjZkY2EyZmQ0YWU1M2IyNTc0MzAyZWY3IiwicHVsbFJlcXVlc3RIZWFkIjoiZTQyNWU4OGU3YzJlZGQyZWUzZWFiYzJkZTdiNjA0M2M4ZDAwM2Y0MyIsInJlcGxheWVkQ2FuZGlkYXRlIjoiOTZlMmM4YjYxN2RmYjk3MjcxNzk3MDExZWM2ZDZjOTEwM2E5MmYyNSIsInJlcGxheWVkVHJlZSI6IjRjY2MwNzUxN2E0MWE0NmY4ZTVmMjhjNmNkMGIwODQ1ZDFhMmIwMDAiLCJxdWV1ZUF0dGVtcHQiOiJlNDI1ZTg4ZTdjMmVkZDJlZTNlYWJjMmRlN2I2MDQzYzhkMDAzZjQzQGU2ZjM2ZTk0NDExZDQyMDRmNmRjYTJmZDRhZTUzYjI1NzQzMDJlZjciLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6MzI2ZjI3ZTE1Zjk1NTg0ZTVmOGMzMmZlYmE5N2VjOGRmZjAxMjkzMzhiYTcwNzA3ZDgwYzJmNTEyZjNiYmY1ZSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjMyNmYyN2UxNWY5NTU4NGU1ZjhjMzJmZWJhOTdlYzhkZmYwMTI5MzM4YmE3MDcwN2Q4MGMyZjUxMmYzYmJmNWUiLCJzaGEyNTY6YzViODJjMTUzNDMxMWU3ZjkzNDc5YWEzMGVlNmE1YWIwZjYzNzY1ZDZmMDZiMzFlNDRjNzMyNGU4MDBmZDUxMiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzIyYzg0YjMxNzAxMDc5ZTIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6MzRlMDJjMjQ1YTY1ZmIyMDI3MjkwZGZkMDRkYzJmOWM0MGYzMDkwMWUxODM5MzZmNmUzYTAwMjVhY2Q2MDMzNiJ9 -->