### PR TITLE
fix(product): bind installed TUI to assembled runtime

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:c6861ec9dc5215720094b0f317fcc0d909d2ae4a138a23f1690316408acde161",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:b79862014f62faeafd78dbaf29a1391591405d7e1e433a77074b36f4f755884f",
+  "sourceRoot": "sha256:c3b28dd07580a8471aec1b786e4586facf0e83ae9e3d778cfb58d75913f87789",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -614,9 +614,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 2382,
+          "currentLines": 2389,
           "baselineLines": 2514,
-          "currentRoot": "sha256:d07480c509c68c55b9a0c7f4bfd4a0f222bee79a38187199f0c5c7dfab3f7804",
+          "currentRoot": "sha256:976eb5983ba8c7210e25920aebeff16a9987812c0e0259556e65b95188d03804",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
@@ -1910,7 +1910,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 2382,
+        "metric": 2389,
         "threshold": 2450,
         "finding": null
       },

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1916,6 +1916,11 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
         }
 
         const kungfuBin = entryPath(installRoot, manifest.entries, 'kungfu');
+        const runtimeEntry = entryPath(
+          installRoot,
+          manifest.entries,
+          'runtime',
+        );
         const compatibility = entryPath(
           installRoot,
           manifest.entries,
@@ -2021,6 +2026,7 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
           'upgradeManifest',
         );
         assertFile(kungfuBin, 'installed kungfu runtime');
+        assertFile(runtimeEntry, 'installed assembled runtime entry');
         assertFile(upgradeManifest, 'installed product upgrade manifest');
         const upgradeIdentity = readJson(upgradeManifest);
         if (upgradeIdentity.schema !== 'kungfu.product-upgrade.manifest/v1') {
@@ -2141,6 +2147,7 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
         runInstalledTuiBootstrapSmoke({
           installRoot,
           kungfuBin,
+          runtimeEntry,
           tuiEntry,
           env: smokeEnv,
         });

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -23,6 +23,7 @@ import {
   runInstalledKungfuAgentHubSmoke,
   runInstalledKungfuAssignmentAdmissionSmoke,
   runInstalledKungfuCommand,
+  runInstalledTuiBootstrapSmoke,
   stageXinfaContract,
   verifyProductObservabilityEvents,
 } from './dist.mjs';
@@ -43,6 +44,40 @@ const {
   esmEntrypointArgs,
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
+
+test('installed TUI binds child CLI calls to the manifest runtime entry', () => {
+  const installRoot = path.resolve('installed-product');
+  const kungfuBin = path.join(installRoot, 'kungfu.cmd');
+  const runtimeEntry = path.join(installRoot, 'runtime', 'kungfu.exe');
+  const tuiEntry = path.join(installRoot, 'tui', 'tui.mjs');
+  let invocation;
+
+  runInstalledTuiBootstrapSmoke(
+    {
+      installRoot,
+      kungfuBin,
+      runtimeEntry,
+      tuiEntry,
+      env: {},
+    },
+    {
+      spawn(command, args, options) {
+        invocation = { command, args, options };
+        return {
+          status: 0,
+          signal: null,
+          stdout: '{"schema":"kungfu.agent-work-lab.report/v1"}\n',
+          stderr: '',
+        };
+      },
+    },
+  );
+
+  assert.equal(invocation.command, kungfuBin);
+  assert.deepEqual(invocation.args, [tuiEntry, '--agent-work-lab-demo']);
+  assert.equal(invocation.options.env.KUNGFU_DIR, path.dirname(runtimeEntry));
+  assert.notEqual(invocation.options.env.KUNGFU_DIR, path.dirname(kungfuBin));
+});
 
 test('trunk staging retains one source-authoritative runtime pin snapshot', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-pin-test-'));

--- a/product/scripts/installed-kungfu/index.mjs
+++ b/product/scripts/installed-kungfu/index.mjs
@@ -50,29 +50,29 @@ export function spawnInstalledKungfu(kungfuBin, args, options) {
   });
 }
 
-export function runInstalledTuiBootstrapSmoke({
-  installRoot,
-  kungfuBin,
-  tuiEntry,
-  env,
-  home = path.join(installRoot, '.tui-qualification-home'),
-}) {
-  const result = spawnInstalledKungfu(
+export function runInstalledTuiBootstrapSmoke(
+  {
+    installRoot,
     kungfuBin,
-    [tuiEntry, '--agent-work-lab-demo'],
-    {
-      cwd: installRoot,
-      env: {
-        ...env,
-        KUNGFU_AS_VARIANT: 'node',
-        KUNGFU_DIR: path.dirname(kungfuBin),
-        KUNGFU_TUI_ENTRY: tuiEntry,
-        KF_HOME: home,
-        KF_RUNTIME_DIR: path.join(home, 'runtime'),
-      },
-      encoding: 'utf8',
+    runtimeEntry,
+    tuiEntry,
+    env,
+    home = path.join(installRoot, '.tui-qualification-home'),
+  },
+  { spawn = spawnInstalledKungfu } = {},
+) {
+  const result = spawn(kungfuBin, [tuiEntry, '--agent-work-lab-demo'], {
+    cwd: installRoot,
+    env: {
+      ...env,
+      KUNGFU_AS_VARIANT: 'node',
+      KUNGFU_DIR: path.dirname(runtimeEntry),
+      KUNGFU_TUI_ENTRY: tuiEntry,
+      KF_HOME: home,
+      KF_RUNTIME_DIR: path.join(home, 'runtime'),
     },
-  );
+    encoding: 'utf8',
+  });
   if (result.status !== 0) {
     throw new Error(
       [


### PR DESCRIPTION
## Summary

- resolve the assembled runtime entry from the installed manifest
- bind child CLI calls from the installed TUI smoke to that runtime
- cover the launcher/runtime separation with a focused regression test

## Failure evidence

AWS Windows qualification run 30611818245 assembled and sealed the product, then failed the installed TUI bootstrap because the child CLI inherited the launcher directory as KUNGFU_DIR and fell back to the standalone uv Python, which had no kungfu module.

## Verification

- focused installed TUI runtime-binding test passed
- Biome check passed for all three changed files
- repository staged gate passed twice, including the commit hook
- DCO sign-off present

## Boundary

This changes only installed-product smoke binding. The shipped manifest and runtime layout remain unchanged.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix installed TUI runtime selection without changing architecture or product contracts"
}
-->