### PR TITLE
fix(ci): quote Windows cache-off dispatch option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
         type: choice
         options:
           - sccache
-          - off
+          - "off"
         default: sccache
       run-kungfu-phase-b:
         description: "Qualify the Linux CLI package with the reviewed build-images Phase B consumer"

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -121,7 +121,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:e057ff9da8582651d9840e3a378295cdc7fbde057cf47328ff87e755cc6651ee"
+          "sourceRoot": "sha256:b7edb089ac2119572d5746ec558d90f9579ea345730ec8bba8078157bed326f4"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -820,5 +820,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:a2da16d381faef52f15e48d44e8c4b791318a1ca824cc46f0abe15b6609bc0f4"
+  "registryRoot": "sha256:36911c41915e9615da5cd5a43eed7651c4152c6dd39a27b38037a95e6e85f3a0"
 }

--- a/scripts/check-shifu-cache-contract.test.mjs
+++ b/scripts/check-shifu-cache-contract.test.mjs
@@ -518,6 +518,10 @@ test('portable-off qualification profiles cover every native Build lane', () => 
   assert.equal(buildWorkflow.split(`sha256:${sccacheDigest}`).length - 1, 1);
   assert.match(
     buildWorkflow,
+    /windows-compiler-cache-mode:[\s\S]*?options:\s*\n\s+- sccache\s*\n\s+- ["']off["']/u,
+  );
+  assert.match(
+    buildWorkflow,
     /compiler-cache-provider: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.windows-compiler-cache-mode == 'off' && 'none' \|\| 'sccache' \}\}/u,
   );
   assert.match(


### PR DESCRIPTION
## Summary

- quote the Windows compiler-cache `off` workflow-dispatch choice so GitHub accepts the intended string value
- add a raw workflow regression assertion that rejects an unquoted YAML token

## Verification

- `node --test scripts/check-shifu-cache-contract.test.mjs` — 39/39 passed before dependency sync
- `./shifu sync` — frozen lockfile, 994 packages reused from the local store
- repository pre-commit staged gate — passed, including 73 dev-latency tests, 17 invariant tests, 137 documentation/release tests, KFD gates, and staged Biome

## Failure evidence

The first same-source A/B dispatch failed before creating a workflow run with HTTP 422 because GitHub did not admit `off` as a string choice. No DARKHERO Defender or power-plan state changed, and the temporary experiment branch was removed.

Goal: `2026-07-31-kungfu-windows-alpha-build-performance`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Workflow-dispatch string parsing bugfix without accepted ADR record changes"
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTMxLWt1bmdmdS13aW5kb3dzLWFscGhhLWJ1aWxkLXBlcmZvcm1hbmNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJhZDk3ZTQyOTlkNTZiOTIwZmJkODRmNTQyMWM3MDkxMGU3YjQwZTc2IiwicHVsbFJlcXVlc3RIZWFkIjoiMmRmN2M4ZmZkMTJmODMwYmJmZTZjMWUyZDY5MTdmYTM1MGRkZjk0MyIsInJlcGxheWVkQ2FuZGlkYXRlIjoiNWYxNmQ4ZWNjOThiMzQ1NTI0ZDQ1NWY1MWFkOWY2NjVkNjI2NjY2YiIsInJlcGxheWVkVHJlZSI6IjQzNzMwYTlkNWI0NjUyZGYzYTBjNDFlMTUzNzMyOWZkNWJkMDVmOGYiLCJxdWV1ZUF0dGVtcHQiOiIyZGY3YzhmZmQxMmY4MzBiYmZlNmMxZTJkNjkxN2ZhMzUwZGRmOTQzQGFkOTdlNDI5OWQ1NmI5MjBmYmQ4NGY1NDIxYzcwOTEwZTdiNDBlNzYiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6ZjZkMmI4ZGQ5MDk3MzQ0OWZlMzcyODA2NzM2MTM3YjFmNWVhN2NhYzQ0ZjJmZmI0MjBmZTlhZTdmZTU5MzEwMCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjA4ODM2MTllZTc3MmYwNDZlNTMyMmQyMjU5M2ViYjVhMzI2ZGQ2YWIyZjhmYmUzMzJkNzljMjE2MmIzYzcwYTkiLCJzaGEyNTY6ZjZkMmI4ZGQ5MDk3MzQ0OWZlMzcyODA2NzM2MTM3YjFmNWVhN2NhYzQ0ZjJmZmI0MjBmZTlhZTdmZTU5MzEwMCJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6MDhjNjIzZTk1N2QwYmUwMDIxNGYxZjQwYzRlNzEwMjgxODBkZjRlNzQzMDZmOTMyMTg5MzdmNmNmZmMzODYxMyJ9 -->