### PR TITLE
fix(core): preserve watcher benchmark carrier continuity

### DIFF
--- a/framework/core/src/bindings/node/binding/watcher.cpp
+++ b/framework/core/src/bindings/node/binding/watcher.cpp
@@ -252,6 +252,9 @@ Napi::Value Watcher::RequestReadFromPublic(const Napi::CallbackInfo &info) {
   if (not is_live()) {
     return Napi::Boolean::New(info.Env(), false);
   }
+  if (not has_writer(get_coordinator_command_uid())) {
+    return Napi::Boolean::New(info.Env(), false);
+  }
   auto source_location = IODevice::ExtractLocation(info, 0, get_locator());
   auto from_time = GetBigInt(info, 1);
   request_read_from_public(now(), source_location->uid, from_time);

--- a/framework/core/tests/bench/dispatch_bench_watcher.mjs
+++ b/framework/core/tests/bench/dispatch_bench_watcher.mjs
@@ -70,10 +70,26 @@ if (!alive(watcher)) {
   process.exit(1);
 }
 
-runLoad(benchDir, home, count, carrierType, env);
+const load = runLoad(benchDir, home, count, carrierType, env);
+if (load.error || load.status !== 0) {
+  console.error(
+    `dispatch load failed${load.error ? `: ${load.error.message}` : ` with status ${load.status}`}`,
+  );
+  process.exit(1);
+}
 
 // the watcher self-exits after its 40s window (+ unwind); wait it out
 await waitExit(watcher, 90000);
+if (alive(watcher)) {
+  watcher.kill();
+  coordinator.kill();
+  await Promise.all([waitExit(watcher, 5000), waitExit(coordinator, 5000)]);
+  console.error('watcher did not exit within 90 seconds');
+  process.exit(1);
+}
+
+coordinator.kill();
+await waitExit(coordinator, 5000);
 
 console.log('--- dispatch probe reports (watcher) ---');
 const reports = collectProbeReports([
@@ -87,4 +103,24 @@ if (reports.length === 0) {
   process.exit(1);
 }
 for (const line of reports) console.log(line);
+
+const carrierHex = Number.parseInt(carrierType, 10)
+  .toString(16)
+  .padStart(8, '0');
+const carrierReports = reports.filter((line) =>
+  line.includes(`carrier_type=0x${carrierHex}`),
+);
+const observed = carrierReports.reduce((maximum, line) => {
+  const match = line.match(/\bn=(\d+)\b/);
+  return match ? Math.max(maximum, Number.parseInt(match[1], 10)) : maximum;
+}, 0);
+if (observed < count) {
+  console.error(
+    `watcher observed ${observed}/${count} requested carrier ${carrierType} frames`,
+  );
+  process.exit(1);
+}
+console.log(
+  `watcher observed ${observed} requested carrier ${carrierType} frames`,
+);
 console.log(`bench home kept for inspection: ${home}`);

--- a/framework/core/tests/bench/dispatch_watcher_bench.js
+++ b/framework/core/tests/bench/dispatch_watcher_bench.js
@@ -37,15 +37,43 @@ const watcher = new binding.Watcher(
   'dispatch_bench',
   true, // bypassRestore
   2, // millisecondsSleepAfterStep
+  true, // captureCustom: enables the explicit public-journal follow contract
 );
+
+const loadLocation = {
+  mode: 'live',
+  role: 'actor',
+  namespace: 'bench',
+  name: 'dispatch_load',
+};
+let followingLoad = false;
 
 console.log('watcher created, starting uv pump for', seconds, 'seconds');
 watcher.start();
 
+// Registering with the same coordinator does not implicitly join another
+// peer's PUBLIC journal. Wait until the load peer is in the live registry,
+// then request the exact source journal from the beginning so the dispatch
+// probe measures the requested carrier instead of coordinator control frames.
+const follow = setInterval(() => {
+  if (followingLoad || !watcher.isLive()) return;
+  const loadUid = watcher.getLocationUID(loadLocation);
+  if (!watcher.getLocation(loadUid)) return;
+  if (!watcher.requestReadFromPublic(loadLocation, 0n)) return;
+  followingLoad = true;
+  clearInterval(follow);
+  console.log('watcher following dispatch_load public journal');
+}, 10);
+
 const sync = setInterval(() => watcher.sync(), 1000);
 
 setTimeout(() => {
+  clearInterval(follow);
   clearInterval(sync);
+  if (!followingLoad) {
+    console.error('watcher never followed dispatch_load public journal');
+    process.exitCode = 1;
+  }
   console.log('watcher bench window done, quitting');
   watcher.quit();
   const deadline = Date.now() + 5000;

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -68,6 +68,10 @@ test('watcher dispatch bench follows and proves the load peer carrier', () => {
   const driver = fs.readFileSync(watcherBenchDriver, 'utf8');
   assert.match(peer, /true, \/\/ captureCustom:/);
   assert.match(peer, /requestReadFromPublic\(loadLocation, 0n\)/);
+  assert.match(
+    fs.readFileSync(watcherSource, 'utf8'),
+    /Watcher::RequestReadFromPublic[\s\S]*?has_writer\(get_coordinator_command_uid\(\)\)[\s\S]*?request_read_from_public/,
+  );
   assert.match(driver, /watcher observed \$\{observed\} requested carrier/);
   assert.match(driver, /if \(observed < count\)/);
   assert.match(driver, /coordinator\.kill\(\)/);

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -18,6 +18,12 @@ const watcherSource = path.join(
   'binding',
   'watcher.cpp',
 );
+const watcherBench = path.join(__dirname, 'bench', 'dispatch_watcher_bench.js');
+const watcherBenchDriver = path.join(
+  __dirname,
+  'bench',
+  'dispatch_bench_watcher.mjs',
+);
 const nativeTest = {
   skip: fs.existsSync(bindingPath)
     ? false
@@ -55,6 +61,16 @@ test('watcher source does not reserve a libuv worker-pool job', () => {
     /"KungfuWatcherBridge", 1, 1/,
     'the native-to-Node bridge must remain single-slot and single-producer',
   );
+});
+
+test('watcher dispatch bench follows and proves the load peer carrier', () => {
+  const peer = fs.readFileSync(watcherBench, 'utf8');
+  const driver = fs.readFileSync(watcherBenchDriver, 'utf8');
+  assert.match(peer, /true, \/\/ captureCustom:/);
+  assert.match(peer, /requestReadFromPublic\(loadLocation, 0n\)/);
+  assert.match(driver, /watcher observed \$\{observed\} requested carrier/);
+  assert.match(driver, /if \(observed < count\)/);
+  assert.match(driver, /coordinator\.kill\(\)/);
 });
 
 test(


### PR DESCRIPTION
## Summary

- make the watcher dispatch benchmark follow the load peer's journal before requesting carrier reads
- prove requested frames come from the target carrier and report target-carrier latency instead of mixing control traffic
- fail closed when the coordinator command writer is not ready, avoiding a native `unordered_map::at` termination during startup races
- supersedes #2061 with the same two verified patches replayed onto the latest `dev/v4/v4.0`

## Verification

- `git range-diff dbe6ee17f6..4281614ab5 7777de45e3..34b6cff2e4` — both patches equivalent
- `./shifu build:core` — pass
- `./shifu test:node-watcher-runtime-boundary` — 5/5 pass
- `./shifu test:agent-session-peer-transport:native` — 4/4 pass
- `./shifu exec node framework/core/tests/bench/dispatch_bench_watcher.mjs 200000 601` — 93,025 frames/s writer throughput; target-carrier mean 1,758 ns; 202,000 target frames observed for 200,000 requested
- `./shifu check:staged` — pass
- `git diff --check` — pass

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair benchmark carrier continuity and harden the existing watcher startup boundary without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

Signed-off-by: Keren Dong <keren.dong+cx@kungfu.link>
