### PR TITLE
fix(product): restore installed TUI autoplay

### DIFF
--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -4,7 +4,6 @@ import { execFile, execFileSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { constants as osConstants } from 'node:os';
-import { homedir } from 'node:os';
 import path from 'node:path';
 import {
   type AgentWorkLab,
@@ -43,15 +42,12 @@ import {
   quickCommandMatches,
   reduceControlPlaneInput,
 } from './profile-shell.js';
+import { resolveTuiRuntimePaths } from './runtime-paths.js';
 import {
   IncrementalTerminalOutput,
   terminalCanvasRows,
 } from './terminal-canvas.js';
-import {
-  TerminalLifecycle,
-  describeCliFailure,
-  resolveTuiRuntimeDir,
-} from './terminal-lifecycle.js';
+import { TerminalLifecycle, describeCliFailure } from './terminal-lifecycle.js';
 import {
   degradedGlobalWorkModel,
   globalWorkContribution,
@@ -70,33 +66,13 @@ function cliEnvironment(): NodeJS.ProcessEnv {
 }
 
 function runtimePaths() {
-  const coreDir = path.dirname(
-    nodeRequire.resolve('@kungfu-tech/core/package.json'),
-  );
-  const kungfuDir =
-    process.env.KUNGFU_DIR || path.join(coreDir, 'dist', 'kungfu');
-  const packagedBin = path.join(
-    kungfuDir,
-    process.platform === 'win32' ? 'kungfu.exe' : 'kungfu',
-  );
-  const configuredBin =
-    process.env.KUNGFU_CLI_BIN || process.env.KUNGFU_BIN || '';
-  return {
-    coreDir,
-    runtimeDir: resolveTuiRuntimeDir({
-      env: process.env,
-      cwd: process.cwd(),
-      contractPath: path.join(
-        kungfuDir,
-        'config',
-        'kungfu-config.contract.json',
-      ),
-    }),
-    configHome:
-      process.env.KF_CONFIG_HOME || path.join(homedir(), '.kungfu-config'),
-    bin: configuredBin || (fs.existsSync(packagedBin) ? packagedBin : 'kungfu'),
-    sourceCliFallback: !configuredBin && !fs.existsSync(packagedBin),
-  };
+  return resolveTuiRuntimePaths({
+    env: process.env,
+    cwd: process.cwd(),
+    platform: process.platform,
+    resolveCorePackagePath: () =>
+      nodeRequire.resolve('@kungfu-tech/core/package.json'),
+  });
 }
 
 function openTuiAgentWorkLab(): AgentWorkLab {

--- a/framework/tui/src/runtime-paths.test.ts
+++ b/framework/tui/src/runtime-paths.test.ts
@@ -6,7 +6,41 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
+import { resolveTuiRuntimePaths } from './runtime-paths.js';
 import { resolveTuiRuntimeDir } from './terminal-lifecycle.js';
+
+test('uses the packaged runtime without resolving the source core package', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-tui-product-'));
+  try {
+    const kungfuDir = path.join(root, 'runtime');
+    const launcher = path.join(kungfuDir, 'kungfu');
+    fs.mkdirSync(kungfuDir, { recursive: true });
+    fs.writeFileSync(launcher, '');
+    let sourceResolutionCalls = 0;
+    const paths = resolveTuiRuntimePaths({
+      env: {
+        HOME: root,
+        KUNGFU_DIR: kungfuDir,
+        KF_CONFIG_HOME: path.join(root, 'config'),
+        KF_RUNTIME_DIR: path.join(root, 'state'),
+      },
+      cwd: root,
+      platform: 'linux',
+      resolveCorePackagePath: () => {
+        sourceResolutionCalls += 1;
+        throw new Error('the installed product has no source npm package');
+      },
+    });
+
+    assert.equal(sourceResolutionCalls, 0);
+    assert.equal(paths.coreDir, root);
+    assert.equal(paths.bin, launcher);
+    assert.equal(paths.sourceCliFallback, false);
+    assert.equal(paths.runtimeDir, path.join(root, 'state'));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test('preserves CLI runtime-root precedence without booting Python', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-tui-runtime-'));

--- a/framework/tui/src/runtime-paths.ts
+++ b/framework/tui/src/runtime-paths.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { resolveTuiRuntimeDir } from './terminal-lifecycle.js';
+
+export function resolveTuiRuntimePaths({
+  env,
+  cwd,
+  platform,
+  resolveCorePackagePath,
+}: {
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+  platform: NodeJS.Platform;
+  resolveCorePackagePath: () => string;
+}) {
+  const configuredKungfuDir = env.KUNGFU_DIR;
+  const coreDir = configuredKungfuDir
+    ? path.dirname(path.resolve(configuredKungfuDir))
+    : path.dirname(resolveCorePackagePath());
+  const kungfuDir = configuredKungfuDir
+    ? path.resolve(configuredKungfuDir)
+    : path.join(coreDir, 'dist', 'kungfu');
+  const packagedBin = path.join(
+    kungfuDir,
+    platform === 'win32' ? 'kungfu.exe' : 'kungfu',
+  );
+  const configuredBin = env.KUNGFU_CLI_BIN || env.KUNGFU_BIN || '';
+  const packagedBinPresent = fs.existsSync(packagedBin);
+  return {
+    coreDir,
+    runtimeDir: resolveTuiRuntimeDir({
+      env,
+      cwd,
+      contractPath: path.join(
+        kungfuDir,
+        'config',
+        'kungfu-config.contract.json',
+      ),
+    }),
+    configHome: env.KF_CONFIG_HOME || path.join(homedir(), '.kungfu-config'),
+    bin: configuredBin || (packagedBinPresent ? packagedBin : 'kungfu'),
+    sourceCliFallback: !configuredBin && !packagedBinPresent,
+  };
+}

--- a/product/scripts/cli-launcher.mjs
+++ b/product/scripts/cli-launcher.mjs
@@ -6,6 +6,7 @@ export function cliLauncherContent(platform = process.platform) {
       '@echo off',
       'set "KUNGFU_PRODUCT_MANIFEST=%~dp0product.json"',
       'set "KUNGFU_UPGRADE_MANIFEST=%~dp0upgrade\\kungfu-release-manifest.json"',
+      'if not defined KF_BUNDLED_EXTENSION_ROOT set "KF_BUNDLED_EXTENSION_ROOT=%~dp0extensions"',
       '"%~dp0runtime\\kungfu.exe" %*',
       '',
     ].join('\r\n');
@@ -23,6 +24,8 @@ done
 here=$(cd "$(dirname "$target")" && pwd)
 export KUNGFU_PRODUCT_MANIFEST="$here/product.json"
 export KUNGFU_UPGRADE_MANIFEST="$here/upgrade/kungfu-release-manifest.json"
+: "\${KF_BUNDLED_EXTENSION_ROOT:=$here/extensions}"
+export KF_BUNDLED_EXTENSION_ROOT
 exec "$here/runtime/kungfu" "$@"
 `;
 }

--- a/product/scripts/cli-launcher.test.mjs
+++ b/product/scripts/cli-launcher.test.mjs
@@ -9,6 +9,7 @@ import { cliLauncherContent } from './cli-launcher.mjs';
 test('CLI launchers defer install ownership to the colocated product manifest', () => {
   const posix = cliLauncherContent('linux');
   assert.match(posix, /KUNGFU_PRODUCT_MANIFEST="\$here\/product\.json"/);
+  assert.match(posix, /KF_BUNDLED_EXTENSION_ROOT:=\$here\/extensions/u);
   assert.match(posix, /while \[ -L "\$target" \]/);
   assert.match(posix, /exec "\$here\/runtime\/kungfu" "\$@"/);
   assert.doesNotMatch(posix, /KUNGFU_INSTALL_SOURCE/);
@@ -16,6 +17,10 @@ test('CLI launchers defer install ownership to the colocated product manifest', 
 
   const windows = cliLauncherContent('win32');
   assert.match(windows, /%~dp0runtime\\kungfu\.exe/);
+  assert.match(
+    windows,
+    /if not defined KF_BUNDLED_EXTENSION_ROOT set "KF_BUNDLED_EXTENSION_ROOT=%~dp0extensions"/u,
+  );
   assert.doesNotMatch(windows, /KUNGFU_INSTALL_SOURCE/);
   assert.doesNotMatch(windows, /electron/i);
 });

--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -569,14 +569,14 @@ def validate_completion(decoded: str) -> dict[str, Any]:
     )
     if (
         completion["schema"] != "kungfu.agent-work-lab.tui-autoplay/v1"
-        or completion["status"] != "passed"
+        or completion["status"] != "qualified"
         or not SHA256.fullmatch(str(completion["reportRoot"]))
         or not isinstance(completion["eventCount"], int)
         or isinstance(completion["eventCount"], bool)
         or completion["eventCount"] < 1
         or completion["eventCount"] > 100_000
     ):
-        fail("installed kungfu autoplay completion sentinel did not pass")
+        fail("installed kungfu autoplay completion sentinel did not qualify")
     return completion
 
 

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -90,7 +90,7 @@ function fixture(
     sourceEvidence = null,
     archiveSymlinkTarget = '',
     stdoutLineCount = 0,
-    completionStatus = 'passed',
+    completionStatus = 'qualified',
     omitSentinel = false,
     exitCode = 0,
     privateOutput = '',
@@ -280,7 +280,7 @@ test('adapter executes only the exact installed archive in a PTY and emits the d
     );
     assert.equal(capture.command, 'kungfu agent-work-lab autoplay');
     assert.deepEqual(capture.dimensions, { columns: 120, rows: 36 });
-    assert.equal(capture.completion.status, 'passed');
+    assert.equal(capture.completion.status, 'qualified');
     assert.deepEqual(capture.authority.grants, []);
     assert.deepEqual(capture.authority.nonAuthorities, [
       'first-party-identity',
@@ -417,7 +417,7 @@ test('adapter rejects absolute and escaping archive symlinks before extraction',
 test('adapter fails closed on missing, failed, or nonzero autoplay completion', () => {
   for (const [options, expected] of [
     [{ omitSentinel: true }, /must emit exactly one/u],
-    [{ completionStatus: 'failed' }, /completion sentinel did not pass/u],
+    [{ completionStatus: 'failed' }, /completion sentinel did not qualify/u],
     [{ exitCode: 9 }, /failed with exit status 9/u],
   ]) {
     const root = fs.mkdtempSync(


### PR DESCRIPTION
## Summary

Restore the installed CLI TUI autoplay contract that blocked the first public Alpha candidate.

## Related issue

Supersedes the failed auditable-demo Gate observed on Alpha PR #1922.

## Changes

- resolve source package paths lazily so packaged runtimes do not require @kungfu-tech/core
- expose the packaged first-party extension root from generated CLI launchers
- align the auditable-demo completion check with the canonical qualified report status

## Verification

- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check
- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check:source
- ./shifu --filter @kungfu-tech/tui test
- ./shifu test:auditable-demo
- exact 663 MB retained Linux artifact adapter replay: exit 0, one qualified sentinel, public projection generated

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores already-declared packaged runtime and auditable-demo contracts without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects the release demo Gate only; the full Buildchain release workflow remains fail-closed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; contract behavior is restored)