### PR TITLE
fix(ci): pin repaired Windows burst runtime

### DIFF
--- a/.github/workflows/aws-us-linux-burst-qualification.yml
+++ b/.github/workflows/aws-us-linux-burst-qualification.yml
@@ -19,9 +19,9 @@ concurrency:
 jobs:
   qualify:
     name: Exact-source Linux core qualification after Buildchain trust gate
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499
     with:
-      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      buildchain-ref: 376fb92fa014102366111b9aaef4856486c1e499
       runner-preset: aws-us-codebuild-linux
       aws-codebuild-project: kungfu-buildchain-linux-burst-poc
       setup-rust: true

--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -43,9 +43,9 @@ jobs:
           (inputs.mode == 'full' && inputs.qualification-id == 'mac-full-01')
         )
       }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499
     with:
-      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      buildchain-ref: 376fb92fa014102366111b9aaef4856486c1e499
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -82,9 +82,9 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499
     with:
-      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      buildchain-ref: 376fb92fa014102366111b9aaef4856486c1e499
       runner-preset: aws-us-ec2-windows-jit
       aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
       setup-rust: true
@@ -121,9 +121,9 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499
     with:
-      buildchain-ref: 407445c43df4888bb4464e91aef0debdc62aa0e6
+      buildchain-ref: 376fb92fa014102366111b9aaef4856486c1e499
       runner-preset: aws-us-ec2-windows-jit
       aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -14,7 +14,9 @@
     "failureBoundary": "bounded caller inputs plus the exact Buildchain runtime's GitHub-hosted write-actor trust gate before reusable burst runners; direct Windows cleanup jobs retain their caller-local trust gate"
   },
   "evidence": {
-    "reviewedBuildchainV3Source": "407445c43df4888bb4464e91aef0debdc62aa0e6",
+    "reviewedBuildchainV3Source": "376fb92fa014102366111b9aaef4856486c1e499",
+    "windowsJitRepairPullRequest": 2083,
+    "windowsJitRepairMergeCommit": "376fb92fa014102366111b9aaef4856486c1e499",
     "v3RequiredInputs": [
       "aws-codebuild-project",
       "aws-ec2-windows-runner-label",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -190,9 +190,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:acd77bbf6e02e67a87538804a8f6676331eb05e8161a40b26acd09e328ae6919",
+          "definitionDigest": "sha256:7b424ae9bed80b7b81322cb4abee22d103739732826a35581ababf11770c2386",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499"],
           "steps": []
         }
       ]
@@ -207,9 +207,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:36a9c8008d54206e8537426fefd68556ff852b149eaf3480f5226f6f48ad78dd",
+          "definitionDigest": "sha256:e7e9044c1cedb55ed79d43af5ae39800d4b9a7e40d79a68b44142ecb99fac53f",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499"],
           "steps": []
         }
       ]
@@ -234,9 +234,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:326250f4cb1c71434147b57c8139bfc71c4be21f6bd9245eb25ead72c569e95e",
+          "definitionDigest": "sha256:7a4a2ebf862dd35dd9e946beffdf03dfe0d0d79f7ec475129fe3f294bee20ef4",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499"],
           "steps": []
         },
         {
@@ -244,9 +244,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:4c5fcd129c2e837b554a7ffa76584ac55bdbc9dc4a7a38e233a8cfa0955b136c",
+          "definitionDigest": "sha256:143b06d990a1dca7b6215617af24b2a20b64775d8e174438bf42d5895dbdbcf9",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@407445c43df4888bb4464e91aef0debdc62aa0e6"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499"],
           "steps": []
         },
         {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -96,21 +96,21 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:f00fdb448f4954fc0344ee6ce0eb6c3e6a0c051b66f1738ec14376aae449e3f5"
+          "sourceRoot": "sha256:ada2b7c9e6587502e4db254a139e340b7ec27c3a7994c1947c322bc9e1336bf6"
         },
         {
           "path": ".github/workflows/aws-us-macos-burst-qualification.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:e80feb249d6e67528439726ecb2f6639c949cd2d6178b8fac37c6535d1b81850"
+          "sourceRoot": "sha256:338f68ed79f6510402ca02e55f6a1352f7957ca714a117d50a4e2a06bc104a25"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:24f85d2cf516dc16f3c4a229a45c1e4dabbf82e9a2ce452e1def39510bf1b508"
+          "sourceRoot": "sha256:9828639e188badfc8a1f2ddfe17ea1d07ba9e737d15289a981a0a9db3906bbbd"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -820,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:bffad5550311229c9b73570ef5559c41dc0d79dd599938d5827d65d314728857"
+  "registryRoot": "sha256:3b0d88cdf91b3f6b99cd4dcce43e0f8db88665cfa01bc6e25f7daa900a19ed25"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -209,7 +209,12 @@ test('reactivated AWS burst workflows pin one reviewed Buildchain v3 source', ()
   assert.equal(retirement.runtimeSafety.burstRunnerWorkflows, 3);
   assert.match(retirement.evidence.historicalBuildchainRef, /^train\/v2\//);
   const buildchainSource = retirement.evidence.reviewedBuildchainV3Source;
-  assert.equal(buildchainSource, '407445c43df4888bb4464e91aef0debdc62aa0e6');
+  assert.equal(buildchainSource, '376fb92fa014102366111b9aaef4856486c1e499');
+  assert.equal(retirement.evidence.windowsJitRepairPullRequest, 2083);
+  assert.equal(
+    retirement.evidence.windowsJitRepairMergeCommit,
+    buildchainSource,
+  );
 
   for (const name of [
     'aws-us-linux-burst-qualification.yml',


### PR DESCRIPTION
## Summary

- pin all three bounded AWS burst callers to reviewed Buildchain repair commit `376fb92fa014102366111b9aaef4856486c1e499`
- record Buildchain PR #2083 as the Windows JIT runtime repair authority
- refresh workflow authority and publication roots

## Root cause and evidence

Exact-source Windows run `30576011490` completed the native product build, then failed at `Seal declared artifact signing requests` with `bash: command not found`. Buildchain PR #2083 adds PortableGit `bin` to the disposable Windows JIT PATH while preserving `cmd`; its merge commit is the exact runtime pinned here.

The failed one-job runner terminated cleanly: EC2 instance terminated, disposable volume deleted, SSM parameters zero, registered GitHub runners zero. Lifecycle and runner diagnostics were retained in the bounded evidence bucket.

## Verification

- repaired Buildchain commit contains the exact PortableGit PATH fix
- actionlint on Linux, Windows, and macOS AWS burst callers
- `node --test scripts/buildchain-install.test.mjs` — 11/11 passed
- workflow authority closed-world check — passed
- publication control-plane check — passed
- full staged repository gate — passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Advance the existing bounded AWS burst callers to the reviewed Buildchain Windows bootstrap repair without changing product architecture, publication authority, or support claims."
}
-->

## Governance risk check

- [x] exact third-party reusable workflow SHA changes to an independently reviewed same-organization commit
- [ ] release publication or credential exposure
- [ ] product architecture or support claim change

## Checklist

- [x] Commit signed off (DCO)
- [x] Generated workflow authority and publication roots refreshed