### PR TITLE
fix(runtime): isolate frozen supervisor process

### DIFF
--- a/framework/core/src/python/kungfu/runtime_service.py
+++ b/framework/core/src/python/kungfu/runtime_service.py
@@ -8,6 +8,7 @@ import os
 import platform
 import signal
 import subprocess
+import sys
 import threading
 import time
 from contextlib import contextmanager
@@ -558,6 +559,15 @@ def command_env(
                 }
             )
     return env
+
+
+def _independent_process_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Detach a long-lived child from the current frozen application instance."""
+
+    child_env = dict(env)
+    if getattr(sys, "frozen", False):
+        child_env["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
+    return child_env
 
 
 def coordinator_run_command(
@@ -1508,13 +1518,15 @@ class ProcessRuntimeHost:
         )
         with supervisor_log_path(self.config_home).open("ab") as log:
             kwargs: dict[str, Any] = {
-                "env": command_env(
-                    home,
-                    runtime_dir,
-                    self.log_level,
-                    self.config_home,
-                    runtime_generation=runtime_generation,
-                    runtime_image=self.runtime_image,
+                "env": _independent_process_env(
+                    command_env(
+                        home,
+                        runtime_dir,
+                        self.log_level,
+                        self.config_home,
+                        runtime_generation=runtime_generation,
+                        runtime_image=self.runtime_image,
+                    )
                 ),
                 "stdout": log,
                 "stderr": log,

--- a/framework/core/tests/python/test_runtime_service.py
+++ b/framework/core/tests/python/test_runtime_service.py
@@ -402,6 +402,32 @@ def test_route_projects_runtime_generation_into_coordinator_environment(tmp_path
     assert env["KF_RUNTIME_GENERATION"] == "17"
 
 
+def test_independent_process_env_resets_frozen_application_instance(monkeypatch):
+    source_env = {
+        "KF_HOME": "/tmp/kungfu",
+        "PYINSTALLER_RESET_ENVIRONMENT": "0",
+    }
+    monkeypatch.setattr(runtime_service.sys, "frozen", True, raising=False)
+
+    child_env = runtime_service._independent_process_env(source_env)
+
+    assert child_env == {
+        "KF_HOME": "/tmp/kungfu",
+        "PYINSTALLER_RESET_ENVIRONMENT": "1",
+    }
+    assert source_env["PYINSTALLER_RESET_ENVIRONMENT"] == "0"
+
+
+def test_independent_process_env_preserves_source_runtime_without_freezing(monkeypatch):
+    source_env = {"KF_HOME": "/tmp/kungfu"}
+    monkeypatch.delattr(runtime_service.sys, "frozen", raising=False)
+
+    child_env = runtime_service._independent_process_env(source_env)
+
+    assert child_env == source_env
+    assert child_env is not source_env
+
+
 def test_coordinator_authority_persists_epoch_and_rejects_stale_generation(
     tmp_path,
 ):
@@ -600,6 +626,7 @@ def test_concurrent_activation_spawns_one_supervisor(tmp_path, monkeypatch):
         spawned.append((args, kwargs))
         return _FakeProcess()
 
+    monkeypatch.setattr(runtime_service.sys, "frozen", True, raising=False)
     monkeypatch.setattr(runtime_service.subprocess, "Popen", _spawn)
     monkeypatch.setattr(
         runtime_service, "_process_start_identity", lambda pid: f"start-{pid}"
@@ -623,6 +650,7 @@ def test_concurrent_activation_spawns_one_supervisor(tmp_path, monkeypatch):
         )
 
     assert len(spawned) == 1
+    assert spawned[0][1]["env"]["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
     assert sum(result["changed"] is True for result in results) == 1
     assert (
         runtime_service.read_pid(runtime_service.supervisor_pid_path(str(config_home)))


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded runtime bugfix detaches the already-declared long-lived supervisor from its parent PyInstaller instance; it does not change runtime architecture, process ownership, product authority, or release policy."
}
-->

## Summary

- reset PyInstaller state only when a frozen Kungfu runtime launches its long-lived supervisor
- preserve ordinary Python, coordinator, worker, and non-frozen process behavior
- prove the frozen launch boundary passes `PYINSTALLER_RESET_ENVIRONMENT=1` without mutating the source environment

## Root cause

Alpha Build run `30539085997` reproduced the Windows Product runtime smoke failure on attempts 3 and 4 after 72/72 build-chain verification passed. The frozen `kungfu.exe` launched the supervisor as an independent process, but PyInstaller continued to treat it as a child worker of the expiring parent application instance; the supervisor then stopped by signal before the coordinator became available.

## Evidence

- `PYTHONPATH=framework/core/src/python ./shifu exec uv run --project framework/core --frozen pytest -q framework/core/tests/python/test_runtime_service.py` — 37 passed
- `./shifu check:source` — passed, including 798 passed / 10 conditional skips in the source-acceptance contract suite
- `TMPDIR=/private/var/folders/lh/63dh4_t12tl7smhvvcr9wwlr0000gn/T ./shifu check` — passed
- targeted macOS temp-path normalization fixture — passed

This PR intentionally leaves installed Product state untouched. The decisive qualification is the protected Windows Alpha Product runtime smoke after this exact head reaches the dev candidate pipeline.
