### PR TITLE
fix(ci): bind Windows burst inputs through trust outputs

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -40,8 +40,21 @@ jobs:
   trust:
     name: Reject non-canonical or untrusted dispatch
     runs-on: ubuntu-24.04
+    outputs:
+      runner_label: ${{ steps.contract.outputs.runner_label }}
+      artifact_name: ${{ steps.contract.outputs.artifact_name }}
+      artifact_paths: ${{ steps.contract.outputs.artifact_paths }}
+      expected_artifacts_json: ${{ steps.contract.outputs.expected_artifacts_json }}
+      require_install: ${{ steps.contract.outputs.require_install }}
+      build_command: ${{ steps.contract.outputs.build_command }}
+      verify_command: ${{ steps.contract.outputs.verify_command }}
+      lifecycle_timeout_minutes: ${{ steps.contract.outputs.lifecycle_timeout_minutes }}
+      requested_parallelism: ${{ steps.contract.outputs.requested_parallelism }}
+      shifu_cache_profile_ref: ${{ steps.contract.outputs.shifu_cache_profile_ref }}
+      shifu_cache_profile_digest: ${{ steps.contract.outputs.shifu_cache_profile_digest }}
     steps:
       - name: Require canonical repository, mode, and label
+        id: contract
         shell: bash
         env:
           EXPECTED_REPOSITORY: kungfu-systems/kungfu
@@ -57,6 +70,31 @@ jobs:
             *) exit 1 ;;
           esac
           test "${RUNNER_LABEL}" = "aws-us-ec2-windows-jit-${QUALIFICATION_ID}"
+          {
+            printf 'runner_label=%s\n' "${RUNNER_LABEL}"
+            printf 'artifact_name=kungfu-aws-windows-%s\n' "${QUALIFICATION_ID}"
+            if [ "${MODE}" = "smoke" ]; then
+              printf 'artifact_paths=product/release/qualification/aws-windows-jit-smoke.json\n'
+              printf 'expected_artifacts_json=%s\n' '{"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-windows-jit-smoke.json"]}'
+              printf 'require_install=false\n'
+              printf 'build_command=node scripts/probe-release-platform.mjs --aws-windows-jit\n'
+              printf 'verify_command=node scripts/probe-release-platform.mjs --aws-windows-jit\n'
+              printf 'lifecycle_timeout_minutes=30\n'
+              printf 'requested_parallelism=1\n'
+              printf 'shifu_cache_profile_ref=\n'
+              printf 'shifu_cache_profile_digest=\n'
+            else
+              printf 'artifact_paths=product/release\n'
+              printf 'expected_artifacts_json=%s\n' '{"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}'
+              printf 'require_install=true\n'
+              printf 'build_command=\n'
+              printf 'verify_command=node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip\n'
+              printf 'lifecycle_timeout_minutes=150\n'
+              printf 'requested_parallelism=8\n'
+              printf 'shifu_cache_profile_ref=docs/shifu/qualification-portable-off.cache-profile.json\n'
+              printf 'shifu_cache_profile_digest=sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c\n'
+            fi
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Require write-capable actor
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -79,26 +117,26 @@ jobs:
     with:
       buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
       runner-preset: aws-us-ec2-windows-jit
-      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
+      aws-ec2-windows-runner-label: ${{ needs.trust.outputs.runner_label }}
       setup-rust: true
       rust-toolchain: "1.96.0"
-      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
-      artifact-paths: ${{ inputs.mode == 'smoke' && 'product/release/qualification/aws-windows-jit-smoke.json' || 'product/release' }}
-      expected-artifacts-json: ${{ inputs.mode == 'smoke' && '{"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-windows-jit-smoke.json"]}' || '{"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}' }}
-      require-install: ${{ inputs.mode == 'full' }}
+      artifact-name: ${{ needs.trust.outputs.artifact_name }}
+      artifact-paths: ${{ needs.trust.outputs.artifact_paths }}
+      expected-artifacts-json: ${{ needs.trust.outputs.expected_artifacts_json }}
+      require-install: ${{ fromJSON(needs.trust.outputs.require_install) }}
       require-build: true
-      build-command: ${{ inputs.mode == 'smoke' && 'node scripts/probe-release-platform.mjs --aws-windows-jit' || '' }}
+      build-command: ${{ needs.trust.outputs.build_command }}
       require-verify: true
-      verify-command: ${{ inputs.mode == 'smoke' && 'node scripts/probe-release-platform.mjs --aws-windows-jit' || 'node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip' }}
-      lifecycle-timeout-minutes: ${{ inputs.mode == 'smoke' && 30 || 150 }}
-      requested-parallelism: ${{ inputs.mode == 'smoke' && 1 || 8 }}
+      verify-command: ${{ needs.trust.outputs.verify_command }}
+      lifecycle-timeout-minutes: ${{ fromJSON(needs.trust.outputs.lifecycle_timeout_minutes) }}
+      requested-parallelism: ${{ fromJSON(needs.trust.outputs.requested_parallelism) }}
       artifact-transfer-mode: github-artifacts
       artifact-retention-days: 14
       checkout-cache-mode: off
       checkout-cache-fallback: github
       checkout-cache-github-timeout-seconds: 1200
-      shifu-cache-profile-ref: ${{ inputs.mode == 'full' && 'docs/shifu/qualification-portable-off.cache-profile.json' || '' }}
-      shifu-cache-profile-digest: ${{ inputs.mode == 'full' && 'sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c' || '' }}
+      shifu-cache-profile-ref: ${{ needs.trust.outputs.shifu_cache_profile_ref }}
+      shifu-cache-profile-digest: ${{ needs.trust.outputs.shifu_cache_profile_digest }}
       publish-channel: none
       release-candidate: false
       buildchain-contract-lock-path: .buildchain/contract-lock.json

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -234,7 +234,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:51b1809ef470f1bc0c17898b200dccbb389553a8af5ba6e93359ac1400bf9b94",
+          "definitionDigest": "sha256:b1b8acba5a911418f36bb609b4f6af0976bae94216673fd9c736c95f6e542f68",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
           "steps": []
@@ -244,10 +244,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e7b8a1634e100d5628adb348fa8524fba6e1f5c48a2ddb8a5f4c271910a85647",
+          "definitionDigest": "sha256:251dde9611e29eb95ca21d3b1c6024d96cc5d78a56a434c3197771b09e1562d5",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
-          "steps": [{"index":1,"label":"name:Require canonical repository, mode, and label","definitionDigest":"sha256:c79ae3993e76974650848389ab59d62f355ae08734717d349c6ea7e144182999"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]
+          "steps": [{"index":1,"label":"id:contract","definitionDigest":"sha256:4f234e58e391cc7b8cc7d23b1e5b700ead3aa413c9c062ea5017dabd4bbbdbe0"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]
         }
       ]
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -110,7 +110,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:f0ae651f01660daf3253a0ffa7588c34d1e37307c304606536c74f6780cb4333"
+          "sourceRoot": "sha256:2523b4d9dcae899ffa6c7bf493ce76a96338150a049798cd701f581f4b740457"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -820,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:c9a6febd09a90b842557dbaf28de6748a7d8e86b53b4b7a5813491d15c096302"
+  "registryRoot": "sha256:de97d5f2cd589d298270a174d1bf8358bcf2e1ec65041e1cd16795bf7769e153"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -277,6 +277,27 @@ test('AWS Windows burst workflow preserves bounded full and cleanup exercises', 
   assert.match(workflow, /win-cancel:cancellation/);
   assert.match(workflow, /win-timeout:timeout/);
   assert.match(workflow, /timeout-minutes:/);
+  assert.match(
+    workflow,
+    /runner_label: \$\{\{ steps\.contract\.outputs\.runner_label \}\}/,
+  );
+  assert.match(workflow, /id: contract/);
+  assert.match(
+    workflow,
+    /aws-ec2-windows-runner-label: \$\{\{ needs\.trust\.outputs\.runner_label \}\}/,
+  );
+  assert.match(
+    workflow,
+    /require-install: \$\{\{ fromJSON\(needs\.trust\.outputs\.require_install\) \}\}/,
+  );
+  assert.match(
+    workflow,
+    /lifecycle-timeout-minutes: \$\{\{ fromJSON\(needs\.trust\.outputs\.lifecycle_timeout_minutes\) \}\}/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /artifact-paths: \$\{\{ inputs\.|expected-artifacts-json: \$\{\{ inputs\.|build-command: \$\{\{ inputs\.|verify-command: \$\{\{ inputs\./,
+  );
 });
 
 test('AWS macOS burst workflow requires three sequential one-job JIT slots', () => {


### PR DESCRIPTION
## Summary

Repair the AWS Windows burst reusable-workflow caller after dispatch `30557755510` failed during workflow startup before any job or AWS resource existed.

The trusted Linux job now validates the manual inputs and projects one typed mode contract through job outputs. The Buildchain reusable caller consumes only `needs.trust.outputs`, including explicit `fromJSON` conversion for boolean and numeric inputs, instead of evaluating `inputs` expressions inside `jobs.<job_id>.with`.

## Related issue

Follow-up to #1967 and the bounded AWS burst qualification campaign.

## Changes

- Project exact runner, artifact, command, timeout, parallelism, and cache-profile values from the trust job.
- Keep smoke and full qualification behavior, immutable Buildchain v3 pin, and non-publication boundary unchanged.
- Add regression assertions for the compiler-safe reusable-caller contract.
- Refresh workflow authority and release publication roots.

## Verification

- `actionlint .github/workflows/aws-us-windows-burst-qualification.yml`
- `./shifu check:release-publication-control-plane`
- `./shifu check:source`: all directly related checks passed; 808/809 aggregate tests passed, with the sole unrelated local cold-read fixture failure reporting `pytest is not available on PATH`
- staged pre-commit checks passed
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repairs the expression transport for an already-admitted manual qualification workflow without changing product or release architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this PR only repairs a manual, exact-source, publish-none qualification caller. It does not allocate AWS resources, create credentials, or change release channels.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
