### PR TITLE
fix(product): qualify packaged TUI autoplay

### DIFF
--- a/framework/core/src/python/kungfu/cli/tui_runtime.py
+++ b/framework/core/src/python/kungfu/cli/tui_runtime.py
@@ -34,16 +34,24 @@ def _resolve_tui_entry():
     return None
 
 
-def run_tui(ctx, commands=()):
-    """Launch the shipped TUI without creating a second command authority."""
-
+def _configure_tui_environment(binding_file, runtime_dir):
     os.environ["KUNGFU_AS_VARIANT"] = "node"
-    os.environ.setdefault("KUNGFU_DIR", os.path.dirname(kungfu.__binding__.__file__))
+    os.environ.setdefault("KUNGFU_DIR", os.path.dirname(binding_file))
+    os.environ.setdefault(
+        "KF_BUNDLED_EXTENSION_ROOT",
+        os.path.abspath(os.path.join(os.environ["KUNGFU_DIR"], "..", "extensions")),
+    )
     os.environ.setdefault(
         "KUNGFU_KFX_CONTRACT",
         os.path.join(os.environ["KUNGFU_DIR"], "config", "kungfu-kfx.contract.json"),
     )
-    os.environ.setdefault("KF_RUNTIME_DIR", ctx.runtime_dir)
+    os.environ.setdefault("KF_RUNTIME_DIR", runtime_dir)
+
+
+def run_tui(ctx, commands=()):
+    """Launch the shipped TUI without creating a second command authority."""
+
+    _configure_tui_environment(kungfu.__binding__.__file__, ctx.runtime_dir)
     entry = _resolve_tui_entry()
     if not entry:
         raise click.ClickException(

--- a/framework/core/tests/python/test_tui_runtime.py
+++ b/framework/core/tests/python/test_tui_runtime.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+
+def _load_tui_runtime(monkeypatch):
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "python"
+        / "kungfu"
+        / "cli"
+        / "tui_runtime.py"
+    )
+    fake_kungfu = types.ModuleType("kungfu")
+    monkeypatch.setitem(sys.modules, "kungfu", fake_kungfu)
+    spec = importlib.util.spec_from_file_location("tui_runtime_fixture", source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_packaged_tui_exports_its_bundled_extension_root(tmp_path, monkeypatch):
+    tui_runtime = _load_tui_runtime(monkeypatch)
+    runtime = tmp_path / "product" / "runtime"
+    binding = runtime / "pykungfu.so"
+    home = tmp_path / "home" / "runtime"
+    monkeypatch.delenv("KUNGFU_DIR", raising=False)
+    monkeypatch.delenv("KF_BUNDLED_EXTENSION_ROOT", raising=False)
+
+    tui_runtime._configure_tui_environment(str(binding), str(home))
+
+    assert os.environ["KUNGFU_DIR"] == str(runtime)
+    assert os.environ["KF_BUNDLED_EXTENSION_ROOT"] == str(
+        tmp_path / "product" / "extensions"
+    )
+    assert os.environ["KF_RUNTIME_DIR"] == str(home)

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -50,6 +50,7 @@ import {
 import {
   TerminalLifecycle,
   describeCliFailure,
+  resolveTuiCoreDir,
   resolveTuiRuntimeDir,
 } from './terminal-lifecycle.js';
 import {
@@ -70,9 +71,11 @@ function cliEnvironment(): NodeJS.ProcessEnv {
 }
 
 function runtimePaths() {
-  const coreDir = path.dirname(
-    nodeRequire.resolve('@kungfu-tech/core/package.json'),
-  );
+  const coreDir = resolveTuiCoreDir({
+    env: process.env,
+    resolveCorePackage: () =>
+      nodeRequire.resolve('@kungfu-tech/core/package.json'),
+  });
   const kungfuDir =
     process.env.KUNGFU_DIR || path.join(coreDir, 'dist', 'kungfu');
   const packagedBin = path.join(

--- a/framework/tui/src/terminal-lifecycle.test.ts
+++ b/framework/tui/src/terminal-lifecycle.test.ts
@@ -14,6 +14,7 @@ import {
   type TerminalInput,
   TerminalLifecycle,
   type TerminalOutput,
+  resolveTuiCoreDir,
 } from './terminal-lifecycle.js';
 
 class FakeOutput extends EventEmitter implements TerminalOutput {
@@ -26,6 +27,31 @@ class FakeOutput extends EventEmitter implements TerminalOutput {
     return true;
   }
 }
+
+test('packaged runtime resolution does not require the source core package', () => {
+  let sourceResolutionCalled = false;
+  assert.equal(
+    resolveTuiCoreDir({
+      env: { KUNGFU_DIR: '/opt/kungfu/product/runtime' },
+      resolveCorePackage: () => {
+        sourceResolutionCalled = true;
+        throw new Error('source package is not installed');
+      },
+    }),
+    path.resolve('/opt/kungfu/product'),
+  );
+  assert.equal(sourceResolutionCalled, false);
+});
+
+test('source runtime resolution keeps the workspace package fallback', () => {
+  assert.equal(
+    resolveTuiCoreDir({
+      env: {},
+      resolveCorePackage: () => '/workspace/framework/core/package.json',
+    }),
+    '/workspace/framework/core',
+  );
+});
 
 test('owns alternate screen, raw mode, resize, and idempotent restoration', () => {
   const output = new FakeOutput();

--- a/framework/tui/src/terminal-lifecycle.ts
+++ b/framework/tui/src/terminal-lifecycle.ts
@@ -35,6 +35,19 @@ export type ProcessSignals = {
   off: (event: string, listener: Listener) => unknown;
 };
 
+export function resolveTuiCoreDir({
+  env,
+  resolveCorePackage,
+}: {
+  env: NodeJS.ProcessEnv;
+  resolveCorePackage: () => string;
+}): string {
+  const packagedRuntime = env.KUNGFU_DIR;
+  return packagedRuntime
+    ? path.dirname(path.resolve(packagedRuntime))
+    : path.dirname(resolveCorePackage());
+}
+
 type RuntimeResolution = {
   runtimeHomeEnv?: string;
   defaultRuntimeHome?: Record<string, string>;

--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -569,7 +569,7 @@ def validate_completion(decoded: str) -> dict[str, Any]:
     )
     if (
         completion["schema"] != "kungfu.agent-work-lab.tui-autoplay/v1"
-        or completion["status"] != "passed"
+        or completion["status"] != "qualified"
         or not SHA256.fullmatch(str(completion["reportRoot"]))
         or not isinstance(completion["eventCount"], int)
         or isinstance(completion["eventCount"], bool)

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -90,7 +90,7 @@ function fixture(
     sourceEvidence = null,
     archiveSymlinkTarget = '',
     stdoutLineCount = 0,
-    completionStatus = 'passed',
+    completionStatus = 'qualified',
     omitSentinel = false,
     exitCode = 0,
     privateOutput = '',
@@ -280,7 +280,7 @@ test('adapter executes only the exact installed archive in a PTY and emits the d
     );
     assert.equal(capture.command, 'kungfu agent-work-lab autoplay');
     assert.deepEqual(capture.dimensions, { columns: 120, rows: 36 });
-    assert.equal(capture.completion.status, 'passed');
+    assert.equal(capture.completion.status, 'qualified');
     assert.deepEqual(capture.authority.grants, []);
     assert.deepEqual(capture.authority.nonAuthorities, [
       'first-party-identity',


### PR DESCRIPTION
## Summary

- resolve the packaged TUI from `KUNGFU_DIR` without requiring the source-only `@kungfu-tech/core` package
- export the CLI product's bundled `extensions/` root before entering embedded Node
- align the auditable-demo completion gate with the Agent Work Lab's authoritative `qualified` verdict

## Evidence

- Alpha candidate Build run `30501250218` built all four platforms; the Linux auditable-demo Gate exposed the missing packaged Core module
- exact retained artifact `kungfu-linux-x64-946789145d68d913eb837cb1c99cc23eea2bb7f3` (`sha256:9d78a4de934889f4f145866e3af5c24ba8f80f6dce6578875c305f0c3817043a`) reproduced the failure on agent-120
- the newly bundled TUI drove that same installed artifact to one `qualified` completion sentinel with exit status zero and no module/catalog error
- TUI tests: 73/73 pass
- auditable-demo tests: 28/28 pass
- packaged-environment Python regression: 1/1 pass
- `./shifu check:source`: pass
- repository pre-commit gate: pass

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded product-packaging repair restores already-declared bundled runtime and Agent Work Lab verdict semantics; it changes no architecture or release authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Checklist

- [x] Commit is signed off (DCO)
- [x] Focused tests and staged/source gates passed
- [x] Exact retained Linux product artifact reproduced and passed after the bounded fixes
