### PR TITLE
fix(ci): scope patrol runner context to capture step

### DIFF
--- a/.github/workflows/dev-gate-latency-patrol.yml
+++ b/.github/workflows/dev-gate-latency-patrol.yml
@@ -171,7 +171,6 @@ jobs:
     timeout-minutes: 15
     env:
       KUNGFU_DOGFOOD_COMMAND: /usr/local/bin/kungfu
-      KUNGFU_DEV_GATE_PATROL_EVIDENCE: ${{ runner.temp }}/dev-gate-latency-patrol-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Check out exact protected source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -193,6 +192,8 @@ jobs:
       - name: Capture or deduplicate native Dogfood Findings
         continue-on-error: true
         shell: bash
+        env:
+          KUNGFU_DEV_GATE_PATROL_EVIDENCE: ${{ runner.temp }}/dev-gate-latency-patrol-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -u
           mkdir -p \

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -436,10 +436,10 @@
           "authority": "diagnostic",
           "publication": "evidence",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:ea7c9b9be3c6729864eef0c844a36ebe3130b05bf6b01fcd038f2ab6369657f8",
+          "definitionDigest": "sha256:c7e4771588d479aed6190dd8b189ca35396424ba670c153a3e1a84be636fcb99",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
-          "steps": [{"index":1,"label":"name:Check out exact protected source","authority":"diagnostic-write","definitionDigest":"sha256:f59a8bf2f2ec268be4a505dfc794e8872e7f5173cd61e8c1f5b5a0cfcd84cabe"},{"index":2,"label":"name:Download bounded diagnostic evidence","authority":"diagnostic-write","definitionDigest":"sha256:6c9f4bfe7f3fc025f06b4faab39ec0a1272640e4b8904ea8bb6c8336cbf3b4f5"},{"index":3,"label":"name:Capture or deduplicate native Dogfood Findings","authority":"diagnostic-write","definitionDigest":"sha256:c8e53b4c6ad73b9ed86364f1814f280578e9e9e8b0a449d2546f33d9621beb09"},{"index":4,"label":"name:Upload bounded native capture receipts","authority":"diagnostic-write","definitionDigest":"sha256:e6ca34479b56d23183578848874e015ec05165197630f0c73cf4ef41a7ba1fdb"}]
+          "steps": [{"index":1,"label":"name:Check out exact protected source","authority":"diagnostic-write","definitionDigest":"sha256:f59a8bf2f2ec268be4a505dfc794e8872e7f5173cd61e8c1f5b5a0cfcd84cabe"},{"index":2,"label":"name:Download bounded diagnostic evidence","authority":"diagnostic-write","definitionDigest":"sha256:6c9f4bfe7f3fc025f06b4faab39ec0a1272640e4b8904ea8bb6c8336cbf3b4f5"},{"index":3,"label":"name:Capture or deduplicate native Dogfood Findings","authority":"diagnostic-write","definitionDigest":"sha256:f3bf35aa19463de3b328141c16d74d7c7c5f45eccfaec2496d490d78f750d5bf"},{"index":4,"label":"name:Upload bounded native capture receipts","authority":"diagnostic-write","definitionDigest":"sha256:e6ca34479b56d23183578848874e015ec05165197630f0c73cf4ef41a7ba1fdb"}]
         },
         {
           "id": "collect",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -169,7 +169,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:aa967c21532e4e06aec2d1ece3f9c76a3573d02ccb6a60162e0aaf50c819b870"
+          "sourceRoot": "sha256:67dd1a06b9cfff33de4cbdfc2355b86c32e1e7f530c7c888330a8660eddfbb5f"
         },
         {
           "path": ".github/workflows/stable-candidate-patrol.yml",
@@ -813,5 +813,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:8022d747f003a4e1d8e9ce6e904b9f1b841668c9531aea18bdc5bcf6476ca025"
+  "registryRoot": "sha256:89629952e8a15b8f340a9dcabe4665aea1e872ce69e3c3fcf74d9b8cb0a0c407"
 }

--- a/scripts/dev-gate-latency-patrol-workflow.test.mjs
+++ b/scripts/dev-gate-latency-patrol-workflow.test.mjs
@@ -58,3 +58,14 @@ test('latency Patrol captures native Findings in persistent agent-121 state', ()
   assert.match(workflow, /GITHUB_STEP_SUMMARY/);
   assert.match(workflow, /reportRoot/);
 });
+
+test('latency Patrol uses runner context only inside steps', () => {
+  assert.doesNotMatch(
+    workflow,
+    /timeout-minutes: 15\n {4}env:\n {6}KUNGFU_DOGFOOD_COMMAND:[^\n]+\n {6}KUNGFU_DEV_GATE_PATROL_EVIDENCE:.*runner\.temp/u,
+  );
+  assert.match(
+    workflow,
+    /Capture or deduplicate native Dogfood Findings[\s\S]*?env:\n {10}KUNGFU_DEV_GATE_PATROL_EVIDENCE:.*runner\.temp/u,
+  );
+});


### PR DESCRIPTION
## Summary

- move `runner.temp` out of job-level `env` into the capture step where the runner context is available
- add a regression contract that rejects job-level runner context
- refresh workflow authority and publication roots

## Validation

- `/opt/homebrew/bin/actionlint -ignore SC2016 .github/workflows/dev-gate-latency-patrol.yml`
- `./shifu test:dev-gate-latency-patrol`
- staged source gate and exact Project Cut queue replay

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes GitHub Actions context scope for an existing diagnostic workflow and changes no architecture contract."
}
-->