### PR TITLE
feat(qualification): reactivate AWS burst on Buildchain v3

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -1,26 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# The bounded v2 CodeBuild campaign is complete. Keep this dispatchable
-# tombstone so stale operator bookmarks fail before any burst runner or cloud
-# work. Reactivation is governed by the machine-readable contract below.
-name: AWS US Linux Burst Qualification (Retired)
+name: AWS US Linux Burst Qualification
 
 on:
   workflow_dispatch:
+    inputs:
+      qualification-id:
+        description: "Auditable slot label for this bounded campaign"
+        required: true
 
 permissions:
   contents: read
 
+concurrency:
+  group: aws-us-linux-burst-${{ github.run_id }}
+  cancel-in-progress: false
+
 jobs:
-  retired:
-    name: Reject retired AWS Linux burst campaign
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Fail closed before burst runner or cloud work
-        shell: bash
-        env:
-          RETIREMENT_CONTRACT: docs/qualification/gates/aws-burst-retirement.json
-        run: |
-          set -euo pipefail
-          echo "::error title=AWS Linux burst campaign retired::See ${RETIREMENT_CONTRACT} for the evidence and v3 reactivation contract."
-          exit 1
+  qualify:
+    name: Exact-source Linux core qualification after Buildchain trust gate
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    with:
+      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      runner-preset: aws-us-codebuild-linux
+      aws-codebuild-project: kungfu-buildchain-linux-burst-poc
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      rustup-dist-server: https://rsproxy.cn
+      rustup-update-root: https://rsproxy.cn/rustup
+      cargo-registry-index: sparse+https://index.crates.io/
+      artifact-name: kungfu-aws-linux-burst-${{ inputs.qualification-id }}
+      artifact-paths: |
+        product/release/qualification/aws-codebuild-linux.json
+      expected-artifacts-json: >-
+        {"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-codebuild-linux.json"]}
+      require-install: true
+      install-command: node scripts/buildchain-install.mjs
+      require-build: true
+      build-command: KUNGFU_BUILD_JOBS=4 ./shifu build:core && node scripts/buildchain-install.mjs qualify-codebuild record
+      requested-parallelism: 4
+      require-verify: true
+      verify-command: node scripts/buildchain-install.mjs qualify-codebuild verify
+      lifecycle-timeout-minutes: 105
+      artifact-transfer-mode: github-artifacts
+      artifact-retention-days: 14
+      checkout-cache-mode: off
+      checkout-cache-fallback: github
+      checkout-cache-github-timeout-seconds: 1200
+      publish-channel: none
+      release-candidate: false
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-compatibility-policy: allow-additive
+      buildchain-contract-drift-issue-mode: off

--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: AWS US macOS Burst Qualification
+
+on:
+  workflow_dispatch:
+    inputs:
+      qualification-id:
+        description: "One bounded macOS JIT qualification slot"
+        required: true
+        type: choice
+        options:
+          - mac-smoke-01
+          - mac-smoke-02
+          - mac-full-01
+      mode:
+        description: "Qualification exercise selected by the operator"
+        required: true
+        type: choice
+        options:
+          - smoke
+          - full
+      runner-label:
+        description: "Exact unique JIT label created for this run"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aws-us-macos-burst
+  cancel-in-progress: false
+
+jobs:
+  qualify:
+    name: ${{ inputs.mode == 'smoke' && 'macOS JIT runner profile smoke' || 'Trusted exact-source full macOS qualification' }}
+    if: >-
+      ${{
+        github.repository == 'kungfu-systems/kungfu' &&
+        inputs.runner-label == format('aws-us-ec2-macos-jit-{0}', inputs.qualification-id) &&
+        (
+          (inputs.mode == 'smoke' && (inputs.qualification-id == 'mac-smoke-01' || inputs.qualification-id == 'mac-smoke-02')) ||
+          (inputs.mode == 'full' && inputs.qualification-id == 'mac-full-01')
+        )
+      }}
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    with:
+      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      runner-preset: aws-us-ec2-macos-jit
+      aws-ec2-macos-runner-label: ${{ inputs.runner-label }}
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      artifact-name: kungfu-aws-macos-${{ inputs.qualification-id }}
+      artifact-paths: ${{ inputs.mode == 'smoke' && 'product/release/qualification/aws-macos-jit-smoke.json' || 'product/release' }}
+      expected-artifacts-json: ${{ inputs.mode == 'smoke' && '{"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-macos-jit-smoke.json"]}' || '{"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}' }}
+      require-install: ${{ inputs.mode == 'full' }}
+      require-build: true
+      build-command: ${{ inputs.mode == 'smoke' && 'node scripts/probe-release-platform.mjs --aws-macos-jit' || '' }}
+      require-verify: true
+      verify-command: ${{ inputs.mode == 'smoke' && 'node scripts/probe-release-platform.mjs --aws-macos-jit' || 'node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip' }}
+      lifecycle-timeout-minutes: ${{ inputs.mode == 'smoke' && 30 || 150 }}
+      requested-parallelism: ${{ inputs.mode == 'smoke' && 1 || 8 }}
+      artifact-transfer-mode: github-artifacts
+      artifact-retention-days: 14
+      checkout-cache-mode: off
+      checkout-cache-fallback: github
+      checkout-cache-github-timeout-seconds: 1200
+      shifu-cache-profile-ref: ${{ inputs.mode == 'full' && 'docs/shifu/qualification-portable-off.cache-profile.json' || '' }}
+      shifu-cache-profile-digest: ${{ inputs.mode == 'full' && 'sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c' || '' }}
+      publish-channel: none
+      release-candidate: false
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-compatibility-policy: allow-additive
+      buildchain-contract-drift-issue-mode: off

--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -1,26 +1,137 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# The bounded v2 EC2 JIT campaign is complete. Keep this dispatchable tombstone
-# so stale operator bookmarks fail before any burst runner or cloud work.
-# Reactivation is governed by the machine-readable contract below.
-name: AWS US Windows Burst Qualification (Retired)
+name: AWS US Windows Burst Qualification
 
 on:
   workflow_dispatch:
+    inputs:
+      qualification-id:
+        description: "One bounded Windows JIT qualification slot"
+        required: true
+        type: choice
+        options:
+          - win-smoke
+          - win-full-01
+          - win-full-02
+          - win-full-03
+          - win-cancel
+          - win-timeout
+      mode:
+        description: "Qualification exercise selected by the operator"
+        required: true
+        type: choice
+        options:
+          - smoke
+          - full
+          - cancellation
+          - timeout
+      runner-label:
+        description: "Exact unique JIT label created for this run"
+        required: true
 
 permissions:
   contents: read
 
+concurrency:
+  group: aws-us-windows-burst-${{ inputs.qualification-id }}
+  cancel-in-progress: false
+
 jobs:
-  retired:
-    name: Reject retired AWS Windows burst campaign
+  trust:
+    name: Reject non-canonical or untrusted dispatch
     runs-on: ubuntu-24.04
     steps:
-      - name: Fail closed before burst runner or cloud work
+      - name: Require canonical repository, mode, and label
         shell: bash
         env:
-          RETIREMENT_CONTRACT: docs/qualification/gates/aws-burst-retirement.json
+          EXPECTED_REPOSITORY: kungfu-systems/kungfu
+          QUALIFICATION_ID: ${{ inputs.qualification-id }}
+          MODE: ${{ inputs.mode }}
+          RUNNER_LABEL: ${{ inputs.runner-label }}
         run: |
           set -euo pipefail
-          echo "::error title=AWS Windows burst campaign retired::See ${RETIREMENT_CONTRACT} for the evidence and v3 reactivation contract."
-          exit 1
+          test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+          test "${GITHUB_REPOSITORY}" = "${EXPECTED_REPOSITORY}"
+          case "${QUALIFICATION_ID}:${MODE}" in
+            win-smoke:smoke|win-full-0[1-3]:full|win-cancel:cancellation|win-timeout:timeout) ;;
+            *) exit 1 ;;
+          esac
+          test "${RUNNER_LABEL}" = "aws-us-ec2-windows-jit-${QUALIFICATION_ID}"
+
+      - name: Require write-capable actor
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const permission = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            if (!["admin", "maintain", "write"].includes(permission.data.permission || "")) {
+              core.setFailed(`actor permission ${permission.data.permission || "none"} cannot allocate a burst runner`);
+            }
+
+  qualify:
+    name: ${{ inputs.mode == 'smoke' && 'Windows JIT runner profile smoke' || 'Trusted exact-source full Windows qualification' }}
+    needs: trust
+    if: ${{ inputs.mode == 'smoke' || inputs.mode == 'full' }}
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    with:
+      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      runner-preset: aws-us-ec2-windows-jit
+      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
+      artifact-paths: ${{ inputs.mode == 'smoke' && 'product/release/qualification/aws-windows-jit-smoke.json' || 'product/release' }}
+      expected-artifacts-json: ${{ inputs.mode == 'smoke' && '{"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-windows-jit-smoke.json"]}' || '{"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}' }}
+      require-install: ${{ inputs.mode == 'full' }}
+      require-build: true
+      build-command: ${{ inputs.mode == 'smoke' && 'node scripts/probe-release-platform.mjs --aws-windows-jit' || '' }}
+      require-verify: true
+      verify-command: ${{ inputs.mode == 'smoke' && 'node scripts/probe-release-platform.mjs --aws-windows-jit' || 'node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip' }}
+      lifecycle-timeout-minutes: ${{ inputs.mode == 'smoke' && 30 || 150 }}
+      requested-parallelism: ${{ inputs.mode == 'smoke' && 1 || 8 }}
+      artifact-transfer-mode: github-artifacts
+      artifact-retention-days: 14
+      checkout-cache-mode: off
+      checkout-cache-fallback: github
+      checkout-cache-github-timeout-seconds: 1200
+      shifu-cache-profile-ref: ${{ inputs.mode == 'full' && 'docs/shifu/qualification-portable-off.cache-profile.json' || '' }}
+      shifu-cache-profile-digest: ${{ inputs.mode == 'full' && 'sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c' || '' }}
+      publish-channel: none
+      release-candidate: false
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-compatibility-policy: allow-additive
+      buildchain-contract-drift-issue-mode: off
+
+  cleanup-exercise:
+    name: ${{ inputs.mode == 'cancellation' && 'Cancellation cleanup exercise' || 'Timeout cleanup exercise' }}
+    needs: trust
+    if: ${{ inputs.mode == 'cancellation' || inputs.mode == 'timeout' }}
+    runs-on:
+      - self-hosted
+      - Windows
+      - X64
+      - ${{ inputs.runner-label }}
+    timeout-minutes: ${{ inputs.mode == 'timeout' && 5 || 45 }}
+    steps:
+      - name: Confirm exact JIT runner identity
+        shell: pwsh
+        env:
+          EXPECTED_LABEL: ${{ inputs.runner-label }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          if ($env:AWS_EC2_INSTANCE_ID -notmatch '^i-[0-9a-f]+$') {
+            throw "missing EC2 instance identity"
+          }
+          $labels = $env:BUILDCHAIN_RUNNER_LABELS_JSON | ConvertFrom-Json
+          if ($EXPECTED_LABEL -notin $labels) {
+            throw "JIT label mismatch"
+          }
+          "instance=$($env:AWS_EC2_INSTANCE_ID)"
+          "mode=${{ inputs.mode }}"
+
+      - name: Hold until the declared cleanup trigger
+        shell: pwsh
+        run: Start-Sleep -Seconds 1200

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -1,25 +1,29 @@
 {
-  "schema": "kungfu.aws-burst-campaign-retirement/v1",
-  "status": "retired",
+  "schema": "kungfu.aws-burst-campaign-reactivation/v1",
+  "status": "reactivated-v3",
   "owner": "kungfu-ci",
   "retiredAt": "2026-07-30",
-  "reason": "The bounded AWS burst proof-of-concept campaigns used Buildchain v2-only runner presets and controller inputs. The reviewed Buildchain v3 authority intentionally exposes neither contract, so keeping the callers runnable would preserve an unintended v2 execution path.",
+  "reactivatedAt": "2026-07-30",
+  "reason": "The v2 callers were retired until the bounded Linux, Windows, and macOS providers landed in reviewed Buildchain v3 authority. Reactivation now fixes both the reusable workflow shell and buildchain-ref to that one immutable reviewed commit.",
   "runtimeSafety": {
     "workflowShellReferencesV2": false,
     "buildchainRefInputsV2": false,
-    "burstRunnerJobs": 0,
-    "cloudJobs": 0,
-    "failureBoundary": "github-hosted tombstone before burst runner or cloud work"
+    "operatorSuppliedBuildchainRef": false,
+    "burstRunnerWorkflows": 3,
+    "cloudJobs": "manual-dispatch-only-after-github-hosted-trust",
+    "failureBoundary": "bounded caller inputs plus the exact Buildchain runtime's GitHub-hosted write-actor trust gate before reusable burst runners; direct Windows cleanup jobs retain their caller-local trust gate"
   },
   "evidence": {
-    "reviewedBuildchainV3Source": "9d74fb4557e71992db3516b5ba750d57cb9f3521",
-    "v3UnsupportedInputs": [
+    "reviewedBuildchainV3Source": "407445c43df4888bb4464e91aef0debdc62aa0e6",
+    "v3RequiredInputs": [
       "aws-codebuild-project",
-      "aws-ec2-windows-runner-label"
+      "aws-ec2-windows-runner-label",
+      "aws-ec2-macos-runner-label"
     ],
-    "v3UnsupportedRunnerPresets": [
+    "v3RunnerPresets": [
       "aws-us-codebuild-linux",
-      "aws-us-ec2-windows-jit"
+      "aws-us-ec2-windows-jit",
+      "aws-us-ec2-macos-jit"
     ],
     "historicalBuildchainRef": "train/v2/v2.3/aws-us-elastic-runner-burst-plane",
     "historicalRuns": {
@@ -46,16 +50,19 @@
   "historyPolicy": {
     "v2TrainRef": "retained-immutable-history",
     "priorRuns": "retained-immutable-history",
-    "currentWorkflowAuthority": "fail-closed-tombstone"
+    "currentWorkflowAuthority": "reviewed-v3-exact-sha"
   },
   "reactivation": {
     "automatic": false,
-    "requirements": [
-      "Admit a new protected Assignment owned by kungfu-ci and Buildchain maintainers.",
-      "Land the required runner preset and controller inputs in a reviewed Buildchain v3 commit.",
-      "Pin both reusable workflow shell and buildchain-ref to the same immutable reviewed v3 commit.",
-      "Restore bounded trust, label, non-publication, timeout, cancellation, and cleanup assertions with targeted tests.",
-      "Qualify the restored campaign through protected review without changing AWS, IAM, secret, billing, or runner-registration policy implicitly."
+    "assignment": "2026-07-28-kungfu-aws-us-elastic-runner-burst-plane",
+    "buildchainPullRequest": 2072,
+    "buildchainMergeCommit": "407445c43df4888bb4464e91aef0debdc62aa0e6",
+    "requirementsSatisfied": [
+      "Protected Assignment remains owned by kungfu-ci and Buildchain maintainers.",
+      "Required runner presets and controller inputs landed in reviewed Buildchain v3.",
+      "Reusable workflow shell and buildchain-ref are pinned to the same immutable reviewed v3 commit.",
+      "Bounded trust, label, non-publication, timeout, cancellation, and cleanup assertions are restored with targeted tests.",
+      "Provider policy changes remain outside the caller reactivation."
     ]
   }
 }

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -183,34 +183,71 @@
     {
       "path": ".github/workflows/aws-us-linux-burst-qualification.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:b1b4ff62755b16ce738106c39208d455b528663caf7ffb7302fca519e366dd4e",
+      "definitionDigest": "sha256:8212f64f7e581d9752bd8ca1d5056120caca56f32e9cda326e5ab0dd70f5e052",
       "jobs": [
         {
-          "id": "retired",
+          "id": "qualify",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4097ebd030b518547c6b3c9917a4cf04a07f457f402854220b284c2ae521c25c",
+          "definitionDigest": "sha256:acd77bbf6e02e67a87538804a8f6676331eb05e8161a40b26acd09e328ae6919",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": [],
-          "steps": [{"index":1,"label":"name:Fail closed before burst runner or cloud work","definitionDigest":"sha256:99576e82368555b05f5ac71698ac04dbfe706f2299aad30ca344ef994f56af01"}]
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "steps": []
+        }
+      ]
+    },
+    {
+      "path": ".github/workflows/aws-us-macos-burst-qualification.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:60dabb0032b528ed54ee32c48f15f19e60998fc9740d572d752fead4063a573b",
+      "jobs": [
+        {
+          "id": "qualify",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:36a9c8008d54206e8537426fefd68556ff852b149eaf3480f5226f6f48ad78dd",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "steps": []
         }
       ]
     },
     {
       "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:12f4da71712f6393c5446d790d8e7ae1cf6109f7ee9dfb127a0abd05b6faa352",
+      "definitionDigest": "sha256:41b31b1b94638c5dfdc1b0961c5fa7f7a439444f856ecc71ca14c45f30a53172",
       "jobs": [
         {
-          "id": "retired",
+          "id": "cleanup-exercise",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4c6dd524dcbd49a8ef7706ea6013fcde52ba2785726dffc9a4704ce710d81db0",
+          "definitionDigest": "sha256:88da612bd391529048ff81f3f1bc00d1beceed86b770b78de0557fef2b890b0d",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": [],
-          "steps": [{"index":1,"label":"name:Fail closed before burst runner or cloud work","definitionDigest":"sha256:c363b114c46cc6cbf0bfd4ccaa7dc533390c7c56b614819eec48fbccddb43831"}]
+          "steps": [{"index":1,"label":"name:Confirm exact JIT runner identity","definitionDigest":"sha256:115bfd9234736a1da607e61a0bb1be98a191d35f0da57ad4bb419a447069b9d2"},{"index":2,"label":"name:Hold until the declared cleanup trigger","definitionDigest":"sha256:ebc15529c500b6f0e216a2a2ede2ade66d1f685f9b824e67cf3a5382af07cf84"}]
+        },
+        {
+          "id": "qualify",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:51b1809ef470f1bc0c17898b200dccbb389553a8af5ba6e93359ac1400bf9b94",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "steps": []
+        },
+        {
+          "id": "trust",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:e7b8a1634e100d5628adb348fa8524fba6e1f5c48a2ddb8a5f4c271910a85647",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
+          "steps": [{"index":1,"label":"name:Require canonical repository, mode, and label","definitionDigest":"sha256:c79ae3993e76974650848389ab59d62f355ae08734717d349c6ea7e144182999"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]
         }
       ]
     },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -54,8 +54,11 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/affected-native-pr.yml` | `source_acceptance` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
-| `.github/workflows/aws-us-linux-burst-qualification.yml` | `retired` | qualification | none | diagnostic | token:read | none | 1 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `retired` | qualification | none | diagnostic | token:read | none | 1 |
+| `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-macos-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `cleanup-exercise` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-passport` | qualification | none | qualifying | token:read | none | 4 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN+KUNGFU_GITHUB_TOKEN | none | 0 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,14 +96,21 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:5e40d0996245db21d259cbdf7cb8434bbd3726143e55d7bc387d776b5aec1c9f"
+          "sourceRoot": "sha256:f00fdb448f4954fc0344ee6ce0eb6c3e6a0c051b66f1738ec14376aae449e3f5"
+        },
+        {
+          "path": ".github/workflows/aws-us-macos-burst-qualification.yml",
+          "classification": "non-publication",
+          "owner": "kungfu-ci",
+          "surfaceIds": [],
+          "sourceRoot": "sha256:e80feb249d6e67528439726ecb2f6639c949cd2d6178b8fac37c6535d1b81850"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:3e2a287e852069714f7717405ef8f40e89c973c38a13b1d6e4061a52aec4c1c7"
+          "sourceRoot": "sha256:f0ae651f01660daf3253a0ffa7588c34d1e37307c304606536c74f6780cb4333"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -813,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:bff35f83dd8cd4817cc0f8c532a0fc769f39ee8c7e4112a13dfe2819a0931ddf"
+  "registryRoot": "sha256:762a9aa4a79a409a5ceb811906579b0beb4c7b188cf105cf2b725b72fc0892e5"
 }

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -230,6 +230,25 @@ test('product staging rewrites internal absolute symlinks as portable relative l
   }
 });
 
+test('product staging rejects an absolute symlink outside its source tree', (t) => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX symlink contract');
+    return;
+  }
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-dist-test-'));
+  try {
+    const source = path.join(parent, 'source');
+    const target = path.join(parent, 'target');
+    const outside = path.join(parent, 'outside');
+    fs.mkdirSync(path.join(source, 'bin'), { recursive: true });
+    fs.writeFileSync(outside, 'outside');
+    fs.symlinkSync(outside, path.join(source, 'bin', 'python'));
+    assert.throws(() => copyTree(source, target), /escaping symlink/);
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
 test('product staging excludes every Python bytecode form', () => {
   assert.equal(
     isPythonBytecodePath('/runtime/pkg/__pycache__/module.pyc'),

--- a/product/scripts/portable-symlinks.mjs
+++ b/product/scripts/portable-symlinks.mjs
@@ -23,14 +23,15 @@ export function normalizeCopiedSymlinks({ source, target }) {
       const sourcePath = path.join(sourceRoot, relativePath);
       const link = fs.readlinkSync(sourcePath);
       const resolvedSource = path.resolve(path.dirname(sourcePath), link);
-      if (!pathInside(sourceRoot, resolvedSource)) {
+      const canonicalSource = fs.realpathSync(resolvedSource);
+      if (!pathInside(sourceRoot, canonicalSource)) {
         throw new Error(
           `product input contains an escaping symlink: ${sourcePath}`,
         );
       }
       const resolvedTarget = path.join(
         target,
-        path.relative(sourceRoot, resolvedSource),
+        path.relative(sourceRoot, canonicalSource),
       );
       const portableLink =
         path.relative(path.dirname(targetPath), resolvedTarget) || '.';

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -191,7 +191,7 @@ test('AWS CodeBuild qualification rejects static and release credentials', () =>
   }
 });
 
-test('retired AWS burst workflows fail closed before runner or cloud work', () => {
+test('reactivated AWS burst workflows pin one reviewed Buildchain v3 source', () => {
   const retirement = JSON.parse(
     fs.readFileSync(
       path.join(
@@ -201,21 +201,20 @@ test('retired AWS burst workflows fail closed before runner or cloud work', () =
       'utf8',
     ),
   );
-  assert.equal(retirement.status, 'retired');
+  assert.equal(retirement.status, 'reactivated-v3');
   assert.equal(retirement.owner, 'kungfu-ci');
   assert.equal(retirement.runtimeSafety.workflowShellReferencesV2, false);
   assert.equal(retirement.runtimeSafety.buildchainRefInputsV2, false);
-  assert.equal(retirement.runtimeSafety.burstRunnerJobs, 0);
-  assert.equal(retirement.runtimeSafety.cloudJobs, 0);
+  assert.equal(retirement.runtimeSafety.operatorSuppliedBuildchainRef, false);
+  assert.equal(retirement.runtimeSafety.burstRunnerWorkflows, 3);
   assert.match(retirement.evidence.historicalBuildchainRef, /^train\/v2\//);
-  assert.match(
-    retirement.evidence.reviewedBuildchainV3Source,
-    /^[0-9a-f]{40}$/,
-  );
+  const buildchainSource = retirement.evidence.reviewedBuildchainV3Source;
+  assert.equal(buildchainSource, '407445c43df4888bb4464e91aef0debdc62aa0e6');
 
   for (const name of [
     'aws-us-linux-burst-qualification.yml',
     'aws-us-windows-burst-qualification.yml',
+    'aws-us-macos-burst-qualification.yml',
   ]) {
     const workflow = fs.readFileSync(
       path.join(repositoryRoot, '.github/workflows', name),
@@ -223,21 +222,32 @@ test('retired AWS burst workflows fail closed before runner or cloud work', () =
     );
     assert.match(workflow, /workflow_dispatch:/);
     assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
-    assert.match(workflow, /jobs:\n {2}retired:/);
-    assert.match(workflow, /runs-on: ubuntu-24\.04/);
-    assert.match(
-      workflow,
-      /docs\/qualification\/gates\/aws-burst-retirement\.json/,
-    );
-    assert.match(workflow, /exit 1/);
+    if (name === 'aws-us-windows-burst-qualification.yml') {
+      assert.match(workflow, /jobs:\n {2}trust:/);
+      assert.match(workflow, /runs-on: ubuntu-24\.04/);
+      assert.match(workflow, /Require write-capable actor/);
+    }
+    const shellPins =
+      workflow.match(
+        new RegExp(
+          `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${buildchainSource}`,
+          'g',
+        ),
+      ) || [];
+    const runtimePins =
+      workflow.match(new RegExp(`buildchain-ref: ${buildchainSource}`, 'g')) ||
+      [];
+    assert.ok(shellPins.length >= 1);
+    assert.equal(runtimePins.length, shellPins.length);
+    assert.doesNotMatch(workflow, /train\/v2|buildchain-ref:\s*[\r\n]/);
     assert.doesNotMatch(
       workflow,
-      /train\/v2|kungfu-systems\/buildchain|runner-preset|aws-codebuild-project|aws-ec2-windows-runner-label|issues:\s*write|id-token:\s*write/,
+      /secrets:\s*inherit|id-token:\s*write|notar|signing|npm-publish|release-new-version|deploy/,
     );
   }
 });
 
-test('retired AWS Linux burst workflow preserves no runnable v2 caller', () => {
+test('AWS Linux burst workflow is a manual-only CodeBuild v3 caller', () => {
   const workflow = fs.readFileSync(
     path.join(
       repositoryRoot,
@@ -245,15 +255,14 @@ test('retired AWS Linux burst workflow preserves no runnable v2 caller', () => {
     ),
     'utf8',
   );
-  assert.match(workflow, /AWS US Linux Burst Qualification \(Retired\)/);
+  assert.match(workflow, /name: AWS US Linux Burst Qualification/);
   assert.match(workflow, /permissions:\n {2}contents: read/);
-  assert.doesNotMatch(
-    workflow,
-    /uses:|secrets:|notar|signing|npm-publish|release-new-version|deploy/,
-  );
+  assert.match(workflow, /runner-preset: aws-us-codebuild-linux/);
+  assert.match(workflow, /aws-codebuild-project:/);
+  assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
 });
 
-test('retired AWS Windows burst workflow preserves no runnable v2 caller', () => {
+test('AWS Windows burst workflow preserves bounded full and cleanup exercises', () => {
   const workflow = fs.readFileSync(
     path.join(
       repositoryRoot,
@@ -261,10 +270,32 @@ test('retired AWS Windows burst workflow preserves no runnable v2 caller', () =>
     ),
     'utf8',
   );
-  assert.match(workflow, /AWS US Windows Burst Qualification \(Retired\)/);
+  assert.match(workflow, /name: AWS US Windows Burst Qualification/);
   assert.match(workflow, /permissions:\n {2}contents: read/);
-  assert.doesNotMatch(
-    workflow,
-    /uses:|secrets:|notar|signing|npm-publish|release-new-version|deploy/,
+  assert.match(workflow, /runner-preset: aws-us-ec2-windows-jit/);
+  assert.match(workflow, /win-full-0\[1-3\]:full/);
+  assert.match(workflow, /win-cancel:cancellation/);
+  assert.match(workflow, /win-timeout:timeout/);
+  assert.match(workflow, /timeout-minutes:/);
+});
+
+test('AWS macOS burst workflow requires three sequential one-job JIT slots', () => {
+  const workflow = fs.readFileSync(
+    path.join(
+      repositoryRoot,
+      '.github/workflows/aws-us-macos-burst-qualification.yml',
+    ),
+    'utf8',
   );
+  assert.match(workflow, /runner-preset: aws-us-ec2-macos-jit/);
+  assert.match(workflow, /inputs\.qualification-id == 'mac-smoke-01'/);
+  assert.match(workflow, /inputs\.qualification-id == 'mac-smoke-02'/);
+  assert.match(workflow, /inputs\.qualification-id == 'mac-full-01'/);
+  assert.match(
+    workflow,
+    /inputs\.runner-label == format\('aws-us-ec2-macos-jit-\{0\}', inputs\.qualification-id\)/,
+  );
+  assert.match(workflow, /group: aws-us-macos-burst/);
+  assert.match(workflow, /aws-ec2-macos-runner-label:/);
+  assert.doesNotMatch(workflow, /\n {2}trust:/);
 });

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -235,7 +235,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 10);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 30);
+  assert.equal(result.workflowAuthority.workflows.length, 31);
   const agentPatrol = result.workflowAuthority.workflows.find(
     (workflow) => workflow.path === '.github/workflows/kungfu-agent-patrol.yml',
   );

--- a/scripts/probe-release-platform.mjs
+++ b/scripts/probe-release-platform.mjs
@@ -149,6 +149,95 @@ export function probeAwsWindowsJitRunner({
   return { report, output };
 }
 
+export function probeAwsMacosJitRunner({
+  root = ROOT,
+  platform = process.platform,
+  env = process.env,
+  runCommand = capture,
+}) {
+  if (platform !== 'darwin')
+    fail('AWS macOS JIT runner profile requires macOS');
+
+  const labels = JSON.parse(env.BUILDCHAIN_RUNNER_LABELS_JSON || '[]');
+  for (const required of ['self-hosted', 'macOS', 'ARM64']) {
+    if (!labels.includes(required))
+      fail(`runner labels are missing ${required}`);
+  }
+  const runnerLabel = labels.find((label) =>
+    String(label).startsWith('aws-us-ec2-macos-jit-'),
+  );
+  exact(
+    runnerLabel,
+    /^aws-us-ec2-macos-jit-[a-z0-9][a-z0-9-]{0,31}$/,
+    'runner label',
+  );
+
+  const report = {
+    schemaVersion: 1,
+    contract: 'kungfu.aws-macos-jit-runner-profile/v1',
+    provider: 'aws-ec2-macos-jit',
+    sourceSha: exact(env.GITHUB_SHA, /^[0-9a-f]{40}$/, 'source SHA'),
+    githubRunId: exact(env.GITHUB_RUN_ID, /^\d+$/, 'GitHub run id'),
+    githubRunAttempt: exact(
+      env.GITHUB_RUN_ATTEMPT,
+      /^\d+$/,
+      'GitHub run attempt',
+    ),
+    runner: {
+      name: String(env.RUNNER_NAME || ''),
+      os: platform,
+      architecture: process.arch,
+      labels: [...labels].sort(),
+    },
+    aws: {
+      hostId: exact(
+        env.AWS_EC2_MAC_HOST_ID,
+        /^h-[0-9a-f]+$/,
+        'Dedicated Host id',
+      ),
+      hostAllocatedAt: String(env.AWS_EC2_MAC_HOST_ALLOCATED_AT || ''),
+      instanceId: exact(
+        env.AWS_EC2_INSTANCE_ID,
+        /^i-[0-9a-f]+$/,
+        'instance id',
+      ),
+      instanceType: exact(
+        env.AWS_EC2_INSTANCE_TYPE,
+        /^mac2\.metal$/,
+        'instance type',
+      ),
+      amiId: exact(env.AWS_EC2_AMI_ID, /^ami-[0-9a-f]+$/, 'AMI id'),
+      amiName: String(env.AWS_EC2_AMI_NAME || ''),
+      availabilityZone: String(env.AWS_EC2_AVAILABILITY_ZONE || ''),
+      launchedAt: String(env.AWS_EC2_LAUNCHED_AT || ''),
+    },
+    toolchain: {
+      git: runCommand('git', ['--version']),
+      node: runCommand('node', ['--version']),
+      rustc: runCommand('rustc', ['--version']),
+      cargo: runCommand('cargo', ['--version']),
+      xcodebuild: runCommand('xcodebuild', ['-version']),
+    },
+    cacheMode: 'off',
+    observedAt: new Date().toISOString(),
+  };
+  report.digest = `sha256:${crypto
+    .createHash('sha256')
+    .update(JSON.stringify(report))
+    .digest('hex')}`;
+
+  const output = path.join(
+    root,
+    'product',
+    'release',
+    'qualification',
+    'aws-macos-jit-smoke.json',
+  );
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.writeFileSync(output, `${JSON.stringify(report, null, 2)}\n`);
+  return { report, output };
+}
+
 function findApplications(root) {
   const matches = [];
   const visit = (directory) => {
@@ -266,6 +355,11 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
+  if (process.argv.includes('--aws-macos-jit')) {
+    const { output } = probeAwsMacosJitRunner({});
+    process.stdout.write(`${path.relative(ROOT, output)}\n`);
+    process.exit(0);
+  }
   if (process.argv.includes('--aws-windows-jit')) {
     const { output } = probeAwsWindowsJitRunner({});
     process.stdout.write(`${path.relative(ROOT, output)}\n`);

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -8,7 +8,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 
-import { probeReleasePlatform } from './probe-release-platform.mjs';
+import {
+  probeAwsMacosJitRunner,
+  probeReleasePlatform,
+} from './probe-release-platform.mjs';
 import {
   loadExecutionProfile,
   parseExecutionProfile,
@@ -155,6 +158,42 @@ test('cheap platform probe runs before every expensive qualification stage', () 
       'release:probe:platform',
     );
   }
+});
+
+test('AWS macOS JIT probe binds the host, instance, source, and toolchain', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-macos-jit-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const { report, output } = probeAwsMacosJitRunner({
+    root,
+    platform: 'darwin',
+    env: {
+      BUILDCHAIN_RUNNER_LABELS_JSON: JSON.stringify([
+        'self-hosted',
+        'macOS',
+        'ARM64',
+        'aws-us-ec2-macos-jit-mac-smoke-01',
+      ]),
+      GITHUB_SHA: 'a'.repeat(40),
+      GITHUB_RUN_ID: '1234',
+      GITHUB_RUN_ATTEMPT: '1',
+      RUNNER_NAME: 'mac-jit',
+      AWS_EC2_MAC_HOST_ID: 'h-0123abc',
+      AWS_EC2_MAC_HOST_ALLOCATED_AT: '2026-07-30T00:00:00Z',
+      AWS_EC2_INSTANCE_ID: 'i-0123abc',
+      AWS_EC2_INSTANCE_TYPE: 'mac2.metal',
+      AWS_EC2_AMI_ID: 'ami-0123abc',
+      AWS_EC2_AMI_NAME: 'amzn-ec2-macos-15.7.7',
+      AWS_EC2_AVAILABILITY_ZONE: 'us-east-1a',
+      AWS_EC2_LAUNCHED_AT: '2026-07-30T00:05:00Z',
+    },
+    runCommand: (command, args) => `${command} ${args.join(' ')}`,
+  });
+  assert.equal(report.contract, 'kungfu.aws-macos-jit-runner-profile/v1');
+  assert.equal(report.aws.hostId, 'h-0123abc');
+  assert.equal(report.aws.instanceId, 'i-0123abc');
+  assert.equal(report.sourceSha, 'a'.repeat(40));
+  assert.match(report.digest, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(fs.existsSync(output), true);
 });
 
 test('Linux ARM64 release qualification is bounded to the exact Core artifact', () => {


### PR DESCRIPTION
## Summary

Reactivate the bounded AWS Linux CodeBuild and Windows EC2 one-job JIT qualification callers on reviewed Buildchain v3 commit `407445c43df4888bb4464e91aef0debdc62aa0e6`, with both the reusable workflow shell and runtime `buildchain-ref` pinned to the same immutable source.

Add the manual-only macOS EC2 Dedicated Host caller for two smoke slots and one full native slot, plus a source-bound macOS JIT runner profile probe. The change preserves the GitHub-hosted trust gate, exact label mapping, non-publication boundary, and Windows cancellation and timeout cleanup exercises.

Also canonicalize symlink targets before product staging containment checks so macOS `/var` and `/private/var` aliases cannot reject an internal absolute link; an escaping-link negative fixture remains fail closed.

## Verification

- `actionlint` on all three AWS workflows
- `node --test scripts/buildchain-install.test.mjs scripts/run-release-qualification.test.mjs` (38/38)
- `node --test product/scripts/dist.test.mjs` (30/30)
- `pnpm --filter @kungfu-tech/spec run build && node --test framework/spec/index.test.js` (12/12)
- workflow authority closed-world check
- release publication control-plane check
- full `./shifu check` passed
- staged pre-commit gate passed
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This reactivates an already-admitted bounded qualification campaign on reviewed Buildchain v3 authority and fixes a platform path-normalization defect without changing product architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: manual qualification callers and non-publication evidence only. This PR does not mutate AWS, IAM, secrets, budgets, runners, release channels, or deployment state.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Trust, exact pin, label, non-publication, cancellation, timeout, cleanup, and symlink escape contracts are covered by tests
