### PR TITLE
fix(qualification): admit safe CLI archive symlinks

### DIFF
--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -11,6 +11,7 @@ import fcntl
 import hashlib
 import json
 import os
+import posixpath
 import pty
 import re
 import select
@@ -347,8 +348,21 @@ def validate_member(member: tarfile.TarInfo) -> None:
         or parts[0] != ARCHIVE_ROOT
     ):
         fail(f"unsafe CLI archive member path: {name!r}")
-    if not (member.isfile() or member.isdir()):
+    if not (member.isfile() or member.isdir() or member.issym()):
         fail(f"unsupported CLI archive member type: {name!r}")
+    if member.issym():
+        linkname = member.linkname
+        if not linkname or linkname.startswith("/") or "\\" in linkname:
+            fail(f"unsafe CLI archive symlink target: {name!r} -> {linkname!r}")
+        normalized = PurePosixPath(
+            posixpath.normpath(str(PurePosixPath(name).parent / linkname))
+        )
+        if (
+            not normalized.parts
+            or normalized.parts[0] != ARCHIVE_ROOT
+            or ".." in normalized.parts
+        ):
+            fail(f"unsafe CLI archive symlink target: {name!r} -> {linkname!r}")
     if member.size < 0 or member.size > MAX_MEMBER_BYTES:
         fail(f"CLI archive member exceeds the bounded size: {name!r}")
 
@@ -369,10 +383,14 @@ def extract_cli(archive_path: Path, target: Path) -> Path:
             extracted_bytes = sum(member.size for member in members)
             if extracted_bytes > MAX_EXTRACTED_BYTES:
                 fail("CLI archive exceeds the bounded extracted size")
+            symlinks = []
             for member in members:
                 destination = target.joinpath(*PurePosixPath(member.name).parts)
                 if member.isdir():
                     destination.mkdir(parents=True, exist_ok=True)
+                    continue
+                if member.issym():
+                    symlinks.append((member, destination))
                     continue
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 source = archive.extractfile(member)
@@ -381,6 +399,24 @@ def extract_cli(archive_path: Path, target: Path) -> Path:
                 with destination.open("xb") as output:
                     shutil.copyfileobj(source, output, length=1024 * 1024)
                 os.chmod(destination, member.mode & 0o777)
+            for member, destination in symlinks:
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.symlink_to(member.linkname)
+            extracted_root = (target / ARCHIVE_ROOT).resolve()
+            for member, destination in symlinks:
+                try:
+                    resolved = destination.resolve(strict=True)
+                    resolved.relative_to(extracted_root)
+                except (OSError, RuntimeError, ValueError):
+                    fail(
+                        "CLI archive symlink does not resolve inside the product: "
+                        f"{member.name!r} -> {member.linkname!r}"
+                    )
+                if not resolved.is_file():
+                    fail(
+                        "CLI archive symlink must resolve to a regular file: "
+                        f"{member.name!r} -> {member.linkname!r}"
+                    )
     except (tarfile.TarError, OSError) as error:
         fail(f"cannot extract CLI archive: {error}")
     return target / ARCHIVE_ROOT

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -205,10 +205,7 @@ function fixture(
     const pythonBin = path.join(productRoot, 'runtime', 'python', 'bin');
     fs.mkdirSync(pythonBin, { recursive: true });
     fs.writeFileSync(path.join(pythonBin, 'python3'), '#!/bin/sh\nexit 0\n');
-    fs.symlinkSync(
-      archiveSymlinkTarget,
-      path.join(pythonBin, 'python'),
-    );
+    fs.symlinkSync(archiveSymlinkTarget, path.join(pythonBin, 'python'));
   }
   const archive = path.join(
     artifact,

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -88,7 +88,7 @@ function fixture(
     source = SOURCE_SHA,
     coordinateSource = source,
     sourceEvidence = null,
-    unsafeArchive = false,
+    archiveSymlinkTarget = '',
     stdoutLineCount = 0,
     completionStatus = 'passed',
     omitSentinel = false,
@@ -201,8 +201,14 @@ function fixture(
     platform: 'linux',
     architecture: 'x64',
   });
-  if (unsafeArchive) {
-    fs.symlinkSync('/tmp', path.join(productRoot, 'escape'));
+  if (archiveSymlinkTarget) {
+    const pythonBin = path.join(productRoot, 'runtime', 'python', 'bin');
+    fs.mkdirSync(pythonBin, { recursive: true });
+    fs.writeFileSync(path.join(pythonBin, 'python3'), '#!/bin/sh\nexit 0\n');
+    fs.symlinkSync(
+      archiveSymlinkTarget,
+      path.join(pythonBin, 'python'),
+    );
   }
   const archive = path.join(
     artifact,
@@ -384,16 +390,30 @@ test('adapter rejects tree-equivalence evidence outside a pull merge ref', () =>
   }
 });
 
-test('adapter rejects symlink members before extraction', () => {
+test('adapter accepts a bounded relative symlink to a regular archive member', () => {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'auditable-demo-adapter-'),
   );
   try {
-    const { result } = run(root, { unsafeArchive: true });
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /unsupported CLI archive member type/);
+    const { result } = run(root, { archiveSymlinkTarget: 'python3' });
+    assert.equal(result.status, 0, result.stderr);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('adapter rejects absolute and escaping archive symlinks before extraction', () => {
+  for (const archiveSymlinkTarget of ['/tmp', '../../../../outside']) {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'auditable-demo-adapter-'),
+    );
+    try {
+      const { result } = run(root, { archiveSymlinkTarget });
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /unsafe CLI archive symlink target/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

- admit relative CLI archive symlinks only when their normalized and resolved targets remain inside the extracted product
- keep hard links, absolute targets, traversal, broken links, cycles, and non-file targets fail-closed
- cover the real Python launcher shape plus absolute and escaping negatives

## Evidence

- Alpha candidate Build run 30491711634 built all four platforms successfully but required auditable-demo Gate rejected `runtime/python/bin/python` as an unsupported member type
- `node --test scripts/auditable-demo-adapter.test.mjs`: 10/10 pass
- staged repository pre-commit/source checks pass

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded qualification adapter repair admits only archive-internal symlinks and changes no architecture, product payload, or release authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Checklist

- [x] Commit is signed off (DCO)
- [x] Focused tests and staged gates passed