### PR TITLE
fix(verify): expose bounded fixture diagnostics

### DIFF
--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -983,7 +983,11 @@ function main() {
         else
           fail(
             `fixture ${name}`,
-            `${runner.label} exit ${exitLabel(r.status, r.signal)}; tail: ${tail3(r)}`,
+            `${runner.label} exit ${exitLabel(r.status, r.signal)}; tail: ${outputTail(
+              r.stdout,
+              r.stderr,
+              24,
+            ).slice(0, 2400)}`,
           );
       }
     }


### PR DESCRIPTION
## Summary

- preserve bounded multi-line verifier diagnostics for native fixture failures
- expose the actionable assertion from the cross-platform storage binding failure on the next exact-source Dev Verify run

The packaged KFX capability expectation is now provided by merged PR #2035; this rebased delta contains only the diagnostic correction.

## Validation

- `node --check scripts/verify.mjs`
- `pnpm exec biome check --no-errors-on-unmatched scripts/verify.mjs`
- staged repository gate (commit hook)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Improves bounded verifier diagnostics without changing an architecture contract or ADR record"
}
-->

## Evolution Map impact

Evolution impact: none

## Checklist

- [x] Commits are signed off (DCO)
- [x] Diagnostic output remains bounded and redacted by the existing verifier path