### PR TITLE
fix(qualification): follow work control test rename

### DIFF
--- a/scripts/run-agent-profile-sdk-tests.mjs
+++ b/scripts/run-agent-profile-sdk-tests.mjs
@@ -48,7 +48,7 @@ const result = spawnSync(
       'core',
       'tests',
       'python',
-      'test_mission_control_profile.py',
+      'test_work_control_profile.py',
     ),
     '-q',
   ],


### PR DESCRIPTION
## Summary

- update the profile-action admission runner to invoke the tracked Work Control test after its canonical rename
- preserve the existing profile SDK and runtime qualification contract

## Failure evidence

- Alpha build run 30476485711 attempt 3, Windows job 90673558601
- 72/72 core verification and all other runtime-activation suites passed
- profile-action-admission failed only because test_mission_control_profile.py no longer exists

## Verification

- 64 profile SDK/composition/Work Control tests passed
- Biome passed
- full staged pre-commit repository gates passed
- Project Cut admission qualified with one replayed commit and no composition change

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded qualification repair follows an existing canonical test-file rename and does not change architecture, runtime behavior, or release authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Checklist

- [x] Commit is signed off (DCO)
- [x] Focused tests and staged gates passed
