### PR TITLE
fix(work): discover native profile source

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "99db7ffa022b10bac425cf16312e292f7df6d4ce",
+    "sourceSha": "c983da6a8a39e7cebafd4aeb2d83ab17c0d8772f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:40e6d55408f13498a28e769917e0fd1bb7e67659680d99858bf4a08deebe07e8"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -258,7 +258,7 @@
           },
           {
             "path": "framework/core/tests/python/test_assignment_orchestration.py",
-            "sha256": "sha256:cd2bdb647d18d559b3c1a2f820647daaf26940ed4b799314e6a136b8e6237686"
+            "sha256": "sha256:f04fc2c7da17d57c2fd38c6a9a81ffe53f1422ab30d9ae179d95bb0837f0dffc"
           }
         ]
       },

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -258,7 +258,7 @@
           },
           {
             "path": "framework/core/tests/python/test_assignment_orchestration.py",
-            "sha256": "sha256:cd2bdb647d18d559b3c1a2f820647daaf26940ed4b799314e6a136b8e6237686"
+            "sha256": "sha256:f04fc2c7da17d57c2fd38c6a9a81ffe53f1422ab30d9ae179d95bb0837f0dffc"
           }
         ]
       },

--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -117,11 +117,11 @@ def _profile_source():
         packaged = profiles / profile_name
         if packaged.is_dir():
             return packaged
-    source = (
-        orchestration.source_root() / "extensions" / "mission-control"
-    )  # compatibility source layout
-    if source.is_dir():
-        return source
+    extensions = orchestration.source_root() / "extensions"
+    for profile_name in ("work-control", "mission-control"):  # compatibility path
+        source = extensions / profile_name
+        if source.is_dir():
+            return source
     raise ValueError("Work Control Profile is absent from this Kungfu product")
 
 

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -35,6 +35,20 @@ def _sha256(marker):
     return "sha256:" + marker * 64
 
 
+def test_assignment_profile_source_prefers_native_source_layout(tmp_path, monkeypatch):
+    package = tmp_path / "package" / "kungfu"
+    package.mkdir(parents=True)
+    checkout = tmp_path / "checkout"
+    native = checkout / "extensions" / "work-control"
+    native.mkdir(parents=True)
+    monkeypatch.setattr(assignment_orchestration, "__file__", package / "module.py")
+    monkeypatch.setattr(
+        assignment_orchestration, "source_root", lambda *_starts: checkout
+    )
+
+    assert ASSIGNMENT_CLI._profile_source() == native
+
+
 def test_assignment_atomic_paths_use_windows_extended_namespace():
     local = assignment_orchestration._filesystem_path(
         Path(r"C:\Users\Administrator\workspace\.kungfu\request.json"),


### PR DESCRIPTION
## Summary

- discover the native `extensions/work-control` source Profile before the bounded compatibility layout
- retain packaged Profile precedence and the existing compatibility fallback
- bind the source-layout regression test into the KFD-5 evidence authority and generated SDK projection

## Motivation

After the source Profile moved from `extensions/mission-control` to `extensions/work-control`, the Assignment CLI source fallback still searched only the compatibility directory. A new source workspace therefore failed before Work Control activation with `Work Control Profile is absent from this Kungfu product`.

## Validation

- `pytest framework/core/tests/python/test_assignment_orchestration.py` (63 passed)
- `node scripts/kfd-support-matrix.mjs --check` (passed)
- `node scripts/buildchain-kfd-evidence.mjs --check` (passed)
- `PATH=/Users/dkr/.cache/uv/archive-v0/_T8kv5tTmZ5O_RLL/bin:$PATH KUNGFU_READONLY_PYTEST=/Users/dkr/.cache/uv/archive-v0/_T8kv5tTmZ5O_RLL/bin/pytest KUNGFU_NATIVE_PATH=/Users/dkr/Worktrees/kungfu/review/codex/qualified-core-consumer-lifetime-e2e/framework/core/dist/kungfu ./shifu check:source` (passed; 770 passed, 10 skipped)
- staged repository gates (passed)

## Evolution Map

No Evolution Map change. This is an ADR-neutral correction to native Work Control Profile discovery.

## Governance risk

- [x] No authority widening
- [x] No schema or CLI compatibility change
- [x] No secret or credential handling change
- [x] No installed-product mutation

## Versioning

Patch.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore native Work Control Profile discovery after the source-layout rename without widening compatibility"
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LXF1YWxpZmllZC1hc3NpZ25tZW50LWNvcmUtY2FjaGUtZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yOS1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtY29uc3VtZXItbWF0ZXJpYWxpemF0aW9uIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJjOTgzZGE2YThhMzllN2NlYmFmZDRhZWIyZDgzYWIxN2MwZDg3NzJmIiwicHVsbFJlcXVlc3RIZWFkIjoiNzJmYTU2ZTAwMTZiODExZThiYjhhYzA3NTMwZGVkY2JhYWVjZWEyZSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiYjNjYWM0MjViZWE0MTJiNzMyOTY4Y2JmYThiMDA2MGFiY2VhNzkwNSIsInJlcGxheWVkVHJlZSI6ImU0NTlhYTZhNGMwOTFiN2RmMDZiMWM2NzgwYjE5YjU5OGQyMWQ0ODEiLCJxdWV1ZUF0dGVtcHQiOiI3MmZhNTZlMDAxNmI4MTFlOGJiOGFjMDc1MzBkZWRjYmFhZWNlYTJlQGM5ODNkYTZhOGEzOWU3Y2ViYWZkNGFlYjJkODNhYjE3YzBkODc3MmYiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6Nzg3ZDljMTZhOGIzODM1MTliYjU3MGQxODgyMzNmMjc0ZDkyODgxZDc5NjhjNDk2NzQyM2E0OWI3ZTk1ZTM2YSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2Ojc4N2Q5YzE2YThiMzgzNTE5YmI1NzBkMTg4MjMzZjI3NGQ5Mjg4MWQ3OTY4YzQ5Njc0MjNhNDliN2U5NWUzNmEiLCJzaGEyNTY6YzViODJjMTUzNDMxMWU3ZjkzNDc5YWEzMGVlNmE1YWIwZjYzNzY1ZDZmMDZiMzFlNDRjNzMyNGU4MDBmZDUxMiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzIyYzg0YjMxNzAxMDc5ZTIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6Mzc1Yjk1YTUxMDg0YzNmZmM3ZDliODlmN2I5ZWJkYjdhNjc1MzJjNzFhOTE2OTAzZTk1YmE1NzQ4OWZhOTMyMiJ9 -->