### PR TITLE
fix(ci): grant Windows burst reusable permissions

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -40,6 +40,8 @@ jobs:
   trust:
     name: Reject non-canonical or untrusted dispatch
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Require canonical repository, mode, and label
         shell: bash
@@ -75,6 +77,11 @@ jobs:
     name: Windows JIT runner profile smoke
     needs: trust
     if: ${{ inputs.mode == 'smoke' }}
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      id-token: write
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
     with:
       buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
@@ -109,6 +116,11 @@ jobs:
     name: Trusted exact-source full Windows qualification
     needs: trust
     if: ${{ inputs.mode == 'full' }}
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      id-token: write
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
     with:
       buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
@@ -144,6 +156,8 @@ jobs:
     name: ${{ inputs.mode == 'cancellation' && 'Cancellation cleanup exercise' || 'Timeout cleanup exercise' }}
     needs: trust
     if: ${{ inputs.mode == 'cancellation' || inputs.mode == 'timeout' }}
+    permissions:
+      contents: read
     runs-on:
       - self-hosted
       - Windows

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -224,7 +224,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:88da612bd391529048ff81f3f1bc00d1beceed86b770b78de0557fef2b890b0d",
+          "definitionDigest": "sha256:23b52a3000961fce92fce68508453a36ebbaefdb4808d41d478d6d24486a4865",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": [],
           "steps": [{"index":1,"label":"name:Confirm exact JIT runner identity","definitionDigest":"sha256:115bfd9234736a1da607e61a0bb1be98a191d35f0da57ad4bb419a447069b9d2"},{"index":2,"label":"name:Hold until the declared cleanup trigger","definitionDigest":"sha256:ebc15529c500b6f0e216a2a2ede2ade66d1f685f9b824e67cf3a5382af07cf84"}]
@@ -234,8 +234,8 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:1781e076386a9744ed42fbc21a6ad24219b69f8280de35ae6a005fa946dbbb51",
-          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "definitionDigest": "sha256:326250f4cb1c71434147b57c8139bfc71c4be21f6bd9245eb25ead72c569e95e",
+          "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
           "steps": []
         },
@@ -244,8 +244,8 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:d60abc0f730c10871219dc930db7e8937b912a15b5b9936467049eb7a25ffaaf",
-          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "definitionDigest": "sha256:4c5fcd129c2e837b554a7ffa76584ac55bdbc9dc4a7a38e233a8cfa0955b136c",
+          "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
           "steps": []
         },
@@ -254,7 +254,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e7b8a1634e100d5628adb348fa8524fba6e1f5c48a2ddb8a5f4c271910a85647",
+          "definitionDigest": "sha256:ed8c39bd07f1a530e41ec91142529b5b5c6e0e345a59f8ffaf6077a779518192",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
           "steps": [{"index":1,"label":"name:Require canonical repository, mode, and label","definitionDigest":"sha256:c79ae3993e76974650848389ab59d62f355ae08734717d349c6ea7e144182999"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -57,8 +57,8 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/aws-us-macos-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `cleanup-exercise` | qualification | none | diagnostic | token:read | none | 2 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `full` | qualification | none | diagnostic | token:read | none | 0 |
-| `.github/workflows/aws-us-windows-burst-qualification.yml` | `smoke` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `full` | qualification | none | diagnostic | token:write, oidc | none | 0 |
+| `.github/workflows/aws-us-windows-burst-qualification.yml` | `smoke` | qualification | none | diagnostic | token:write, oidc | none | 0 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `trust` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `auditable-demo` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `auditable-demo-fast-sentinel` | qualification | none | diagnostic | token:read | none | 2 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -110,7 +110,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:b562998febe443a87d3a14b16e90acfa9232d30ad350a1e11af219d09d287aff"
+          "sourceRoot": "sha256:24f85d2cf516dc16f3c4a229a45c1e4dabbf82e9a2ce452e1def39510bf1b508"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -820,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:c14e9e7bc99a1b318a5cb46ebf347b3216ee626314b9165219283f6c8a6654b9"
+  "registryRoot": "sha256:bffad5550311229c9b73570ef5559c41dc0d79dd599938d5827d65d314728857"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -242,8 +242,24 @@ test('reactivated AWS burst workflows pin one reviewed Buildchain v3 source', ()
     assert.doesNotMatch(workflow, /train\/v2|buildchain-ref:\s*[\r\n]/);
     assert.doesNotMatch(
       workflow,
-      /secrets:\s*inherit|id-token:\s*write|notar|signing|npm-publish|release-new-version|deploy/,
+      /secrets:\s*inherit|notar|signing|npm-publish|release-new-version|deploy/,
     );
+    if (name === 'aws-us-windows-burst-qualification.yml') {
+      assert.doesNotMatch(
+        workflow,
+        /permissions:\n {2}actions: read\n {2}contents: read\n {2}issues: write\n {2}id-token: write/,
+      );
+      assert.equal(
+        (
+          workflow.match(
+            /permissions:\n {6}actions: read\n {6}contents: read\n {6}issues: write\n {6}id-token: write/g,
+          ) || []
+        ).length,
+        2,
+      );
+    } else {
+      assert.doesNotMatch(workflow, /id-token:\s*write/);
+    }
   }
 });
 
@@ -272,6 +288,22 @@ test('AWS Windows burst workflow preserves bounded full and cleanup exercises', 
   );
   assert.match(workflow, /name: AWS US Windows Burst Qualification/);
   assert.match(workflow, /permissions:\n {2}contents: read/);
+  assert.equal(
+    (
+      workflow.match(
+        /permissions:\n {6}actions: read\n {6}contents: read\n {6}issues: write\n {6}id-token: write/g,
+      ) || []
+    ).length,
+    2,
+  );
+  assert.match(
+    workflow,
+    /\n {2}trust:[\s\S]*?\n {4}permissions:\n {6}contents: read\n/,
+  );
+  assert.match(
+    workflow,
+    /\n {2}cleanup-exercise:[\s\S]*?\n {4}permissions:\n {6}contents: read\n/,
+  );
   assert.match(workflow, /runner-preset: aws-us-ec2-windows-jit/);
   assert.match(workflow, /win-full-0\[1-3\]:full/);
   assert.match(workflow, /win-cancel:cancellation/);


### PR DESCRIPTION
## Summary

- grant the exact token permissions declared by the pinned Buildchain v3 reusable workflow
- keep local trust and cleanup jobs restricted to contents read
- add a regression assertion for the caller permission contract

## Root cause

Run 30571491548 resolved the pinned Buildchain workflow but failed at startup with zero jobs. The Buildchain v3 reusable workflow declares actions read, contents read, issues write, and id-token write; the Windows caller exposed only contents read. GitHub reusable workflows cannot elevate permissions beyond the caller. Branch compile probe 30572196733 creates the trust job after this patch.

## Verification

- actionlint .github/workflows/aws-us-windows-burst-qualification.yml
- targeted AWS Windows workflow contract test
- workflow authority refresh
- release publication roots and control-plane check
- full staged repository gate
- live branch compile probe: 30572196733

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair the existing Windows burst reusable-workflow permission contract without changing product architecture, publication authority, or support claims."
}
-->

## Governance risk check

- [x] GitHub token permissions: exact called-workflow contract, with local jobs reduced to contents read
- [ ] release publication or credential exposure
- [ ] product architecture or support claim change

## Checklist

- [x] Commit signed off (DCO)
- [x] Generated workflow authority and publication roots refreshed