### PR TITLE
fix(qualification): keep NSIS paths below MAX_PATH

### DIFF
--- a/tests/qualification/layers/surfaces/run.mjs
+++ b/tests/qualification/layers/surfaces/run.mjs
@@ -47,6 +47,10 @@ export function surfaceQualificationTempRoot(
   return platform === 'win32' && hostTemporary ? hostTemporary : fallback;
 }
 
+export function surfaceQualificationTempPrefix(tempRoot) {
+  return path.join(tempRoot, 'kfs-');
+}
+
 function parseArgs(argv) {
   const options = {
     validateOnly: false,
@@ -254,9 +258,7 @@ function directoryBytes(root) {
 async function exactQualification(options, fixture) {
   const tempRoot = surfaceQualificationTempRoot();
   fs.mkdirSync(tempRoot, { recursive: true });
-  const temp = fs.mkdtempSync(
-    path.join(tempRoot, 'kungfu-surface-qualification-'),
-  );
+  const temp = fs.mkdtempSync(surfaceQualificationTempPrefix(tempRoot));
   try {
     if (options.cliArchive.endsWith('.zip'))
       extractZip({ archiveFile: options.cliArchive, targetDir: temp });
@@ -318,7 +320,7 @@ async function exactQualification(options, fixture) {
 
     const desktopInstall = installDesktopArtifact(
       options.desktopInstaller,
-      path.join(temp, 'desktop-installation'),
+      temp,
     );
     const guiExecutable = findGuiExecutable(desktopInstall.installRoot);
     const guiStarted = process.hrtime.bigint();

--- a/tests/qualification/layers/surfaces/run.test.mjs
+++ b/tests/qualification/layers/surfaces/run.test.mjs
@@ -9,7 +9,11 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { guiQualificationArgs } from './installer.mjs';
-import { findArtifact, surfaceQualificationTempRoot } from './run.mjs';
+import {
+  findArtifact,
+  surfaceQualificationTempPrefix,
+  surfaceQualificationTempRoot,
+} from './run.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const runner = path.join(here, 'run.mjs');
@@ -50,6 +54,83 @@ test('Windows installer qualification uses the preserved short host temp', () =>
     ),
     '/repo/.buildchain/tmp',
   );
+});
+
+test('Windows installer qualification stays below the legacy path budget', () => {
+  const repositoryRoot = path.resolve(here, '..', '..', '..', '..');
+  const packageSources = [
+    {
+      root: path.join(
+        repositoryRoot,
+        'framework',
+        'core',
+        'src',
+        'python',
+        'kungfu',
+      ),
+      installedPrefix: [],
+    },
+    {
+      root: path.join(repositoryRoot, 'extensions', 'work-dashboard'),
+      installedPrefix: [
+        'profiles',
+        'work-control',
+        'members',
+        'work-dashboard',
+      ],
+    },
+    {
+      root: path.join(
+        repositoryRoot,
+        'extensions',
+        'work-control',
+        'work-control-actions',
+      ),
+      installedPrefix: ['profiles', 'work-control', 'work-control-actions'],
+    },
+  ];
+  const files = [];
+  const visit = (directory, installedPrefix, relativeDirectory = '') => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const relative = path.join(relativeDirectory, entry.name);
+      if (entry.isDirectory())
+        visit(path.join(directory, entry.name), installedPrefix, relative);
+      else if (entry.isFile())
+        files.push(path.join(...installedPrefix, relative));
+    }
+  };
+  for (const source of packageSources)
+    visit(source.root, source.installedPrefix);
+  const runnerTemp = 'C:\\actions-runner\\kungfu-systems\\_work\\_temp';
+  const workspace = `${surfaceQualificationTempPrefix(runnerTemp)}xxxxxx`;
+  const legacyWorkspace = path.win32.join(
+    runnerTemp,
+    'kungfu-surface-qualification-xxxxxx',
+    'desktop-installation',
+  );
+  const installedLength = (root, relative) =>
+    path.win32.join(
+      root,
+      'installed-desktop',
+      'resources',
+      'kungfu',
+      'python',
+      'Lib',
+      'site-packages',
+      'kungfu',
+      ...relative.split(path.sep),
+    ).length;
+  const longest = Math.max(
+    ...files.map((relative) => installedLength(workspace, relative)),
+  );
+  const legacyLongest = Math.max(
+    ...files.map((relative) => installedLength(legacyWorkspace, relative)),
+  );
+  assert.ok(
+    legacyLongest >= 260,
+    `fixture no longer covers the legacy path overflow (${legacyLongest})`,
+  );
+  assert.ok(longest < 260, `longest installed Python path is ${longest}`);
 });
 
 test('desktop discovery treats a matched app bundle as one artifact root', () => {


### PR DESCRIPTION
## Summary

- shorten the surface qualification workspace prefix and remove one test-only desktop nesting layer
- preserve the fail-closed NSIS uninstall check; no residual files are deleted by the harness
- derive a Windows path-budget regression from the exact Python and profile sources assembled into the desktop package

## Evidence

- failed run: https://github.com/kungfu-systems/kungfu/actions/runs/30626449970
- legacy longest assembled path: 264 characters
- qualified layout longest assembled path: 218 characters
- ./shifu node --test tests/qualification/layers/surfaces/installer.test.mjs tests/qualification/layers/surfaces/run.test.mjs (15/15)
- pnpm exec biome check (passed)
- pre-commit gate (137/137 plus repository gates)

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Shorten test-only Windows qualification paths so the existing fail-closed NSIS uninstall contract can evaluate packaged files below legacy MAX_PATH; no architecture contract is introduced or altered."
}
-->