### PR TITLE
fix(gui): retry Windows runtime uninstall cleanup

### DIFF
--- a/framework/gui/electron-builder.base.json
+++ b/framework/gui/electron-builder.base.json
@@ -81,6 +81,9 @@
       "AppImage"
     ]
   },
+  "nsis": {
+    "include": "resources/installer.nsh"
+  },
   "win": {
     "target": [
       "dir",

--- a/framework/gui/electron-builder.yml
+++ b/framework/gui/electron-builder.yml
@@ -83,6 +83,9 @@
       "AppImage"
     ]
   },
+  "nsis": {
+    "include": "resources/installer.nsh"
+  },
   "win": {
     "target": [
       "dir",

--- a/framework/gui/resources/installer.nsh
+++ b/framework/gui/resources/installer.nsh
@@ -1,0 +1,24 @@
+; SPDX-License-Identifier: Apache-2.0
+
+; Native DLL/PYD files can be held briefly by Windows scanners after the
+; packaged runtime exits. electron-builder's default recursive removal makes
+; only one attempt, so retry this owned runtime subtree before the default
+; uninstall section removes the rest of $INSTDIR.
+!macro customUnInstall
+  SetOutPath "$TEMP"
+  Push $R8
+  StrCpy $R8 60
+
+kungfu_runtime_retry:
+  RMDir /r "$INSTDIR\resources\kungfu"
+  IfFileExists "$INSTDIR\resources\kungfu\*.*" 0 kungfu_runtime_removed
+  Sleep 500
+  IntOp $R8 $R8 - 1
+  IntCmp $R8 0 kungfu_runtime_timeout kungfu_runtime_retry kungfu_runtime_retry
+
+kungfu_runtime_timeout:
+  DetailPrint "Kungfu runtime files remain busy; the default uninstall pass will retry once."
+
+kungfu_runtime_removed:
+  Pop $R8
+!macroend

--- a/framework/gui/scripts/electron-builder-config.test.mjs
+++ b/framework/gui/scripts/electron-builder-config.test.mjs
@@ -44,6 +44,7 @@ test('product overlay preserves common policy and owns only product resources', 
     'files',
     'mac',
     'linux',
+    'nsis',
     'win',
   ]) {
     assert.deepEqual(product[key], framework[key], key);
@@ -72,4 +73,18 @@ test('product overlay preserves common policy and owns only product resources', 
     'kungfu-codex-app-server.contract.json',
     'schemas/**/*',
   ]);
+});
+
+test('Windows uninstall retries the owned native runtime subtree', () => {
+  const framework = readProjection('framework/gui/electron-builder.yml');
+  assert.equal(framework.nsis.include, 'resources/installer.nsh');
+
+  const include = fs.readFileSync(
+    new URL('../resources/installer.nsh', import.meta.url),
+    'utf8',
+  );
+  assert.match(include, /!macro customUnInstall/);
+  assert.match(include, /RMDir \/r "\$INSTDIR\\resources\\kungfu"/);
+  assert.match(include, /StrCpy \$R8 60/);
+  assert.doesNotMatch(include, /RMDir \/r "?\$INSTDIR"?\s*$/m);
 });

--- a/product/electron-builder.yml
+++ b/product/electron-builder.yml
@@ -104,6 +104,9 @@
       "AppImage"
     ]
   },
+  "nsis": {
+    "include": "resources/installer.nsh"
+  },
   "win": {
     "target": [
       "dir",


### PR DESCRIPTION
## Summary

- retry removal of the owned Windows runtime subtree before the default NSIS uninstall pass
- keep the retry bounded to 30 seconds and leave the default installer cleanup semantics intact
- bind the same NSIS include into framework and product projections with focused contract coverage

## Failure evidence

Kungfu Build run 30626449970 reached release qualification on Windows and failed because uninstall left only resources\\kungfu profile files under the installed desktop root. The qualification diagnostics reported no process under the install root. Linux x64, Linux ARM64, and macOS ARM64 passed; macOS signing and notarization also passed.

## Verification

- node --test framework/gui/scripts/electron-builder-config.test.mjs tests/qualification/layers/surfaces/installer.test.mjs: 11 passed, 1 platform skip, 0 failed
- git diff origin/dev/v4/v4.0...HEAD --check: passed

## Boundary

The custom uninstall macro removes only $INSTDIR\\resources\\kungfu, retries for at most 30 seconds, and then returns control to the default uninstall pass. It does not change signing, notarization, publication authority, runner routing, or release topology.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Bounded Windows installer cleanup repair without architecture or release topology change"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs a release qualification failure but grants no publication authority and changes no protected signing boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Focused tests passed
