### PR TITLE
fix(qualification): quiesce Windows runtime before uninstall

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "93dd59d45783df1358e0fc17880973fd810e094e",
+    "sourceSha": "5a67eee69329e552039129571466eb0483458dd1",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "3cacb8586e11680915daec7abea7d57b6edf0f77",
+    "sourceSha": "93dd59d45783df1358e0fc17880973fd810e094e",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },

--- a/tests/qualification/layers/surfaces/installer.mjs
+++ b/tests/qualification/layers/surfaces/installer.mjs
@@ -59,6 +59,71 @@ export function nsisUninstallArgs() {
   return ['/S'];
 }
 
+export function windowsProcessesUnderRoot(target) {
+  const script = [
+    '$root = [IO.Path]::GetFullPath($env:KF_QUALIFICATION_INSTALL_ROOT)',
+    '$matches = @(Get-CimInstance -ClassName Win32_Process | Where-Object {',
+    '  $_.ExecutablePath -and $_.ExecutablePath.StartsWith($root, [StringComparison]::OrdinalIgnoreCase)',
+    '} | Select-Object ProcessId, Name, ExecutablePath)',
+    '$matches | ConvertTo-Json -Compress',
+  ].join('\n');
+  const result = spawnSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    {
+      encoding: 'utf8',
+      windowsHide: true,
+      env: { ...process.env, KF_QUALIFICATION_INSTALL_ROOT: target },
+    },
+  );
+  if (result.status !== 0)
+    return [
+      {
+        diagnostic_error: (
+          result.stderr ||
+          result.error?.message ||
+          'PowerShell failed'
+        ).trim(),
+      },
+    ];
+  try {
+    const parsed = JSON.parse(result.stdout || '[]');
+    return Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+  } catch (error) {
+    return [
+      {
+        diagnostic_error: `invalid PowerShell JSON: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      },
+    ];
+  }
+}
+
+export async function waitForWindowsProcessesUnderRootExit(
+  target,
+  {
+    platform = process.platform,
+    timeoutMs = 60_000,
+    pollIntervalMs = 100,
+    processesUnderRoot = windowsProcessesUnderRoot,
+  } = {},
+) {
+  if (platform !== 'win32') return;
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const processes = processesUnderRoot(target);
+    if (processes.length === 0) return;
+    if (Date.now() >= deadline)
+      fail(
+        `timed out waiting for installed Windows processes to exit under ${target}; processes=${JSON.stringify(
+          processes,
+        )}`,
+      );
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}
+
 export function pathRemovalDiagnostics(
   target,
   { platform = process.platform } = {},
@@ -90,51 +155,7 @@ export function pathRemovalDiagnostics(
     ];
   }
   if (platform !== 'win32') return diagnostics;
-
-  const script = [
-    '$root = [IO.Path]::GetFullPath($env:KF_QUALIFICATION_INSTALL_ROOT)',
-    '$matches = @(Get-CimInstance -ClassName Win32_Process | Where-Object {',
-    '  $_.ExecutablePath -and $_.ExecutablePath.StartsWith($root, [StringComparison]::OrdinalIgnoreCase)',
-    '} | Select-Object ProcessId, Name, ExecutablePath)',
-    '$matches | ConvertTo-Json -Compress',
-  ].join('\n');
-  const result = spawnSync(
-    'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-Command', script],
-    {
-      encoding: 'utf8',
-      windowsHide: true,
-      env: { ...process.env, KF_QUALIFICATION_INSTALL_ROOT: target },
-    },
-  );
-  if (result.status !== 0) {
-    diagnostics.processes_under_root = [
-      {
-        diagnostic_error: (
-          result.stderr ||
-          result.error?.message ||
-          'PowerShell failed'
-        ).trim(),
-      },
-    ];
-    return diagnostics;
-  }
-  try {
-    const parsed = JSON.parse(result.stdout || '[]');
-    diagnostics.processes_under_root = Array.isArray(parsed)
-      ? parsed
-      : parsed
-        ? [parsed]
-        : [];
-  } catch (error) {
-    diagnostics.processes_under_root = [
-      {
-        diagnostic_error: `invalid PowerShell JSON: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      },
-    ];
-  }
+  diagnostics.processes_under_root = windowsProcessesUnderRoot(target);
   return diagnostics;
 }
 
@@ -236,6 +257,11 @@ export function installDesktopArtifact(installer, tempRoot) {
             entry.isFile() && /uninstall.*\.exe$/i.test(path.basename(target)),
           'NSIS uninstaller',
         );
+        // A bounded GUI startup can leave a short-lived packaged runtime child
+        // after Electron's main process exits. Starting NSIS before that child
+        // releases its DLLs makes the one-shot uninstaller skip those files
+        // permanently, even though no process remains by the final timeout.
+        await waitForWindowsProcessesUnderRootExit(installRoot);
         run(uninstaller, nsisUninstallArgs());
         await waitForPathRemoval(installRoot);
         return;

--- a/tests/qualification/layers/surfaces/installer.test.mjs
+++ b/tests/qualification/layers/surfaces/installer.test.mjs
@@ -14,6 +14,7 @@ import {
   pathRemovalDiagnostics,
   removeEmptyDirectoryShells,
   waitForPathRemoval,
+  waitForWindowsProcessesUnderRootExit,
 } from './installer.mjs';
 
 test('recognizes every supported desktop installer family', () => {
@@ -28,6 +29,47 @@ test('NSIS uninstall keeps the standard temporary-copy behavior', () => {
   assert.equal(
     nsisUninstallArgs().some((arg) => arg.startsWith('_?=')),
     false,
+  );
+});
+
+test('waits for packaged Windows runtime children before starting NSIS', async () => {
+  const observations = [
+    [
+      {
+        ProcessId: 42,
+        Name: 'kungfu.exe',
+        ExecutablePath: 'C:\\installed\\resources\\kungfu\\kungfu.exe',
+      },
+    ],
+    [],
+  ];
+  let calls = 0;
+  await waitForWindowsProcessesUnderRootExit('C:\\installed', {
+    platform: 'win32',
+    pollIntervalMs: 1,
+    processesUnderRoot() {
+      calls += 1;
+      return observations.shift();
+    },
+  });
+  assert.equal(calls, 2);
+});
+
+test('fails closed when an installed Windows process does not exit', async () => {
+  await assert.rejects(
+    waitForWindowsProcessesUnderRootExit('C:\\installed', {
+      platform: 'win32',
+      timeoutMs: 5,
+      pollIntervalMs: 1,
+      processesUnderRoot: () => [
+        {
+          ProcessId: 42,
+          Name: 'kungfu.exe',
+          ExecutablePath: 'C:\\installed\\resources\\kungfu\\kungfu.exe',
+        },
+      ],
+    }),
+    /timed out waiting for installed Windows processes.*kungfu\.exe/,
   );
 });
 


### PR DESCRIPTION
## Summary

- wait for packaged Windows runtime children to exit before starting the one-shot NSIS uninstaller
- reuse the bounded process-under-install-root diagnostics for uninstall failures
- fail closed after a bounded timeout; do not force-kill processes or post-delete installed files

## Failure evidence

Windows burst qualification run 30629454081 passed build, sealing, AgentSession, control-plane, presentation, catalog, contract, format, and SDK checks. `layers.surfaces` alone failed because NSIS started while a short-lived installed runtime child still held packaged DLLs, skipped those files, and did not retry them.

## Verification

- `./shifu exec node --test tests/qualification/layers/surfaces/installer.test.mjs` (11/11)
- `./shifu exec biome check tests/qualification/layers/surfaces/installer.mjs tests/qualification/layers/surfaces/installer.test.mjs`
- `./shifu check:staged`

## Boundary

This changes qualification harness behavior only. It does not change shipped installer/uninstaller behavior.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair changes only the Windows qualification harness timing and does not alter an architecture contract or shipped product behavior"
}
-->