### PR TITLE
fix(kfx): admit Projects capability in Core policy

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "d5a849f8a67d9320bb984b9ca916b314fae8cc998c3c9ea2d9285a41fb4accde"
+    "sha256": "de0de7f1362a3ae601554525ea46fcac01187bccf330ef8a998ba441720724d0"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+      "sourceSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+      "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -88,13 +88,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "d1290c13bbf619285cf25054e8b21352c4131eef3c4683270e78eedcbda2bd56",
+      "preBuildWitnessSha256": "daacdc13856a19c2a8f85f14785621f8a249ba10d3b043359f5bd902c07f54fe",
       "sourceHashes": {
-        "sha256": "401efc64bdc1f9ae272fa944b267cafbca86bfcb67d337d31b9914b6946d546a",
+        "sha256": "b852999981e7967630c952991d1815db50e2ccab106ff54680e2cb20a1b61ff4",
         "surfaceCount": 21
       },
       "artifactHashes": {
-        "sha256": "c208d1f4f494c6c71fe561f3a50d4c43307be45d165ab89e6e42fe4fd0e058c7",
+        "sha256": "6878c230b6e4e17d786550632632aa77a6640b1e4b938c3689f21c716cc1a725",
         "surfaceCount": 21
       },
       "witness": {
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "d5a849f8a67d9320bb984b9ca916b314fae8cc998c3c9ea2d9285a41fb4accde"
+          "sha256": "de0de7f1362a3ae601554525ea46fcac01187bccf330ef8a998ba441720724d0"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -152,9 +152,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "sourceSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "byteForByte": true
           },
           {
@@ -397,8 +397,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
-            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
+            "actualSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "status": "passed",
             "reason": ""
           },
@@ -574,10 +574,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "sourceSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
-            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
+            "actualSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "4ce8f691a56fea017142182081aae44fb2e1a800",
+    "sourceSha": "241d8d970f0fa00e601037475f8f426e12ae545c",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:2473a464af91e95359fe1fe02ead250af3b64d26e079fe93ada8f3b6c37af7d0"
   },

--- a/config/kungfu-agent-first-canonical-policy.json
+++ b/config/kungfu-agent-first-canonical-policy.json
@@ -238,13 +238,13 @@
       },
       "source": {
         "path": "framework/kfx/kungfu-kfx.contract.json",
-        "sha256": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
-        "renderedSha256": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+        "sha256": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
+        "renderedSha256": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-kfx.contract.json",
-        "expectedSha256": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff"
+        "expectedSha256": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0"
       }
     },
     {
@@ -523,13 +523,13 @@
       },
       "source": {
         "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
-        "sha256": "sha256:db25eef3f02290c7cef1faa821e99fccb94ba6734f3c7f81b206ae16b80828b7",
-        "renderedSha256": "sha256:db25eef3f02290c7cef1faa821e99fccb94ba6734f3c7f81b206ae16b80828b7",
+        "sha256": "sha256:4632c930854e495d12d620e531089b5dbf4bdc565bff95960b5f2141ff994f0a",
+        "renderedSha256": "sha256:4632c930854e495d12d620e531089b5dbf4bdc565bff95960b5f2141ff994f0a",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/primitive/kungfu-primitive-catalog.contract.json",
-        "expectedSha256": "sha256:db25eef3f02290c7cef1faa821e99fccb94ba6734f3c7f81b206ae16b80828b7"
+        "expectedSha256": "sha256:4632c930854e495d12d620e531089b5dbf4bdc565bff95960b5f2141ff994f0a"
       }
     }
   ]

--- a/config/kungfu-kfx.contract.json
+++ b/config/kungfu-kfx.contract.json
@@ -128,6 +128,7 @@
     "ledger",
     "process",
     "profile",
+    "projects",
     "rewind",
     "storage",
     "terminal",

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "d5a849f8a67d9320bb984b9ca916b314fae8cc998c3c9ea2d9285a41fb4accde"
+    "sha256": "de0de7f1362a3ae601554525ea46fcac01187bccf330ef8a998ba441720724d0"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -53,9 +53,9 @@
     {
       "name": "kungfu-kfx",
       "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-      "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+      "sourceSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
       "artifactPath": "config/kungfu-kfx.contract.json",
-      "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+      "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -88,13 +88,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "d1290c13bbf619285cf25054e8b21352c4131eef3c4683270e78eedcbda2bd56",
+      "preBuildWitnessSha256": "daacdc13856a19c2a8f85f14785621f8a249ba10d3b043359f5bd902c07f54fe",
       "sourceHashes": {
-        "sha256": "401efc64bdc1f9ae272fa944b267cafbca86bfcb67d337d31b9914b6946d546a",
+        "sha256": "b852999981e7967630c952991d1815db50e2ccab106ff54680e2cb20a1b61ff4",
         "surfaceCount": 21
       },
       "artifactHashes": {
-        "sha256": "c208d1f4f494c6c71fe561f3a50d4c43307be45d165ab89e6e42fe4fd0e058c7",
+        "sha256": "6878c230b6e4e17d786550632632aa77a6640b1e4b938c3689f21c716cc1a725",
         "surfaceCount": 21
       },
       "witness": {
@@ -134,7 +134,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "d5a849f8a67d9320bb984b9ca916b314fae8cc998c3c9ea2d9285a41fb4accde"
+          "sha256": "de0de7f1362a3ae601554525ea46fcac01187bccf330ef8a998ba441720724d0"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -152,9 +152,9 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "sourceSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "byteForByte": true
           },
           {
@@ -397,8 +397,8 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
-            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
+            "actualSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "status": "passed",
             "reason": ""
           },
@@ -574,10 +574,10 @@
           {
             "name": "kungfu-kfx",
             "sourcePath": "framework/kfx/kungfu-kfx.contract.json",
-            "sourceSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "sourceSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "artifactPath": "config/kungfu-kfx.contract.json",
-            "expectedSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
-            "actualSha256": "485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+            "expectedSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
+            "actualSha256": "d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -238,13 +238,13 @@
       },
       "source": {
         "path": "framework/kfx/kungfu-kfx.contract.json",
-        "sha256": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
-        "renderedSha256": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+        "sha256": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
+        "renderedSha256": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-kfx.contract.json",
-        "expectedSha256": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff"
+        "expectedSha256": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0"
       }
     },
     {
@@ -523,13 +523,13 @@
       },
       "source": {
         "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
-        "sha256": "sha256:db25eef3f02290c7cef1faa821e99fccb94ba6734f3c7f81b206ae16b80828b7",
-        "renderedSha256": "sha256:db25eef3f02290c7cef1faa821e99fccb94ba6734f3c7f81b206ae16b80828b7",
+        "sha256": "sha256:4632c930854e495d12d620e531089b5dbf4bdc565bff95960b5f2141ff994f0a",
+        "renderedSha256": "sha256:4632c930854e495d12d620e531089b5dbf4bdc565bff95960b5f2141ff994f0a",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/primitive/kungfu-primitive-catalog.contract.json",
-        "expectedSha256": "sha256:db25eef3f02290c7cef1faa821e99fccb94ba6734f3c7f81b206ae16b80828b7"
+        "expectedSha256": "sha256:4632c930854e495d12d620e531089b5dbf4bdc565bff95960b5f2141ff994f0a"
       }
     }
   ]

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json
@@ -226,6 +226,6 @@
   "expected": {
     "envelopeRoot": "sha256:d46314fbc2e999e31216f677d2e6f5fa7c39ff00e69f7a1687af8da90165724c",
     "kfdReportRoot": "sha256:63670117b00f6a5de4a2af48aa0aa3cc06337b2768d611a67039dbf50d8cf444",
-    "coreReportRoot": "sha256:d475e28c26e6d363a91a5c97434ff27c2390be3df6a6969736f5651822ca1f52"
+    "coreReportRoot": "sha256:4d7df9709aee396f1a538a23d26154aebfe73661ac36fe6a439d5db5942f6566"
   }
 }

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
@@ -1,9 +1,9 @@
 {
   "lifecycleGraphRoot": "sha256:7cb9bcb2def111c9fb5e1a45ff82c8ef87e8adad25c4b696df4dba8bbb41f337",
-  "lifecyclePlanRoot": "sha256:d43f521243b752e7ab39649edd0f6c99a5e7257a68615daa1bbe5bcb3fecd62a",
+  "lifecyclePlanRoot": "sha256:ff76ad58969e20b5aa67b94d4836098a889052f2f1ba937392d7cb4417f0e38d",
   "lifecycleReceiptDependencyRoot": "sha256:683bbc2f5d8d6bbbaa6acefba35681b0999c7b80b1d83a9e6d7d633863dfc33f",
-  "lifecycleRegistryRoot": "sha256:1b9dc85250629996785ef335cd24a0f274bb033af4502eefa4d080da46a6e377",
+  "lifecycleRegistryRoot": "sha256:cea603e23cef82cbcf70b560459d62b17d64ade1144f81ad0929e34164003175",
   "semanticGraphRoot": "sha256:73c812c0dd01017ddf275355efbb4e5b0e6994e42063477a484b974800aa5d9f",
-  "semanticHostReceiptDependencyRoot": "sha256:e66cbaf1b713679ffc920fa7ef89cd7fbd1f58e3e6525b9d39c77b59211d2cc7",
-  "semanticPlanRoot": "sha256:420aa3bcf42908d48b1724ca62f3e16de1921e98b02941998c1bbbe6bce76074"
+  "semanticHostReceiptDependencyRoot": "sha256:4e14295415f0f69e09ad01cb33a54dd65bd8975d147e51d43b67f141a67c30b7",
+  "semanticPlanRoot": "sha256:7931c09b8ae8ea60ae708f10221b7b687363a9955e2d9a88c391f4f669a7c80d"
 }

--- a/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
@@ -100,7 +100,9 @@ void test_contract_is_versioned_and_core_owned() {
   require(first.at("contractVersion") == 3, "native contract version drifted");
   require(first.at("versionNegotiation").at("supported") == nlohmann::json::array({3}),
           "native contract retained pre-cutover authority documents");
-  require(first.at("sourceContractVersion") == 12, "native contract did not expose its source compatibility version");
+  require(first.at("sourceContractVersion") == 13, "native contract did not expose its source compatibility version");
+  require(contains_text(first.at("coreCapabilityPolicy").at("allowedCapabilities"), "projects"),
+          "native Core capability policy omitted the Projects application service");
   require(first.at("runtimeTiers") == nlohmann::json::array({"isolated", "integrated-explicit", "metadata-only"}),
           "native contract exposed an origin-derived runtime tier");
   require(first.at("admissionGrades") == nlohmann::json::array({"unverified", "identity-verified", "kfd-attested"}),

--- a/framework/kfx/kungfu-kfx.contract.json
+++ b/framework/kfx/kungfu-kfx.contract.json
@@ -128,6 +128,7 @@
     "ledger",
     "process",
     "profile",
+    "projects",
     "rewind",
     "storage",
     "terminal",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:c6861ec9dc5215720094b0f317fcc0d909d2ae4a138a23f1690316408acde161",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:f2ad78d210d33a04518402691e7d89e343dc783857daa918345ff76671bd5eed",
+  "sourceRoot": "sha256:b79862014f62faeafd78dbaf29a1391591405d7e1e433a77074b36f4f755884f",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -518,9 +518,9 @@
       "measurements": [
         {
           "path": "framework/kfx/kungfu-kfx.contract.json",
-          "currentLines": 1482,
+          "currentLines": 1483,
           "baselineLines": 1244,
-          "currentRoot": "sha256:485b4daac0aa2f61a0e77ae439a3ce119ee96f3636b8e5ef2fe9ae1b089b3295",
+          "currentRoot": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
           "baselineRoot": "sha256:09461dda185e075d08137b51d8fcada3e862ff8e4f3cecd725ec7410021bbb99",
           "changedSinceBaseline": true
         },
@@ -582,9 +582,9 @@
         },
         {
           "path": "scripts/run-native-kfx-admission-tests.mjs",
-          "currentLines": 354,
+          "currentLines": 358,
           "baselineLines": 99,
-          "currentRoot": "sha256:2db3127734f4e0f4d9b54420f35f4bb1be5159fe1b2cbed3acd97ee9f4c870cd",
+          "currentRoot": "sha256:e513967e3be6fc61f2580a998278fdceb91fdac79ff6a3959488970e930eeef2",
           "baselineRoot": "sha256:32bb3806ac0541fd4230c78febce26efcfb85b56ef8ce19b4a374d0a07f1c4a4",
           "changedSinceBaseline": true
         },

--- a/scripts/run-native-kfx-admission-tests.mjs
+++ b/scripts/run-native-kfx-admission-tests.mjs
@@ -73,6 +73,10 @@ function checkIdentityNeutralAuthority() {
       }
     }
   }
+  assert.ok(
+    sourceContract.knownCapabilities.includes('projects'),
+    'KFX capability catalog omitted the Projects application service',
+  );
   assert.deepEqual(native.runtimeTiers, [
     'isolated',
     'integrated-explicit',

--- a/tests/fixtures/kfx-demo-install/check_install.py
+++ b/tests/fixtures/kfx-demo-install/check_install.py
@@ -35,7 +35,7 @@ if os.path.isfile(manifest_path):
     check("key is work-dashboard", config.get("key") == "work-dashboard")
     check(
         "view declares capabilities",
-        view.get("capabilities") == ["storage"],
+        view.get("capabilities") == ["storage", "projects"],
     )
     check(
         "package name is the published one",


### PR DESCRIPTION
## Summary
- admit the existing Projects application service through the Core-owned KFX capability ceiling
- advance the governed KFX contract to v13 and refresh exact cross-language roots and canonical policy projections
- update the work-dashboard qualification fixtures from the retired Portfolio wording to the current All Work surface

## Verification
- `./shifu build`
- `node scripts/run-native-kfx-admission-tests.mjs`
- install plus both work-dashboard fixtures pass
- `./shifu qualify:embedding-membranes` passes, followed by two further three-trial dual-engine passes
- release promotion rehearsal passes 16/16 with no side effects
- commit hooks pass apart from one explained concurrent-ref observation; the isolated rerun passes

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects capability and qualification projections for the already governed Projects application service and current All Work UI; no new architectural decision is introduced"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Governed projections and fixtures updated with the behavior

Goal: 2026-07-24-buildchain-linux-github-attestation
