### PR TITLE
fix(windows): preload sibling libnode for TUI bootstrap

### DIFF
--- a/crates/trunk/src/variant.rs
+++ b/crates/trunk/src/variant.rs
@@ -159,28 +159,49 @@ fn run_node() -> Option<i32> {
     extern "system" {
         fn LoadLibraryW(lp_lib_file_name: *const u16) -> *mut c_void;
         fn GetProcAddress(h_module: *mut c_void, lp_proc_name: *const c_char) -> *mut c_void;
+        fn FreeLibrary(h_lib_module: *mut c_void) -> i32;
     }
 
     // The host DLL ships next to this binary (dist/kungfu); the exe directory is
-    // on the default DLL search path. If we cannot resolve our own path, fall
-    // through rather than guess.
+    // not searched for the host's dependencies when the host is loaded by an
+    // absolute path on Windows. Preload the sibling libnode.dll by its exact path
+    // so loading the host cannot silently fall through to the Python variant.
+    // If we cannot resolve our own path, fall through rather than guess.
     let exe = env::current_exe().ok()?;
-    let lib_path = exe.parent()?.join(NODE_HOST_LIB);
+    let runtime_dir = exe.parent()?;
+    let libnode_path = runtime_dir.join("libnode.dll");
+    let lib_path = runtime_dir.join(NODE_HOST_LIB);
     // LoadLibraryW wants a NUL-terminated wide string.
+    let libnode_wide: Vec<u16> = libnode_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
     let wide: Vec<u16> = lib_path
         .as_os_str()
         .encode_wide()
         .chain(std::iter::once(0))
         .collect();
 
-    // Absent library → not the product build → fall through to the Python path.
+    // Absent dependency or host → not a complete product build → fall through
+    // to the Python path. Release the dependency on a failed native admission;
+    // successful node::Start owns the process lifetime, as before.
+    let libnode_handle = unsafe { LoadLibraryW(libnode_wide.as_ptr()) };
+    if libnode_handle.is_null() {
+        return None;
+    }
     let handle = unsafe { LoadLibraryW(wide.as_ptr()) };
     if handle.is_null() {
+        unsafe { FreeLibrary(libnode_handle) };
         return None;
     }
     let symbol = CString::new("kungfu_node_run").unwrap();
     let entry = unsafe { GetProcAddress(handle, symbol.as_ptr()) };
     if entry.is_null() {
+        unsafe {
+            FreeLibrary(handle);
+            FreeLibrary(libnode_handle);
+        }
         return None;
     }
     let run: NodeRunFn = unsafe { std::mem::transmute(entry) };


### PR DESCRIPTION
## Summary

- preload the packaged sibling `libnode.dll` by exact path before loading `kungfu_node_host.dll` on Windows
- preserve the Python fallback for incomplete product layouts while releasing native handles on failed admission
- remove the deterministic `No module named kungfu` fallback seen in Windows Alpha installed-TUI qualification

## Evidence

- failed Alpha A/B control run `30613558251`, Windows job `91102078593`: full package build reached installed TUI bootstrap, then fell through to Python with `No module named kungfu`
- DARKHERO `dumpbin /dependents` and `/exports`: host depends on sibling `libnode.dll` and exports `kungfu_node_run`
- direct Windows loader reproduction: host load succeeds after exact-path `libnode.dll` preload
- pre-commit staged gate passed, including 73 dev-latency tests, 137 docs tests, Rust format/clippy, and complete Rust workspace tests
- `cargo test --manifest-path crates/Cargo.toml -p kungfu-trunk`: 53/53 passed

## Scope boundary

This PR fixes the product bootstrap prerequisite. The five-group same-SHA sccache/Defender/power-plan A/B resumes only after the fix is merged and has an exact successful dev Alpha preflight.

Goal: `2026-07-31-kungfu-windows-alpha-build-performance`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Windows packaged runtime loader bugfix without accepted ADR record changes"
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTMxLWt1bmdmdS13aW5kb3dzLWFscGhhLWJ1aWxkLXBlcmZvcm1hbmNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiIzYzVjM2Q3NTg1MDVhY2UwZWU4ZDhhYWVlODQzMDcxMzBlNGRiZmRhIiwicHVsbFJlcXVlc3RIZWFkIjoiZTQyN2RjMzViMTNjNWI0OGVhMzQwMjZmNjgwNTA2YjVhNDFiYWU4YyIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMjA2ZWQ3MWQ3YmY3ZTc2MmYxYjM5ZTU3MTYyOTdlNGM5MDI2NDlmZCIsInJlcGxheWVkVHJlZSI6ImNlOTUyOTczZGM0MzZmNTNhMGY5ZDc1MWYzYTM5MzY5NmE4MmI4OWEiLCJxdWV1ZUF0dGVtcHQiOiJlNDI3ZGMzNWIxM2M1YjQ4ZWEzNDAyNmY2ODA1MDZiNWE0MWJhZThjQDNjNWMzZDc1ODUwNWFjZTBlZThkOGFhZWU4NDMwNzEzMGU0ZGJmZGEiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6NWQzYzg2ZDVkZDhiZWY0ZDdhOWM0ODg3ZjE3ZWJkMmNmZjQ0Mzg2ZGZiYjU3YmVmNzFkY2JlNmQ2MGJkNjA5ZSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjA4ODM2MTllZTc3MmYwNDZlNTMyMmQyMjU5M2ViYjVhMzI2ZGQ2YWIyZjhmYmUzMzJkNzljMjE2MmIzYzcwYTkiLCJzaGEyNTY6NWQzYzg2ZDVkZDhiZWY0ZDdhOWM0ODg3ZjE3ZWJkMmNmZjQ0Mzg2ZGZiYjU3YmVmNzFkY2JlNmQ2MGJkNjA5ZSJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6YjAyNDJhMTRmYTI0NWVjNjZjN2ZhZDQ0ZGUzNGQ2MDI4ZDExYTgxNWQ4ZmI3N2Q3YzA4Zjg0ZTQ5MDMwNDlkNCJ9 -->