### PR TITLE
fix(profile): follow work control test rename

### DIFF
--- a/scripts/run-agent-profile-sdk-tests.mjs
+++ b/scripts/run-agent-profile-sdk-tests.mjs
@@ -48,7 +48,7 @@ const result = spawnSync(
       'core',
       'tests',
       'python',
-      'test_mission_control_profile.py',
+      'test_work_control_profile.py',
     ),
     '-q',
   ],


### PR DESCRIPTION
## Summary

Repair the Agent Profile SDK lifecycle entry after the Work Control test file rename. The stale path blocked Windows Alpha qualification even though the replacement test was present.

## Related issue

Supersedes the failed Windows lifecycle qualification observed in Alpha candidate PR #1904.

## Changes

- point the Agent Profile SDK pytest runner at `test_work_control_profile.py`

## Verification

- verified every declared pytest path exists
- `KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check:source`
- staged source, documentation, ADR, lint, and format gates passed in the signed-off commit hook
- local runtime entry advanced past path discovery; native `pykungfu` remains a build prerequisite and is covered by Windows CI

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair updates a test runner path after an already-reviewed file rename; it changes no architecture contract or release policy."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: restores the Windows lifecycle evidence consumed by Alpha qualification; source and protected CI gates validate the exact commit.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; no behavior or public contract changed)

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjMta3VuZ2Z1LXN0YW5kYWxvbmUtY2xpLWRpc3RyaWJ1dGlvbi1hbmQtb25lLWNvbW1hbmQtdXBkYXRlIiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yNC1rdW5nZnUtcHVibGljLWFscGhhLXJlbGVhc2UtY2xvc3VyZSIsImRlbGl2ZXJ5Q2xhc3MiOiJub24tbmF0aXZlLWZhc3QiLCJkZXZIZWFkIjoiZTdiYWViMGQ1Y2I3Y2FjMzYxNDJjZjk2NDIwMTdmM2NhMTBlNmNiYiIsInB1bGxSZXF1ZXN0SGVhZCI6IjExMzFjYzQ2MjM5Y2FlZTIwNWY3ZDQ4MjhmZGZlZWI5NzAyZDY1YjgiLCJyZXBsYXllZENhbmRpZGF0ZSI6Ijk3ODkyOGZhZWYzYjFkMGY0ZjVmMzQ0NzI3NWM0NjM0NGFhZDQyYTUiLCJyZXBsYXllZFRyZWUiOiJmMDI5MjdmM2I4NDhjYmMzMmRjN2JhZjQwY2I4NmY5ZGI1NWFhNmMxIiwicXVldWVBdHRlbXB0IjoiMTEzMWNjNDYyMzljYWVlMjA1ZjdkNDgyOGZkZmVlYjk3MDJkNjViOEBlN2JhZWIwZDVjYjdjYWMzNjE0MmNmOTY0MjAxN2YzY2ExMGU2Y2JiIiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OjNhYWE4YzU3NTY2ZjcwZmJiY2FiOWQ4Y2E1YzRiNTFiZjQyM2QzZjUwYzAyODA5ZjI4NDc5MmYwMzNjZWMzNjIiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1NjozYWFhOGM1NzU2NmY3MGZiYmNhYjlkOGNhNWM0YjUxYmY0MjNkM2Y1MGMwMjgwOWYyODQ3OTJmMDMzY2VjMzYyIiwic2hhMjU2OjdlY2ZkZTI4OTQzNWRhNTc2N2M4ZGVjMjY4ZmU1NDI3NjMxMDJlMGE1ZjM2ZDhmZWEwNzljMzkxMmRhZWMxN2IiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9jNDNkOWZmNWIxYWE2NTVmIiwibGVhc2VSb290Ijoic2hhMjU2OmI2YzhiOGRkNTI0MjFmN2QzNzYwZDI3Y2JkNTVlZWY5NDQwMDQyNzZiMDc4MDFjMDJjNjQ4YThhZGEwODFiOWMifQ -->