### PR TITLE
chore(kfd): bind final merged source witness

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "d49b115b1c8bbdf38d6719d2fdd17cf8ecc85085",
+    "sourceSha": "266694ddc52c61b110a1c81ee0dd36caf069bae2",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },


### PR DESCRIPTION
## Summary

- refresh the Buildchain KFD prebuild witness to the actual protected rebase-merge commit 266694ddc52c61b110a1c81ee0dd36caf069bae2
- make the final dev source ancestry-verifiable on every qualification runner

## Evidence

- generated evidence-only change
- full repository pre-commit qualification hook passed
- KFD checks passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Refresh generated KFD prebuild evidence so the existing Buildchain contract is bound to the actual protected rebase-merge source without changing any ADR-governed behavior."
}
-->