### PR TITLE
fix(ci): anchor Windows sccache cache to workspace

### DIFF
--- a/.github/actions/require-alpha-preflight/windows-alpha-sccache.mjs
+++ b/.github/actions/require-alpha-preflight/windows-alpha-sccache.mjs
@@ -258,6 +258,7 @@ export async function ensureWindowsSccache({
     },
   };
   const toolRoot = digest(toolIdentity);
+  const resolvedCacheDirectory = path.resolve(cwd, WINDOWS_SCCACHE_DIR);
   const body = {
     schemaVersion: 1,
     contract: WINDOWS_SCCACHE_TOOL_CONTRACT,
@@ -276,6 +277,7 @@ export async function ensureWindowsSccache({
     bindings: {
       sourceCommit: env.BUILDCHAIN_SOURCE_SHA || env.GITHUB_SHA || '',
       cacheDirectory: WINDOWS_SCCACHE_DIR,
+      cacheDirectoryResolution: 'repository-workspace',
     },
   };
   const receipt = { ...body, root: digest(body) };
@@ -289,8 +291,8 @@ export async function ensureWindowsSccache({
   appendEnvironment(env.GITHUB_ENV, {
     BUILDCHAIN_COMPILER_CACHE_TOOL_ROOT: receipt.root,
     BUILDCHAIN_COMPILER_CACHE_TOOL_EVIDENCE_PATH: evidencePath,
-    KUNGFU_WINDOWS_ALPHA_SCCACHE_DIR: WINDOWS_SCCACHE_DIR,
-    SCCACHE_DIR: WINDOWS_SCCACHE_DIR,
+    KUNGFU_WINDOWS_ALPHA_SCCACHE_DIR: resolvedCacheDirectory,
+    SCCACHE_DIR: resolvedCacheDirectory,
   });
   return receipt;
 }

--- a/scripts/ensure-windows-sccache.test.mjs
+++ b/scripts/ensure-windows-sccache.test.mjs
@@ -66,13 +66,28 @@ test('Windows sccache installer verifies pinned bytes and exports auditable bind
     assert.equal(receipt.reused, false);
     assert.equal(receipt.bindings.sourceCommit, 'a'.repeat(40));
     assert.equal(receipt.bindings.cacheDirectory, WINDOWS_SCCACHE_DIR);
+    assert.equal(
+      receipt.bindings.cacheDirectoryResolution,
+      'repository-workspace',
+    );
     assert.match(receipt.root, /^sha256:[0-9a-f]{64}$/u);
     assert.match(receipt.toolRoot, /^sha256:[0-9a-f]{64}$/u);
     const exported = fs.readFileSync(githubEnv, 'utf8');
-    assert.match(
-      exported,
-      new RegExp(`SCCACHE_DIR=${WINDOWS_SCCACHE_DIR}`, 'u'),
+    const exportedEnvironment = Object.fromEntries(
+      exported
+        .trim()
+        .split('\n')
+        .map((line) => {
+          const separator = line.indexOf('=');
+          return [line.slice(0, separator), line.slice(separator + 1)];
+        }),
     );
+    const resolvedCacheDirectory = path.resolve(root, WINDOWS_SCCACHE_DIR);
+    assert.equal(
+      exportedEnvironment.KUNGFU_WINDOWS_ALPHA_SCCACHE_DIR,
+      resolvedCacheDirectory,
+    );
+    assert.equal(exportedEnvironment.SCCACHE_DIR, resolvedCacheDirectory);
     assert.match(
       exported,
       new RegExp(`BUILDCHAIN_COMPILER_CACHE_TOOL_ROOT=${receipt.root}`, 'u'),


### PR DESCRIPTION
## Summary

- resolve the Windows sccache directory against the repository workspace before exporting it to the compiler process
- retain the portable relative cache binding while recording the workspace-resolution rule in the auditable tool receipt
- prevent cache bytes from being nested under the sccache executable cache and make cold/warm qualification inspect the intended directory

## Failure evidence

A live DARKHERO build exported the relative `.buildchain/cache/compiler/windows-sccache-v1` value. The sccache server resolved that value from its executable directory, not the checked-out repository, and wrote 233 files (270,956,024 bytes) beneath the tool cache. The existing A/B operator therefore inspected the wrong path and could falsely call the run cold.

## Verification

- `./shifu check:shifu-cache-contract` passed, including 2/2 focused Windows sccache tests
- repository commit hook and staged gate passed
- `./shifu check:source` passed 846/847 tests; the sole local-environment failure was the cold read-only fixture reporting `pytest is not available on PATH`
- `./shifu check` reached the unrelated layer harness and failed because a clean worktree lacked prebuilt `framework/spec/dist/reader-matrix.json`
- DCO sign-off present

## Boundary

This changes only cache path resolution and its receipt binding. It does not change the sccache version or digest, cache profile identity, compiler-cache provider, release publication authority, Defender state, or runner power plan.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Fix Windows compiler-cache path resolution without changing architecture or publication authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects a source-bound compiler-cache tool receipt, but grants no release or publication authority. Focused receipt tests and the repository staged gate passed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no user-facing documentation change required)
