### PR TITLE
fix(demo): retain full-width ANSI autoplay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,7 +394,7 @@ jobs:
       source-artifact-name: ${{ needs.resolve-auditable-demo-source.outputs.artifact-name }}
       source-artifact-digest: ${{ needs.resolve-auditable-demo-source.outputs.artifact-digest }}
       adapter-path: scripts/auditable-demo-adapter.py
-      renderer-image: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:880b07771b04aedfbfa215185a3e3a62984fcd107fecae3c4ce5012636b2024e
+      renderer-image: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:06141e3d01a13e6d44766d3acc115ca07c58443f59840f313ecd938b2b0c138c
       render-media: ${{ (github.event_name == 'workflow_dispatch' && inputs.render-auditable-demo) || (github.event_name == 'pull_request' && startsWith(github.base_ref, 'alpha/')) }}
       artifact-retention-days: 14
       require-trusted-event: true
@@ -524,7 +524,7 @@ jobs:
           MEDIA_ARTIFACT_EXPIRES_AT: ${{ steps.artifact-expiry.outputs.media-artifact-expires-at }}
           MEDIA_ROOT: ${{ needs.auditable-demo.outputs.media-root }}
           BUILDCHAIN_SHA: 3272608ba28ef714fe710dd8da99d00fdeb4c619
-          RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:880b07771b04aedfbfa215185a3e3a62984fcd107fecae3c4ce5012636b2024e
+          RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:06141e3d01a13e6d44766d3acc115ca07c58443f59840f313ecd938b2b0c138c
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 
       - name: Upload exact auditable demo Release Passport

--- a/docs/qualification/auditable-demo-artifact-pipeline.md
+++ b/docs/qualification/auditable-demo-artifact-pipeline.md
@@ -39,8 +39,8 @@ disables the Gate.
 
 | Component | Immutable coordinate |
 | --- | --- |
-| Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:880b07771b04aedfbfa215185a3e3a62984fcd107fecae3c4ce5012636b2024e` |
-| Renderer release | [`v1.3.0-alpha.18`](https://github.com/kungfu-systems/build-images/releases/tag/v1.3.0-alpha.18), exact source `8605faf2651252a427679757c5667de027481ace`, containing protected merge `24aff5eb17a07ce13b1a3b518ee94557f7f94074` |
+| Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:06141e3d01a13e6d44766d3acc115ca07c58443f59840f313ecd938b2b0c138c` |
+| Renderer release | [`v1.3.0-alpha.19`](https://github.com/kungfu-systems/build-images/releases/tag/v1.3.0-alpha.19), exact source `0dc471bfdec50e06afd12493a279d3c0056dae1f`, containing protected merge `f6bccf6ecb5753386a502a335748c6a0b1ecb7a9` |
 | Buildchain Gate | `3272608ba28ef714fe710dd8da99d00fdeb4c619` (Buildchain issue `#2057`, canonical `qualified` autoplay sentinel admission) |
 | Consumer adapter | `scripts/auditable-demo-adapter.py` from the exact qualified Kungfu source SHA |
 
@@ -57,9 +57,12 @@ The adapter opens exactly one release qualification root, rejects unsafe or
 unbounded archive members, validates the retained layer, live-Peer, runtime
 activation, zero-burden, and invariant reports, and executes the installed
 archive's declared launcher with `kungfu agent-work-lab autoplay` in a
-disposable home directory and a real `120x36` PTY. The capture is limited to
-60 seconds, 4 MiB, and 10,000 quantized events. A successful result requires
-one valid `KUNGFU_TUI_DEMO_COMPLETE` payload and exit status zero.
+disposable home directory and a real `150x36` PTY. The isolated process removes
+`NO_COLOR`, sets `FORCE_COLOR=3`, and declares `TERM=xterm-256color` plus
+`COLORTERM=truecolor` so the capture retains the installed TUI's ANSI styling.
+The capture is limited to 60 seconds, 4 MiB, and 10,000 quantized events. A
+successful result requires one valid `KUNGFU_TUI_DEMO_COMPLETE` payload and
+exit status zero.
 
 Its public evidence class is
 `exact-installed-artifact-agent-work-lab-autoplay/v1`. It claims only that the

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -261,7 +261,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:e28198fc3f5c129c77ff94be033014f69f25b52ab41920faaf3364bb3231b7ad",
+          "definitionDigest": "sha256:d2837a97186272d1e630e8e60ef3677d9c2c86d57c82f2a027a69af427a17764",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@3272608ba28ef714fe710dd8da99d00fdeb4c619"],
           "steps": []
@@ -271,10 +271,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:1231d76e7254baca3622e21a67791a27a2a3c051f3029a99b8261e981d616985",
+          "definitionDigest": "sha256:0c6dcd35823b210212cecb4101d266ec544d610b27038c271c20edd207bb37d6",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
-          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:dea19e83ea0cd9f14dcc5b5fb088765072a719d5a4eca4d22b28cf2780b793d5"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
+          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:a47c75038305c63d534dcea5c9957d3dc3ba971a3aa3e900be7a094955baca45"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
         },
         {
           "id": "build",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -121,7 +121,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:bc291021373d45dfa52588260ca26370aaff41c9983f2220af7a4383bda9d483"
+          "sourceRoot": "sha256:52731f6ad20b5c738a259910bc23436ce06e9e35449bf4dd1979f435677ae3fc"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -820,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:6b54323735a8a79da0eb84f0a970422612d92cc19f360f791155a6b07351224e"
+  "registryRoot": "sha256:6107dfccf9fc441764b44a4f45129797533d774a9ffc68142010078f510e0a3b"
 }

--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -38,7 +38,7 @@ MAX_MEMBERS = 100_000
 EPISODE_RELEASE_EVIDENCE = "qualification/episode-release-evidence.json"
 PULL_MERGE_REF = re.compile(r"^refs/pull/[1-9][0-9]*/merge$")
 COMPLETION_SENTINEL = re.compile(r"KUNGFU_TUI_DEMO_COMPLETE ([^\r\n]+)")
-TERMINAL_COLUMNS = 120
+TERMINAL_COLUMNS = 150
 TERMINAL_ROWS = 36
 TERMINAL_TIMEOUT_SECONDS = 60
 TERMINAL_EVENT_QUANTUM_MS = 20
@@ -570,7 +570,7 @@ def isolated_environment(home: Path) -> dict[str, str]:
         "TZ": "UTC",
         "CI": "true",
         "SOURCE_DATE_EPOCH": "0",
-        "NO_COLOR": "0",
+        "FORCE_COLOR": "3",
         "TERM": "xterm-256color",
         "COLORTERM": "truecolor",
     }

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -160,8 +160,8 @@ function fixture(
           'done',
         ]
       : [
-          'printf "\\033[2J\\033[HKungfu Agent Work Lab fixture\\r\\n"',
-          'printf "Fresh process continues from governed Work.\\r\\n"',
+          'printf "\\033[2J\\033[H\\033[1;36mKungfu Agent Work Lab fixture\\033[0m\\r\\n"',
+          'printf "\\033[38;2;103;232;165mFresh process continues from governed Work.\\033[0m\\r\\n"',
         ];
   const sentinel = omitSentinel
     ? []
@@ -172,6 +172,10 @@ function fixture(
     '#!/bin/sh',
     '[ "$1" = "agent-work-lab" ] && [ "$2" = "autoplay" ] || exit 7',
     '[ -t 0 ] && [ -t 1 ] || exit 8',
+    '[ "${FORCE_COLOR:-}" = "3" ] || exit 9',
+    '[ -z "${NO_COLOR+x}" ] || exit 10',
+    '[ "${TERM:-}" = "xterm-256color" ] || exit 11',
+    '[ "${COLORTERM:-}" = "truecolor" ] || exit 12',
     ...outputLines,
     ...(privateOutput ? [`printf '%s\\r\\n' '${privateOutput}'`] : []),
     ...sentinel,
@@ -336,7 +340,7 @@ test('adapter executes only the exact installed archive in a PTY and emits the d
       fs.readFileSync(path.join(output, 'terminal-capture.json'), 'utf8'),
     );
     assert.equal(capture.command, 'kungfu agent-work-lab autoplay');
-    assert.deepEqual(capture.dimensions, { columns: 120, rows: 36 });
+    assert.deepEqual(capture.dimensions, { columns: 150, rows: 36 });
     assert.equal(capture.completion.status, 'qualified');
     assert.deepEqual(capture.authority.grants, []);
     assert.deepEqual(capture.authority.nonAuthorities, [
@@ -355,6 +359,11 @@ test('adapter executes only the exact installed archive in a PTY and emits the d
         /^[A-Za-z0-9+/]+={0,2}$/u.test(event.data),
       ),
     );
+    const terminalBytes = Buffer.concat(
+      capture.events.map((event) => Buffer.from(event.data, 'base64')),
+    ).toString('utf8');
+    assert.ok(terminalBytes.includes('\u001b[1;36m'));
+    assert.ok(terminalBytes.includes('\u001b[38;2;103;232;165m'));
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Retain the installed Kungfu Agent Work Lab autoplay at full-width and with its ANSI styling, then bind the auditable-demo Gate and Passport to the independently released ANSI-faithful renderer.

## Related issue

#1624

## Changes

- Capture the exact installed kungfu agent-work-lab autoplay command in a 150x36 PTY.
- Remove NO_COLOR and set FORCE_COLOR=3 while retaining xterm-256color and truecolor declarations.
- Pin demo-renderer v1.3.0-alpha.19 by immutable OCI digest in both the Gate and Passport.
- Refresh the governed workflow-authority and release-publication source-root projections.
- Document the frozen capture boundary.

## Verification

- ./shifu test:auditable-demo (34 passed after rebasing onto the latest dev/v4/v4.0).
- ./shifu check:release-publication-control-plane passed with registry root sha256:6107dfccf9fc441764b44a4f45129797533d774a9ffc68142010078f510e0a3b.
- Pre-commit staged gate passed for both signed-off commits, including documentation, workflow-authority, and release-publication checks.
- Anonymous GHCR manifest verification matched sha256:06141e3d01a13e6d44766d3acc115ca07c58443f59840f313ecd938b2b0c138c.
- Build Images v1.3.0-alpha.19 Release Passport and protected promotion runs completed successfully.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix changes only terminal capture dimensions, color environment, and the immutable demo renderer input; it does not alter a product architecture contract or grant authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates only evidence-generation inputs. The demo path retains read-only permissions and explicitly grants no publication or deployment authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
