### PR TITLE
fix(kfx): align bundled capabilities with core policy

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+      "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+      "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -88,13 +88,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "ec523e9f81bc2031c873c23c1cd627db19c574d8b80ffe451d317aa262ec7e43",
+      "preBuildWitnessSha256": "d1290c13bbf619285cf25054e8b21352c4131eef3c4683270e78eedcbda2bd56",
       "sourceHashes": {
-        "sha256": "e8dc34cf0de35e20f4f31d350152ccd4810e97a635be3868ab37409ed3e11848",
+        "sha256": "401efc64bdc1f9ae272fa944b267cafbca86bfcb67d337d31b9914b6946d546a",
         "surfaceCount": 21
       },
       "artifactHashes": {
-        "sha256": "6546aaccb98243a8e959e25ea9c9f8aaf75c1a1e3fdbd0d964e46c8bfb21559a",
+        "sha256": "c208d1f4f494c6c71fe561f3a50d4c43307be45d165ab89e6e42fe4fd0e058c7",
         "surfaceCount": 21
       },
       "witness": {
@@ -152,9 +152,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "byteForByte": true
           },
           {
@@ -397,8 +397,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
-            "actualSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "status": "passed",
             "reason": ""
           },
@@ -574,10 +574,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
-            "actualSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "4fc5aaf9f9f44998599875dc2323f53d1f87a524",
+    "sourceSha": "4ce8f691a56fea017142182081aae44fb2e1a800",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:2473a464af91e95359fe1fe02ead250af3b64d26e079fe93ada8f3b6c37af7d0"
   },

--- a/config/kungfu-kfx.contract.json
+++ b/config/kungfu-kfx.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.kfx.contract/v1",
   "id": "kungfu-kfx",
-  "version": 12,
+  "version": 13,
   "weldedSurface": "kfx-contract",
   "description": "Single source for KFX package manifests, discovery rules, trust inputs, and build detection.",
   "contractSchema": {
@@ -877,6 +877,7 @@
         "ledger",
         "process",
         "profile",
+        "projects",
         "rewind",
         "storage",
         "terminal",

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+      "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+      "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -88,13 +88,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "ec523e9f81bc2031c873c23c1cd627db19c574d8b80ffe451d317aa262ec7e43",
+      "preBuildWitnessSha256": "d1290c13bbf619285cf25054e8b21352c4131eef3c4683270e78eedcbda2bd56",
       "sourceHashes": {
-        "sha256": "e8dc34cf0de35e20f4f31d350152ccd4810e97a635be3868ab37409ed3e11848",
+        "sha256": "401efc64bdc1f9ae272fa944b267cafbca86bfcb67d337d31b9914b6946d546a",
         "surfaceCount": 21
       },
       "artifactHashes": {
-        "sha256": "6546aaccb98243a8e959e25ea9c9f8aaf75c1a1e3fdbd0d964e46c8bfb21559a",
+        "sha256": "c208d1f4f494c6c71fe561f3a50d4c43307be45d165ab89e6e42fe4fd0e058c7",
         "surfaceCount": 21
       },
       "witness": {
@@ -152,9 +152,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "byteForByte": true
           },
           {
@@ -397,8 +397,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
-            "actualSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "status": "passed",
             "reason": ""
           },
@@ -574,10 +574,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
-            "actualSha256": "f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/framework/kfx/kungfu-kfx.contract.json
+++ b/framework/kfx/kungfu-kfx.contract.json
@@ -1,7 +1,7 @@
 {
   "schema": "kungfu.kfx.contract/v1",
   "id": "kungfu-kfx",
-  "version": 12,
+  "version": 13,
   "weldedSurface": "kfx-contract",
   "description": "Single source for KFX package manifests, discovery rules, trust inputs, and build detection.",
   "contractSchema": {
@@ -877,6 +877,7 @@
         "ledger",
         "process",
         "profile",
+        "projects",
         "rewind",
         "storage",
         "terminal",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:c6861ec9dc5215720094b0f317fcc0d909d2ae4a138a23f1690316408acde161",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:136a77dd9addba48ea0b0dfd034ae8aaa918b074380f759825ec8450b0da31cb",
+  "sourceRoot": "sha256:f2ad78d210d33a04518402691e7d89e343dc783857daa918345ff76671bd5eed",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -518,9 +518,9 @@
       "measurements": [
         {
           "path": "framework/kfx/kungfu-kfx.contract.json",
-          "currentLines": 1481,
+          "currentLines": 1482,
           "baselineLines": 1244,
-          "currentRoot": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+          "currentRoot": "sha256:485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
           "baselineRoot": "sha256:09461dda185e075d08137b51d8fcada3e862ff8e4f3cecd725ec7410021bbb99",
           "changedSinceBaseline": true
         },
@@ -582,9 +582,9 @@
         },
         {
           "path": "scripts/run-native-kfx-admission-tests.mjs",
-          "currentLines": 336,
+          "currentLines": 354,
           "baselineLines": 99,
-          "currentRoot": "sha256:a608dff058df11577c0387a0da05bc1f9f36d17658d766ae00900fca36cc5926",
+          "currentRoot": "sha256:2db3127734f4e0f4d9b54420f35f4bb1be5159fe1b2cbed3acd97ee9f4c870cd",
           "baselineRoot": "sha256:32bb3806ac0541fd4230c78febce26efcfb85b56ef8ce19b4a374d0a07f1c4a4",
           "changedSinceBaseline": true
         },

--- a/scripts/run-native-kfx-admission-tests.mjs
+++ b/scripts/run-native-kfx-admission-tests.mjs
@@ -55,6 +55,24 @@ function checkIdentityNeutralAuthority() {
   assert.equal(native.coreCapabilityPolicy.originAuthority, false);
   assert.equal(native.coreCapabilityPolicy.productAssemblyAuthority, false);
   assert.equal(native.coreCapabilityPolicy.kfdAuthority, 'eligibility-only');
+  const coreCapabilityCeiling = new Set(
+    native.coreCapabilityPolicy.allowedCapabilities,
+  );
+  for (const manifestPath of git(['ls-files', 'extensions/**/kungfu.kfx.json'])
+    .split('\n')
+    .filter(Boolean)) {
+    const manifest = json(manifestPath);
+    const config = manifest.kungfuConfig?.config ?? {};
+    for (const facet of ['view', 'adapter', 'service']) {
+      for (const capability of config[facet]?.capabilities ?? []) {
+        assert.equal(
+          coreCapabilityCeiling.has(capability),
+          true,
+          `${manifestPath} ${facet} capability is outside the embedded Core policy ceiling: ${capability}`,
+        );
+      }
+    }
+  }
   assert.deepEqual(native.runtimeTiers, [
     'isolated',
     'integrated-explicit',

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
@@ -76,6 +76,11 @@ const fakeCaps = {
   storage: {
     savedQueries: () => ({ entries: [] }),
   },
+  projects: {
+    list: async () => ({ schema: 'kungfu.projects.catalog/v1', projects: [] }),
+    runs: () => [],
+    subscribeRuns: () => () => undefined,
+  },
 };
 const fakeShell = {
   params: {},
@@ -137,12 +142,13 @@ const html = ReactDomServer.renderToStaticMarkup(
 );
 
 for (const needle of [
-  'Portfolio · Live federated view',
-  'connecting live Portfolio…',
+  'All Work',
+  'Connecting All Work…',
   'active local project workspace',
-  'no current work across active local workspaces',
+  'Loading retained Project Work…',
+  'All Work remains open while Kungfu restores its Work graph.',
 ]) {
-  if (!html.includes(needle)) fail(`live Portfolio view missing ${needle}`);
+  if (!html.includes(needle)) fail(`live All Work view missing ${needle}`);
 }
 
-console.log('[kfx-demo-work-dashboard-atlas-live] profile + Portfolio render ok');
+console.log('[kfx-demo-work-dashboard-atlas-live] profile + All Work render ok');

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
@@ -98,6 +98,11 @@ const fakeCaps = {
   storage: {
     savedQueries: () => ({ entries: [] }),
   },
+  projects: {
+    list: async () => ({ schema: 'kungfu.projects.catalog/v1', projects: [] }),
+    runs: () => [],
+    subscribeRuns: () => () => undefined,
+  },
 };
 
 const fakeShell = {
@@ -162,12 +167,13 @@ const html = ReactDomServer.renderToStaticMarkup(
 );
 
 for (const needle of [
-  'Portfolio · Live federated view',
-  'connecting live Portfolio…',
+  'All Work',
+  'Connecting All Work…',
   'active local project workspace',
-  'no current work across active local workspaces',
+  'Loading retained Project Work…',
+  'All Work remains open while Kungfu restores its Work graph.',
 ]) {
-  if (!html.includes(needle)) fail(`rendered Portfolio view missing ${needle}`);
+  if (!html.includes(needle)) fail(`rendered All Work view missing ${needle}`);
 }
 
-console.log('[kfx-demo-work-dashboard-atlas-view] Portfolio render ok');
+console.log('[kfx-demo-work-dashboard-atlas-view] All Work render ok');


### PR DESCRIPTION
## Summary

- admit the bundled `projects` capability in the embedded Core KFX ceiling
- validate every shipped extension manifest against that ceiling
- align Work Dashboard fixtures with the current All Work surface
- refresh generated KFD and maintainability evidence

## Validation

- `./shifu test:kfx-profile-suite`
- `./shifu check:kfx-identity-neutral-authority --identity-neutral-only`
- `node --test scripts/readonly-agent-bootstrap.test.mjs`
- staged repository gate (commit hook)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Aligns an already shipped bundled capability with the existing embedded Core KFX policy without changing an architecture contract or ADR record"
}
-->

## Evolution Map impact

Evolution impact: none

## Checklist

- [x] Commits are signed off (DCO)
- [x] Generated evidence is current