### PR TITLE
fix(qualification): retain failed suite diagnostics

### DIFF
--- a/framework/core/tests/qualification/live-peer-continuity/run.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.mjs
@@ -184,8 +184,17 @@ function runSuite(suite, outputDir) {
     result.error ? `${result.error.name}: ${result.error.message}\n` : ''
   }`;
   const rawLog = `${suite.id}.log`;
-  fs.writeFileSync(path.join(outputDir, rawLog), output, { flag: 'wx' });
+  const rawLogPath = path.join(outputDir, rawLog);
+  fs.writeFileSync(rawLogPath, output, { flag: 'wx' });
   const passed = !result.error && result.status === 0;
+  if (!passed) {
+    const tail = boundedDiagnosticTail(rawLogPath);
+    if (tail) {
+      console.error(
+        `[live-peer-continuity] suite-log-tail-start suite=${suite.id}\n${tail}\n[live-peer-continuity] suite-log-tail-end suite=${suite.id}`,
+      );
+    }
+  }
   if (!passed && suite.id === 'native-cross-process-restart') {
     const campaign = nativeCampaignReport(outputDir);
     const detail =

--- a/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
+++ b/framework/core/tests/qualification/live-peer-continuity/run.test.mjs
@@ -161,7 +161,7 @@ test('native campaign uses a short platform-owned temp root', () => {
   );
 });
 
-test('native campaign failure diagnostics retain only a bounded log tail', () => {
+test('suite failure diagnostics retain only a bounded log tail', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'peer-log-tail-'));
   const log = path.join(root, 'peer.log');
   try {


### PR DESCRIPTION
## Summary

- emit a bounded raw-log tail for every failed live Peer qualification suite
- preserve the existing native campaign diagnostics
- keep successful suite logs out of the console

## Failure evidence

AWS Windows qualification run 30587669164 failed `peer-lifecycle-control-plane`, but the controller log retained only the suite status because its raw pytest log lived on the terminated ephemeral instance. The missing tail prevented root-cause diagnosis even though infrastructure cleanup completed correctly.

## Verification

- 13 focused live Peer qualification harness tests passed
- Biome check passed for both changed files
- repository staged gate passed, including 73 merge/latency tests, 17 invariant tests, 436-document validation, and 132 documentation/promotion tests
- DCO sign-off present

## Boundary

This changes failure observability only. Passing qualification behavior, evidence bundles, and runtime semantics are unchanged.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Retain bounded failed-suite diagnostics without changing architecture or product contracts"
}
-->
