### PR TITLE
Expose Windows native peer coordinator diagnostics

### DIFF
--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -302,7 +302,18 @@ test(
 
     const writer = spawnPeer('writer', runtimeDir);
     peers.push(writer);
-    const written = await waitForJsonLine(writer, 'writer-ready');
+    let written;
+    try {
+      written = await waitForJsonLine(writer, 'writer-ready');
+    } catch (error) {
+      const coordinatorLog = fs.readFileSync(coordinatorOutput, 'utf8');
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}\n` +
+          `coordinatorExited=${coordinatorExited}\n` +
+          `coordinator output:\n${coordinatorLog || '<empty>'}`,
+        { cause: error },
+      );
+    }
     const reader = spawnPeer('reader', runtimeDir);
     peers.push(reader);
     const received = await waitForJsonLine(reader, 'reader-received');

--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -303,6 +303,7 @@ test(
     const writer = spawnPeer('writer', runtimeDir);
     peers.push(writer);
     let written;
+    // Preserve the original failure while exposing the coordinator side of startup.
     try {
       written = await waitForJsonLine(writer, 'writer-ready');
     } catch (error) {


### PR DESCRIPTION
## Summary
- preserve the existing 60-second native peer registration boundary
- on writer registration failure, report whether the coordinator exited
- include the bounded coordinator stdout/stderr so repeated Windows runner failures become actionable

## Evidence
- Windows Qualified Core candidate attempts 1 and 2 both failed after the full registration window
- watcher runtime boundary passed before the failure
- targeted syntax, Biome, and diff checks passed
- no production code or timeout semantics changed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This test-only diagnostic change exposes existing coordinator output without changing architecture, runtime behavior, or qualification thresholds."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above