### PR TITLE
fix(qualification): shorten Windows installer temp path

### DIFF
--- a/tests/qualification/layers/surfaces/run.mjs
+++ b/tests/qualification/layers/surfaces/run.mjs
@@ -34,6 +34,19 @@ function fail(message) {
   throw new Error(message);
 }
 
+export function surfaceQualificationTempRoot(
+  platform = process.platform,
+  env = process.env,
+  fallback = os.tmpdir(),
+) {
+  const hostTemporary = String(env.KUNGFU_QUALIFICATION_HOST_TEMP || '').trim();
+  // Release qualification redirects generic temp files into the checkout for
+  // cleanup, but that makes deeply nested NSIS payload paths exceed legacy
+  // Windows deletion limits. Keep installer qualification on the short runner
+  // temp that the release driver preserved before applying that redirect.
+  return platform === 'win32' && hostTemporary ? hostTemporary : fallback;
+}
+
 function parseArgs(argv) {
   const options = {
     validateOnly: false,
@@ -239,8 +252,10 @@ function directoryBytes(root) {
 }
 
 async function exactQualification(options, fixture) {
+  const tempRoot = surfaceQualificationTempRoot();
+  fs.mkdirSync(tempRoot, { recursive: true });
   const temp = fs.mkdtempSync(
-    path.join(os.tmpdir(), 'kungfu-surface-qualification-'),
+    path.join(tempRoot, 'kungfu-surface-qualification-'),
   );
   try {
     if (options.cliArchive.endsWith('.zip'))

--- a/tests/qualification/layers/surfaces/run.test.mjs
+++ b/tests/qualification/layers/surfaces/run.test.mjs
@@ -9,7 +9,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { guiQualificationArgs } from './installer.mjs';
-import { findArtifact } from './run.mjs';
+import { findArtifact, surfaceQualificationTempRoot } from './run.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const runner = path.join(here, 'run.mjs');
@@ -23,6 +23,33 @@ test('surface qualification source contract validates without artifacts', () => 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /source-valid/);
   assert.match(result.stdout, /does not qualify installed artifacts/);
+});
+
+test('Windows installer qualification uses the preserved short host temp', () => {
+  assert.equal(
+    surfaceQualificationTempRoot(
+      'win32',
+      { KUNGFU_QUALIFICATION_HOST_TEMP: 'D:\\a\\_temp' },
+      'D:\\a\\kungfu\\kungfu\\.buildchain\\tmp',
+    ),
+    'D:\\a\\_temp',
+  );
+  assert.equal(
+    surfaceQualificationTempRoot(
+      'win32',
+      { KUNGFU_QUALIFICATION_HOST_TEMP: '  ' },
+      'D:\\fallback',
+    ),
+    'D:\\fallback',
+  );
+  assert.equal(
+    surfaceQualificationTempRoot(
+      'linux',
+      { KUNGFU_QUALIFICATION_HOST_TEMP: '/runner/temp' },
+      '/repo/.buildchain/tmp',
+    ),
+    '/repo/.buildchain/tmp',
+  );
 });
 
 test('desktop discovery treats a matched app bundle as one artifact root', () => {


### PR DESCRIPTION
## Summary

- run Windows surface installer qualification under the preserved short host temp
- keep Linux and macOS temp routing unchanged
- cover Windows host-temp selection and fallback behavior

## Failure evidence

AWS Windows qualification run 30581097394 built the product and reached the verify lifecycle, then NSIS uninstall left files under a 273-character path even though no process remained under the install root. The release driver already preserves RUNNER_TEMP as KUNGFU_QUALIFICATION_HOST_TEMP before redirecting general temp files into the checkout.

## Verification

- 14 focused surface installer tests passed
- Biome check passed for both changed files
- repository staged gate passed, including 73 merge/latency tests, 17 invariant tests, 436-document validation, and 132 documentation/promotion tests
- DCO sign-off present

## Boundary

This changes only the Windows qualification scratch location. Product installation paths and shipped installer behavior are unchanged.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix Windows qualification scratch path without changing architecture or product contracts"
}
-->