### PR TITLE
fix(work): defer Windows long-path admission validation

### DIFF
--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -258,7 +258,7 @@
           },
           {
             "path": "framework/core/tests/python/test_assignment_orchestration.py",
-            "sha256": "sha256:f04fc2c7da17d57c2fd38c6a9a81ffe53f1422ab30d9ae179d95bb0837f0dffc"
+            "sha256": "sha256:0054fc4698af5d9e53c04cd7d3638d5435b8b97b462d249777c8bbce3608a0b9"
           }
         ]
       },

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -258,7 +258,7 @@
           },
           {
             "path": "framework/core/tests/python/test_assignment_orchestration.py",
-            "sha256": "sha256:f04fc2c7da17d57c2fd38c6a9a81ffe53f1422ab30d9ae179d95bb0837f0dffc"
+            "sha256": "sha256:0054fc4698af5d9e53c04cd7d3638d5435b8b97b462d249777c8bbce3608a0b9"
           }
         ]
       },

--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -239,9 +239,7 @@ def capture(ctx, request_value, workspace_root, home, cwd, json_output):
 
 
 @assignment.command(help="admit one verified captured request into this workspace")
-@click.argument(
-    "request_file", type=click.Path(exists=True, dir_okay=False, path_type=Path)
-)
+@click.argument("request_file", type=click.Path(dir_okay=False, path_type=Path))
 @click.option("--workspace", "workspace_root", type=click.Path(file_okay=False))
 @click.option("--home", is_flag=True, help="admit into the logical Home Workspace")
 @click.option("--initiative-id", default="")

--- a/framework/core/tests/python/test_assignment_orchestration.py
+++ b/framework/core/tests/python/test_assignment_orchestration.py
@@ -63,6 +63,22 @@ def test_assignment_atomic_paths_use_windows_extended_namespace():
     assert network == (r"\\?\UNC\server\share\workspace\.kungfu\request.json")
 
 
+def test_assignment_admit_defers_request_path_validation_to_orchestration():
+    request_argument = next(
+        parameter
+        for parameter in ASSIGNMENT_CLI.admit.params
+        if parameter.name == "request_file"
+    )
+    request_path = (
+        Path("C:/actions-runner/_work/kungfu/kungfu/.buildchain/tmp")
+        / ("long-assignment-path-" + "x" * 240)
+        / "request.json"
+    )
+
+    assert request_argument.type.exists is False
+    assert request_argument.type.convert(str(request_path), None, None) == request_path
+
+
 def test_captured_request_reads_all_paths_through_filesystem_namespace(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- defer captured Assignment request path existence validation from Click to the orchestration filesystem boundary
- allow Windows extended-length path handling to occur before the request is opened
- preserve fail-closed request, receipt, content, and semantic validation in `load_captured_request`
- refresh the governed KFD-5 evidence root and SDK projection

## Verification

- `PYTHONPATH=framework/core/src/python:<ancestor-native> uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_assignment_orchestration.py` (64 passed)
- `./shifu check:source` (passed; source contracts, KFD gates, docs, type checks, Ruff and Biome)
- repository staged/pre-commit gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix Windows MAX_PATH handling at the existing Assignment admission boundary without changing product architecture or release authority."
}
-->

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression test added
- [x] No release credentials or publication authority
- [x] Assignment request semantics and receipt identity are unchanged