### PR TITLE
fix(demo): admit bounded product archive links

### DIFF
--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -347,10 +347,33 @@ def validate_member(member: tarfile.TarInfo) -> None:
         or parts[0] != ARCHIVE_ROOT
     ):
         fail(f"unsafe CLI archive member path: {name!r}")
-    if not (member.isfile() or member.isdir()):
+    if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
         fail(f"unsupported CLI archive member type: {name!r}")
+    if member.issym() or member.islnk():
+        linkname = member.linkname
+        link_parts = PurePosixPath(linkname).parts
+        if (
+            not linkname
+            or linkname.startswith("/")
+            or "\\" in linkname
+            or ".." in link_parts
+        ):
+            fail(f"unsafe CLI archive link target: {name!r} -> {linkname!r}")
+        if member.islnk() and (not link_parts or link_parts[0] != ARCHIVE_ROOT):
+            fail(f"unsafe CLI archive hardlink target: {name!r} -> {linkname!r}")
     if member.size < 0 or member.size > MAX_MEMBER_BYTES:
         fail(f"CLI archive member exceeds the bounded size: {name!r}")
+
+
+def member_path(target: Path, name: str) -> Path:
+    return target.joinpath(*PurePosixPath(name).parts)
+
+
+def link_target_path(target: Path, member: tarfile.TarInfo) -> Path:
+    link_parts = PurePosixPath(member.linkname).parts
+    if member.issym():
+        return member_path(target, member.name).parent.joinpath(*link_parts)
+    return target.joinpath(*link_parts)
 
 
 def extract_cli(archive_path: Path, target: Path) -> Path:
@@ -370,9 +393,11 @@ def extract_cli(archive_path: Path, target: Path) -> Path:
             if extracted_bytes > MAX_EXTRACTED_BYTES:
                 fail("CLI archive exceeds the bounded extracted size")
             for member in members:
-                destination = target.joinpath(*PurePosixPath(member.name).parts)
+                destination = member_path(target, member.name)
                 if member.isdir():
                     destination.mkdir(parents=True, exist_ok=True)
+                    continue
+                if member.issym() or member.islnk():
                     continue
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 source = archive.extractfile(member)
@@ -381,6 +406,34 @@ def extract_cli(archive_path: Path, target: Path) -> Path:
                 with destination.open("xb") as output:
                     shutil.copyfileobj(source, output, length=1024 * 1024)
                 os.chmod(destination, member.mode & 0o777)
+            for member in members:
+                if not (member.issym() or member.islnk()):
+                    continue
+                destination = member_path(target, member.name)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                source = link_target_path(target, member)
+                if member.issym():
+                    os.symlink(member.linkname, destination)
+                    continue
+                if source.is_symlink() or not source.is_file():
+                    fail(
+                        "CLI archive hardlink target must be an extracted regular "
+                        f"file: {member.name!r} -> {member.linkname!r}"
+                    )
+                os.link(source, destination)
+            archive_root = (target / ARCHIVE_ROOT).resolve()
+            for member in members:
+                if not member.issym():
+                    continue
+                destination = member_path(target, member.name)
+                try:
+                    resolved = destination.resolve(strict=True)
+                    resolved.relative_to(archive_root)
+                except (FileNotFoundError, RuntimeError, ValueError):
+                    fail(
+                        "CLI archive symlink must resolve inside the extracted "
+                        f"product: {member.name!r} -> {member.linkname!r}"
+                    )
     except (tarfile.TarError, OSError) as error:
         fail(f"cannot extract CLI archive: {error}")
     return target / ARCHIVE_ROOT

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -89,6 +89,8 @@ function fixture(
     coordinateSource = source,
     sourceEvidence = null,
     unsafeArchive = false,
+    safeArchiveLinks = false,
+    unsupportedArchiveMember = false,
     stdoutLineCount = 0,
     completionStatus = 'passed',
     omitSentinel = false,
@@ -203,6 +205,21 @@ function fixture(
   });
   if (unsafeArchive) {
     fs.symlinkSync('/tmp', path.join(productRoot, 'escape'));
+  }
+  if (safeArchiveLinks) {
+    const pythonRoot = path.join(productRoot, 'runtime', 'python', 'bin');
+    fs.mkdirSync(pythonRoot, { recursive: true });
+    const python3 = path.join(pythonRoot, 'python3');
+    fs.writeFileSync(python3, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(python3, 0o755);
+    fs.symlinkSync('python3', path.join(pythonRoot, 'python'));
+    fs.linkSync(python3, path.join(pythonRoot, 'python-copy'));
+  }
+  if (unsupportedArchiveMember) {
+    const fifo = spawnSync('mkfifo', [
+      path.join(productRoot, 'runtime', 'unsupported-fifo'),
+    ]);
+    assert.equal(fifo.status, 0, fifo.stderr?.toString());
   }
   const archive = path.join(
     artifact,
@@ -384,12 +401,37 @@ test('adapter rejects tree-equivalence evidence outside a pull merge ref', () =>
   }
 });
 
-test('adapter rejects symlink members before extraction', () => {
+test('adapter accepts bounded internal symlink and hardlink members', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'auditable-demo-adapter-'),
+  );
+  try {
+    const { result } = run(root, { safeArchiveLinks: true });
+    assert.equal(result.status, 0, result.stderr);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('adapter rejects symlink members that escape the archive root', () => {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'auditable-demo-adapter-'),
   );
   try {
     const { result } = run(root, { unsafeArchive: true });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unsafe CLI archive link target/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('adapter rejects unsupported archive member types', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'auditable-demo-adapter-'),
+  );
+  try {
+    const { result } = run(root, { unsupportedArchiveMember: true });
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /unsupported CLI archive member type/);
   } finally {


### PR DESCRIPTION
The first public Alpha candidate exposed a fail-closed mismatch between the real
Linux product archive and the auditable-demo extractor.

- Failure evidence: run 30491711634, job 90726484206
- Exact diagnostic: unsupported CLI archive member type:
  kungfu-episodes-cli-linux-x64/runtime/python/bin/python
- The product archive uses bounded internal symlink/hardlink members for the
  embedded Python runtime.

This patch admits only safe relative symlink/hardlink members, extracts links
after regular files, verifies symlinks resolve inside the product root, and
continues to reject absolute/parent-escaping targets and unsupported member
types such as FIFOs.

Validation:

- node --test scripts/auditable-demo-adapter.test.mjs (11/11 pass)
- python3 -m py_compile scripts/auditable-demo-adapter.py
- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check:source reached the final contract
  suite; the fresh local worktree lacked ajv/pytest and Shifu correctly
  rejected a direct package-manager install. Protected CI supplies the complete
  environment and remains authoritative.

Signed-off-by: Keren Dong <keren.dong+cx@kungfu.link>

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Admit only bounded in-product archive links required by packaged runtime layouts without widening release semantics"
}
-->