### PR TITLE
fix(ci): restore static Windows burst caller jobs

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -40,21 +40,8 @@ jobs:
   trust:
     name: Reject non-canonical or untrusted dispatch
     runs-on: ubuntu-24.04
-    outputs:
-      runner_label: ${{ steps.contract.outputs.runner_label }}
-      artifact_name: ${{ steps.contract.outputs.artifact_name }}
-      artifact_paths: ${{ steps.contract.outputs.artifact_paths }}
-      expected_artifacts_json: ${{ steps.contract.outputs.expected_artifacts_json }}
-      require_install: ${{ steps.contract.outputs.require_install }}
-      build_command: ${{ steps.contract.outputs.build_command }}
-      verify_command: ${{ steps.contract.outputs.verify_command }}
-      lifecycle_timeout_minutes: ${{ steps.contract.outputs.lifecycle_timeout_minutes }}
-      requested_parallelism: ${{ steps.contract.outputs.requested_parallelism }}
-      shifu_cache_profile_ref: ${{ steps.contract.outputs.shifu_cache_profile_ref }}
-      shifu_cache_profile_digest: ${{ steps.contract.outputs.shifu_cache_profile_digest }}
     steps:
       - name: Require canonical repository, mode, and label
-        id: contract
         shell: bash
         env:
           EXPECTED_REPOSITORY: kungfu-systems/kungfu
@@ -70,31 +57,6 @@ jobs:
             *) exit 1 ;;
           esac
           test "${RUNNER_LABEL}" = "aws-us-ec2-windows-jit-${QUALIFICATION_ID}"
-          {
-            printf 'runner_label=%s\n' "${RUNNER_LABEL}"
-            printf 'artifact_name=kungfu-aws-windows-%s\n' "${QUALIFICATION_ID}"
-            if [ "${MODE}" = "smoke" ]; then
-              printf 'artifact_paths=product/release/qualification/aws-windows-jit-smoke.json\n'
-              printf 'expected_artifacts_json=%s\n' '{"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-windows-jit-smoke.json"]}'
-              printf 'require_install=false\n'
-              printf 'build_command=node scripts/probe-release-platform.mjs --aws-windows-jit\n'
-              printf 'verify_command=node scripts/probe-release-platform.mjs --aws-windows-jit\n'
-              printf 'lifecycle_timeout_minutes=30\n'
-              printf 'requested_parallelism=1\n'
-              printf 'shifu_cache_profile_ref=\n'
-              printf 'shifu_cache_profile_digest=\n'
-            else
-              printf 'artifact_paths=product/release\n'
-              printf 'expected_artifacts_json=%s\n' '{"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}'
-              printf 'require_install=true\n'
-              printf 'build_command=\n'
-              printf 'verify_command=node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip\n'
-              printf 'lifecycle_timeout_minutes=150\n'
-              printf 'requested_parallelism=8\n'
-              printf 'shifu_cache_profile_ref=docs/shifu/qualification-portable-off.cache-profile.json\n'
-              printf 'shifu_cache_profile_digest=sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c\n'
-            fi
-          } >> "${GITHUB_OUTPUT}"
 
       - name: Require write-capable actor
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -109,34 +71,69 @@ jobs:
               core.setFailed(`actor permission ${permission.data.permission || "none"} cannot allocate a burst runner`);
             }
 
-  qualify:
-    name: ${{ inputs.mode == 'smoke' && 'Windows JIT runner profile smoke' || 'Trusted exact-source full Windows qualification' }}
+  smoke:
+    name: Windows JIT runner profile smoke
     needs: trust
-    if: ${{ inputs.mode == 'smoke' || inputs.mode == 'full' }}
+    if: ${{ inputs.mode == 'smoke' }}
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
     with:
       buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
       runner-preset: aws-us-ec2-windows-jit
-      aws-ec2-windows-runner-label: ${{ needs.trust.outputs.runner_label }}
+      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
       setup-rust: true
       rust-toolchain: "1.96.0"
-      artifact-name: ${{ needs.trust.outputs.artifact_name }}
-      artifact-paths: ${{ needs.trust.outputs.artifact_paths }}
-      expected-artifacts-json: ${{ needs.trust.outputs.expected_artifacts_json }}
-      require-install: ${{ fromJSON(needs.trust.outputs.require_install) }}
+      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
+      artifact-paths: |
+        product/release/qualification/aws-windows-jit-smoke.json
+      expected-artifacts-json: >-
+        {"minFiles":1,"minTotalBytes":1,"requiredPaths":["product/release/qualification/aws-windows-jit-smoke.json"]}
+      require-install: false
       require-build: true
-      build-command: ${{ needs.trust.outputs.build_command }}
+      build-command: node scripts/probe-release-platform.mjs --aws-windows-jit
       require-verify: true
-      verify-command: ${{ needs.trust.outputs.verify_command }}
-      lifecycle-timeout-minutes: ${{ fromJSON(needs.trust.outputs.lifecycle_timeout_minutes) }}
-      requested-parallelism: ${{ fromJSON(needs.trust.outputs.requested_parallelism) }}
+      verify-command: node scripts/probe-release-platform.mjs --aws-windows-jit
+      lifecycle-timeout-minutes: 30
+      requested-parallelism: 1
       artifact-transfer-mode: github-artifacts
       artifact-retention-days: 14
       checkout-cache-mode: off
       checkout-cache-fallback: github
       checkout-cache-github-timeout-seconds: 1200
-      shifu-cache-profile-ref: ${{ needs.trust.outputs.shifu_cache_profile_ref }}
-      shifu-cache-profile-digest: ${{ needs.trust.outputs.shifu_cache_profile_digest }}
+      publish-channel: none
+      release-candidate: false
+      buildchain-contract-lock-path: .buildchain/contract-lock.json
+      buildchain-contract-compatibility-policy: allow-additive
+      buildchain-contract-drift-issue-mode: off
+
+  full:
+    name: Trusted exact-source full Windows qualification
+    needs: trust
+    if: ${{ inputs.mode == 'full' }}
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    with:
+      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      runner-preset: aws-us-ec2-windows-jit
+      aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
+      setup-rust: true
+      rust-toolchain: "1.96.0"
+      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
+      artifact-paths: |
+        product/release
+      expected-artifacts-json: >-
+        {"minFiles":3,"minTotalBytes":1,"requiredPaths":["product/release/qualification/layer-qualification-summary.json"]}
+      require-install: true
+      require-build: true
+      require-verify: true
+      verify-command: node scripts/run-release-qualification.mjs --execution-profile alpha --native-upgrade-policy skip
+      lifecycle-timeout-minutes: 150
+      requested-parallelism: 8
+      artifact-transfer-mode: github-artifacts
+      artifact-retention-days: 14
+      checkout-cache-mode: off
+      checkout-cache-fallback: github
+      checkout-cache-github-timeout-seconds: 1200
+      shifu-cache-profile-ref: docs/shifu/qualification-portable-off.cache-profile.json
+      shifu-cache-profile-digest: sha256:d7002041716ea1e5ad703492815c9557576d5679227743541c13d42b6ea9de5c
       publish-channel: none
       release-candidate: false
       buildchain-contract-lock-path: .buildchain/contract-lock.json

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -230,11 +230,21 @@
           "steps": [{"index":1,"label":"name:Confirm exact JIT runner identity","definitionDigest":"sha256:115bfd9234736a1da607e61a0bb1be98a191d35f0da57ad4bb419a447069b9d2"},{"index":2,"label":"name:Hold until the declared cleanup trigger","definitionDigest":"sha256:ebc15529c500b6f0e216a2a2ede2ade66d1f685f9b824e67cf3a5382af07cf84"}]
         },
         {
-          "id": "qualify",
+          "id": "full",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:b1b8acba5a911418f36bb609b4f6af0976bae94216673fd9c736c95f6e542f68",
+          "definitionDigest": "sha256:1781e076386a9744ed42fbc21a6ad24219b69f8280de35ae6a005fa946dbbb51",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "steps": []
+        },
+        {
+          "id": "smoke",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:d60abc0f730c10871219dc930db7e8937b912a15b5b9936467049eb7a25ffaaf",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
           "steps": []
@@ -244,10 +254,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:251dde9611e29eb95ca21d3b1c6024d96cc5d78a56a434c3197771b09e1562d5",
+          "definitionDigest": "sha256:e7b8a1634e100d5628adb348fa8524fba6e1f5c48a2ddb8a5f4c271910a85647",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
-          "steps": [{"index":1,"label":"id:contract","definitionDigest":"sha256:4f234e58e391cc7b8cc7d23b1e5b700ead3aa413c9c062ea5017dabd4bbbdbe0"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]
+          "steps": [{"index":1,"label":"name:Require canonical repository, mode, and label","definitionDigest":"sha256:c79ae3993e76974650848389ab59d62f355ae08734717d349c6ea7e144182999"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]
         }
       ]
     },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -57,7 +57,8 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/aws-us-macos-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `cleanup-exercise` | qualification | none | diagnostic | token:read | none | 2 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `full` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `smoke` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-fast-sentinel` | qualification | none | diagnostic | token:read | none | 2 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -110,7 +110,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:2523b4d9dcae899ffa6c7bf493ce76a96338150a049798cd701f581f4b740457"
+          "sourceRoot": "sha256:b562998febe443a87d3a14b16e90acfa9232d30ad350a1e11af219d09d287aff"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -820,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:c42bc56a0a7c457455df4d8611e19367931d850b82169661a35848e7f0a97881"
+  "registryRoot": "sha256:8531b5bc22ccaf91c6dcb2b39ff7ab051db68a7b96b5ec80eb6e67e4ff9bdb56"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -277,27 +277,17 @@ test('AWS Windows burst workflow preserves bounded full and cleanup exercises', 
   assert.match(workflow, /win-cancel:cancellation/);
   assert.match(workflow, /win-timeout:timeout/);
   assert.match(workflow, /timeout-minutes:/);
+  assert.match(workflow, /\n {2}smoke:\n/);
+  assert.match(workflow, /\n {2}full:\n/);
+  assert.match(workflow, /if: \$\{\{ inputs\.mode == 'smoke' \}\}/);
+  assert.match(workflow, /if: \$\{\{ inputs\.mode == 'full' \}\}/);
   assert.match(
     workflow,
-    /runner_label: \$\{\{ steps\.contract\.outputs\.runner_label \}\}/,
+    /aws-ec2-windows-runner-label: \$\{\{ inputs\.runner-label \}\}/,
   );
-  assert.match(workflow, /id: contract/);
-  assert.match(
-    workflow,
-    /aws-ec2-windows-runner-label: \$\{\{ needs\.trust\.outputs\.runner_label \}\}/,
-  );
-  assert.match(
-    workflow,
-    /require-install: \$\{\{ fromJSON\(needs\.trust\.outputs\.require_install\) \}\}/,
-  );
-  assert.match(
-    workflow,
-    /lifecycle-timeout-minutes: \$\{\{ fromJSON\(needs\.trust\.outputs\.lifecycle_timeout_minutes\) \}\}/,
-  );
-  assert.doesNotMatch(
-    workflow,
-    /artifact-paths: \$\{\{ inputs\.|expected-artifacts-json: \$\{\{ inputs\.|build-command: \$\{\{ inputs\.|verify-command: \$\{\{ inputs\./,
-  );
+  assert.match(workflow, /require-install: false/);
+  assert.match(workflow, /require-install: true/);
+  assert.doesNotMatch(workflow, /needs\.trust\.outputs|fromJSON\(/);
 });
 
 test('AWS macOS burst workflow requires three sequential one-job JIT slots', () => {


### PR DESCRIPTION
## Summary

- restore separate static smoke and full reusable-workflow jobs for the Windows JIT qualification caller
- keep the immutable Buildchain v3 workflow and contract lock
- retain trust validation and bounded cleanup exercises

## Why

The dynamic caller and the trust-output repair both failed during workflow startup before any job could be created. The prior static two-job shape is proven by run 30533043881 to compile and reach the Windows runner. This patch restores that caller structure while retaining the current immutable Buildchain v3 revision.

## Verification

- actionlint
- workflow authority refresh
- release publication write-roots and control-plane check
- directly related Buildchain install/AWS workflow contract tests
- staged pre-commit gate
- full local source check: 798 passed, 10 skipped; one environment-only failure because pytest is unavailable on this Mac PATH

## Governance

- [x] ADR-neutral CI bug fix
- [x] No release publication or credential widening
- [x] DCO signed-off commit
- [x] Generated workflow authority and publication roots refreshed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the previously proven static Windows JIT reusable-workflow caller shape without changing product architecture, support claims, or publication authority."
}
-->