### PR TITLE
fix(assignment): retain qualified core extraction

### DIFF
--- a/framework/assignment-capture/qualified-assignment-core-consumer.mjs
+++ b/framework/assignment-capture/qualified-assignment-core-consumer.mjs
@@ -782,7 +782,7 @@ export async function consumeQualifiedCoreForCheckout({
     } else {
       throw new QualifiedCoreUnavailable('qualified-core-cache-miss');
     }
-    return materializeQualifiedCoreBundle({
+    return await materializeQualifiedCoreBundle({
       ...discovered,
       repositoryRoot,
       publicationRoot,

--- a/scripts/qualified-assignment-core-artifact.test.mjs
+++ b/scripts/qualified-assignment-core-artifact.test.mjs
@@ -638,6 +638,54 @@ test('consumer leaves no GitHub artifact bytes after retry exhaustion', async (t
   assert.deepEqual(fs.readdirSync(temporary), []);
 });
 
+test('consumer keeps an extracted archive alive through async retention', async (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'qualified-core-archive-lifetime-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+  const { bundleRoot } = await promotedConsumerFixture(temporary);
+  const archive = path.join(temporary, 'qualified-core.zip');
+  const zip = spawnSync(
+    'python3',
+    [
+      '-c',
+      [
+        'import os, sys, zipfile',
+        'source, target = sys.argv[1:]',
+        "with zipfile.ZipFile(target, 'w', zipfile.ZIP_STORED) as archive:",
+        '  for root, _, files in os.walk(source):',
+        '    for name in sorted(files):',
+        '      path = os.path.join(root, name)',
+        '      archive.write(path, os.path.relpath(path, source))',
+      ].join('\n'),
+      bundleRoot,
+      archive,
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(zip.status, 0, zip.stderr);
+  const previousBundle = process.env.KUNGFU_QUALIFIED_CORE_BUNDLE;
+  process.env.KUNGFU_QUALIFIED_CORE_BUNDLE = archive;
+  try {
+    const result = await consumeQualifiedCoreForCheckout({
+      repositoryRoot: ROOT,
+      publicationRoot: path.join(temporary, 'checkout'),
+      cacheRoot: path.join(temporary, 'cache'),
+      now: CONSUMER_NOW,
+      checkout: consumerCheckout(),
+      platform: 'darwin',
+      architecture: 'arm64',
+    });
+    assert.equal(result.status, 'materialized');
+  } finally {
+    if (previousBundle === undefined) {
+      Reflect.deleteProperty(process.env, 'KUNGFU_QUALIFIED_CORE_BUNDLE');
+    } else {
+      process.env.KUNGFU_QUALIFIED_CORE_BUNDLE = previousBundle;
+    }
+  }
+});
+
 test('consumer rejects two locally retained authorities for one exact checkout', async (t) => {
   const temporary = fs.mkdtempSync(
     path.join(os.tmpdir(), 'qualified-core-consumer-ambiguous-'),


### PR DESCRIPTION
## Summary

- await Qualified Assignment Core materialization before removing the extracted promotion bundle
- retain the existing exact-identity, verification, and atomic-publication contract
- add an archive-backed regression test that exercises the asynchronous retention boundary

## Motivation

A real empty-cache consumption of the promoted macOS ARM64 artifact verified the transport and bundle, then failed while retaining the extracted payload because the extraction directory was removed by `finally` before asynchronous materialization completed.

## Validation

- `node --test scripts/qualified-assignment-core-artifact.test.mjs scripts/run-core-affected-native.test.mjs` (17 passed)
- `PATH=/Users/dkr/.cache/uv/archive-v0/_T8kv5tTmZ5O_RLL/bin:$PATH KUNGFU_READONLY_PYTEST=/Users/dkr/.cache/uv/archive-v0/_T8kv5tTmZ5O_RLL/bin/pytest ./shifu check:source` (passed; 770 passed, 10 skipped)
- staged repository gates (passed)

## Evolution Map

No Evolution Map change. This is an ADR-neutral correction to the existing Qualified Assignment Core consumer lifecycle.

## Governance risk

- [x] No authority widening
- [x] No schema or CLI compatibility change
- [x] No secret or credential handling change
- [x] No installed-product mutation

## Versioning

Patch.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Preserve the existing Qualified Assignment Core artifact contract while fixing asynchronous extraction lifetime"
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LXF1YWxpZmllZC1hc3NpZ25tZW50LWNvcmUtY2FjaGUtZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOS1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtY29uc3VtZXItbWF0ZXJpYWxpemF0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiIzMmJlN2YzN2QzZDgyMjZjZTc0OGNmNGVmOTY1MjNlYzkzYWRhOWRmIiwicHVsbFJlcXVlc3RIZWFkIjoiYTk2MzA3MzcwZDU1NWIwMzYwYzkzM2IyZDgyYTM0N2ZlYWM4Y2JmZCIsInJlcGxheWVkQ2FuZGlkYXRlIjoiNTAxNDEwMzg0MWQ0M2IwMzlhNTBhYWI0MTI0ZjA3ZmZhN2E0OTBmMSIsInJlcGxheWVkVHJlZSI6IjE2MmQ5YTUyOGQxNmViMzM0YjkwNzA4NzYyZTJhNjFmYjdmODQ5NGIiLCJxdWV1ZUF0dGVtcHQiOiJhOTYzMDczNzBkNTU1YjAzNjBjOTMzYjJkODJhMzQ3ZmVhYzhjYmZkQDMyYmU3ZjM3ZDNkODIyNmNlNzQ4Y2Y0ZWY5NjUyM2VjOTNhZGE5ZGYiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6Yjc2ODQxY2M1MzhmMGMwZTQxMzg5MjZkNmJlMjgzYjUwYjU5ZDdiMDM2OTlmNzdhZmI2ZTIyZjk1M2NhYjJkZCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OmI3Njg0MWNjNTM4ZjBjMGU0MTM4OTI2ZDZiZTI4M2I1MGI1OWQ3YjAzNjk5Zjc3YWZiNmUyMmY5NTNjYWIyZGQiLCJzaGEyNTY6YzViODJjMTUzNDMxMWU3ZjkzNDc5YWEzMGVlNmE1YWIwZjYzNzY1ZDZmMDZiMzFlNDRjNzMyNGU4MDBmZDUxMiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzIyYzg0YjMxNzAxMDc5ZTIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6NTYyZThjNjk5NDVkMDZjMGNmNDllMDBjMzJhNzJiMDM4NDY5MDU2YjYzZTdhZTNjNzU0OTFiYjVkZmEwODliZiJ9 -->