### PR TITLE
fix(qualification): let NSIS self-copy before uninstall

### DIFF
--- a/tests/qualification/layers/surfaces/installer.mjs
+++ b/tests/qualification/layers/surfaces/installer.mjs
@@ -52,6 +52,25 @@ export function copyMacApplication(source, destination) {
   run('ditto', [source, destination]);
 }
 
+export function nsisUninstallArgs() {
+  // Keep the standard NSIS temporary-copy behavior. The _?= override runs the
+  // uninstaller from $INSTDIR, where electron-builder's process check can
+  // mistake the uninstaller itself for a packaged application process.
+  return ['/S'];
+}
+
+export async function waitForPathRemoval(
+  target,
+  { timeoutMs = 60_000, pollIntervalMs = 100 } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (fs.existsSync(target)) {
+    if (Date.now() >= deadline)
+      fail(`timed out waiting for uninstall to remove ${target}`);
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
 export function installDesktopArtifact(installer, tempRoot) {
   const kind = installerKind(installer);
   const installRoot = path.join(tempRoot, 'installed-desktop');
@@ -88,7 +107,7 @@ export function installDesktopArtifact(installer, tempRoot) {
   return {
     kind,
     installRoot,
-    uninstall() {
+    async uninstall() {
       if (kind === 'nsis') {
         const uninstaller = findOne(
           installRoot,
@@ -96,7 +115,9 @@ export function installDesktopArtifact(installer, tempRoot) {
             entry.isFile() && /uninstall.*\.exe$/i.test(path.basename(target)),
           'NSIS uninstaller',
         );
-        run(uninstaller, ['/S', `_?=${installRoot}`]);
+        run(uninstaller, nsisUninstallArgs());
+        await waitForPathRemoval(installRoot);
+        return;
       }
       if (fs.existsSync(installRoot))
         fs.rmSync(installRoot, { recursive: true, force: true });

--- a/tests/qualification/layers/surfaces/installer.test.mjs
+++ b/tests/qualification/layers/surfaces/installer.test.mjs
@@ -5,13 +5,34 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { copyMacApplication, findOne, installerKind } from './installer.mjs';
+import {
+  copyMacApplication,
+  findOne,
+  installerKind,
+  nsisUninstallArgs,
+  waitForPathRemoval,
+} from './installer.mjs';
 
 test('recognizes every supported desktop installer family', () => {
   assert.equal(installerKind('Kungfu.dmg'), 'dmg');
   assert.equal(installerKind('Kungfu.AppImage'), 'appimage');
   assert.equal(installerKind('Kungfu Setup.exe'), 'nsis');
   assert.throws(() => installerKind('Kungfu.zip'), /unsupported/);
+});
+
+test('NSIS uninstall keeps the standard temporary-copy behavior', () => {
+  assert.deepEqual(nsisUninstallArgs(), ['/S']);
+  assert.equal(
+    nsisUninstallArgs().some((arg) => arg.startsWith('_?=')),
+    false,
+  );
+});
+
+test('waits for a detached NSIS uninstaller to remove its install root', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-wait-'));
+  setTimeout(() => fs.rmSync(root, { recursive: true, force: true }), 20);
+  await waitForPathRemoval(root, { timeoutMs: 500, pollIntervalMs: 5 });
+  assert.equal(fs.existsSync(root), false);
 });
 
 test('DMG discovery stops below the matched application bundle', () => {

--- a/tests/qualification/layers/surfaces/run.mjs
+++ b/tests/qualification/layers/surfaces/run.mjs
@@ -320,7 +320,7 @@ async function exactQualification(options, fixture) {
     if (!guiMemory.stdout.includes('KF_GUI_QUALIFICATION_READY'))
       fail('packaged GUI did not reach qualification-ready state');
     const installedDesktopBytes = directoryBytes(desktopInstall.installRoot);
-    desktopInstall.uninstall();
+    await desktopInstall.uninstall();
     if (fs.existsSync(desktopInstall.installRoot))
       fail('GUI install root survived uninstall');
 


### PR DESCRIPTION
## Summary

Fix GitHub-hosted Windows surface qualification by preserving the standard NSIS temporary-copy uninstall behavior. The previous `_?=` override kept the uninstaller inside the install root, where electron-builder 26.15.3 process detection could terminate the uninstaller itself.

## Related issue

None.

## Changes

- invoke the NSIS uninstaller with `/S` without the no-copy override
- wait boundedly for a detached temporary uninstaller to remove the install root
- make the surface qualification await real uninstall completion
- add regression coverage for the command boundary and asynchronous removal

## Verification

- `./shifu check`
- GitHub-hosted Windows alpha qualification will provide the exact installer/uninstaller regression proof

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fix corrects the existing Windows installer qualification harness without changing an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects release qualification evidence only; it does not publish artifacts or change release identity.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed — not applicable; product behavior is unchanged

## GitHub-hosted Windows proof

- Exact source: `51941f9db831b938ff022e61475de7faf2a3269a`
- Alpha preflight: https://github.com/kungfu-systems/kungfu/actions/runs/30501796822 (success)
- Windows-only full lifecycle: https://github.com/kungfu-systems/kungfu/actions/runs/30501919863 (success)
- Windows job: 2h21m57s total; build 59m08s; verify 50m20s. The NSIS uninstall qualification completed successfully.