### PR TITLE
fix(spec): refresh generated KFX authority root

### DIFF
--- a/framework/spec/generated/registry.json
+++ b/framework/spec/generated/registry.json
@@ -96,7 +96,7 @@
       "protocol_id": "kungfu.kfx.manifest/v1",
       "source": "config/kungfu-kfx.contract.json",
       "source_role": "KFX-identity-neutral-package-declaration-schema",
-      "source_root": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff",
+      "source_root": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0",
       "version_axis": "KFX package manifest schema version"
     },
     {
@@ -157,7 +157,7 @@
       },
       {
         "path": "config/kungfu-kfx.contract.json",
-        "root": "sha256:f9f99ee94a91580f0e5e4592c260e32f2ab3d2c12f1c439db1e31d6ee0cfadff"
+        "root": "sha256:d157e2749808ece583f793845ea7a1547eaab720a230cb00a2e7095fa498a3e0"
       },
       {
         "path": "framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/common.h",


### PR DESCRIPTION
## Summary

- refresh the committed portable-format registry projection after the KFX contract changed
- restore release qualification and package verification on every platform

## Validation

- `node framework/spec/scripts/generate.js --check`
- `node framework/spec/scripts/aggregate.js`
- `node framework/spec/scripts/verify.js`
- `node --test framework/spec/index.test.js`
- repository pre-commit checks with `KUNGFU_DEV_BRANCH=dev/v4/v4.0`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Refreshes a deterministic generated source root after an already-governed KFX contract change; no architecture contract or ADR record changes"
}
-->

## Evolution Map impact

Evolution impact: none
