### PR TITLE
fix(ci): serialize Alpha candidates and add fast sentinels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'control' && format('alpha-macos-overflow-{0}', fromJSON(inputs.macos-overflow-request-json).requestId) || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted') && format('alpha-macos-candidate-{0}-{1}', fromJSON(inputs.macos-overflow-request-json).requestId, fromJSON(inputs.macos-overflow-request-json).mode) || format('alpha-promotion-build-{0}', github.event.pull_request.number || github.ref) }}
+  group: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'control' && format('alpha-macos-overflow-{0}', fromJSON(inputs.macos-overflow-request-json).requestId) || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted') && format('alpha-macos-candidate-{0}-{1}', fromJSON(inputs.macos-overflow-request-json).requestId, fromJSON(inputs.macos-overflow-request-json).mode) || format('alpha-promotion-build-{0}', github.event.pull_request.base.ref || github.ref) }}
   cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' && inputs.diagnostic-mode) }}
 
 jobs:
@@ -82,9 +82,52 @@ jobs:
           controller-request-json: ${{ inputs.macos-overflow-request-json || '{}' }}
           runner-inventory-token: ${{ github.event_name == 'workflow_dispatch' && fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'control' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && secrets.KUNGFU_GITHUB_TOKEN || '' }}
 
-  build:
+  windows-fast-sentinel:
+    name: Windows exact-source fast sentinel
     needs: preflight
     if: ${{ needs.preflight.result == 'success' && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
+    runs-on: windows-2025
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact candidate source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Reject known-invalid Windows entry contracts
+        shell: pwsh
+        env:
+          GITHUB_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
+        run: .\shifu.cmd node scripts/alpha-promotion-preflight.mjs fast-sentinel --kind windows --out .buildchain/fast-sentinel/windows.json
+
+  auditable-demo-fast-sentinel:
+    name: Auditable demo exact-source fast sentinel
+    needs: preflight
+    if: ${{ needs.preflight.result == 'success' && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact candidate source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Reject known-invalid auditable demo contracts
+        env:
+          GITHUB_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
+        run: ./shifu node scripts/alpha-promotion-preflight.mjs fast-sentinel --kind auditable-demo --out .buildchain/fast-sentinel/auditable-demo.json
+
+  build:
+    needs: [preflight, windows-fast-sentinel, auditable-demo-fast-sentinel]
+    if: ${{ needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@2522e79e4c00233a5d15f887360547ed1034c39e # protected artifact-signing authority
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: boolean
         default: false
+      fast-sentinels-only:
+        description: "Run only the source-bound Windows and auditable-demo fast sentinels"
+        required: false
+        type: boolean
+        default: false
       render-auditable-demo:
         description: "Render full media after the exact Linux artifact passes the required auditable-demo Gate"
         required: false
@@ -59,6 +64,7 @@ concurrency:
 jobs:
   preflight:
     name: Require exact-source Alpha preflight
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.fast-sentinels-only }}
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'control' && 360 || 10 }}
     outputs:
@@ -85,7 +91,7 @@ jobs:
   windows-fast-sentinel:
     name: Windows exact-source fast sentinel
     needs: preflight
-    if: ${{ needs.preflight.result == 'success' && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
+    if: ${{ always() && (needs.preflight.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.fast-sentinels-only && needs.preflight.result == 'skipped')) && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
     runs-on: windows-2025
     timeout-minutes: 10
     permissions:
@@ -107,7 +113,7 @@ jobs:
   auditable-demo-fast-sentinel:
     name: Auditable demo exact-source fast sentinel
     needs: preflight
-    if: ${{ needs.preflight.result == 'success' && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
+    if: ${{ always() && (needs.preflight.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.fast-sentinels-only && needs.preflight.result == 'skipped')) && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -127,7 +133,7 @@ jobs:
 
   build:
     needs: [preflight, windows-fast-sentinel, auditable-demo-fast-sentinel]
-    if: ${{ needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
+    if: ${{ needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && !inputs.fast-sentinels-only && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@2522e79e4c00233a5d15f887360547ed1034c39e # protected artifact-signing authority
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -79,9 +79,9 @@ jobs:
       pull-requests: write
     # The reusable workflow and its runtime are pinned to the same merged,
     # immutable Buildchain source.
-    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@1222846e7a21c022260775ed021737010577237b
+    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@f6b0cddea283495414ac3481364c1c27ae5c6485
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '1222846e7a21c022260775ed021737010577237b' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || 'f6b0cddea283495414ac3481364c1c27ae5c6485' }}
       source-branch: ${{ needs.resolve-channels.outputs.source-branch }}
       target-branch: ${{ needs.resolve-channels.outputs.target-branch }}
       dev-workflow-path: .github/workflows/dev-verify-patrol.yml

--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -34,6 +34,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: dev-alpha-candidate-patrol-${{ github.repository }}-${{ github.event.repository.default_branch }}
+  cancel-in-progress: false
+
 jobs:
   resolve-channels:
     runs-on: ubuntu-24.04

--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: boolean
         default: true
+      reactivation-authorized:
+        description: Explicitly authorize reactivation of a tombstoned exact source
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -74,9 +79,9 @@ jobs:
       pull-requests: write
     # The reusable workflow and its runtime are pinned to the same merged,
     # immutable Buildchain source.
-    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@009c00d7c0145b5991f56aa97a98d5d1bbcc350f
+    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@1222846e7a21c022260775ed021737010577237b
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '009c00d7c0145b5991f56aa97a98d5d1bbcc350f' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || '1222846e7a21c022260775ed021737010577237b' }}
       source-branch: ${{ needs.resolve-channels.outputs.source-branch }}
       target-branch: ${{ needs.resolve-channels.outputs.target-branch }}
       dev-workflow-path: .github/workflows/dev-verify-patrol.yml
@@ -85,5 +90,6 @@ jobs:
       pull-request-body-prefix-renderer: scripts/adr-release-gate.mjs
       settlement-authorized: ${{ github.event_name != 'workflow_dispatch' || inputs.create-pull-request }}
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
+      reactivation-authorized: ${{ github.event_name == 'workflow_dispatch' && inputs.create-pull-request && inputs.reactivation-authorized }}
     secrets:
       promotion-token: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -254,7 +254,7 @@
     {
       "path": ".github/workflows/build.yml",
       "authority": "product-publication",
-      "definitionDigest": "sha256:f59a9a4985ef2706b6550f38359b584874d817fc249b20b6667b58e11824888c",
+      "definitionDigest": "sha256:09589d1c2d1d08c15d1e3c55520f956709cccbc2862b5508442122da2e23f47b",
       "jobs": [
         {
           "id": "auditable-demo",
@@ -271,7 +271,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5bf87892b530faf158b92bf510918439cdd79515743b661962ab5749e74d891d",
+          "definitionDigest": "sha256:5789a7261baee8de3dfaa359cdb65086bfc36fc70735267ff6ba9700ad24f7a1",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Reject known-invalid auditable demo contracts","definitionDigest":"sha256:6680331f1967c56036aac5897f6b2275dfe45149d40cfcea537e8d16a13d94fc"}]
@@ -291,7 +291,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:20a39c5d5315cd33b783b8701e5dd1ba630c2b1da712b767b4a3a16b97651f0d",
+          "definitionDigest": "sha256:8a838e8caf605fee5b7a55dc9c00d200cdf450bc516aa62a55b18a3cd749cbd8",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@2522e79e4c00233a5d15f887360547ed1034c39e"],
           "steps": []
@@ -341,7 +341,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a0a907e296f43d063b77e4e43e508e664a65b214d4db91707d3fe0d8d84c9eae",
+          "definitionDigest": "sha256:e69c4a3c073f9dff53924eae6e646ce855aa6bb29dafbf4692290d4d5d440fd0",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
@@ -361,7 +361,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:375f3a9381a01dc0b24df420d3be463252f49c67f372e8b5ca7c2861a2225881",
+          "definitionDigest": "sha256:bce62fa5a7da528dc1ff453cb140e5b8de976daca0ddc1019f0232bdbfd5b5b4",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Reject known-invalid Windows entry contracts","definitionDigest":"sha256:ebf365cac4ac6f116e8c4befa7efbdbb54d86a142e6576ab47a868d57914047f"}]

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -254,7 +254,7 @@
     {
       "path": ".github/workflows/build.yml",
       "authority": "product-publication",
-      "definitionDigest": "sha256:a1b6d41585f46748e54b3950fab70f3c3ec01d7d37d842b26945e0be8db83923",
+      "definitionDigest": "sha256:f59a9a4985ef2706b6550f38359b584874d817fc249b20b6667b58e11824888c",
       "jobs": [
         {
           "id": "auditable-demo",
@@ -265,6 +265,16 @@
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@3272608ba28ef714fe710dd8da99d00fdeb4c619"],
           "steps": []
+        },
+        {
+          "id": "auditable-demo-fast-sentinel",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:5bf87892b530faf158b92bf510918439cdd79515743b661962ab5749e74d891d",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Reject known-invalid auditable demo contracts","definitionDigest":"sha256:6680331f1967c56036aac5897f6b2275dfe45149d40cfcea537e8d16a13d94fc"}]
         },
         {
           "id": "auditable-demo-passport",
@@ -281,7 +291,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:20e960641ca26d409e202f2541d6cb121cd82a9dcf7066c57fbfca4a98e0fec1",
+          "definitionDigest": "sha256:20a39c5d5315cd33b783b8701e5dd1ba630c2b1da712b767b4a3a16b97651f0d",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@2522e79e4c00233a5d15f887360547ed1034c39e"],
           "steps": []
@@ -345,6 +355,16 @@
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
           "steps": [{"index":1,"label":"id:resolve","definitionDigest":"sha256:c7fb80856c78364e30e47cf16634ef4d0f94abcefc8af3ecb58a32a526d3828b"},{"index":2,"label":"name:Retain machine-readable inapplicable reason","authority":"evidence-publication","definitionDigest":"sha256:a7a896172c158f321b28ee061bc1048c1d616464509938d0930aafcc361c6ba6"}]
+        },
+        {
+          "id": "windows-fast-sentinel",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:375f3a9381a01dc0b24df420d3be463252f49c67f372e8b5ca7c2861a2225881",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Reject known-invalid Windows entry contracts","definitionDigest":"sha256:ebf365cac4ac6f116e8c4befa7efbdbb54d86a142e6576ab47a868d57914047f"}]
         }
       ]
     },
@@ -439,7 +459,7 @@
     {
       "path": ".github/workflows/dev-alpha-candidate-patrol.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:3ff18e83f04173578323efb2bc799758d3e193465b92ca70e120f1d2df899307",
+      "definitionDigest": "sha256:43f7de2fb0199961b2242dc83bd50b09219df2e4f0ecc31268cf0eb669249bb8",
       "jobs": [
         {
           "id": "candidate",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -459,16 +459,16 @@
     {
       "path": ".github/workflows/dev-alpha-candidate-patrol.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:43f7de2fb0199961b2242dc83bd50b09219df2e4f0ecc31268cf0eb669249bb8",
+      "definitionDigest": "sha256:3e1f841dcea6bbf21a63e15577fc768421f7908809f238462eedd2b33ce8d99c",
       "jobs": [
         {
           "id": "candidate",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:1979ee6fe060c2d74dbbb2c1358997a1b1d7a07cd1d074a10a2688ec1bd9b73e",
+          "definitionDigest": "sha256:a20b9e9c06995e3e4605287eb503ab3dbb0451f32dcc8360be0a5243a1be37e2",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@009c00d7c0145b5991f56aa97a98d5d1bbcc350f"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@1222846e7a21c022260775ed021737010577237b"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -466,9 +466,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a20b9e9c06995e3e4605287eb503ab3dbb0451f32dcc8360be0a5243a1be37e2",
+          "definitionDigest": "sha256:c50e857eb62f1c7e323d8e462261829889e50a683c70e4bcadf40e875b811096",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@1222846e7a21c022260775ed021737010577237b"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@f6b0cddea283495414ac3481364c1c27ae5c6485"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -60,6 +60,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
+| `.github/workflows/build.yml` | `auditable-demo-fast-sentinel` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo-passport` | qualification | none | qualifying | token:read | none | 4 |
 | `.github/workflows/build.yml` | `build` | qualification | none | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN+BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN+KUNGFU_GITHUB_TOKEN | none | 0 |
 | `.github/workflows/build.yml` | `credential-island-macos` | product-publication | product | none | token:read, repo-secret:BUILDCHAIN_MACOS_CERTIFICATE_P12_BASE64+BUILDCHAIN_MACOS_CERTIFICATE_PASSWORD+BUILDCHAIN_MACOS_NOTARY_API_ISSUER+BUILDCHAIN_MACOS_NOTARY_API_KEY_ID+BUILDCHAIN_MACOS_NOTARY_API_KEY_P8_BASE64 | `buildchain-artifact-signing` | 6 |
@@ -68,6 +69,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/build.yml` | `precompute-alpha-publication-tail` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/build.yml` | `preflight` | qualification | none | diagnostic | token:write, oidc, repo-secret:KUNGFU_GITHUB_TOKEN | none | 2 |
 | `.github/workflows/build.yml` | `resolve-auditable-demo-source` | qualification | none | diagnostic | token:read | none | 2 |
+| `.github/workflows/build.yml` | `windows-fast-sentinel` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/buildchain-validate.yml` | `promotion-rehearsal` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/buildchain-validate.yml` | `validate` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/cancel-dequeued-merge-group.yml` | `cancel` | qualification | none | diagnostic | token:write, repo-secret:GITHUB_TOKEN | none | 3 |

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -469,7 +469,11 @@
         "kind": "job-uses",
         "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@2522e79e4c00233a5d15f887360547ed1034c39e",
         "job": {
-          "needs": "preflight",
+      "needs": [
+        "preflight",
+        "windows-fast-sentinel",
+        "auditable-demo-fast-sentinel"
+      ],
           "secrets": {
             "BUILDCHAIN_PROMOTION_TOKEN": "${{ secrets.KUNGFU_GITHUB_TOKEN }}",
             "BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN": "${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b947a743b8b8b286f60f4e0e0a30040c6da2d5faed36e6bdd0adf3efb336aca5",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:a2a7f2dd8d603d2dcdfdb8cf3e9b3a2a9d00265cbc6f11fd41886d9c97110632",
+  "sourceRoot": "sha256:07264b70512a156ed51c2a6871ca8a33dd859f7a68695fcda5ef27fbd7f1816e",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1095,7 +1095,7 @@
           "path": "scripts/release-promotion-rehearsal.mjs",
           "currentLines": 771,
           "baselineLines": 713,
-          "currentRoot": "sha256:02875445c3ba0d317c9ee7058e8301b93b59abbfc2b00f808be3df68e00ab1ac",
+          "currentRoot": "sha256:1a4c9595a581c960691b98ab471928825b4019e83853f89afaee5790ad64ac43",
           "baselineRoot": "sha256:12df72a7b881c2c3c83d5a19f1ab8d4189156a4d09ef759fe1e36328f5b4ed1d",
           "changedSinceBaseline": true
         },
@@ -1109,9 +1109,9 @@
         },
         {
           "path": "docs/qualification/gates/workflow-bindings.json",
-          "currentLines": 653,
+          "currentLines": 657,
           "baselineLines": 580,
-          "currentRoot": "sha256:2aa5291412a540f5416a2ef051c0ba19861f70b880fd32a4b8e3cb450e2e266c",
+          "currentRoot": "sha256:d224d5a6fc84b6f64ce397272a7e65ce20394628b8d37ed43a0d1dfc261c95cc",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -121,7 +121,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:52731f6ad20b5c738a259910bc23436ce06e9e35449bf4dd1979f435677ae3fc"
+          "sourceRoot": "sha256:307fe898ecaa1c4512438f3715bdbc037b06f89797f55a65ec10f22ae02dde75"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -169,7 +169,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:15777b210457731881da12af84b5007a8246b5a41e6a30a76997b167d6eeabfd"
+          "sourceRoot": "sha256:5dbafeda2b8f802e7b0944c40412f269bd0028280873ba96735b078d918a4de4"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -820,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4309c415bbc4dca3c4c70bb1ac1b046dbbf5b72c3e8cc6741ffda0c6493b9a16"
+  "registryRoot": "sha256:c42bc56a0a7c457455df4d8611e19367931d850b82169661a35848e7f0a97881"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -169,7 +169,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:394e2237a7542ec1fbb58cbea3ad7ff682d6edc7279d3d31e8ed58667ee30f3a"
+          "sourceRoot": "sha256:15777b210457731881da12af84b5007a8246b5a41e6a30a76997b167d6eeabfd"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -169,7 +169,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:32ec604066c03642684a8297467977924b6d2af817083359c0aac0a081f34b70"
+          "sourceRoot": "sha256:394e2237a7542ec1fbb58cbea3ad7ff682d6edc7279d3d31e8ed58667ee30f3a"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",

--- a/scripts/alpha-promotion-preflight.mjs
+++ b/scripts/alpha-promotion-preflight.mjs
@@ -67,6 +67,102 @@ const NON_REUSABLE_EVIDENCE = [
   'publication',
   'signing',
 ];
+const EXACT_BUILDCHAIN_SHA = /^[0-9a-f]{40}$/u;
+
+function requirePattern(issues, source, pattern, message) {
+  if (!pattern.test(source)) issues.push(message);
+}
+
+export function inspectWindowsFastSentinel({ shifuCmd, lifecycle }) {
+  const issues = [];
+  requirePattern(
+    issues,
+    shifuCmd,
+    /if \/i not "%~1"=="check:source" goto native/iu,
+    'shifu.cmd no longer routes check:source through the build-free source gate',
+  );
+  requirePattern(
+    issues,
+    shifuCmd,
+    /source-acceptance\.mjs/iu,
+    'shifu.cmd no longer invokes the source-acceptance authority',
+  );
+  requirePattern(
+    issues,
+    lifecycle,
+    /export function windowsCmdArgs/iu,
+    'release qualification no longer exposes the reviewed Windows command adapter',
+  );
+  requirePattern(
+    issues,
+    lifecycle,
+    /windowsVerbatimArguments:\s*true/iu,
+    'Windows qualification no longer preserves verbatim cmd.exe arguments',
+  );
+  requirePattern(
+    issues,
+    lifecycle,
+    /\['\/d',\s*'\/s',\s*'\/c'/u,
+    'Windows qualification no longer uses the bounded cmd.exe /d /s /c entry',
+  );
+  return issues;
+}
+
+export function inspectAuditableDemoFastSentinel({ adapter, workflow }) {
+  const issues = [];
+  requirePattern(
+    issues,
+    adapter,
+    /COMPLETION_SENTINEL\s*=\s*re\.compile\(r"KUNGFU_TUI_DEMO_COMPLETE/iu,
+    'auditable-demo adapter no longer requires the installed completion sentinel',
+  );
+  requirePattern(
+    issues,
+    adapter,
+    /completion\["status"\]\s*!=\s*"qualified"/iu,
+    'auditable-demo adapter regressed to a non-canonical completion verdict',
+  );
+  const runtime = workflow.match(
+    /uses:\s*kungfu-systems\/buildchain\/\.github\/workflows\/\.auditable-demo\.yml@([0-9a-f]{40})/u,
+  );
+  if (!runtime || !EXACT_BUILDCHAIN_SHA.test(runtime[1])) {
+    issues.push(
+      'auditable-demo Gate is not pinned to one exact Buildchain SHA',
+    );
+  }
+  requirePattern(
+    issues,
+    workflow,
+    /issue #2057 canonical qualified sentinel/iu,
+    'auditable-demo Gate no longer names the reviewed qualified-sentinel correction',
+  );
+  return issues;
+}
+
+export function runAlphaFastSentinel(kind, root = ROOT) {
+  if (kind === 'windows') {
+    return inspectWindowsFastSentinel({
+      shifuCmd: fs.readFileSync(path.join(root, 'shifu.cmd'), 'utf8'),
+      lifecycle: fs.readFileSync(
+        path.join(root, 'scripts', 'run-shifu-lifecycle.mjs'),
+        'utf8',
+      ),
+    });
+  }
+  if (kind === 'auditable-demo') {
+    return inspectAuditableDemoFastSentinel({
+      adapter: fs.readFileSync(
+        path.join(root, 'scripts', 'auditable-demo-adapter.py'),
+        'utf8',
+      ),
+      workflow: fs.readFileSync(
+        path.join(root, '.github', 'workflows', 'build.yml'),
+        'utf8',
+      ),
+    });
+  }
+  throw new Error(`unknown Alpha fast sentinel: ${kind || '<empty>'}`);
+}
 
 function canonical(value) {
   if (Array.isArray(value)) return value.map(canonical);
@@ -344,6 +440,26 @@ function main(argv = process.argv.slice(2)) {
     process.stdout.write(
       `[alpha-preflight] verified ${receipt.receiptRoot} for ${receipt.binding.sourceCommit} tree ${receipt.binding.sourceTree}\n`,
     );
+    return;
+  }
+  if (command === 'fast-sentinel') {
+    if (!options.kind || !options.out)
+      throw new Error('fast-sentinel requires --kind and --out');
+    const startedAt = Date.now();
+    const issues = runAlphaFastSentinel(options.kind);
+    const result = {
+      schema: 'kungfu.alpha-fast-sentinel/v1',
+      kind: options.kind,
+      sourceSha: process.env.GITHUB_SHA || '',
+      status: issues.length ? 'failed' : 'passed',
+      issues,
+      durationMs: Date.now() - startedAt,
+      claimBoundary:
+        'source-contract-only; does not claim platform or full Alpha qualification',
+    };
+    writeJson(path.resolve(options.out), result);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (issues.length) process.exitCode = 1;
     return;
   }
   throw new Error(`unknown alpha preflight command: ${command || '<missing>'}`);

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -312,6 +312,19 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
     build,
     /needs: \[preflight, windows-fast-sentinel, auditable-demo-fast-sentinel\]/u,
   );
+  assert.match(
+    build,
+    /fast-sentinels-only:[\s\S]*Run only the source-bound Windows and auditable-demo fast sentinels/u,
+  );
+  assert.match(
+    build,
+    /preflight:[\s\S]*if: \$\{\{ github\.event_name != 'workflow_dispatch' \|\| !inputs\.fast-sentinels-only \}\}/u,
+  );
+  assert.match(
+    build,
+    /windows-fast-sentinel:[\s\S]*always\(\)[\s\S]*inputs\.fast-sentinels-only[\s\S]*needs\.preflight\.result == 'skipped'/u,
+  );
+  assert.match(build, /build:[\s\S]*!inputs\.fast-sentinels-only/u);
   const preBuild = build.slice(0, build.indexOf('\n  build:'));
   assert.doesNotMatch(
     preBuild,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -292,6 +292,10 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
     /group: dev-alpha-candidate-patrol-\$\{\{ github\.repository \}\}-\$\{\{ github\.event\.repository\.default_branch \}\}[\s\S]*cancel-in-progress: false/u,
   );
   assert.match(
+    patrol,
+    /reactivation-authorized:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.create-pull-request && inputs\.reactivation-authorized\s*\}\}/u,
+  );
+  assert.match(
     build,
     /format\('alpha-promotion-build-\{0\}', github\.event\.pull_request\.base\.ref \|\| github\.ref\)/u,
   );

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -10,6 +10,9 @@ import { test } from 'node:test';
 import {
   aggregatePlatformReceipts,
   buildPlatformReceipt,
+  inspectAuditableDemoFastSentinel,
+  inspectWindowsFastSentinel,
+  runAlphaFastSentinel,
   verifyAggregateReceipt,
 } from './alpha-promotion-preflight.mjs';
 
@@ -245,5 +248,69 @@ test('receipt root, source commit, age and platform coverage fail closed', (t) =
         now: Date.parse('2026-08-01T00:00:00.000Z'),
       }),
     /receipt age/u,
+  );
+});
+
+test('current exact source passes both bounded pre-build sentinels', () => {
+  assert.deepEqual(runAlphaFastSentinel('windows'), []);
+  assert.deepEqual(runAlphaFastSentinel('auditable-demo'), []);
+});
+
+test('fast sentinels fail the representative recent invalid fixtures', () => {
+  const windowsIssues = inspectWindowsFastSentinel({
+    shifuCmd: '@echo off\nif /i not "%~1"=="build" goto native\n',
+    lifecycle: 'export function windowsCmdArgs() { return []; }\n',
+  });
+  assert.ok(windowsIssues.length >= 3);
+  assert.match(
+    windowsIssues.join('\n'),
+    /source gate|source-acceptance|verbatim/u,
+  );
+  const demoIssues = inspectAuditableDemoFastSentinel({
+    adapter: [
+      'COMPLETION_SENTINEL = re.compile(r"KUNGFU_TUI_DEMO_COMPLETE ([^\\\\r\\\\n]+)")',
+      'completion["status"] != "passed"',
+    ].join('\n'),
+    workflow:
+      'uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@main',
+  });
+  assert.ok(demoIssues.length >= 2);
+  assert.match(
+    demoIssues.join('\n'),
+    /canonical completion verdict|exact Buildchain SHA/u,
+  );
+});
+
+test('patrol, normal Alpha builds and sentinels keep one controller authority', () => {
+  const patrol = fs.readFileSync(
+    '.github/workflows/dev-alpha-candidate-patrol.yml',
+    'utf8',
+  );
+  const build = fs.readFileSync('.github/workflows/build.yml', 'utf8');
+  assert.match(
+    patrol,
+    /group: dev-alpha-candidate-patrol-\$\{\{ github\.repository \}\}-\$\{\{ github\.event\.repository\.default_branch \}\}[\s\S]*cancel-in-progress: false/u,
+  );
+  assert.match(
+    build,
+    /format\('alpha-promotion-build-\{0\}', github\.event\.pull_request\.base\.ref \|\| github\.ref\)/u,
+  );
+  assert.doesNotMatch(
+    build,
+    /alpha-promotion-build-\{0\}'.*pull_request\.number/u,
+  );
+  assert.match(build, /windows-fast-sentinel:[\s\S]*runs-on: windows-2025/u);
+  assert.match(
+    build,
+    /auditable-demo-fast-sentinel:[\s\S]*runs-on: ubuntu-24\.04/u,
+  );
+  assert.match(
+    build,
+    /needs: \[preflight, windows-fast-sentinel, auditable-demo-fast-sentinel\]/u,
+  );
+  const preBuild = build.slice(0, build.indexOf('\n  build:'));
+  assert.doesNotMatch(
+    preBuild,
+    /actions\/upload-artifact|npm publish|gh release|git tag/iu,
   );
 });

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -109,7 +109,7 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     extractWorkflowJob(build, 'build'),
-    /needs: preflight/,
+    /needs: (?:preflight|\[[^\]\n]*\bpreflight\b[^\]\n]*\])/,
     findings,
     'the expensive Buildchain matrix must depend on Alpha preflight admission',
   );

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -29,6 +29,25 @@ test('the committed Buildchain promotion consumer contract is coherent', () => {
   assert.equal(result.ok, true, JSON.stringify(result.findings, null, 2));
 });
 
+test('the expensive build retains preflight when additional fast sentinels are required', () => {
+  const buildPath = CONTRACT.workflows.build;
+  const original = fs.readFileSync(path.join(ROOT, buildPath), 'utf8');
+  const drifted = original.replace(
+    'needs: [preflight, windows-fast-sentinel, auditable-demo-fast-sentinel]',
+    'needs: [windows-fast-sentinel, auditable-demo-fast-sentinel]',
+  );
+  assert.notEqual(drifted, original);
+  const result = validateWorkflowSources(ROOT, CONTRACT, {
+    build: drifted,
+  });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.findings.some((entry) =>
+      entry.message.includes('must depend on Alpha preflight admission'),
+    ),
+  );
+});
+
 test('alpha and stable promotion fixtures cover admission and fail-closed paths', () => {
   const result = runFixtureSuite(ROOT);
   assert.equal(result.ok, true);


### PR DESCRIPTION
## Summary

Restore one Alpha candidate flight across the Kungfu caller and Buildchain controller, and reject two recent known-invalid source classes before expensive four-platform qualification.

## Changes

- serialize Dev-to-Alpha patrol triggers without cancelling the active controller
- serialize normal Alpha builds across pull-request numbers while preserving separate experiment identities
- add bounded Windows and auditable-demo exact-source sentinels ahead of the expensive build
- expose explicit tombstone reactivation only for an authorized manual create-PR request
- pin the consumer to Buildchain remediation train commit `f6b0cddea283495414ac3481364c1c27ae5c6485` after protected Buildchain merge

## Verification

- `./shifu node --test scripts/alpha-promotion-preflight.test.mjs scripts/release-promotion-rehearsal.test.mjs`
- `./shifu check:source` (790 passed, 10 explicitly skipped, 0 failed)
- generated workflow-authority and publication-control-plane projections are current

No release, package publication, signing, notarization, or artifact upload is performed by this change.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix narrows CI scheduling and source rejection behavior without changing an accepted architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects pre-publication CI evidence only. It adds no publication authority and preserves the existing single publisher boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation projections updated for workflow behavior

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTMwLWt1bmdmdS1hbHBoYS1jYW5kaWRhdGUtc2luZ2xlLWZsaWdodC1yZW1lZGlhdGlvbiIsImRlbGl2ZXJ5Q2xhc3MiOiJuYXRpdmUtcHJvb2YtcmVxdWlyZWQiLCJkZXZIZWFkIjoiZDFmMWYzODI3NTNiOTYxODU0Y2ZjOWYxNmRhZjhhNzQ0MjhjYTdiOCIsInB1bGxSZXF1ZXN0SGVhZCI6IjRkYTA2ZjAxNmIzNTU1YzEyNzc4ZTMyNzk5NDdhOTVkZjdkODMxMzYiLCJyZXBsYXllZENhbmRpZGF0ZSI6IjIxMzE2NWIxMzgyM2RiNGE0MDcwNGMyM2YzMmJkZDI1NWM2YzdmZTAiLCJyZXBsYXllZFRyZWUiOiJjZWViODg4OGYxMjcyNTY2OWMxYjBlNzFhNTBmY2U1YjMyOGQ3NWNiIiwicXVldWVBdHRlbXB0IjoiNGRhMDZmMDE2YjM1NTVjMTI3NzhlMzI3OTk0N2E5NWRmN2Q4MzEzNkBkMWYxZjM4Mjc1M2I5NjE4NTRjZmM5ZjE2ZGFmOGE3NDQyOGNhN2I4IiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OmFlYTdlOTUzNjBkZmQ4NjhiZmZiYTljNjdlYTg3ZWEyNTkwYmRmMWFkMzMwNDlkMjgwYzZmNTk5ODJlNGZjYTYiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1Njo0YTdjNzkzZjAzNGUyMTE1YWU2ZDdlODBlZmYxNmNmNmM5MjUxNWY4NDg4M2E3YmM5ZTA2OTQ0OTJlYzkxZThmIiwic2hhMjU2OmFlYTdlOTUzNjBkZmQ4NjhiZmZiYTljNjdlYTg3ZWEyNTkwYmRmMWFkMzMwNDlkMjgwYzZmNTk5ODJlNGZjYTYiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kOTlmM2E5MTY2NzM5ZTBkIiwibGVhc2VSb290Ijoic2hhMjU2OjcwODc4NmU0ZDFhNjc4MTg0NWQ3ZTI0NGQyNzA2MWVjOTRlYjkzOGFiODQ5NTUyZTRkNTFkZWU1Yzc4YWU4MTAifQ -->