### PR TITLE
fix(release): align Alpha sentinel with demo catalog

### DIFF
--- a/scripts/alpha-promotion-preflight.mjs
+++ b/scripts/alpha-promotion-preflight.mjs
@@ -108,19 +108,43 @@ export function inspectWindowsFastSentinel({ shifuCmd, lifecycle }) {
   return issues;
 }
 
-export function inspectAuditableDemoFastSentinel({ adapter, workflow }) {
+export function inspectAuditableDemoFastSentinel({
+  adapter,
+  workflow,
+  catalog,
+}) {
   const issues = [];
+  let catalogValue;
+  try {
+    catalogValue = typeof catalog === 'string' ? JSON.parse(catalog) : catalog;
+  } catch {
+    issues.push('auditable-demo catalog is not valid JSON');
+  }
+  const defaultDemo = catalogValue?.demos?.find(
+    (demo) => demo?.id === catalogValue?.defaultDemoId,
+  );
+  if (
+    catalogValue?.schema !== 'kungfu.auditable-demo.catalog/v1' ||
+    !defaultDemo ||
+    defaultDemo.completion?.status !== 'qualified' ||
+    typeof defaultDemo.completion?.sentinel !== 'string' ||
+    defaultDemo.completion.sentinel.length === 0
+  ) {
+    issues.push(
+      'auditable-demo catalog no longer declares one qualified default completion sentinel',
+    );
+  }
   requirePattern(
     issues,
     adapter,
-    /COMPLETION_SENTINEL\s*=\s*re\.compile\(r"KUNGFU_TUI_DEMO_COMPLETE/iu,
-    'auditable-demo adapter no longer requires the installed completion sentinel',
+    /completion_contract\s*=\s*demo\["completion"\][\s\S]*re\.compile\(re\.escape\(completion_contract\["sentinel"\]\)/iu,
+    'auditable-demo adapter no longer compiles the catalog completion sentinel',
   );
   requirePattern(
     issues,
     adapter,
-    /completion\["status"\]\s*!=\s*"qualified"/iu,
-    'auditable-demo adapter regressed to a non-canonical completion verdict',
+    /completion\["status"\]\s*!=\s*completion_contract\["status"\]/iu,
+    'auditable-demo adapter no longer enforces the catalog completion verdict',
   );
   const runtime = workflow.match(
     /uses:\s*kungfu-systems\/buildchain\/\.github\/workflows\/\.auditable-demo\.yml@([0-9a-f]{40})/u,
@@ -133,8 +157,8 @@ export function inspectAuditableDemoFastSentinel({ adapter, workflow }) {
   requirePattern(
     issues,
     workflow,
-    /issue #2057 canonical qualified sentinel/iu,
-    'auditable-demo Gate no longer names the reviewed qualified-sentinel correction',
+    /adapter-path:\s*scripts\/auditable-demo-adapter\.py[\s\S]*adapter-arguments-json:\s*\$\{\{\s*format\('\["--demo-id",\{0\}\]'/iu,
+    'auditable-demo Gate no longer passes one bounded catalog demo id',
   );
   return issues;
 }
@@ -157,6 +181,10 @@ export function runAlphaFastSentinel(kind, root = ROOT) {
       ),
       workflow: fs.readFileSync(
         path.join(root, '.github', 'workflows', 'build.yml'),
+        'utf8',
+      ),
+      catalog: fs.readFileSync(
+        path.join(root, 'framework', 'auditable-demo', 'catalog.json'),
         'utf8',
       ),
     });

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -273,16 +273,27 @@ test('fast sentinels fail the representative recent invalid fixtures', () => {
   );
   const demoIssues = inspectAuditableDemoFastSentinel({
     adapter: [
-      'COMPLETION_SENTINEL = re.compile(r"KUNGFU_TUI_DEMO_COMPLETE ([^\\\\r\\\\n]+)")',
-      'completion["status"] != "passed"',
+      'completion_contract = demo["completion"]',
+      'sentinel = re.compile(re.escape(completion_contract["sentinel"]) + r"([^\\\\r\\\\n]+)")',
+      'completion["status"] != completion_contract["status"]',
     ].join('\n'),
     workflow:
       'uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@main',
+    catalog: {
+      schema: 'kungfu.auditable-demo.catalog/v1',
+      defaultDemoId: 'fixture',
+      demos: [
+        {
+          id: 'fixture',
+          completion: { sentinel: 'FIXTURE_COMPLETE ', status: 'passed' },
+        },
+      ],
+    },
   });
   assert.ok(demoIssues.length >= 2);
   assert.match(
     demoIssues.join('\n'),
-    /canonical completion verdict|exact Buildchain SHA/u,
+    /qualified default completion sentinel|exact Buildchain SHA/u,
   );
 });
 


### PR DESCRIPTION
## Summary

- validate the catalog-declared qualified completion sentinel for the default auditable demo
- prove the adapter consumes the catalog sentinel and verdict instead of requiring retired literal constants
- bind the fast sentinel to an exact Buildchain SHA and one bounded catalog demo id

## Failure evidence

Alpha promotion preflight run `30601568824` rejected exact dev source `306a289dd3bac20131c2397e954b275f744b30ff` because its legacy text probe did not understand the catalog-driven adapter introduced by the multi-demo delivery.

## Validation

- `node --test scripts/alpha-promotion-preflight.test.mjs product/scripts/cli-surface-qualification.test.mjs`
- `./shifu check:staged`
- `./shifu check:source`
- Biome check for both changed files

## Evolution impact

None. This repairs a qualification probe to follow the already-established auditable-demo catalog authority; it does not alter the product or architecture contract.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This qualification repair follows the established auditable-demo catalog authority without altering a Kungfu architecture contract"
}
-->

Goal: `2026-07-24-buildchain-linux-github-attestation`