### PR TITLE
fix(qualification): keep durable host out of installer smoke

### DIFF
--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -1255,13 +1255,19 @@ app.whenReady().then(() => {
       console.log(`KF_TERMINAL_HOST_MAIN_FAIL ${(e as Error).message}`);
     }
   }
-  try {
-    const agentSessionHost = createMainAgentSessionHost(
-      process.env.KF_RUNTIME_DIR || app.getPath('userData'),
-    );
-    bindElectronAgentSessionHost(ipcMain, agentSessionHost);
-  } catch (e) {
-    console.log(`KF_AGENT_SESSION_HOST_FAIL ${(e as Error).message}`);
+  // The detached host deliberately survives the Electron main process. An
+  // installer qualification immediately uninstalls its temporary application,
+  // so starting that durable worker would leave an executable under $INSTDIR
+  // while NSIS is proving removal. Normal product launches retain the host.
+  if (!qualificationMode) {
+    try {
+      const agentSessionHost = createMainAgentSessionHost(
+        process.env.KF_RUNTIME_DIR || app.getPath('userData'),
+      );
+      bindElectronAgentSessionHost(ipcMain, agentSessionHost);
+    } catch (e) {
+      console.log(`KF_AGENT_SESSION_HOST_FAIL ${(e as Error).message}`);
+    }
   }
   // KF-ADR-019f86da-4f90-7153-a6c1-ab7a0a3cf481 stage 2 (flagged): let a session pop out of the in-shell grid into
   // its own restorable OS window. The handlers are global, so bind once; the

--- a/framework/gui/src/renderer/src/runtime.ts
+++ b/framework/gui/src/renderer/src/runtime.ts
@@ -541,7 +541,13 @@ function createRuntime(): Runtime {
         return result.stdout;
       },
     });
-    const agentSession = createAgentSessionProxy(cliIpc);
+    // Installer qualification is intentionally one-shot. Do not expose the
+    // durable Agent Session capability there: its worker outlives Electron and
+    // would keep the temporary installation active during the uninstall gate.
+    const agentSession =
+      env.KF_QUALIFICATION_MODE === '1'
+        ? null
+        : createAgentSessionProxy(cliIpc);
     const workspace = openWorkspaceGuidance(cliOptions);
     const remoteWork = openRemoteWork({
       binding,

--- a/tests/qualification/layers/surfaces/installer.mjs
+++ b/tests/qualification/layers/surfaces/installer.mjs
@@ -59,14 +59,86 @@ export function nsisUninstallArgs() {
   return ['/S'];
 }
 
+export function pathRemovalDiagnostics(
+  target,
+  { platform = process.platform } = {},
+) {
+  const diagnostics = { remaining_entries: [], processes_under_root: [] };
+  try {
+    diagnostics.remaining_entries = fs
+      .readdirSync(target, { withFileTypes: true })
+      .slice(0, 24)
+      .map((entry) => `${entry.isDirectory() ? 'dir' : 'file'}:${entry.name}`);
+  } catch (error) {
+    diagnostics.remaining_entries = [
+      `unreadable:${error instanceof Error ? error.message : String(error)}`,
+    ];
+  }
+  if (platform !== 'win32') return diagnostics;
+
+  const script = [
+    '$root = [IO.Path]::GetFullPath($env:KF_QUALIFICATION_INSTALL_ROOT)',
+    '$matches = @(Get-CimInstance -ClassName Win32_Process | Where-Object {',
+    '  $_.ExecutablePath -and $_.ExecutablePath.StartsWith($root, [StringComparison]::OrdinalIgnoreCase)',
+    '} | Select-Object ProcessId, Name, ExecutablePath)',
+    '$matches | ConvertTo-Json -Compress',
+  ].join('\n');
+  const result = spawnSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    {
+      encoding: 'utf8',
+      windowsHide: true,
+      env: { ...process.env, KF_QUALIFICATION_INSTALL_ROOT: target },
+    },
+  );
+  if (result.status !== 0) {
+    diagnostics.processes_under_root = [
+      {
+        diagnostic_error: (
+          result.stderr ||
+          result.error?.message ||
+          'PowerShell failed'
+        ).trim(),
+      },
+    ];
+    return diagnostics;
+  }
+  try {
+    const parsed = JSON.parse(result.stdout || '[]');
+    diagnostics.processes_under_root = Array.isArray(parsed)
+      ? parsed
+      : parsed
+        ? [parsed]
+        : [];
+  } catch (error) {
+    diagnostics.processes_under_root = [
+      {
+        diagnostic_error: `invalid PowerShell JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      },
+    ];
+  }
+  return diagnostics;
+}
+
 export async function waitForPathRemoval(
   target,
-  { timeoutMs = 60_000, pollIntervalMs = 100 } = {},
+  {
+    timeoutMs = 60_000,
+    pollIntervalMs = 100,
+    diagnostics = pathRemovalDiagnostics,
+  } = {},
 ) {
   const deadline = Date.now() + timeoutMs;
   while (fs.existsSync(target)) {
     if (Date.now() >= deadline)
-      fail(`timed out waiting for uninstall to remove ${target}`);
+      fail(
+        `timed out waiting for uninstall to remove ${target}; diagnostics=${JSON.stringify(
+          diagnostics(target),
+        )}`,
+      );
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 }

--- a/tests/qualification/layers/surfaces/installer.test.mjs
+++ b/tests/qualification/layers/surfaces/installer.test.mjs
@@ -5,11 +5,13 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import {
   copyMacApplication,
   findOne,
   installerKind,
   nsisUninstallArgs,
+  pathRemovalDiagnostics,
   waitForPathRemoval,
 } from './installer.mjs';
 
@@ -33,6 +35,47 @@ test('waits for a detached NSIS uninstaller to remove its install root', async (
   setTimeout(() => fs.rmSync(root, { recursive: true, force: true }), 20);
   await waitForPathRemoval(root, { timeoutMs: 500, pollIntervalMs: 5 });
   assert.equal(fs.existsSync(root), false);
+});
+
+test('reports bounded removal diagnostics instead of hiding an uninstall lock', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-lock-'));
+  fs.writeFileSync(path.join(root, 'locked.exe'), 'fixture');
+  try {
+    await assert.rejects(
+      waitForPathRemoval(root, {
+        timeoutMs: 10,
+        pollIntervalMs: 1,
+        diagnostics: (target) =>
+          pathRemovalDiagnostics(target, { platform: 'linux' }),
+      }),
+      /diagnostics=.*file:locked\.exe/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('one-shot GUI qualification cannot start the durable Agent Session host', () => {
+  const root = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../../..',
+  );
+  const mainSource = fs.readFileSync(
+    path.join(root, 'framework/gui/src/main/index.ts'),
+    'utf8',
+  );
+  const rendererSource = fs.readFileSync(
+    path.join(root, 'framework/gui/src/renderer/src/runtime.ts'),
+    'utf8',
+  );
+  assert.match(
+    mainSource,
+    /if \(!qualificationMode\) \{[\s\S]*createMainAgentSessionHost/u,
+  );
+  assert.match(
+    rendererSource,
+    /env\.KF_QUALIFICATION_MODE === '1'[\s\S]*\? null[\s\S]*createAgentSessionProxy/u,
+  );
 });
 
 test('DMG discovery stops below the matched application bundle', () => {


### PR DESCRIPTION
## Summary

Keep the detached Agent Session host out of one-shot installer qualification so its worker cannot retain an executable under the temporary Windows install root while NSIS proves uninstall removal. Normal product launches retain the durable host.

## Related issue

None.

## Changes

- do not start or expose the durable Agent Session host in `KF_QUALIFICATION_MODE`
- preserve the existing host for every normal product launch
- retain the bounded 60-second uninstall deadline
- report bounded remaining-entry and process-path diagnostics if removal times out
- add regression coverage for the qualification boundary and timeout evidence

## Verification

- `./shifu check:source`
- installer surface tests: 7/7 passed
- changed GUI TypeScript check: 2 files passed
- GitHub-hosted Windows full lifecycle will provide the exact installer/uninstaller proof

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fix enforces the existing one-shot installer qualification boundary without changing the Agent Session product architecture."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects release qualification evidence only. Diagnostics omit command lines and remain bounded; no artifacts are published and release identity is unchanged.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed — not applicable; normal product behavior is unchanged
