### PR TITLE
fix(kfx): align native source contract fixtures

### DIFF
--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json
@@ -226,6 +226,6 @@
   "expected": {
     "envelopeRoot": "sha256:d46314fbc2e999e31216f677d2e6f5fa7c39ff00e69f7a1687af8da90165724c",
     "kfdReportRoot": "sha256:63670117b00f6a5de4a2af48aa0aa3cc06337b2768d611a67039dbf50d8cf444",
-    "coreReportRoot": "sha256:d475e28c26e6d363a91a5c97434ff27c2390be3df6a6969736f5651822ca1f52"
+    "coreReportRoot": "sha256:8d309b62d0f775101b444608e75c155ea547d397bffffe1ea23a5ccfe4b14bef"
   }
 }

--- a/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
+++ b/framework/core/src/libkungfu/tests/fixtures/native_kfx_registry/expected-roots.json
@@ -1,9 +1,9 @@
 {
   "lifecycleGraphRoot": "sha256:7cb9bcb2def111c9fb5e1a45ff82c8ef87e8adad25c4b696df4dba8bbb41f337",
-  "lifecyclePlanRoot": "sha256:d43f521243b752e7ab39649edd0f6c99a5e7257a68615daa1bbe5bcb3fecd62a",
+  "lifecyclePlanRoot": "sha256:ff76ad58969e20b5aa67b94d4836098a889052f2f1ba937392d7cb4417f0e38d",
   "lifecycleReceiptDependencyRoot": "sha256:683bbc2f5d8d6bbbaa6acefba35681b0999c7b80b1d83a9e6d7d633863dfc33f",
-  "lifecycleRegistryRoot": "sha256:1b9dc85250629996785ef335cd24a0f274bb033af4502eefa4d080da46a6e377",
+  "lifecycleRegistryRoot": "sha256:cea603e23cef82cbcf70b560459d62b17d64ade1144f81ad0929e34164003175",
   "semanticGraphRoot": "sha256:73c812c0dd01017ddf275355efbb4e5b0e6994e42063477a484b974800aa5d9f",
-  "semanticHostReceiptDependencyRoot": "sha256:e66cbaf1b713679ffc920fa7ef89cd7fbd1f58e3e6525b9d39c77b59211d2cc7",
-  "semanticPlanRoot": "sha256:420aa3bcf42908d48b1724ca62f3e16de1921e98b02941998c1bbbe6bce76074"
+  "semanticHostReceiptDependencyRoot": "sha256:4e14295415f0f69e09ad01cb33a54dd65bd8975d147e51d43b67f141a67c30b7",
+  "semanticPlanRoot": "sha256:7931c09b8ae8ea60ae708f10221b7b687363a9955e2d9a88c391f4f669a7c80d"
 }

--- a/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp
@@ -100,7 +100,7 @@ void test_contract_is_versioned_and_core_owned() {
   require(first.at("contractVersion") == 3, "native contract version drifted");
   require(first.at("versionNegotiation").at("supported") == nlohmann::json::array({3}),
           "native contract retained pre-cutover authority documents");
-  require(first.at("sourceContractVersion") == 12, "native contract did not expose its source compatibility version");
+  require(first.at("sourceContractVersion") == 13, "native contract did not expose its source compatibility version");
   require(first.at("runtimeTiers") == nlohmann::json::array({"isolated", "integrated-explicit", "metadata-only"}),
           "native contract exposed an origin-derived runtime tier");
   require(first.at("admissionGrades") == nlohmann::json::array({"unverified", "identity-verified", "kfd-attested"}),


### PR DESCRIPTION
## Summary

- align the native KFX source compatibility assertion with the merged v13 contract authority
- refresh the exact Core report and registry/semantic golden roots affected by that authority change
- preserve exact fail-closed assertions across C++, Python, Node, and public Storage API projections

## Evidence

- CTest `kungfu_native_kfx_contract_tests`: 1/1 passed
- Python `test_native_kfx_contract.py`: 9/9 passed
- Node KFX/storage tests: 21/21 passed
- public Storage API tests: 4/4 passed
- staged repository gate: passed

Assignment: `2026-07-31-kungfu-kfx-source-version-qualification-repair`
Finding: `sha256:ab3cf09ebbd05fda34e9568a34074789126edd59712990873377e70806d47cea`
Issue: `sha256:d73280f93cf30708dd2007ff15d41896d486a1f55fb2bae838444fd69af129ae`

This repairs the base-owned regression observed in protected run 30616010761; it does not modify KFX authority or weaken the version assertion.