### PR TITLE
fix(kfd): recover shallow history before evidence checks

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "3484f580ac4961f64aabdf0de9948bfd4b393703",
+    "sourceSha": "dc6c932e43894335fb40a8cf32e2e73b2ac33eb3",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:82798c19dac7fd3640e754ffc234fd398b38c0b1f60574abfcb80c14dbd23efb"
   },

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -24,6 +24,7 @@ import {
   checkColdBuildchainKfd,
   loadBuildchainKfdRuntime,
 } from '../framework/release/buildchain-kfd-runtime.mjs';
+import { prepareGateMeasurementHistory } from './prepare-gate-measurement-history.mjs';
 import {
   assertKfdEvidenceSourceBinding,
   findGitTreeEquivalentAncestor,
@@ -577,6 +578,7 @@ function isGitAncestor(sourceSha, headSha) {
 }
 
 function resolveKfdEvidenceSourceSha({ write }) {
+  if (!write) prepareGateMeasurementHistory(ROOT);
   const headSha = gitValue(['rev-parse', 'HEAD']);
   const configured =
     process.env.BUILDCHAIN_SOURCE_SHA || process.env.KUNGFU_KFD_SOURCE_SHA;

--- a/scripts/buildchain-kfd-evidence.mjs
+++ b/scripts/buildchain-kfd-evidence.mjs
@@ -30,9 +30,7 @@ import {
   findGitTreeEquivalentAncestor,
   resolveKfdProductGateCheckedAt,
 } from './source-acceptance.mjs';
-
 let runtime;
-
 const KFD3_SURFACE_REGISTRY_CONTRACT =
   'kungfu-buildchain-kfd-3-surface-registry';
 


### PR DESCRIPTION
## Summary

Recover complete Git ancestry before read-only Buildchain KFD evidence validation so shallow CI checkouts can prove the protected source ancestry deterministically.

## Changes

- Reuse the existing gate-history preparation helper before read-only KFD evidence validation.
- Preserve the historical evidence checker line budget.

## Verification

- node --test scripts/prepare-gate-measurement-history.test.mjs scripts/source-acceptance.test.mjs
- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check
- KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu kfd:buildchain:check
- KUNGFU_DEV_BRANCH=dev/v4/v4.0 node scripts/code-complexity-budget.mjs
- Biome and commit hooks

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance restores complete source ancestry for release evidence validation without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The history hydration is filter-limited, read-only, and covered by shallow-clone tests.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; the release contract is unchanged)