### PR TITLE
fix(kfd): recover witnesses from cached checkouts

### DIFF
--- a/scripts/prepare-gate-measurement-history.mjs
+++ b/scripts/prepare-gate-measurement-history.mjs
@@ -25,6 +25,22 @@ export function bundleFetchUrl(value, platform = process.platform) {
   return value;
 }
 
+export function githubRepositoryFetchUrl({ repository, serverUrl } = {}) {
+  const normalizedRepository = String(repository || '').trim();
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(normalizedRepository)) {
+    return '';
+  }
+  let normalizedServer;
+  try {
+    normalizedServer = new URL(String(serverUrl || 'https://github.com'));
+  } catch {
+    return '';
+  }
+  if (!['http:', 'https:'].includes(normalizedServer.protocol)) return '';
+  normalizedServer.pathname = normalizedServer.pathname.replace(/\/+$/u, '');
+  return `${normalizedServer.toString().replace(/\/+$/u, '')}/${normalizedRepository}.git`;
+}
+
 function rewrittenBundleOrigin(cwd) {
   const remote = git(cwd, ['remote', 'get-url', 'origin'], {
     encoding: 'utf8',
@@ -55,6 +71,18 @@ function rewrittenBundleOrigin(cwd) {
   return match ? bundleFetchUrl(match.rewritten) : '';
 }
 
+function fetchSources(cwd, sourceRepositoryUrl = '') {
+  const sources = [];
+  const origin = git(cwd, ['remote', 'get-url', 'origin'], {
+    encoding: 'utf8',
+  });
+  if (origin.status === 0 && origin.stdout.trim()) sources.push('origin');
+  const bundle = rewrittenBundleOrigin(cwd);
+  if (bundle) sources.push(bundle);
+  if (sourceRepositoryUrl) sources.push(sourceRepositoryUrl);
+  return [...new Set(sources)];
+}
+
 function recoverCompleteLocalHistory(cwd) {
   const shallowPathResult = git(cwd, ['rev-parse', '--git-path', 'shallow'], {
     encoding: 'utf8',
@@ -80,32 +108,25 @@ function recoverCompleteLocalHistory(cwd) {
   return false;
 }
 
-function ensureRemoteBaseRef(cwd, baseRef) {
+function ensureRemoteBaseRef(cwd, baseRef, sources) {
   if (!baseRef) return;
   const remoteRef = `refs/remotes/origin/${baseRef}`;
   const current = git(cwd, ['rev-parse', '--verify', remoteRef], {
     stdio: ['ignore', 'ignore', 'ignore'],
   });
   if (current.status === 0) return;
-  const fetched = git(
-    cwd,
-    ['fetch', '--no-tags', 'origin', `+refs/heads/${baseRef}:${remoteRef}`],
-    { stdio: 'inherit' },
-  );
-  if (fetched.status === 0) return;
-  const bundle = rewrittenBundleOrigin(cwd);
-  if (bundle) {
-    const recovered = git(
+  for (const source of sources) {
+    const fetched = git(
       cwd,
-      ['fetch', '--no-tags', bundle, `+refs/heads/${baseRef}:${remoteRef}`],
+      ['fetch', '--no-tags', source, `+refs/heads/${baseRef}:${remoteRef}`],
       { stdio: 'inherit' },
     );
-    if (recovered.status === 0) return;
+    if (fetched.status === 0) return;
   }
   throw new Error(`cannot fetch measurement base ref: ${baseRef}`);
 }
 
-function ensureCommitObject(cwd, requiredCommit) {
+function ensureCommitObject(cwd, requiredCommit, sources) {
   if (!requiredCommit) return;
   if (!/^[0-9a-f]{40}$/u.test(requiredCommit)) {
     throw new Error(`invalid required measurement commit: ${requiredCommit}`);
@@ -114,7 +135,6 @@ function ensureCommitObject(cwd, requiredCommit) {
     stdio: ['ignore', 'ignore', 'ignore'],
   });
   if (present.status === 0) return;
-  const sources = ['origin', rewrittenBundleOrigin(cwd)].filter(Boolean);
   for (const source of sources) {
     const fetched = git(cwd, ['fetch', '--no-tags', source, requiredCommit], {
       stdio: 'inherit',
@@ -134,8 +154,18 @@ function ensureCommitObject(cwd, requiredCommit) {
 
 export function prepareGateMeasurementHistory(
   cwd = process.cwd(),
-  { baseRef = '', requiredCommit = '' } = {},
+  {
+    baseRef = '',
+    requiredCommit = '',
+    sourceRepositoryUrl = githubRepositoryFetchUrl({
+      repository:
+        process.env.BUILDCHAIN_SOURCE_REPOSITORY ||
+        process.env.GITHUB_REPOSITORY,
+      serverUrl: process.env.GITHUB_SERVER_URL,
+    }),
+  } = {},
 ) {
+  const sources = fetchSources(cwd, sourceRepositoryUrl);
   const shallow = git(cwd, ['rev-parse', '--is-shallow-repository'], {
     encoding: 'utf8',
   });
@@ -145,8 +175,8 @@ export function prepareGateMeasurementHistory(
     );
   }
   if (shallow.stdout.trim() === 'false') {
-    ensureRemoteBaseRef(cwd, baseRef);
-    ensureCommitObject(cwd, requiredCommit);
+    ensureRemoteBaseRef(cwd, baseRef, sources);
+    ensureCommitObject(cwd, requiredCommit, sources);
     return 'already-complete';
   }
 
@@ -155,8 +185,8 @@ export function prepareGateMeasurementHistory(
   // store. Prove connectivity without the shallow boundary before reaching out
   // to GitHub; restore the marker unchanged when that proof fails.
   if (recoverCompleteLocalHistory(cwd)) {
-    ensureRemoteBaseRef(cwd, baseRef);
-    ensureCommitObject(cwd, requiredCommit);
+    ensureRemoteBaseRef(cwd, baseRef, sources);
+    ensureCommitObject(cwd, requiredCommit, sources);
     return 'recovered-local';
   }
 
@@ -166,22 +196,29 @@ export function prepareGateMeasurementHistory(
   if (head.status !== 0 || !head.stdout.trim()) {
     throw new Error('cannot resolve measurement source head');
   }
-  const fetched = git(
-    cwd,
-    [
-      'fetch',
-      '--unshallow',
-      '--filter=blob:none',
-      '--no-tags',
-      'origin',
-      head.stdout.trim(),
-    ],
-    { stdio: 'inherit' },
-  );
-  if (fetched.status !== 0) {
+  let fetched = false;
+  for (const source of sources) {
+    const result = git(
+      cwd,
+      [
+        'fetch',
+        '--unshallow',
+        '--filter=blob:none',
+        '--no-tags',
+        source,
+        head.stdout.trim(),
+      ],
+      { stdio: 'inherit' },
+    );
+    if (result.status === 0) {
+      fetched = true;
+      break;
+    }
+  }
+  if (!fetched) {
     throw new Error('cannot fetch complete measurement source history');
   }
-  ensureRemoteBaseRef(cwd, baseRef);
-  ensureCommitObject(cwd, requiredCommit);
+  ensureRemoteBaseRef(cwd, baseRef, sources);
+  ensureCommitObject(cwd, requiredCommit, sources);
   return 'fetched-origin';
 }

--- a/scripts/prepare-gate-measurement-history.test.mjs
+++ b/scripts/prepare-gate-measurement-history.test.mjs
@@ -9,6 +9,7 @@ import test from 'node:test';
 
 import {
   bundleFetchUrl,
+  githubRepositoryFetchUrl,
   prepareGateMeasurementHistory,
 } from './prepare-gate-measurement-history.mjs';
 
@@ -38,6 +39,30 @@ test('normalizes a Windows bundle path to an unambiguous file URL', () => {
   assert.equal(
     bundleFetchUrl('/runner/cache/kungfu.bundle', 'linux'),
     '/runner/cache/kungfu.bundle',
+  );
+});
+
+test('derives only a valid HTTP GitHub repository fetch URL', () => {
+  assert.equal(
+    githubRepositoryFetchUrl({
+      repository: 'kungfu-systems/kungfu',
+      serverUrl: 'https://github.example.test/',
+    }),
+    'https://github.example.test/kungfu-systems/kungfu.git',
+  );
+  assert.equal(
+    githubRepositoryFetchUrl({
+      repository: 'not-a-repository',
+      serverUrl: 'https://github.com',
+    }),
+    '',
+  );
+  assert.equal(
+    githubRepositoryFetchUrl({
+      repository: 'kungfu-systems/kungfu',
+      serverUrl: 'file:///tmp/source',
+    }),
+    '',
   );
 });
 
@@ -167,6 +192,72 @@ test('fetches the exact required witness commit outside the checked branch', () 
       'already-complete',
     );
     assert.equal(git(checkout, 'cat-file', '-t', requiredCommit), 'commit');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('fetches the exact witness from an explicit source when origin is absent', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gate-history-no-origin-'),
+  );
+  try {
+    const origin = makeRepository(root);
+    const primaryBranch = git(origin, 'branch', '--show-current');
+    git(origin, 'switch', '-c', 'witness', 'HEAD~1');
+    fs.writeFileSync(path.join(origin, 'witness.txt'), 'witness\n');
+    git(origin, 'add', 'witness.txt');
+    git(origin, 'commit', '-m', 'witness');
+    const requiredCommit = git(origin, 'rev-parse', 'HEAD');
+    git(origin, 'switch', primaryBranch);
+
+    const checkout = path.join(root, 'checkout');
+    execFileSync(
+      'git',
+      [
+        'clone',
+        '--single-branch',
+        '--branch',
+        primaryBranch,
+        `file://${origin}`,
+        checkout,
+      ],
+      { stdio: 'ignore' },
+    );
+    git(checkout, 'remote', 'remove', 'origin');
+    assert.throws(() => git(checkout, 'cat-file', '-e', requiredCommit));
+
+    assert.equal(
+      prepareGateMeasurementHistory(checkout, {
+        requiredCommit,
+        sourceRepositoryUrl: `file://${origin}`,
+      }),
+      'already-complete',
+    );
+    assert.equal(git(checkout, 'cat-file', '-t', requiredCommit), 'commit');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('fails closed when a required witness is absent and no source exists', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gate-history-no-source-'),
+  );
+  try {
+    const origin = makeRepository(root);
+    const checkout = path.join(root, 'checkout');
+    execFileSync('git', ['clone', `file://${origin}`, checkout], {
+      stdio: 'ignore',
+    });
+    git(checkout, 'remote', 'remove', 'origin');
+    assert.throws(
+      () =>
+        prepareGateMeasurementHistory(checkout, {
+          requiredCommit: 'f'.repeat(40),
+        }),
+      /cannot fetch required measurement commit/u,
+    );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Recover committed KFD prebuild witness commits when Buildchain restores a locked consumer checkout from the trusted local/reference cache and therefore has no `origin` remote.

## Related issue

Follow-up from final Buildchain Linux GitHub Artifact Attestation qualification.

## Changes

- derive a sanitized HTTP(S) source repository URL from the GitHub Actions repository context
- try the existing origin, rewritten bundle, and declared source repository without weakening exact-commit verification
- preserve fail-closed behavior when the witness or every trusted fetch source is unavailable
- cover no-origin cache checkouts, URL validation, and the no-source negative case

## Verification

- `./shifu check`: changed files, KFD evidence, and target tests pass; the broader local run reaches only the known missing `framework/spec/dist` build-artifact prerequisite
- `./shifu check:source`: 854 tests pass; the sole local environment failure is the known bare `pytest` PATH prerequisite
- pre-commit staged gate: pass

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the existing exact-source KFD verification contract for Buildchain cache-hit checkouts; it does not alter architecture authority or release claims."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only recovery of the exact historical commit object needed to verify already-committed KFD release evidence. SHA identity remains mandatory and missing history remains non-qualifying.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; external behavior and authority are unchanged)
