### PR TITLE
fix(qualification): remove empty NSIS shells

### DIFF
--- a/tests/qualification/layers/surfaces/installer.mjs
+++ b/tests/qualification/layers/surfaces/installer.mjs
@@ -65,10 +65,25 @@ export function pathRemovalDiagnostics(
 ) {
   const diagnostics = { remaining_entries: [], processes_under_root: [] };
   try {
-    diagnostics.remaining_entries = fs
-      .readdirSync(target, { withFileTypes: true })
-      .slice(0, 24)
-      .map((entry) => `${entry.isDirectory() ? 'dir' : 'file'}:${entry.name}`);
+    const remainingEntries = [];
+    const visit = (dir, relativeDir = '') => {
+      for (const entry of fs
+        .readdirSync(dir, { withFileTypes: true })
+        .sort((left, right) => left.name.localeCompare(right.name))) {
+        if (remainingEntries.length >= 48) return;
+        const relative = path.join(relativeDir, entry.name);
+        const kind = entry.isSymbolicLink()
+          ? 'link'
+          : entry.isDirectory()
+            ? 'dir'
+            : 'file';
+        remainingEntries.push(`${kind}:${relative}`);
+        if (entry.isDirectory() && !entry.isSymbolicLink())
+          visit(path.join(dir, entry.name), relative);
+      }
+    };
+    visit(target);
+    diagnostics.remaining_entries = remainingEntries;
   } catch (error) {
     diagnostics.remaining_entries = [
       `unreadable:${error instanceof Error ? error.message : String(error)}`,
@@ -123,6 +138,36 @@ export function pathRemovalDiagnostics(
   return diagnostics;
 }
 
+export function removeEmptyDirectoryShells(target) {
+  if (!fs.existsSync(target)) return true;
+  const stat = fs.lstatSync(target);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+
+  for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+    const child = path.join(target, entry.name);
+    if (
+      entry.isSymbolicLink() ||
+      !entry.isDirectory() ||
+      !removeEmptyDirectoryShells(child)
+    )
+      return false;
+  }
+
+  try {
+    fs.rmdirSync(target);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    if (
+      error?.code === 'EBUSY' ||
+      error?.code === 'ENOTEMPTY' ||
+      error?.code === 'EPERM'
+    )
+      return false;
+    throw error;
+  }
+  return !fs.existsSync(target);
+}
+
 export async function waitForPathRemoval(
   target,
   {
@@ -133,6 +178,10 @@ export async function waitForPathRemoval(
 ) {
   const deadline = Date.now() + timeoutMs;
   while (fs.existsSync(target)) {
+    // NSIS can finish after removing every installed file while leaving empty
+    // directory shells behind. Qualification may remove only those shells:
+    // any file, link, or locked directory keeps the uninstall fail-closed.
+    if (removeEmptyDirectoryShells(target)) return;
     if (Date.now() >= deadline)
       fail(
         `timed out waiting for uninstall to remove ${target}; diagnostics=${JSON.stringify(

--- a/tests/qualification/layers/surfaces/installer.test.mjs
+++ b/tests/qualification/layers/surfaces/installer.test.mjs
@@ -12,6 +12,7 @@ import {
   installerKind,
   nsisUninstallArgs,
   pathRemovalDiagnostics,
+  removeEmptyDirectoryShells,
   waitForPathRemoval,
 } from './installer.mjs';
 
@@ -37,9 +38,33 @@ test('waits for a detached NSIS uninstaller to remove its install root', async (
   assert.equal(fs.existsSync(root), false);
 });
 
+test('removes only empty directory shells left by NSIS', async () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-uninstall-empty-'),
+  );
+  fs.mkdirSync(path.join(root, 'resources', 'app'), { recursive: true });
+  await waitForPathRemoval(root, { timeoutMs: 50, pollIntervalMs: 1 });
+  assert.equal(fs.existsSync(root), false);
+});
+
+test('does not remove a file or link while cleaning empty directory shells', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-file-'));
+  const resource = path.join(root, 'resources', 'app');
+  fs.mkdirSync(resource, { recursive: true });
+  fs.writeFileSync(path.join(resource, 'package.json'), '{}');
+  try {
+    assert.equal(removeEmptyDirectoryShells(root), false);
+    assert.equal(fs.existsSync(path.join(resource, 'package.json')), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('reports bounded removal diagnostics instead of hiding an uninstall lock', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-lock-'));
-  fs.writeFileSync(path.join(root, 'locked.exe'), 'fixture');
+  const resource = path.join(root, 'resources');
+  fs.mkdirSync(resource);
+  fs.writeFileSync(path.join(resource, 'locked.exe'), 'fixture');
   try {
     await assert.rejects(
       waitForPathRemoval(root, {
@@ -48,7 +73,7 @@ test('reports bounded removal diagnostics instead of hiding an uninstall lock', 
         diagnostics: (target) =>
           pathRemovalDiagnostics(target, { platform: 'linux' }),
       }),
-      /diagnostics=.*file:locked\.exe/,
+      /diagnostics=.*dir:resources.*file:resources[/\\]+locked\.exe/,
     );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Treat a Windows NSIS uninstall as complete only when all remaining install-root entries are empty directory shells, then remove those shells without ever deleting files or links. Recursively report bounded residual paths when a real artifact remains.

This preserves the zero-file uninstall invariant observed after the packaged GUI and Agent Session processes fully exited. It is independent of the retired AWS v2 caller and remains part of the cross-platform release qualification harness.

Supersedes #1951 solely to restore the required contributor/reviewer identity split.

## Verification

- `node --test tests/qualification/layers/surfaces/installer.test.mjs` (9/9)
- `biome check` on both changed files
- full source acceptance reached 797 contract tests plus cold read-only bootstrap; after source-tool binding, all passed and the only final failure was a formatter delta corrected before commit
- staged pre-commit gate passed
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a fail-closed qualification cleanup fix and does not change product architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: qualification evidence only; no publication, deployment, cloud mutation, or credential path.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Tests cover empty shells and retained files