### PR TITLE
fix(ci): retire Buildchain v2 AWS burst campaigns

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -1,93 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
-name: AWS US Linux Burst Qualification
+# The bounded v2 CodeBuild campaign is complete. Keep this dispatchable
+# tombstone so stale operator bookmarks fail before any burst runner or cloud
+# work. Reactivation is governed by the machine-readable contract below.
+name: AWS US Linux Burst Qualification (Retired)
 
 on:
   workflow_dispatch:
-    inputs:
-      qualification-id:
-        description: "Auditable slot label for this bounded PoC run"
-        required: true
-      buildchain-ref:
-        description: "Exact reviewed Buildchain train for this campaign"
-        required: true
-        default: "train/v2/v2.3/aws-us-elastic-runner-burst-plane"
 
 permissions:
   contents: read
-  issues: write
-
-concurrency:
-  group: aws-us-linux-burst-${{ github.run_id }}
-  cancel-in-progress: false
 
 jobs:
-  trust:
-    name: Reject non-canonical or untrusted dispatch
+  retired:
+    name: Reject retired AWS Linux burst campaign
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
     steps:
-      - name: Require canonical repository and reviewed train
+      - name: Fail closed before burst runner or cloud work
         shell: bash
         env:
-          EXPECTED_REPOSITORY: kungfu-systems/kungfu
-          EXPECTED_BUILDCHAIN_REF: train/v2/v2.3/aws-us-elastic-runner-burst-plane
-          REQUESTED_BUILDCHAIN_REF: ${{ inputs.buildchain-ref }}
-          QUALIFICATION_ID: ${{ inputs.qualification-id }}
+          RETIREMENT_CONTRACT: docs/qualification/gates/aws-burst-retirement.json
         run: |
           set -euo pipefail
-          test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
-          test "${GITHUB_REPOSITORY}" = "${EXPECTED_REPOSITORY}"
-          test "${REQUESTED_BUILDCHAIN_REF}" = "${EXPECTED_BUILDCHAIN_REF}"
-          [[ "${QUALIFICATION_ID}" =~ ^poc-(0[1-9]|1[0-7])$ ]]
-
-      - name: Require write-capable actor
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const permission = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor,
-            });
-            if (!["admin", "maintain", "write"].includes(permission.data.permission || "")) {
-              core.setFailed(`actor permission ${permission.data.permission || "none"} cannot allocate a burst runner`);
-            }
-
-  qualify:
-    name: Exact-source Linux core qualification
-    needs: trust
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane
-    with:
-      buildchain-ref: train/v2/v2.3/aws-us-elastic-runner-burst-plane
-      runner-preset: aws-us-codebuild-linux
-      aws-codebuild-project: kungfu-buildchain-linux-burst-poc
-      setup-rust: true
-      rust-toolchain: "1.96.0"
-      rustup-dist-server: https://rsproxy.cn
-      rustup-update-root: https://rsproxy.cn/rustup
-      cargo-registry-index: sparse+https://index.crates.io/
-      artifact-name: kungfu-aws-linux-burst-${{ inputs.qualification-id }}
-      artifact-paths: |
-        product/release/qualification/aws-codebuild-linux.json
-      expected-artifacts-json: >-
-        {"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-codebuild-linux.json"]}
-      require-install: true
-      install-command: node scripts/buildchain-install.mjs
-      require-build: true
-      build-command: KUNGFU_BUILD_JOBS=4 ./shifu build:core && node scripts/buildchain-install.mjs qualify-codebuild record
-      requested-parallelism: 4
-      require-verify: true
-      verify-command: node scripts/buildchain-install.mjs qualify-codebuild verify
-      lifecycle-timeout-minutes: 105
-      artifact-transfer-mode: github-artifacts
-      artifact-retention-days: 14
-      checkout-cache-mode: off
-      checkout-cache-fallback: github
-      checkout-cache-github-timeout-seconds: 1200
-      publish-channel: none
-      release-candidate: false
-      buildchain-contract-lock-path: .buildchain/contract-lock.json
-      buildchain-contract-compatibility-policy: allow-additive
-      buildchain-contract-drift-issue-mode: off
+          echo "::error title=AWS Linux burst campaign retired::See ${RETIREMENT_CONTRACT} for the evidence and v3 reactivation contract."
+          exit 1

--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -1,182 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
-name: AWS US Windows Burst Qualification
+# The bounded v2 EC2 JIT campaign is complete. Keep this dispatchable tombstone
+# so stale operator bookmarks fail before any burst runner or cloud work.
+# Reactivation is governed by the machine-readable contract below.
+name: AWS US Windows Burst Qualification (Retired)
 
 on:
   workflow_dispatch:
-    inputs:
-      qualification-id:
-        description: "One bounded Windows JIT qualification slot"
-        required: true
-        type: choice
-        options:
-          - win-smoke
-          - win-full-01
-          - win-full-02
-          - win-full-03
-          - win-cancel
-          - win-timeout
-      mode:
-        description: "Qualification exercise selected by the operator"
-        required: true
-        type: choice
-        options:
-          - smoke
-          - full
-          - cancellation
-          - timeout
-      runner-label:
-        description: "Exact unique JIT label created for this run"
-        required: true
-      buildchain-ref:
-        description: "Exact reviewed Buildchain train for this campaign"
-        required: true
-        default: "train/v2/v2.3/aws-us-elastic-runner-burst-plane"
 
 permissions:
   contents: read
-  issues: write
-
-concurrency:
-  group: aws-us-windows-burst-${{ inputs.qualification-id }}
-  cancel-in-progress: false
 
 jobs:
-  trust:
-    name: Reject non-canonical or untrusted dispatch
+  retired:
+    name: Reject retired AWS Windows burst campaign
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
     steps:
-      - name: Require canonical repository, mode, label, and reviewed train
+      - name: Fail closed before burst runner or cloud work
         shell: bash
         env:
-          EXPECTED_REPOSITORY: kungfu-systems/kungfu
-          EXPECTED_BUILDCHAIN_REF: train/v2/v2.3/aws-us-elastic-runner-burst-plane
-          REQUESTED_BUILDCHAIN_REF: ${{ inputs.buildchain-ref }}
-          QUALIFICATION_ID: ${{ inputs.qualification-id }}
-          MODE: ${{ inputs.mode }}
-          RUNNER_LABEL: ${{ inputs.runner-label }}
+          RETIREMENT_CONTRACT: docs/qualification/gates/aws-burst-retirement.json
         run: |
           set -euo pipefail
-          test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
-          test "${GITHUB_REPOSITORY}" = "${EXPECTED_REPOSITORY}"
-          test "${REQUESTED_BUILDCHAIN_REF}" = "${EXPECTED_BUILDCHAIN_REF}"
-          case "${QUALIFICATION_ID}:${MODE}" in
-            win-smoke:smoke|win-full-0[1-3]:full|win-cancel:cancellation|win-timeout:timeout) ;;
-            *) exit 1 ;;
-          esac
-          test "${RUNNER_LABEL}" = "aws-us-ec2-windows-jit-${QUALIFICATION_ID}"
-
-      - name: Require write-capable actor
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const permission = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor,
-            });
-            if (!["admin", "maintain", "write"].includes(permission.data.permission || "")) {
-              core.setFailed(`actor permission ${permission.data.permission || "none"} cannot allocate a burst runner`);
-            }
-
-  smoke:
-    name: Windows JIT runner profile smoke
-    needs: trust
-    if: ${{ inputs.mode == 'smoke' }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane
-    with:
-      buildchain-ref: train/v2/v2.3/aws-us-elastic-runner-burst-plane
-      runner-preset: aws-us-ec2-windows-jit
-      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
-      setup-rust: true
-      rust-toolchain: "1.96.0"
-      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
-      artifact-paths: |
-        product/release/qualification/aws-windows-jit-smoke.json
-      expected-artifacts-json: >-
-        {"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-windows-jit-smoke.json"]}
-      require-install: false
-      require-build: true
-      build-command: node scripts/probe-release-platform.mjs --aws-windows-jit
-      require-verify: true
-      verify-command: node scripts/probe-release-platform.mjs --aws-windows-jit
-      lifecycle-timeout-minutes: 30
-      requested-parallelism: 1
-      artifact-transfer-mode: github-artifacts
-      artifact-retention-days: 14
-      checkout-cache-mode: off
-      checkout-cache-fallback: github
-      checkout-cache-github-timeout-seconds: 1200
-      publish-channel: none
-      release-candidate: false
-      buildchain-contract-lock-path: .buildchain/contract-lock.json
-      buildchain-contract-compatibility-policy: allow-additive
-      buildchain-contract-drift-issue-mode: off
-
-  full:
-    name: Trusted exact-source full Windows qualification
-    needs: trust
-    if: ${{ inputs.mode == 'full' }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane
-    with:
-      buildchain-ref: train/v2/v2.3/aws-us-elastic-runner-burst-plane
-      runner-preset: aws-us-ec2-windows-jit
-      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
-      setup-rust: true
-      rust-toolchain: "1.96.0"
-      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
-      artifact-paths: |
-        product/release
-      expected-artifacts-json: >-
-        {"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}
-      require-install: true
-      require-build: true
-      require-verify: true
-      verify-command: node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip
-      lifecycle-timeout-minutes: 150
-      requested-parallelism: 8
-      artifact-transfer-mode: github-artifacts
-      artifact-retention-days: 14
-      checkout-cache-mode: off
-      checkout-cache-fallback: github
-      checkout-cache-github-timeout-seconds: 1200
-      shifu-cache-profile-ref: docs/shifu/qualification-portable-off.cache-profile.json
-      shifu-cache-profile-digest: sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c
-      publish-channel: none
-      release-candidate: false
-      buildchain-contract-lock-path: .buildchain/contract-lock.json
-      buildchain-contract-compatibility-policy: allow-additive
-      buildchain-contract-drift-issue-mode: off
-
-  cleanup-exercise:
-    name: ${{ inputs.mode == 'cancellation' && 'Cancellation cleanup exercise' || 'Timeout cleanup exercise' }}
-    needs: trust
-    if: ${{ inputs.mode == 'cancellation' || inputs.mode == 'timeout' }}
-    runs-on:
-      - self-hosted
-      - Windows
-      - X64
-      - ${{ inputs.runner-label }}
-    timeout-minutes: ${{ inputs.mode == 'timeout' && 5 || 45 }}
-    steps:
-      - name: Confirm exact JIT runner identity
-        shell: pwsh
-        env:
-          EXPECTED_LABEL: ${{ inputs.runner-label }}
-        run: |
-          $ErrorActionPreference = "Stop"
-          if ($env:AWS_EC2_INSTANCE_ID -notmatch '^i-[0-9a-f]+$') {
-            throw "missing EC2 instance identity"
-          }
-          $labels = $env:BUILDCHAIN_RUNNER_LABELS_JSON | ConvertFrom-Json
-          if ($EXPECTED_LABEL -notin $labels) {
-            throw "JIT label mismatch"
-          }
-          "instance=$($env:AWS_EC2_INSTANCE_ID)"
-          "mode=${{ inputs.mode }}"
-
-      - name: Hold until the declared cleanup trigger
-        shell: pwsh
-        run: Start-Sleep -Seconds 1200
+          echo "::error title=AWS Windows burst campaign retired::See ${RETIREMENT_CONTRACT} for the evidence and v3 reactivation contract."
+          exit 1

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -1,0 +1,61 @@
+{
+  "schema": "kungfu.aws-burst-campaign-retirement/v1",
+  "status": "retired",
+  "owner": "kungfu-ci",
+  "retiredAt": "2026-07-30",
+  "reason": "The bounded AWS burst proof-of-concept campaigns used Buildchain v2-only runner presets and controller inputs. The reviewed Buildchain v3 authority intentionally exposes neither contract, so keeping the callers runnable would preserve an unintended v2 execution path.",
+  "runtimeSafety": {
+    "workflowShellReferencesV2": false,
+    "buildchainRefInputsV2": false,
+    "burstRunnerJobs": 0,
+    "cloudJobs": 0,
+    "failureBoundary": "github-hosted tombstone before burst runner or cloud work"
+  },
+  "evidence": {
+    "reviewedBuildchainV3Source": "9d74fb4557e71992db3516b5ba750d57cb9f3521",
+    "v3UnsupportedInputs": [
+      "aws-codebuild-project",
+      "aws-ec2-windows-runner-label"
+    ],
+    "v3UnsupportedRunnerPresets": [
+      "aws-us-codebuild-linux",
+      "aws-us-ec2-windows-jit"
+    ],
+    "historicalBuildchainRef": "train/v2/v2.3/aws-us-elastic-runner-burst-plane",
+    "historicalRuns": {
+      "linux": {
+        "latestSuccessfulRun": 30408889144,
+        "latestSuccessfulAt": "2026-07-28T23:43:38Z",
+        "caller": "dongkeren",
+        "result": "success"
+      },
+      "windows": {
+        "latestSuccessfulRun": 30418721314,
+        "latestSuccessfulAt": "2026-07-29T03:07:48Z",
+        "caller": "dongkeren",
+        "result": "success"
+      },
+      "observedFinalCampaignRun": {
+        "run": 30533043881,
+        "startedAt": "2026-07-30T10:01:24Z",
+        "caller": "dongkeren",
+        "observedStateAtDecision": "in_progress"
+      }
+    }
+  },
+  "historyPolicy": {
+    "v2TrainRef": "retained-immutable-history",
+    "priorRuns": "retained-immutable-history",
+    "currentWorkflowAuthority": "fail-closed-tombstone"
+  },
+  "reactivation": {
+    "automatic": false,
+    "requirements": [
+      "Admit a new protected Assignment owned by kungfu-ci and Buildchain maintainers.",
+      "Land the required runner preset and controller inputs in a reviewed Buildchain v3 commit.",
+      "Pin both reusable workflow shell and buildchain-ref to the same immutable reviewed v3 commit.",
+      "Restore bounded trust, label, non-publication, timeout, cancellation, and cleanup assertions with targeted tests.",
+      "Qualify the restored campaign through protected review without changing AWS, IAM, secret, billing, or runner-registration policy implicitly."
+    ]
+  }
+}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -764,36 +764,21 @@
     {
       "path": ".github/workflows/aws-us-linux-burst-qualification.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:2ceb58f323b6d996b5b7a9a80c2ab652059db3aa6186f2bfd0b8944236928cfb",
+      "definitionDigest": "sha256:b1b4ff62755b16ce738106c39208d455b528663caf7ffb7302fca519e366dd4e",
       "jobs": [
         {
-          "id": "qualify",
+          "id": "retired",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:644f282b34d334d136bfd353a94686c857493b811636ef045ec6290151ac66bb",
-          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
-          "steps": []
-        },
-        {
-          "id": "trust",
-          "authority": "qualification",
-          "publication": "none",
-          "receipt": "diagnostic",
-          "definitionDigest": "sha256:c4f5796c26eafa948658ce4b8d412bd20d1801e3c99e03ddff4893588d0b7a00",
+          "definitionDigest": "sha256:4097ebd030b518547c6b3c9917a4cf04a07f457f402854220b284c2ae521c25c",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
+          "externalActions": [],
           "steps": [
             {
               "index": 1,
-              "label": "name:Require canonical repository and reviewed train",
-              "definitionDigest": "sha256:1f7dcb35de9fe34c43b4d544588ece4228538d8e8c052d3f7ff8f514d264294e"
-            },
-            {
-              "index": 2,
-              "label": "name:Require write-capable actor",
-              "definitionDigest": "sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"
+              "label": "name:Fail closed before burst runner or cloud work",
+              "definitionDigest": "sha256:99576e82368555b05f5ac71698ac04dbfe706f2299aad30ca344ef994f56af01"
             }
           ]
         }
@@ -802,67 +787,21 @@
     {
       "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:e925eda66d0b6255f16b916e107957e9fb52ad56794bb4b4c196746426ab79ab",
+      "definitionDigest": "sha256:12f4da71712f6393c5446d790d8e7ae1cf6109f7ee9dfb127a0abd05b6faa352",
       "jobs": [
         {
-          "id": "cleanup-exercise",
+          "id": "retired",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:88da612bd391529048ff81f3f1bc00d1beceed86b770b78de0557fef2b890b0d",
-          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "definitionDigest": "sha256:4c6dd524dcbd49a8ef7706ea6013fcde52ba2785726dffc9a4704ce710d81db0",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": [],
           "steps": [
             {
               "index": 1,
-              "label": "name:Confirm exact JIT runner identity",
-              "definitionDigest": "sha256:115bfd9234736a1da607e61a0bb1be98a191d35f0da57ad4bb419a447069b9d2"
-            },
-            {
-              "index": 2,
-              "label": "name:Hold until the declared cleanup trigger",
-              "definitionDigest": "sha256:ebc15529c500b6f0e216a2a2ede2ade66d1f685f9b824e67cf3a5382af07cf84"
-            }
-          ]
-        },
-        {
-          "id": "full",
-          "authority": "qualification",
-          "publication": "none",
-          "receipt": "diagnostic",
-          "definitionDigest": "sha256:692b6f39dfd98c7343f8ca18c14a67458a910cc762693c9b016cc9c1155d1627",
-          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
-          "steps": []
-        },
-        {
-          "id": "smoke",
-          "authority": "qualification",
-          "publication": "none",
-          "receipt": "diagnostic",
-          "definitionDigest": "sha256:59e0cef37723c0658648a83e8e7b7b9facf3117fad6c4ef8d3eebcc008ce4165",
-          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@train/v2/v2.3/aws-us-elastic-runner-burst-plane"],
-          "steps": []
-        },
-        {
-          "id": "trust",
-          "authority": "qualification",
-          "publication": "none",
-          "receipt": "diagnostic",
-          "definitionDigest": "sha256:0ab3755153f464566cfd91816f58d3abb1bbd9d2ea4a45ea6e328bebcc70020f",
-          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
-          "steps": [
-            {
-              "index": 1,
-              "label": "name:Require canonical repository, mode, label, and reviewed train",
-              "definitionDigest": "sha256:4e46e0fffd538e23ae01e63788a115e079e81318b2ce724060155d77a2012d70"
-            },
-            {
-              "index": 2,
-              "label": "name:Require write-capable actor",
-              "definitionDigest": "sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"
+              "label": "name:Fail closed before burst runner or cloud work",
+              "definitionDigest": "sha256:c363b114c46cc6cbf0bfd4ccaa7dc533390c7c56b614819eec48fbccddb43831"
             }
           ]
         }
@@ -1812,12 +1751,12 @@
               "label": "name:Classify bounded outcomes",
               "definitionDigest": "sha256:8cce1484f56a0abc478ec75f3373e4e812aee51778f5ed78850cd8345ff66b2f"
             },
-        {
-          "index": 7,
-          "label": "name:Produce and enforce bounded Patrol evidence",
-          "authority": "evidence-publication",
-          "definitionDigest": "sha256:d1159245a243daf8a37dd9cce3c1c59bf811df11d5cd81c012f4a89fcc6c2edc"
-        },
+            {
+              "index": 7,
+              "label": "name:Produce and enforce bounded Patrol evidence",
+              "authority": "evidence-publication",
+              "definitionDigest": "sha256:d1159245a243daf8a37dd9cce3c1c59bf811df11d5cd81c012f4a89fcc6c2edc"
+            },
             {
               "index": 8,
               "label": "name:Assemble and audit retained evidence",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -54,12 +54,8 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/affected-native-pr.yml` | `source_acceptance` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
-| `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:write | none | 0 |
-| `.github/workflows/aws-us-linux-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `cleanup-exercise` | qualification | none | diagnostic | token:write | none | 2 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `full` | qualification | none | diagnostic | token:write | none | 0 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `smoke` | qualification | none | diagnostic | token:write | none | 0 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/aws-us-linux-burst-qualification.yml` | `retired` | qualification | none | diagnostic | token:read | none | 1 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `retired` | qualification | none | diagnostic | token:read | none | 1 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-passport` | qualification | none | qualifying | token:read | none | 4 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN+KUNGFU_GITHUB_TOKEN | none | 0 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,14 +96,14 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:67b6fac7c86c473ce4cc96ba35536f53273715806af60e9663bbb09b33a00ef4"
+          "sourceRoot": "sha256:5e40d0996245db21d259cbdf7cb8434bbd3726143e55d7bc387d776b5aec1c9f"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:cb2e7b9c9d569b1795ff8e3b41130b596056ca3826458d324e0a940c2b09ec29"
+          "sourceRoot": "sha256:3e2a287e852069714f7717405ef8f40e89c973c38a13b1d6e4061a52aec4c1c7"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -806,5 +806,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:f498e5a82735bc7442a767c8e684677c80aef056b1055e4284df80a40273e1c9"
+  "registryRoot": "sha256:692a2af0bfad92e388ca3ace2d149635cf042779ecef3fcbd27ca87da6ce41c3"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -191,7 +191,53 @@ test('AWS CodeBuild qualification rejects static and release credentials', () =>
   }
 });
 
-test('AWS Linux burst workflow is trusted exact-train qualification only', () => {
+test('retired AWS burst workflows fail closed before runner or cloud work', () => {
+  const retirement = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        repositoryRoot,
+        'docs/qualification/gates/aws-burst-retirement.json',
+      ),
+      'utf8',
+    ),
+  );
+  assert.equal(retirement.status, 'retired');
+  assert.equal(retirement.owner, 'kungfu-ci');
+  assert.equal(retirement.runtimeSafety.workflowShellReferencesV2, false);
+  assert.equal(retirement.runtimeSafety.buildchainRefInputsV2, false);
+  assert.equal(retirement.runtimeSafety.burstRunnerJobs, 0);
+  assert.equal(retirement.runtimeSafety.cloudJobs, 0);
+  assert.match(retirement.evidence.historicalBuildchainRef, /^train\/v2\//);
+  assert.match(
+    retirement.evidence.reviewedBuildchainV3Source,
+    /^[0-9a-f]{40}$/,
+  );
+
+  for (const name of [
+    'aws-us-linux-burst-qualification.yml',
+    'aws-us-windows-burst-qualification.yml',
+  ]) {
+    const workflow = fs.readFileSync(
+      path.join(repositoryRoot, '.github/workflows', name),
+      'utf8',
+    );
+    assert.match(workflow, /workflow_dispatch:/);
+    assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
+    assert.match(workflow, /jobs:\n {2}retired:/);
+    assert.match(workflow, /runs-on: ubuntu-24\.04/);
+    assert.match(
+      workflow,
+      /docs\/qualification\/gates\/aws-burst-retirement\.json/,
+    );
+    assert.match(workflow, /exit 1/);
+    assert.doesNotMatch(
+      workflow,
+      /train\/v2|kungfu-systems\/buildchain|runner-preset|aws-codebuild-project|aws-ec2-windows-runner-label|issues:\s*write|id-token:\s*write/,
+    );
+  }
+});
+
+test('retired AWS Linux burst workflow preserves no runnable v2 caller', () => {
   const workflow = fs.readFileSync(
     path.join(
       repositoryRoot,
@@ -199,39 +245,15 @@ test('AWS Linux burst workflow is trusted exact-train qualification only', () =>
     ),
     'utf8',
   );
-  assert.match(workflow, /workflow_dispatch:/);
-  assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
-  assert.match(workflow, /needs: trust/);
-  assert.match(workflow, /train\/v2\/v2\.3\/aws-us-elastic-runner-burst-plane/);
-  assert.match(workflow, /runner-preset: aws-us-codebuild-linux/);
-  assert.match(
-    workflow,
-    /aws-codebuild-project: kungfu-buildchain-linux-burst-poc/,
-  );
-  assert.match(
-    workflow,
-    /build-command: KUNGFU_BUILD_JOBS=4 \.\/shifu build:core/,
-  );
-  assert.match(workflow, /requested-parallelism: 4/);
+  assert.match(workflow, /AWS US Linux Burst Qualification \(Retired\)/);
   assert.match(workflow, /permissions:\n {2}contents: read/);
-  assert.doesNotMatch(workflow, /\b(?:id-token|packages):\s*write/);
-  assert.match(workflow, /publish-channel: none/);
-  assert.match(workflow, /release-candidate: false/);
-  assert.match(workflow, /artifact-transfer-mode: github-artifacts/);
-  assert.match(workflow, /checkout-cache-mode: off/);
-  assert.doesNotMatch(workflow, /checkout-cache-mode: (?:auto|require|github)/);
-  assert.match(
-    workflow,
-    /cargo-registry-index: sparse\+https:\/\/index\.crates\.io\//,
-  );
-  assert.doesNotMatch(workflow, /BUILDCHAIN_CARGO_REGISTRY_INDEX/);
   assert.doesNotMatch(
     workflow,
-    /secrets:|notar|signing|npm-publish|release-new-version|deploy/,
+    /uses:|secrets:|notar|signing|npm-publish|release-new-version|deploy/,
   );
 });
 
-test('AWS Windows JIT qualification is trusted, exact-label, and non-publication', () => {
+test('retired AWS Windows burst workflow preserves no runnable v2 caller', () => {
   const workflow = fs.readFileSync(
     path.join(
       repositoryRoot,
@@ -239,17 +261,10 @@ test('AWS Windows JIT qualification is trusted, exact-label, and non-publication
     ),
     'utf8',
   );
-  assert.match(workflow, /workflow_dispatch:/);
-  assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
-  assert.match(workflow, /needs: trust/);
-  assert.match(workflow, /aws-us-ec2-windows-jit-\$\{QUALIFICATION_ID\}/);
-  assert.match(workflow, /runner-preset: aws-us-ec2-windows-jit/);
-  assert.match(
+  assert.match(workflow, /AWS US Windows Burst Qualification \(Retired\)/);
+  assert.match(workflow, /permissions:\n {2}contents: read/);
+  assert.doesNotMatch(
     workflow,
-    /require-verify: true\n {6}verify-command: node scripts\/probe-release-platform\.mjs --aws-windows-jit/,
+    /uses:|secrets:|notar|signing|npm-publish|release-new-version|deploy/,
   );
-  assert.match(workflow, /publish-channel: none/);
-  assert.match(workflow, /release-candidate: false/);
-  assert.match(workflow, /win-cancel:cancellation\|win-timeout:timeout/);
-  assert.doesNotMatch(workflow, /\b(?:id-token|packages):\s*write/);
 });


### PR DESCRIPTION
## Summary

Retire the two bounded AWS burst qualification campaigns because their runner contracts exist only on the historical Buildchain v2 train and are not supported by the reviewed Buildchain v3 authority.

The retained manual workflows now fail closed on a GitHub-hosted runner before any burst runner allocation or cloud work. Historical v2 runs remain immutable evidence, and reactivation requires a new protected Assignment plus an exact reviewed v3 implementation.

## Related issue

Native Assignment `2026-07-30-kungfu-aws-burst-buildchain-v3-cutover`.

## Changes

- replace the Linux CodeBuild and Windows EC2 JIT callers with least-privilege dispatchable tombstones
- add a machine-readable retirement, history, safety, and reactivation contract
- refresh workflow authority and publication-surface projections
- replace runnable-v2 assertions with fail-closed retirement tests

## Verification

- `KUNGFU_DEV_BRANCH=origin/dev/v4/v4.0 ./shifu check:source`
- staged pre-commit gate
- `./shifu check:gate-catalog`
- `git diff --check`
- reviewed Buildchain v3 source `9d74fb4557e71992db3516b5ba750d57cb9f3521` exposes none of the retired AWS inputs or runner presets

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded CI retirement removes obsolete v2 execution authority without changing a product architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this PR removes AWS-capable jobs and their write permissions. It does not call or change AWS, IAM, runner registration, secrets, billing, quota, or infrastructure. No new campaign was dispatched.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTMwLWt1bmdmdS1hd3MtYnVyc3QtYnVpbGRjaGFpbi12My1jdXRvdmVyIiwiZGVsaXZlcnlDbGFzcyI6ImluaXRpYXRpdmUtY2hpbGQiLCJkZXZIZWFkIjoiZDNhN2Q2YmRjZjQyNDJjMTc3MWQ5YWQxMjljN2RlNmU4ZjBmMDZjZSIsInB1bGxSZXF1ZXN0SGVhZCI6IjZkYWJjYTVlN2Y5YmMyOGI4MTgwNDkzNjMxMGMxNjdmZTY0YjcyYjYiLCJyZXBsYXllZENhbmRpZGF0ZSI6Ijc2MDAyOWVlNTY2ZDk3YjhlZmZkMmVmZGU2ZWU4NmE0MjgwYjljMDAiLCJyZXBsYXllZFRyZWUiOiJjNjk2MWI2OTAwYWFmMWJhMjAzZGE3Zjg2MTEzOGI1YjgxNTAwNTJlIiwicXVldWVBdHRlbXB0IjoiNmRhYmNhNWU3ZjliYzI4YjgxODA0OTM2MzEwYzE2N2ZlNjRiNzJiNkBkM2E3ZDZiZGNmNDI0MmMxNzcxZDlhZDEyOWM3ZGU2ZThmMGYwNmNlIiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OmY3OTYwNmZjOWQyNTJjYjJmNWVmMmNlZTI5ZDljYTBjZWEwNzgxODlhYjUyMmQxYzE0NGJmM2Q5ZTU5ZDNjZWEiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1Njo0MWU3MTgwNDU0ZWIxNDJiOWZjOWFjMGM2NzBlMTk3MjcwZDFiODVlMWE3YTZlYjkwMDAwYmUzODUyYzc2NjdjIiwic2hhMjU2OmY3OTYwNmZjOWQyNTJjYjJmNWVmMmNlZTI5ZDljYTBjZWEwNzgxODlhYjUyMmQxYzE0NGJmM2Q5ZTU5ZDNjZWEiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kOTlmM2E5MTY2NzM5ZTBkIiwibGVhc2VSb290Ijoic2hhMjU2OjZlNTFlNjk3NzJjNGVhZDMwN2JiOGNkODFlOTdlMWVmYzNmMmE2YjdiNWEwZGMyY2M0YjQ1NTY1OThkNDYyMTkifQ -->