### PR TITLE
fix(qualification): register path-loaded Python guests

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "9d8dc2c57617b572ffcadff1a1eddde92f7f9536",
+    "sourceSha": "2a29edb1f2b2b7d79ad8244ac91aef26f5a0775e",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },

--- a/tests/fixtures/kfx-demo-sandbox-launch/child.py
+++ b/tests/fixtures/kfx-demo-sandbox-launch/child.py
@@ -19,6 +19,9 @@ _guest_path = os.path.join(
 )
 _spec = importlib.util.spec_from_file_location("_kungfu_capability_guest", _guest_path)
 _guest = importlib.util.module_from_spec(_spec)
+# Match import machinery semantics before executing decorators. Python 3.14's
+# dataclasses resolve annotations through sys.modules[cls.__module__].
+sys.modules[_spec.name] = _guest
 _spec.loader.exec_module(_guest)
 
 fails = []

--- a/tests/fixtures/kfx-demo-subprocess-caps/child.py
+++ b/tests/fixtures/kfx-demo-subprocess-caps/child.py
@@ -21,6 +21,9 @@ _guest_path = os.path.join(
 )
 _spec = importlib.util.spec_from_file_location("_kungfu_capability_guest", _guest_path)
 _guest = importlib.util.module_from_spec(_spec)
+# Match import machinery semantics before executing decorators. Python 3.14's
+# dataclasses resolve annotations through sys.modules[cls.__module__].
+sys.modules[_spec.name] = _guest
 _spec.loader.exec_module(_guest)
 connect = _guest.connect
 


### PR DESCRIPTION
## Summary

- register path-loaded guest modules in `sys.modules` before `exec_module`
- preserve Python import machinery semantics required by `dataclasses` on Python 3.14
- repair both sandbox-launch and subprocess-capability qualification fixtures
- rebind the KFD prebuild witness to the exact protected-main replay commit after the preceding release-cut delivery tightened commit-object validation

## Evidence

The exact-runtime Dev Verify run 30636673838 completed the Gate profile but produced non-qualifying receipts on macOS and Linux. The macOS log showed `dataclasses` resolving `cls.__module__` through `sys.modules` and failing because the path-loaded guest module had not been registered.

After protected dev advanced, source acceptance correctly exposed that the KFD witness still named the original work-branch commit even though the exact tree-equivalent replay commit is `2a29edb1f2b2b7d79ad8244ac91aef26f5a0775e` on main. The witness now names that reachable protected commit without changing KFD content.

Validated locally:

- Python 3.14.6 fixture runs for sandbox-launch and subprocess-caps
- `node scripts/buildchain-kfd-evidence.mjs --check`
- `./shifu check:source`: 852 passed, 10 conditional skips; the sole initial local failure was missing bare pytest
- locked uv pytest rerun of `scripts/readonly-agent-bootstrap.test.mjs`: 1/1 passed
- full repository pre-commit qualification hook
- `git diff --check`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore standard import machinery semantics in two qualification fixtures and bind the existing KFD witness to its exact protected replay commit; no architecture or runtime product contract changes."
}
-->