### PR TITLE
fix(runtime): detach Windows resident supervisor

### DIFF
--- a/framework/core/src/python/kungfu/runtime_service.py
+++ b/framework/core/src/python/kungfu/runtime_service.py
@@ -1536,10 +1536,28 @@ class ProcessRuntimeHost:
                 new_process_group = getattr(
                     subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
                 )
-                kwargs["creationflags"] = detached_process | new_process_group
+                breakaway_from_job = getattr(
+                    subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0x01000000
+                )
+                kwargs["creationflags"] = (
+                    detached_process | new_process_group | breakaway_from_job
+                )
             else:
                 kwargs["start_new_session"] = True
-            child = subprocess.Popen(command, **kwargs)
+            try:
+                child = subprocess.Popen(command, **kwargs)
+            except OSError as error:
+                # Some Windows service managers place clients in a job that
+                # explicitly forbids breakaway. Preserve the existing resident
+                # process behavior there, while allowing CI and other
+                # kill-on-close jobs to release the supervisor when permitted.
+                if (
+                    platform.system() != "Windows"
+                    or getattr(error, "winerror", None) != 5
+                ):
+                    raise
+                kwargs["creationflags"] = detached_process | new_process_group
+                child = subprocess.Popen(command, **kwargs)
         write_pid(supervisor_pid_path(self.config_home), child.pid)
         _json_write(
             supervisor_state_path(self.config_home),

--- a/framework/core/tests/python/test_runtime_service.py
+++ b/framework/core/tests/python/test_runtime_service.py
@@ -847,6 +847,79 @@ def test_windows_stop_supervisor_terminates_verified_process_tree(monkeypatch):
     assert delivered == [(4242, "recorded-start")]
 
 
+def test_windows_supervisor_breaks_away_from_parent_job(tmp_path, monkeypatch):
+    spawned = []
+
+    class _FakeProcess:
+        pid = 4242
+
+    def _spawn(command, **kwargs):
+        spawned.append((command, kwargs))
+        return _FakeProcess()
+
+    monkeypatch.setattr(runtime_service.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(runtime_service.subprocess, "Popen", _spawn)
+    monkeypatch.setattr(runtime_service, "command_env", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        runtime_service, "supervisor_command", lambda *args, **kwargs: ["supervisor"]
+    )
+    monkeypatch.setattr(
+        runtime_service, "_process_start_identity", lambda pid: f"start-{pid}"
+    )
+
+    host = runtime_service.ProcessRuntimeHost(
+        config_home=str(tmp_path / "config"), runtime_image={}
+    )
+    child, _ = host.spawn_supervisor(str(tmp_path / "home"), str(tmp_path / "runtime"))
+
+    expected = (
+        getattr(runtime_service.subprocess, "DETACHED_PROCESS", 0x00000008)
+        | getattr(runtime_service.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+        | getattr(runtime_service.subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0x01000000)
+    )
+    assert child.pid == 4242
+    assert spawned[0][1]["creationflags"] == expected
+
+
+def test_windows_supervisor_falls_back_when_job_forbids_breakaway(
+    tmp_path, monkeypatch
+):
+    spawned = []
+
+    class _FakeProcess:
+        pid = 4242
+
+    def _spawn(command, **kwargs):
+        spawned.append((command, kwargs))
+        if len(spawned) == 1:
+            error = OSError("job forbids breakaway")
+            error.winerror = 5
+            raise error
+        return _FakeProcess()
+
+    monkeypatch.setattr(runtime_service.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(runtime_service.subprocess, "Popen", _spawn)
+    monkeypatch.setattr(runtime_service, "command_env", lambda *args, **kwargs: {})
+    monkeypatch.setattr(
+        runtime_service, "supervisor_command", lambda *args, **kwargs: ["supervisor"]
+    )
+    monkeypatch.setattr(
+        runtime_service, "_process_start_identity", lambda pid: f"start-{pid}"
+    )
+
+    host = runtime_service.ProcessRuntimeHost(
+        config_home=str(tmp_path / "config"), runtime_image={}
+    )
+    child, _ = host.spawn_supervisor(str(tmp_path / "home"), str(tmp_path / "runtime"))
+
+    expected = getattr(
+        runtime_service.subprocess, "DETACHED_PROCESS", 0x00000008
+    ) | getattr(runtime_service.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+    assert child.pid == 4242
+    assert len(spawned) == 2
+    assert spawned[1][1]["creationflags"] == expected
+
+
 def test_runtime_demand_status_reaches_drain_after_idle_grace(tmp_path):
     fixture = LEASE_FIXTURES["adoption"]
     config_home = tmp_path / "config"

--- a/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
+++ b/framework/core/tests/qualification/runtime-activation/product_smoke.mjs
@@ -105,8 +105,21 @@ function waitForRunning(home, configHome) {
     if (runtimeReady(latest.payload)) return latest;
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
   }
+  const logs = [
+    path.join(configHome, 'runtime', 'supervisor', 'supervisor.log'),
+    path.join(home, 'runtime', 'coordinator', 'coordinator.log'),
+  ]
+    .map((logPath) => {
+      try {
+        const content = fs.readFileSync(logPath, 'utf8');
+        return `${logPath}:\n${content.slice(-16_384)}`;
+      } catch (error) {
+        return `${logPath}: unavailable (${error.code || error.message})`;
+      }
+    })
+    .join('\n');
   throw new Error(
-    `product runtime did not become running: ${JSON.stringify(latest?.payload)}`,
+    `product runtime did not become running: ${JSON.stringify(latest?.payload)}\n${logs}`,
   );
 }
 


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded Windows resident-process repair restores the declared runtime lifecycle on the qualified product artifact; it does not change runtime architecture, public commands, or release authority."
}
-->

## Summary

- detach the Windows resident supervisor from kill-on-close parent jobs while retaining a controlled fallback for hosts that forbid breakaway
- preserve the existing detached process group semantics on every Windows host
- include bounded supervisor and coordinator log tails when product runtime qualification times out

## Evidence

- `PYTHONPATH=framework/core/src/python uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_runtime_service.py` (37 passed)
- `./shifu exec node --test framework/core/tests/qualification/runtime-activation/run.test.mjs` (16 passed)
- Ruff format and lint passed
- full staged pre-commit gate passed

This fixes the reproducible Windows product smoke failure seen after `runtime restart`: cold activation and warm reuse passed, then the replacement supervisor exited at the spawning command boundary.