### PR TITLE
fix(release): converge local artifact identity

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "5a67eee69329e552039129571466eb0483458dd1",
+    "sourceSha": "d49b115b1c8bbdf38d6719d2fdd17cf8ecc85085",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },

--- a/product/scripts/upgrade-manifest.mjs
+++ b/product/scripts/upgrade-manifest.mjs
@@ -34,6 +34,7 @@ const CUT_BINDING_FIELDS = new Set([
 const MANIFEST_IDENTITY_EXCLUDED_FIELDS = new Set([
   ...CUT_BINDING_FIELDS,
   'artifacts',
+  'localArtifact',
   'qualificationEvidenceRef',
 ]);
 

--- a/product/scripts/upgrade-manifest.test.mjs
+++ b/product/scripts/upgrade-manifest.test.mjs
@@ -370,6 +370,14 @@ test('desktop local tree bytes are part of the exact Release Cut', () => {
     });
     assert.equal(first.localArtifact.format, 'directory');
     assert.notEqual(first.localArtifact.digest, second.localArtifact.digest);
+    assert.equal(
+      first.manifestIdentityRoot,
+      bundledManifest.manifestIdentityRoot,
+    );
+    assert.equal(
+      second.manifestIdentityRoot,
+      bundledManifest.manifestIdentityRoot,
+    );
     assert.notEqual(first.releaseCutRoot, second.releaseCutRoot);
   } finally {
     fs.rmSync(f.root, { recursive: true, force: true });
@@ -405,6 +413,7 @@ test('CLI finalization adds an exact archive without losing desktop evidence', (
     const output = path.join(f.root, 'release', 'manifest.json');
     const release = finalizeCliUpgradeManifest({
       bundledManifest: desktopManifest,
+      embeddedManifest: bundledManifest,
       cliArtifact: archive,
       artifactUrl: 'https://example.invalid/kungfu-cli.tar.gz',
       output,


### PR DESCRIPTION
## Summary

- exclude release-only local desktop artifact bytes from the shared product manifest identity
- keep those bytes bound by the platform slice and Product Release Cut
- cover the real desktop-finalized base plus CLI-embedded identity path

## Evidence

The exact Build run 30647417124 completed macOS packaging through wheel, GUI, DMG/ZIP, and CLI installed-layout smoke, then failed with "CLI archive and desktop release base have divergent upgrade identities". The two manifests shared source, runtime, and frontend identities; only the finalized desktop manifest carried localArtifact, which was already bound separately into the platform slice.

Validated locally:

- node --test product/scripts/upgrade-manifest.test.mjs product/scripts/dist.test.mjs: 42/42 passed
- full repository pre-commit qualification hook
- staged Biome check
- git diff --check

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct the projection of an existing product upgrade identity contract so release-only local artifact evidence remains in the Product Release Cut without splitting the shared CLI and desktop manifest identity."
}
-->