### PR TITLE
test(shifu): harden direct entry correction assertion

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -349,7 +349,7 @@ test('runtime guard rejects a direct task and accepts Shifu provenance', () => {
   assert.equal(accepted.status, 0);
 });
 
-test('package manager cannot run a guarded root task without Shifu', () => {
+test('package manager cannot run a guarded root task without a canonical Shifu correction', () => {
   const corepack = process.platform === 'win32' ? 'corepack.cmd' : 'corepack';
   const direct = spawnSync(corepack, ['pnpm', 'run', 'check:entry-contract'], {
     cwd: ROOT,
@@ -357,13 +357,12 @@ test('package manager cannot run a guarded root task without Shifu', () => {
     env: { ...process.env, SHIFU_ENTRYPOINT: '' },
     shell: process.platform === 'win32',
   });
+  const output = `${direct.stdout}\n${direct.stderr}`;
   assert.equal(direct.status, 1);
+  assert.match(output, /Direct package-manager invocation is unsupported/);
   assert.match(
-    `${direct.stdout}\n${direct.stderr}`,
-    /Direct package-manager invocation is unsupported/,
+    output,
+    /\[shifu-entry\] Run: \.\/shifu (?:install|check:entry-contract)(?:\r?\n|$)/,
   );
-  assert.match(
-    `${direct.stdout}\n${direct.stderr}`,
-    /\.\/shifu check:entry-contract/,
-  );
+  assert.doesNotMatch(output, /\[shifu-entry\] Run: (?:corepack|node|pnpm)\b/);
 });


### PR DESCRIPTION
## Summary

Make the direct package-manager guard regression deterministic across both a synchronized checkout and a first-run dependency synchronization.

## Related issue

None.

## Changes

- accept only the two canonical Shifu corrections emitted by the guarded root lifecycle: `./shifu install` during dependency synchronization or `./shifu check:entry-contract` after synchronization
- reject correction text that recommends direct `corepack`, `node`, or `pnpm` invocation
- reuse one captured process output for all assertions

## Verification

- `./shifu test:shifu-xinfa-source` (28 passed)
- `./shifu test:shifu-kfd-readonly` with the Buildchain-equivalent source-tool projection (40 passed, including the cold read-only nested source gate)
- `./shifu check:entry-contract`
- `./shifu check:source` against protected base `be1023eb60638b4c94c0543d6203e50774fe55df` (770 passed, 10 skipped, 0 failed)
- commit-time staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This test-only fix preserves the existing Shifu entry contract and narrows accepted correction text without changing architecture or release semantics."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; test-only contract hardening)
