### PR TITLE
chore(kfd): anchor Alpha evidence to dev

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "d49b115b1c8bbdf38d6719d2fdd17cf8ecc85085",
+    "sourceSha": "266694ddc52c61b110a1c81ee0dd36caf069bae2",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },


### PR DESCRIPTION
## Summary

Anchor the checked-in Buildchain KFD release evidence to the current protected dev commit so post-rebase Alpha verification can prove ancestry from the ordinary checkout.

## Related issue

Alpha release closure.

## Changes

- Regenerate the Buildchain KFD evidence through the official Shifu generator.
- Replace the unreachable pre-rebase PR source with protected dev commit 266694ddc52c61b110a1c81ee0dd36caf069bae2.

## Verification

- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check
- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu kfd:buildchain:check
- git diff --check
- Signed commit staged gate
- CI failure reproduction: the prior source d49b115b1c8bbdf38d6719d2fdd17cf8ecc85085 was unavailable and not an ancestor after rebase merge.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance refreshes generated release evidence provenance without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The exact source ancestry and deterministic regeneration were verified locally.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; behavior is unchanged)