### PR TITLE
chore(kfd): refresh Alpha release evidence

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "4bb783e8a5202915dd2b8a6c9af51ab5e89355ae",
+    "sourceSha": "3cacb8586e11680915daec7abea7d57b6edf0f77",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },


### PR DESCRIPTION
## Summary

Refresh the checked-in Buildchain KFD collaboration evidence so Alpha qualification is bound to the current admitted dev ancestry.

## Related issue

Alpha release closure.

## Changes

- Regenerate the Buildchain KFD evidence through the official Shifu generator.
- Bind the prebuild collaboration interface evidence to source commit 3cacb8586e11680915daec7abea7d57b6edf0f77.

## Verification

- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check
- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu kfd:buildchain:check
- git diff --check
- Signed commit hook staged gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance refreshes generated release evidence provenance without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates generated release evidence only; its exact source ancestry and deterministic regeneration were verified locally.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; behavior is unchanged)