### PR TITLE
fix(core): follow watcher benchmark load journal

### DIFF
--- a/framework/core/tests/bench/dispatch_bench_watcher.mjs
+++ b/framework/core/tests/bench/dispatch_bench_watcher.mjs
@@ -70,10 +70,26 @@ if (!alive(watcher)) {
   process.exit(1);
 }
 
-runLoad(benchDir, home, count, carrierType, env);
+const load = runLoad(benchDir, home, count, carrierType, env);
+if (load.error || load.status !== 0) {
+  console.error(
+    `dispatch load failed${load.error ? `: ${load.error.message}` : ` with status ${load.status}`}`,
+  );
+  process.exit(1);
+}
 
 // the watcher self-exits after its 40s window (+ unwind); wait it out
 await waitExit(watcher, 90000);
+if (alive(watcher)) {
+  watcher.kill();
+  coordinator.kill();
+  await Promise.all([waitExit(watcher, 5000), waitExit(coordinator, 5000)]);
+  console.error('watcher did not exit within 90 seconds');
+  process.exit(1);
+}
+
+coordinator.kill();
+await waitExit(coordinator, 5000);
 
 console.log('--- dispatch probe reports (watcher) ---');
 const reports = collectProbeReports([
@@ -87,4 +103,24 @@ if (reports.length === 0) {
   process.exit(1);
 }
 for (const line of reports) console.log(line);
+
+const carrierHex = Number.parseInt(carrierType, 10)
+  .toString(16)
+  .padStart(8, '0');
+const carrierReports = reports.filter((line) =>
+  line.includes(`carrier_type=0x${carrierHex}`),
+);
+const observed = carrierReports.reduce((maximum, line) => {
+  const match = line.match(/\bn=(\d+)\b/);
+  return match ? Math.max(maximum, Number.parseInt(match[1], 10)) : maximum;
+}, 0);
+if (observed < count) {
+  console.error(
+    `watcher observed ${observed}/${count} requested carrier ${carrierType} frames`,
+  );
+  process.exit(1);
+}
+console.log(
+  `watcher observed ${observed} requested carrier ${carrierType} frames`,
+);
 console.log(`bench home kept for inspection: ${home}`);

--- a/framework/core/tests/bench/dispatch_watcher_bench.js
+++ b/framework/core/tests/bench/dispatch_watcher_bench.js
@@ -37,15 +37,43 @@ const watcher = new binding.Watcher(
   'dispatch_bench',
   true, // bypassRestore
   2, // millisecondsSleepAfterStep
+  true, // captureCustom: enables the explicit public-journal follow contract
 );
+
+const loadLocation = {
+  mode: 'live',
+  role: 'actor',
+  namespace: 'bench',
+  name: 'dispatch_load',
+};
+let followingLoad = false;
 
 console.log('watcher created, starting uv pump for', seconds, 'seconds');
 watcher.start();
 
+// Registering with the same coordinator does not implicitly join another
+// peer's PUBLIC journal. Wait until the load peer is in the live registry,
+// then request the exact source journal from the beginning so the dispatch
+// probe measures the requested carrier instead of coordinator control frames.
+const follow = setInterval(() => {
+  if (followingLoad || !watcher.isLive()) return;
+  const loadUid = watcher.getLocationUID(loadLocation);
+  if (!watcher.getLocation(loadUid)) return;
+  if (!watcher.requestReadFromPublic(loadLocation, 0n)) return;
+  followingLoad = true;
+  clearInterval(follow);
+  console.log('watcher following dispatch_load public journal');
+}, 10);
+
 const sync = setInterval(() => watcher.sync(), 1000);
 
 setTimeout(() => {
+  clearInterval(follow);
   clearInterval(sync);
+  if (!followingLoad) {
+    console.error('watcher never followed dispatch_load public journal');
+    process.exitCode = 1;
+  }
   console.log('watcher bench window done, quitting');
   watcher.quit();
   const deadline = Date.now() + 5000;

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -18,6 +18,12 @@ const watcherSource = path.join(
   'binding',
   'watcher.cpp',
 );
+const watcherBench = path.join(__dirname, 'bench', 'dispatch_watcher_bench.js');
+const watcherBenchDriver = path.join(
+  __dirname,
+  'bench',
+  'dispatch_bench_watcher.mjs',
+);
 const nativeTest = {
   skip: fs.existsSync(bindingPath)
     ? false
@@ -55,6 +61,16 @@ test('watcher source does not reserve a libuv worker-pool job', () => {
     /"KungfuWatcherBridge", 1, 1/,
     'the native-to-Node bridge must remain single-slot and single-producer',
   );
+});
+
+test('watcher dispatch bench follows and proves the load peer carrier', () => {
+  const peer = fs.readFileSync(watcherBench, 'utf8');
+  const driver = fs.readFileSync(watcherBenchDriver, 'utf8');
+  assert.match(peer, /true, \/\/ captureCustom:/);
+  assert.match(peer, /requestReadFromPublic\(loadLocation, 0n\)/);
+  assert.match(driver, /watcher observed \$\{observed\} requested carrier/);
+  assert.match(driver, /if \(observed < count\)/);
+  assert.match(driver, /coordinator\.kill\(\)/);
 });
 
 test(


### PR DESCRIPTION
## Summary

Make the Node watcher dispatch benchmark explicitly follow the load peer public journal and fail closed when the requested carrier is not fully observed.

This PR supersedes #2046 with a one-commit linear Project Cut replay from the latest dev/v4/v4.0 base.

## Related issue

None.

## Changes

- enable custom carrier capture in the benchmark watcher
- follow the registered dispatch load public journal from the beginning
- validate load and watcher process outcomes and cleanly stop the coordinator
- require the observed carrier count to cover the requested frame count
- lock the benchmark continuity contract in the watcher runtime boundary test

## Verification

- ./shifu build:core — passed
- ./shifu test:node-watcher-runtime-boundary — 5 passed
- ./shifu test:agent-session-peer-transport:native — 4 passed
- ./shifu exec node framework/core/tests/bench/dispatch_bench_watcher.mjs 200000 601 — 200000 requested frames observed (202000 total target carriers); writer 86441 frames/s; watcher target-carrier mean dispatch 1935 ns; max 7852292 ns
- Project Cut merge-queue admission — qualified; one replayed commit; composition unchanged
- git diff --check — passed
- staged source gate on the original business commit — passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This benchmark repair restores the existing explicit public-journal follow contract and does not alter runtime architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
