### PR TITLE
fix(shifu): activate Work from pinned uv cache

### DIFF
--- a/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
+++ b/docs/adr/SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1808, https://github.com/kungfu-systems/kungfu/pull/1836, https://github.com/kungfu-systems/kungfu/pull/1840, https://github.com/kungfu-systems/kungfu/pull/1889, https://github.com/kungfu-systems/kungfu/pull/1930, https://github.com/kungfu-systems/kungfu/pull/1934, https://github.com/kungfu-systems/kungfu/pull/1942, https://github.com/kungfu-systems/kungfu/pull/1944, https://github.com/kungfu-systems/kungfu/pull/1981]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1808, https://github.com/kungfu-systems/kungfu/pull/1836, https://github.com/kungfu-systems/kungfu/pull/1840, https://github.com/kungfu-systems/kungfu/pull/1889, https://github.com/kungfu-systems/kungfu/pull/1930, https://github.com/kungfu-systems/kungfu/pull/1934, https://github.com/kungfu-systems/kungfu/pull/1942, https://github.com/kungfu-systems/kungfu/pull/1944, https://github.com/kungfu-systems/kungfu/pull/1981, https://github.com/kungfu-systems/kungfu/pull/1984]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1808
 qualification_refs: [scripts/check-shifu-cache-contract.mjs, scripts/check-shifu-cache-contract.test.mjs, scripts/qualified-assignment-core-artifact.test.mjs, tests/qualification/qualified-assignment-core/cold-path-benchmark.mjs, docs/qualification/evidence/qualified-core-cold-path-darwin-arm64.json, framework/assignment-capture/qualified-assignment-core-consumer.mjs, framework/assignment-capture/qualified-assignment-core-platform-matrix.mjs, framework/release/qualified-assignment-core-artifact.mjs, shifu, docs/shifu/schema/qualified-assignment-core-artifact-v1.schema.json, docs/shifu/schema/qualified-assignment-core-qualification-v1.schema.json, docs/shifu/schema/qualified-assignment-core-artifact-v2.schema.json, docs/shifu/schema/qualified-assignment-core-qualification-v2.schema.json, docs/shifu/schema/qualified-assignment-core-platform-matrix-v1.schema.json, docs/shifu/qualified-assignment-core-platform-matrix.json, docs/shifu/artifact-contract.json, docs/shifu/cache-contract.json, .github/workflows/affected-native-pr.yml, .github/workflows/affected-native-cache-promote.yml]
 review_state: maintainer-reviewed
@@ -20,7 +20,7 @@ ai_provenance: GPT-5 via Codex, updated 2026-07-30; based on repository contract
 
 # SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa: Qualified Assignment Core artifacts bind identity, qualification, and promotion authority
 
-- Status: accepted; contract merged in PR #1808, exact producer/promotion delivery merged in PR #1836, hosted runtime activation independently reviewed in PR #1840, automatic source consumer delivery proposed in PR #1889, bounded usage observability merged in PR #1930, native compatibility identity proposed in PR #1934, bounded cold-path transport proposed in PR #1944 after PR #1942 was superseded to preserve linear Project Cut replay, and Linux x86_64 consumer qualification proposed in PR #1981
+- Status: accepted; contract merged in PR #1808, exact producer/promotion delivery merged in PR #1836, hosted runtime activation independently reviewed in PR #1840, automatic source consumer delivery proposed in PR #1889, bounded usage observability merged in PR #1930, native compatibility identity proposed in PR #1934, bounded cold-path transport proposed in PR #1944 after PR #1942 was superseded to preserve linear Project Cut replay, Linux x86_64 consumer qualification proposed in PR #1981, and pinned uv activation repair proposed in PR #1984
 - Date: 2026-07-30
 
 ## Context
@@ -141,6 +141,13 @@ qualifies a second detached checkout from the retained immutable local CAS with
 GitHub transport disabled. Both observations retain exact receipt roots while
 remaining optimization evidence only. Linux ARM64 and every other Python ABI
 remain explicit unsupported-host fallbacks.
+
+Work activation resolves the repository-pinned `uv` binary from Shifu's native
+tool cache when a fresh runner does not expose `uv` on `PATH`. Resolution binds
+the checked-in pin, normalized host target, regular-file identity, and
+executable mode; unsafe pin segments and unavailable tools retain the existing
+machine-actionable source-build fallback. This repair adds no download,
+credential, global configuration, or alternative artifact authority.
 
 Each consumer attempt may also publish one immutable, bounded observation under
 the Qualified Core cache root and expose a read-only summary through

--- a/framework/assignment-capture/qualified-assignment-core-consumer.mjs
+++ b/framework/assignment-capture/qualified-assignment-core-consumer.mjs
@@ -41,6 +41,14 @@ const ACTIVE_CONSUMER_ROWS = new Set([
   'darwin-arm64-cp313',
   'linux-x86_64-cp313',
 ]);
+const TOOL_CACHE_TARGETS = {
+  'darwin-arm64': 'macos-aarch64',
+  'darwin-x64': 'macos-x86_64',
+  'linux-arm64': 'linux-aarch64',
+  'linux-x64': 'linux-x86_64',
+  'win32-x64': 'windows-x86_64',
+};
+const SAFE_CACHE_SEGMENT = /^[A-Za-z0-9._-]+$/u;
 
 class QualifiedCoreUnavailable extends Error {
   constructor(reason, detail = '', context = null) {
@@ -56,6 +64,47 @@ function writeJson(file, value) {
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, {
     flag: 'wx',
   });
+}
+
+export function resolveShifuCachedTool({
+  tool,
+  repositoryRoot = process.cwd(),
+  platform = process.platform,
+  architecture = process.arch,
+  env = process.env,
+}) {
+  if (tool !== 'uv') return '';
+  const pin = path.join(repositoryRoot, '.uv-version');
+  const version = String(
+    env.KUNGFU_UV_VERSION ||
+      (fs.existsSync(pin)
+        ? fs
+            .readFileSync(pin, 'utf8')
+            .split(/\r?\n/u)
+            .map((line) => line.trim())
+            .find(Boolean)
+        : '') ||
+      '',
+  ).trim();
+  const target = TOOL_CACHE_TARGETS[`${platform}-${architecture}`] || '';
+  if (!SAFE_CACHE_SEGMENT.test(version) || !SAFE_CACHE_SEGMENT.test(target)) {
+    return '';
+  }
+  const binary = path.join(
+    env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'),
+    'kungfu',
+    'tools',
+    tool,
+    version,
+    target,
+    platform === 'win32' ? `${tool}.exe` : tool,
+  );
+  if (!fs.existsSync(binary)) return '';
+  const stat = fs.statSync(binary);
+  if (!stat.isFile() || (platform !== 'win32' && !(stat.mode & 0o111))) {
+    return '';
+  }
+  return binary;
 }
 
 function bytesRoot(bytes) {
@@ -1436,6 +1485,12 @@ function diagnosis(error) {
 
 async function main() {
   const [command, ...args] = process.argv.slice(2);
+  if (command === 'resolve-cached-tool') {
+    const resolved =
+      args.length === 1 ? resolveShifuCachedTool({ tool: args[0] }) : '';
+    if (resolved) process.stdout.write(`${resolved}\n`);
+    return;
+  }
   if (!['materialize', 'status'].includes(command)) {
     throw new QualifiedCoreUnavailable('invalid-command');
   }

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -112,6 +112,100 @@ test('partial Core assembly cannot masquerade as Work readiness', (t) => {
   );
 });
 
+test('cached pinned uv activates Work after Qualified Core materialization', (t) => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX launcher contract');
+    return;
+  }
+  const cacheTargets = {
+    'darwin-arm64': 'macos-aarch64',
+    'darwin-x64': 'macos-x86_64',
+    'linux-arm64': 'linux-aarch64',
+    'linux-x64': 'linux-x86_64',
+  };
+  const cacheTarget = cacheTargets[`${process.platform}-${process.arch}`];
+  if (!cacheTarget) {
+    t.skip('unsupported Shifu bootstrap target');
+    return;
+  }
+  const temp = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-shifu-cached-uv-'),
+  );
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
+  const launcher = path.join(temp, 'shifu');
+  const capture = path.join(temp, 'framework', 'assignment-capture');
+  const core = path.join(temp, 'framework', 'core');
+  const dist = path.join(core, 'dist', 'kungfu');
+  const cache = path.join(temp, 'cache');
+  const uv = path.join(
+    cache,
+    'kungfu',
+    'tools',
+    'uv',
+    '0.11.23',
+    cacheTarget,
+    'uv',
+  );
+  const callLog = path.join(temp, 'uv-call.txt');
+  fs.mkdirSync(dist, { recursive: true });
+  fs.mkdirSync(capture, { recursive: true });
+  fs.mkdirSync(path.dirname(uv), { recursive: true });
+  fs.copyFileSync(path.join(ROOT, 'shifu'), launcher);
+  fs.writeFileSync(
+    path.join(capture, 'qualified-assignment-core-consumer.mjs'),
+    [
+      "import fs from 'node:fs';",
+      "import path from 'node:path';",
+      "const binary = path.join(process.env.XDG_CACHE_HOME, 'kungfu', 'tools', 'uv', '0.11.23', process.env.SHIFU_TEST_CACHE_TARGET, 'uv');",
+      "if (process.argv[2] === 'resolve-cached-tool' && fs.existsSync(binary)) console.log(binary);",
+      '',
+    ].join('\n'),
+  );
+  fs.chmodSync(launcher, 0o755);
+  fs.writeFileSync(path.join(temp, '.uv-version'), '0.11.23\n');
+  fs.writeFileSync(path.join(dist, 'pykungfu.cached.so'), '');
+  fs.writeFileSync(path.join(dist, 'kungfubuildinfo.json'), '{}\n');
+  fs.writeFileSync(
+    uv,
+    ['#!/bin/sh', 'echo "$PWD|$*" > "$UV_CALL_LOG"', ''].join('\n'),
+  );
+  fs.chmodSync(uv, 0o755);
+
+  const result = spawnSync(launcher, ['work', '--help'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: temp,
+      PATH: `${path.dirname(process.execPath)}:/usr/bin:/bin`,
+      SHIFU_TEST_CACHE_TARGET: cacheTarget,
+      UV_CALL_LOG: callLog,
+      XDG_CACHE_HOME: cache,
+      XDG_CONFIG_HOME: path.join(temp, 'config'),
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(
+    fs.readFileSync(callLog, 'utf8'),
+    `${core}|run --frozen python .devtools/kungfu_cli.py work --help\n`,
+  );
+  fs.rmSync(callLog);
+  const rejected = spawnSync(launcher, ['work', '--help'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      HOME: temp,
+      KUNGFU_UV_VERSION: '../0.11.23',
+      PATH: `${path.dirname(process.execPath)}:/usr/bin:/bin`,
+      SHIFU_TEST_CACHE_TARGET: 'invalid-target',
+      UV_CALL_LOG: callLog,
+      XDG_CACHE_HOME: cache,
+      XDG_CONFIG_HOME: path.join(temp, 'config'),
+    },
+  });
+  assert.equal(rejected.status, 127);
+  assert.equal(fs.existsSync(callLog), false);
+});
+
 test('Windows cold source Work failure carries the same diagnosis', () => {
   const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
   assert.match(

--- a/scripts/qualified-assignment-core-artifact.test.mjs
+++ b/scripts/qualified-assignment-core-artifact.test.mjs
@@ -14,6 +14,7 @@ import {
   downloadGithubArtifact,
   downloadHttpArtifact,
   materializeQualifiedCoreBundle,
+  resolveShifuCachedTool,
 } from '../framework/assignment-capture/qualified-assignment-core-consumer.mjs';
 import {
   appendQualifiedCoreUsage,
@@ -360,6 +361,48 @@ function compatibilityCheckoutFixture(temporary) {
   }
   return repositoryRoot;
 }
+
+test('cached Shifu tool resolution binds pin, platform, and executable file', (t) => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'qualified-core-cached-tool-'),
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const cache = path.join(root, 'cache');
+  const uv = path.join(
+    cache,
+    'kungfu',
+    'tools',
+    'uv',
+    '0.11.23',
+    'linux-x86_64',
+    'uv',
+  );
+  fs.mkdirSync(path.dirname(uv), { recursive: true });
+  fs.writeFileSync(path.join(root, '.uv-version'), '0.11.23\n');
+  fs.writeFileSync(uv, '');
+  fs.chmodSync(uv, 0o755);
+  const options = {
+    tool: 'uv',
+    repositoryRoot: root,
+    platform: 'linux',
+    architecture: 'x64',
+    env: { XDG_CACHE_HOME: cache },
+  };
+  assert.equal(resolveShifuCachedTool(options), uv);
+  assert.equal(
+    resolveShifuCachedTool({
+      ...options,
+      env: {
+        KUNGFU_UV_VERSION: '../0.11.23',
+        XDG_CACHE_HOME: cache,
+      },
+    }),
+    '',
+  );
+  fs.chmodSync(uv, 0o644);
+  assert.equal(resolveShifuCachedTool(options), '');
+  assert.equal(resolveShifuCachedTool({ ...options, tool: 'fnm' }), '');
+});
 
 test('platform matrix binds exactly four collision-free producer rows', (t) => {
   const matrix = qualifiedCorePlatformMatrix(ROOT);

--- a/shifu
+++ b/shifu
@@ -293,15 +293,15 @@ if [ "${1:-}" = "work" ]; then
   }
   _kungfu_checkout_binding="$(kungfu_checkout_binding)"
   _kungfu_checkout_build_info="./framework/core/dist/kungfu/kungfubuildinfo.json"
+  _kungfu_uv="$(command -v uv || { command -v node >/dev/null 2>&1 && node ./framework/assignment-capture/qualified-assignment-core-consumer.mjs resolve-cached-tool uv 2>/dev/null; } || true)"
   if [ -z "$_kungfu_checkout_binding" ] \
     && { [ "$(kungfu_native_platform)" = "macos-arm64" ] || [ "$(kungfu_native_platform)" = "linux-x64" ]; } \
     && command -v node >/dev/null 2>&1 && [ -f "./framework/assignment-capture/qualified-assignment-core-consumer.mjs" ]; then
     node ./framework/assignment-capture/qualified-assignment-core-consumer.mjs materialize --repository-root "$PWD" || exit $?
     _kungfu_checkout_binding="$(kungfu_checkout_binding)"
   fi
-  if [ -n "$_kungfu_checkout_binding" ] && [ -f "$_kungfu_checkout_build_info" ] && command -v uv >/dev/null 2>&1; then
-    cd ./framework/core
-    exec uv run --frozen python .devtools/kungfu_cli.py work "$@"
+  if [ -n "$_kungfu_checkout_binding" ] && [ -f "$_kungfu_checkout_build_info" ] && [ -n "$_kungfu_uv" ]; then
+    cd ./framework/core && exec "$_kungfu_uv" run --frozen python .devtools/kungfu_cli.py work "$@"
   fi
   printf '%s\n' '{"schema":"kungfu.assignment-orchestration.diagnosis/v1","ok":false,"code":"assignment-current-checkout-binding-missing","message":"Assignment admission requires pykungfu from the current checkout","next_actions":[{"action":"build-core","command":"./shifu build:core","description":"Assemble pykungfu from the current checkout"}]}'
   exit 127


### PR DESCRIPTION
## Summary

- resolve the repository-pinned uv binary from the native Shifu tool cache when uv is absent from PATH
- activate Work immediately after a Qualified Core bundle is materialized in a fresh Linux checkout
- reject unsafe pin segments, non-files, and non-executable cached tools without widening network or artifact authority

## Related issue

- Native Assignment `2026-07-30-kungfu-qualified-core-linux-x86-64-consumer`
- Parent Initiative `2026-07-30-kungfu-qualified-core-developer-acceleration-family`

## Verification

- `node --test scripts/check-shifu-entry-contract.test.mjs scripts/qualified-assignment-core-artifact.test.mjs` — 51/51 pass
- `node --test scripts/readonly-agent-bootstrap.test.mjs` — pass in the existing pinned Core test environment
- Biome — pass
- pre-commit staged gate — pass
- protected post-push Linux qualification will prove the real remote-hit and second-checkout local-CAS Work activation

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["SHIFU-ADR-019fab1a-2853-737e-8c67-a9b1aa9035aa"],
  "summary": "Repair Linux Qualified Core Work activation by binding Shifu to the repository-pinned uv binary already provisioned in its native tool cache.",
  "verification": ["51 focused Shifu and Qualified Core tests", "cold read-only source route fixture", "protected Linux remote-hit and local-CAS qualification", "independent protected review"]
}
-->

## Evolution Map impact

Evolution impact: extends

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [x] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] none of the above

The repair consumes only an already provisioned repository-pinned uv binary. It does not add downloads, credentials, global configuration, or alternate qualification authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] ADR implementation evidence updated with this PR

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMzAta3VuZ2Z1LXF1YWxpZmllZC1jb3JlLWRldmVsb3Blci1hY2NlbGVyYXRpb24tZmFtaWx5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0zMC1rdW5nZnUtcXVhbGlmaWVkLWNvcmUtbGludXgteDg2LTY0LWNvbnN1bWVyIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJjNjYxMGE5ZDQzZTkzMTYzODRhOTU4OTJmNTVhZWZlMjExODYwY2UxIiwicHVsbFJlcXVlc3RIZWFkIjoiNGFmMTMyZjA2NzQ4ZjAyZmJmMjJmYWViMDU4M2NhYTI4MjFkMzc4OSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiNjM0MGQwZjQ1ZDI0MDA5YTcyNWNmZWFlYTkyOWU1NmY2ZDkzZDJiOCIsInJlcGxheWVkVHJlZSI6IjQxMWViYmQ0MDU0ZmUzOWZiY2E5M2JkNmJmNDllNTMzZTI5YmIwODMiLCJxdWV1ZUF0dGVtcHQiOiI0YWYxMzJmMDY3NDhmMDJmYmYyMmZhZWIwNTgzY2FhMjgyMWQzNzg5QGM2NjEwYTlkNDNlOTMxNjM4NGE5NTg5MmY1NWFlZmUyMTE4NjBjZTEiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6N2YzMDExOGE4ZWYyNzY1ZDQ5M2Y0NGE4MTk2M2FlMzM3MWRmYjYzNjcyNzhmODFlNDY5YzM4ZjNjYWVhYjYwOCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjZkYTgxNTlkNWYzMjFhYTE5YTkxNzQyNjg1N2FlMGRmOThhMzlhNjc3YzYwNTA2YzViMjA2Njc0MmE5M2RhYTMiLCJzaGEyNTY6N2YzMDExOGE4ZWYyNzY1ZDQ5M2Y0NGE4MTk2M2FlMzM3MWRmYjYzNjcyNzhmODFlNDY5YzM4ZjNjYWVhYjYwOCJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlLzk2ZDNiZmY1NzFiMDRiYjIiLCJsZWFzZVJvb3QiOiJzaGEyNTY6OTExZThlYzgxZjJjNDE2MjI1MTY1NzhiNDM4ZDgxNWFhOGIzOTliYTkzODJhMTI3MjZjOGJhYTViYzExMWRlOCJ9 -->