### PR TITLE
fix(ci): keep scheduled dev verify on workflow runtime

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -41,7 +41,7 @@ jobs:
       # ref. Checkout
       # cache hits are optional: every source/runtime checkout verifies the
       # locked SHA and falls back to GitHub when a retained bundle is stale.
-      buildchain-ref: ${{ inputs.buildchain-ref || 'f8ef93be41b0badd75eb35cc1506c2be12198984' }}
+      buildchain-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}
       checkout-cache-mode: auto
       checkout-cache-fallback: github
       rust-toolchain: "1.96.0"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1444,7 +1444,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:423ea47d9104d4c8891a2d28d15d0d1dae4acdaf6b6999028d6a723ba2c8284e",
+          "definitionDigest": "sha256:da26aa181f3760649aaa18086fd6fe045172c40410b013c7156201457cb0293c",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -343,7 +343,7 @@
       "invocation": {
         "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984",
         "with": {
-          "buildchain-ref": "${{ inputs.buildchain-ref || 'f8ef93be41b0badd75eb35cc1506c2be12198984' }}",
+          "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
           "cargo-registry-index": "${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}",
           "checkout-cache-fallback": "github",
           "checkout-cache-mode": "auto",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b947a743b8b8b286f60f4e0e0a30040c6da2d5faed36e6bdd0adf3efb336aca5",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:e73971530000d23121411bbff42c8a344c52be773e7fd78f856c8d7a5425afee",
+  "sourceRoot": "sha256:791daf8af619e8c3d138ee969fbce1ebff9895f5e8c6de405a4295f79b076c2e",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1111,7 +1111,7 @@
           "path": "docs/qualification/gates/workflow-bindings.json",
           "currentLines": 650,
           "baselineLines": 580,
-          "currentRoot": "sha256:a9e7bb044c0e7cee46ef335d277cbbf1e7901f12861a95318a3f59f55d273896",
+          "currentRoot": "sha256:0e64662c1b31d631c962cd37de68322da677095d2174ed8fdf8321437b7e02b6",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -181,7 +181,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:8655685b9293c2af41c0b19b8be3123b8baf23679fd72105f8b27409338bf9ad"
+          "sourceRoot": "sha256:80ecf6fe4554d33e1dc72146064a91094544c03739e40d0e2516071c4fde3918"
         },
         {
           "path": ".github/workflows/docs-check.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:b3f3418db68c814009e5e421e7879f21e4702474e914dc1dc9f78c55913ed17e"
+  "registryRoot": "sha256:25faaeeb2408b4e59b474dbc06c86e2bc700c4df8c51523caed23b8ee0fef621"
 }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -1063,7 +1063,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRuntimeWorkflow, 'utf8')
       .replace(
-        "buildchain-ref: ${{ inputs.buildchain-ref || 'f8ef93be41b0badd75eb35cc1506c2be12198984' }}",
+        "buildchain-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
         "buildchain-ref: ${{ inputs.buildchain-ref || '' }}",
       ),
   );

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -16,6 +16,14 @@ test('Dev Patrol runs at 04:00 Asia/Shanghai with an explicit UTC contract', () 
   assert.match(source, /04:00 Asia\/Shanghai/u);
   assert.match(source, /cron: "0 20 \* \* \*"/u);
   assert.doesNotMatch(source, /cron: "23 3 \* \* \*"/u);
+  assert.match(
+    source,
+    /buildchain-ref: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.buildchain-ref \|\| '' \}\}/u,
+  );
+  assert.doesNotMatch(
+    source,
+    /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| '[0-9a-f]{40}' \}\}/u,
+  );
 });
 
 test('candidate patrol is a thin Buildchain caller with exact channel and evidence inputs', () => {


### PR DESCRIPTION
## Summary

- leave `buildchain-ref` empty for scheduled Dev Verify runs so Buildchain resolves the exact reusable-workflow runtime without treating it as an event override
- retain the trusted `workflow_dispatch` override path
- refresh the closed-world workflow authority and binding projection

## Verification

- focused Dev Patrol and workflow catalog tests passed
- complete staged pre-commit repository gate passed
- 58 Gate latency, 27 workflow authority/catalog, 17 invariant, 131 docs/ADR, and 18 KFD support tests passed in the commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded CI scheduling repair preserves the existing Buildchain runtime authority and changes no architecture, product behavior, or release contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Checklist

- [x] Commit is signed off (DCO)
- [x] Focused tests and staged gates passed
