### PR TITLE
fix(auditable-demo): generate native responsive renditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -502,14 +502,14 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@0e4ac58013ff3e09abb18da9896fad5f5b823ef7 # PR #2104 responsive media qualification
+    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@afd75d295fcd2d55cfebf621f5ca6d05a9904830 # PR #2126 native rendition qualification
     with:
       source-ref: ${{ needs.build.outputs.publish-source-sha }}
       source-artifact-name: ${{ needs.resolve-auditable-demo-source.outputs.artifact-name }}
       source-artifact-digest: ${{ needs.resolve-auditable-demo-source.outputs.artifact-digest }}
       adapter-path: scripts/auditable-demo-adapter.py
       adapter-arguments-json: ${{ format('["--demo-id",{0}]', toJSON(needs.auditable-demo-plan.outputs.demo-id)) }}
-      renderer-image: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:b70a2f5631665f685280bc9d7434c5ed5cf48b760b728873734d0c47bff72b25
+      renderer-image: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591
       render-media: ${{ needs.auditable-demo-plan.outputs.render-media == 'true' }}
       media-profile: responsive-web-delivery-v1
       artifact-retention-days: 14
@@ -642,8 +642,8 @@ jobs:
           MEDIA_PROFILE: ${{ needs.auditable-demo.outputs.media-profile }}
           MEDIA_QUALIFICATION_ROOT: ${{ needs.auditable-demo.outputs.media-qualification-root }}
           AUDITABLE_DEMO_ID: ${{ needs.auditable-demo-plan.outputs.demo-id }}
-          BUILDCHAIN_SHA: 0e4ac58013ff3e09abb18da9896fad5f5b823ef7
-          RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:b70a2f5631665f685280bc9d7434c5ed5cf48b760b728873734d0c47bff72b25
+          BUILDCHAIN_SHA: afd75d295fcd2d55cfebf621f5ca6d05a9904830
+          RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 
       - name: Upload exact auditable demo Release Passport

--- a/docs/qualification/auditable-demo-artifact-pipeline.md
+++ b/docs/qualification/auditable-demo-artifact-pipeline.md
@@ -9,8 +9,8 @@ confidence: high
 sensitivity: public
 evidence_grade: A
 review_state: self-reviewed
-last_reviewed: 2026-07-31
-ai_provenance: GPT-5 via Codex on 2026-07-31; based on checked-in Kungfu, Buildchain, and build-images source plus protected GitHub workflow evidence visible to this task; this update adds the unified manual, Alpha, and Release trigger-plan contract without claiming production deployment or unobserved runtime
+last_reviewed: 2026-08-01
+ai_provenance: GPT-5 via Codex on 2026-08-01; based on checked-in Kungfu, Buildchain, and build-images source plus protected GitHub workflow evidence visible to this task; this update binds independently captured native 1080p and 720p renditions without claiming production deployment or unobserved runtime
 ---
 
 # Auditable Demo Artifact Pipeline
@@ -24,8 +24,8 @@ The required path is:
 ```text
 Buildchain producer-owned artifact coordinate
 -> checked-in Kungfu exact-output adapter
--> exact installed `kungfu agent-work-lab autoplay` execution in a bounded PTY
--> bounded terminal capture + complete transcript + public projection + scene
+-> two exact installed `kungfu agent-work-lab autoplay` executions in distinct bounded PTYs
+-> independent native 1080p and 720p capture, transcript, projection, and scene sets
 -> Buildchain Gate and immutable terminal-replay renderer smoke
 -> content-addressed qualified Gate bundle
 -> exact Release Passport
@@ -71,9 +71,9 @@ they cannot replace the README managed block.
 
 | Component | Immutable coordinate |
 | --- | --- |
-| Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:b70a2f5631665f685280bc9d7434c5ed5cf48b760b728873734d0c47bff72b25` |
-| Renderer release | `v1.3.0-alpha.20`, exact version-state source `b3cebc2deb5f140af74db24b1b45233ac6733ef1`, containing the renderer merge from Build Images PR `#339` |
-| Buildchain Gate | `0e4ac58013ff3e09abb18da9896fad5f5b823ef7` (Buildchain PR `#2104`, responsive 1080p/720p media qualification) |
+| Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591` |
+| Renderer release | `v1.3.0-alpha.25`, exact version-state source `f327dd2c2879b5fe26982f3d60ddb00b55a64a25`, built from source `8f5581cdffcfbb695c6738de1a8935e3ee8774f2` containing Build Images PR `#350` |
+| Buildchain Gate | `afd75d295fcd2d55cfebf621f5ca6d05a9904830` (Buildchain PR `#2126`, independent native rendition qualification) |
 | Consumer adapter | `scripts/auditable-demo-adapter.py` from the exact qualified Kungfu source SHA |
 
 Buildchain's reusable build emits
@@ -87,15 +87,17 @@ coordinate.
 
 The adapter opens exactly one release qualification root, rejects unsafe or
 unbounded archive members, validates the retained layer, live-Peer, runtime
-activation, zero-burden, and invariant reports, resolves one catalog demo, and
-executes the installed archive's declared launcher with the selected exact argv
-in a disposable home directory and a real catalog-bounded PTY. The default
-selection remains `kungfu agent-work-lab autoplay` at `150x36`. The isolated process removes
-`NO_COLOR`, sets `FORCE_COLOR=3`, and declares `TERM=xterm-256color` plus
-`COLORTERM=truecolor` so the capture retains the installed TUI's ANSI styling.
-The capture is limited to 60 seconds, 4 MiB, and 10,000 quantized events. A
-successful result requires one valid `KUNGFU_TUI_DEMO_COMPLETE` payload and
-exit status zero.
+activation, zero-burden, and invariant reports, and resolves one catalog demo.
+It then executes the installed archive's declared launcher twice with the same
+selected exact argv: once in an isolated `150x36` PTY for the native 1920x1080
+scene and once in a separate isolated `100x28` PTY for the native 1280x720
+scene. Each execution receives its own disposable home, so responsive content
+is reflowed by the actual TUI rather than scaled from the 1080p output. Both
+isolated processes remove `NO_COLOR`, set `FORCE_COLOR=3`, and declare
+`TERM=xterm-256color` plus `COLORTERM=truecolor` so the captures retain the
+installed TUI's ANSI styling. Each capture is limited to 60 seconds, 4 MiB,
+and 10,000 quantized events. A successful result requires a valid
+`KUNGFU_TUI_DEMO_COMPLETE` payload and exit status zero from both executions.
 
 Its public evidence class is
 `exact-installed-artifact-agent-work-lab-autoplay/v1`. It claims only that the
@@ -118,6 +120,14 @@ Core policy, Work or Warrant, an explicit capability grant, and runtime
 isolation.
 
 ## Retained evidence
+
+The Gate rejects equal capture roots, incorrect PTY dimensions, missing native
+inputs, or a renderer manifest that does not declare
+`independent-native-frame-sets/v1`. The renderer creates separate Chromium
+frame directories for the two capture sets; the native path contains no scale
+filter. It records every output operation as `native-frame-set-encode`, and its
+qualification compares the 720p first frame with a scaled 1080p first frame to
+prove that the content is not the same image at a smaller resolution.
 
 The Gate and optional media are ordinary GitHub Artifacts with explicit ids,
 names, archive digests, URLs, roots, and expiries. A separate

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -281,9 +281,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:97e0f4af7f678d36b5f32f68d64298b5d321385a247c852234dead25e0700019",
+          "definitionDigest": "sha256:5d96929ec45001d15f36a59c3cbd97342c3ed64e68a048b0c8afbb0f12db8aa7",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@0e4ac58013ff3e09abb18da9896fad5f5b823ef7"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@afd75d295fcd2d55cfebf621f5ca6d05a9904830"],
           "steps": []
         },
         {
@@ -301,10 +301,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:9f2c68d593567265cd9a58ef590abf3525d5f1c947579be77a21b3eccc6c9639",
+          "definitionDigest": "sha256:c7218a748e04f4445bcf7daac7cde19288e7fc3c280b55df7e2d3d5224ac1709",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
-          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:a02727f54c70e124e17b7bd4400e9963989d8fde0e9dce8c49a4efa5b9175d44"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
+          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:49d631c2178af0fff7a27292912e64fef6d234578c1b7639882bbec0e6fce371"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
         },
         {
           "id": "auditable-demo-plan",

--- a/framework/auditable-demo/catalog.json
+++ b/framework/auditable-demo/catalog.json
@@ -47,6 +47,44 @@
         "background": "#0B1020",
         "accent": "#67E8A5"
       },
+      "renditions": [
+        {
+          "id": "1080p",
+          "role": "primary",
+          "terminal": {
+            "columns": 150,
+            "rows": 36,
+            "timeoutSeconds": 60
+          },
+          "scene": {
+            "id": "kungfu-agent-work-lab-autoplay",
+            "width": 1920,
+            "height": 1080,
+            "fps": 15,
+            "title": "Kungfu Agent Work Lab — exact installed artifact",
+            "background": "#0B1020",
+            "accent": "#67E8A5"
+          }
+        },
+        {
+          "id": "720p",
+          "role": "responsive",
+          "terminal": {
+            "columns": 100,
+            "rows": 28,
+            "timeoutSeconds": 60
+          },
+          "scene": {
+            "id": "kungfu-agent-work-lab-autoplay-720p",
+            "width": 1280,
+            "height": 720,
+            "fps": 15,
+            "title": "Kungfu Agent Work Lab — exact installed artifact",
+            "background": "#0B1020",
+            "accent": "#67E8A5"
+          }
+        }
+      ],
       "publication": {
         "readmeFeatured": true,
         "siteSlug": "agent-work-lab"

--- a/framework/auditable-demo/catalog.mjs
+++ b/framework/auditable-demo/catalog.mjs
@@ -108,6 +108,7 @@ function validateDemo(value, index) {
       'terminal',
       'completion',
       'scene',
+      'renditions',
       'publication',
       'claimBoundary',
       'claims',
@@ -217,6 +218,123 @@ function validateDemo(value, index) {
       7,
     ),
   };
+  if (!Array.isArray(value.renditions) || value.renditions.length !== 2) {
+    fail(
+      `${label}.renditions must declare exactly primary and responsive captures`,
+    );
+  }
+  const renditions = value.renditions.map((rendition, renditionIndex) => {
+    const renditionLabel = `${label}.renditions[${renditionIndex}]`;
+    exactKeys(
+      rendition,
+      ['id', 'role', 'terminal', 'scene'],
+      [],
+      renditionLabel,
+    );
+    const renditionId = string(
+      rendition.id,
+      ID_PATTERN,
+      `${renditionLabel}.id`,
+      32,
+    );
+    if (!['primary', 'responsive'].includes(rendition.role)) {
+      fail(`${renditionLabel}.role is unsupported`);
+    }
+    exactKeys(
+      rendition.terminal,
+      ['columns', 'rows', 'timeoutSeconds'],
+      [],
+      `${renditionLabel}.terminal`,
+    );
+    const renditionTerminal = {
+      columns: integer(
+        rendition.terminal.columns,
+        40,
+        240,
+        `${renditionLabel}.terminal.columns`,
+      ),
+      rows: integer(
+        rendition.terminal.rows,
+        12,
+        80,
+        `${renditionLabel}.terminal.rows`,
+      ),
+      timeoutSeconds: integer(
+        rendition.terminal.timeoutSeconds,
+        1,
+        60,
+        `${renditionLabel}.terminal.timeoutSeconds`,
+      ),
+    };
+    exactKeys(
+      rendition.scene,
+      ['id', 'width', 'height', 'fps', 'title', 'background', 'accent'],
+      [],
+      `${renditionLabel}.scene`,
+    );
+    const renditionScene = {
+      id: string(
+        rendition.scene.id,
+        ID_PATTERN,
+        `${renditionLabel}.scene.id`,
+        128,
+      ),
+      width: integer(
+        rendition.scene.width,
+        320,
+        3840,
+        `${renditionLabel}.scene.width`,
+      ),
+      height: integer(
+        rendition.scene.height,
+        240,
+        2160,
+        `${renditionLabel}.scene.height`,
+      ),
+      fps: integer(rendition.scene.fps, 1, 60, `${renditionLabel}.scene.fps`),
+      title: string(
+        rendition.scene.title,
+        null,
+        `${renditionLabel}.scene.title`,
+        256,
+      ),
+      background: string(
+        rendition.scene.background,
+        /^#[0-9A-Fa-f]{6}$/u,
+        `${renditionLabel}.scene.background`,
+        7,
+      ),
+      accent: string(
+        rendition.scene.accent,
+        /^#[0-9A-Fa-f]{6}$/u,
+        `${renditionLabel}.scene.accent`,
+        7,
+      ),
+    };
+    return {
+      id: renditionId,
+      role: rendition.role,
+      terminal: renditionTerminal,
+      scene: renditionScene,
+    };
+  });
+  if (
+    JSON.stringify(renditions.map(({ id, role }) => ({ id, role }))) !==
+      JSON.stringify([
+        { id: '1080p', role: 'primary' },
+        { id: '720p', role: 'responsive' },
+      ]) ||
+    JSON.stringify(renditions[0].terminal) !== JSON.stringify(terminal) ||
+    JSON.stringify(renditions[0].scene) !== JSON.stringify(scene) ||
+    renditions[0].scene.width !== 1920 ||
+    renditions[0].scene.height !== 1080 ||
+    renditions[1].scene.width !== 1280 ||
+    renditions[1].scene.height !== 720 ||
+    JSON.stringify(renditions[0].terminal) ===
+      JSON.stringify(renditions[1].terminal)
+  ) {
+    fail(`${label}.renditions must be distinct native 1080p and 720p captures`);
+  }
   exactKeys(
     value.publication,
     ['readmeFeatured', 'siteSlug'],
@@ -253,6 +371,7 @@ function validateDemo(value, index) {
     terminal,
     completion,
     scene,
+    renditions,
     publication,
     claimBoundary: string(
       value.claimBoundary,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:431cabdd86711ae2b5b544c36fc6ed97b7b7379a03fffe53b2741ebcf1b7e330"
+          "sourceRoot": "sha256:852a7bfa1f74b3d9bc0eef28d7f6009415e51a6eac9efe0690b6ca58dbf418fe"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -821,5 +821,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:0f63db8338bb298b9e651b3162ad70dbb9e3c02b6185a5faeed84e4515bff7b1"
+  "registryRoot": "sha256:3aa3cb73862cf4b797f19adb296040d469b5a0680e75746631356d9963ad0bb5"
 }

--- a/scripts/auditable-demo-adapter.py
+++ b/scripts/auditable-demo-adapter.py
@@ -697,10 +697,12 @@ def read_pty_chunk(
 
 
 def run_demo(
-    launcher: Path, home: Path, demo: dict[str, Any]
+    launcher: Path,
+    home: Path,
+    demo: dict[str, Any],
+    terminal: dict[str, Any],
 ) -> tuple[dict[str, Any], bytes, int]:
     environment = isolated_environment(home)
-    terminal = demo["terminal"]
     terminal_columns = terminal["columns"]
     terminal_rows = terminal["rows"]
     terminal_timeout_seconds = terminal["timeoutSeconds"]
@@ -928,38 +930,88 @@ def build_projection(
     }
 
 
+def rendition_paths(rendition_id: str) -> dict[str, str]:
+    suffix = "" if rendition_id == "1080p" else "-720p"
+    return {
+        "transcript": f"complete-transcript{suffix}.txt",
+        "projection": f"public-projection{suffix}.json",
+        "scene": f"scene{suffix}.json",
+        "terminalCapture": f"terminal-capture{suffix}.json",
+    }
+
+
 def write_outputs(
     output: Path,
-    lines: list[str],
-    projection: dict[str, Any],
-    capture: dict[str, Any],
+    captures: list[dict[str, Any]],
     demo: dict[str, Any],
 ) -> None:
     if output.exists() and (not output.is_dir() or any(output.iterdir())):
         fail("adapter output must be an empty directory")
     output.mkdir(parents=True, exist_ok=True)
-    (output / "complete-transcript.txt").write_text(
-        "\n".join(lines) + "\n", encoding="utf-8"
-    )
-    (output / "public-projection.json").write_text(
-        stable_json(projection), encoding="utf-8"
-    )
-    (output / "terminal-capture.json").write_text(
-        stable_json(capture), encoding="utf-8"
-    )
-    scene = {
-        "schema": "build-images.demo-scene/v1",
-        "id": demo["scene"]["id"],
-        "width": demo["scene"]["width"],
-        "height": demo["scene"]["height"],
-        "fps": demo["scene"]["fps"],
-        "durationMs": capture["durationMs"],
-        "title": demo["scene"]["title"],
-        "commandLabel": demo["commandLabel"],
-        "background": demo["scene"]["background"],
-        "accent": demo["scene"]["accent"],
+    manifest_renditions = []
+    capture_roots = []
+    for item in captures:
+        rendition = item["rendition"]
+        paths = rendition_paths(rendition["id"])
+        scene_input = rendition["scene"]
+        scene = {
+            "schema": "build-images.demo-scene/v1",
+            "id": scene_input["id"],
+            "width": scene_input["width"],
+            "height": scene_input["height"],
+            "fps": scene_input["fps"],
+            "durationMs": item["capture"]["durationMs"],
+            "title": scene_input["title"],
+            "commandLabel": demo["commandLabel"],
+            "background": scene_input["background"],
+            "accent": scene_input["accent"],
+        }
+        transcript_bytes = ("\n".join(item["lines"]) + "\n").encode("utf-8")
+        capture_bytes = stable_json(item["capture"]).encode("utf-8")
+        (output / paths["transcript"]).write_bytes(transcript_bytes)
+        (output / paths["projection"]).write_text(
+            stable_json(item["projection"]), encoding="utf-8"
+        )
+        (output / paths["terminalCapture"]).write_bytes(capture_bytes)
+        (output / paths["scene"]).write_text(stable_json(scene), encoding="utf-8")
+        capture_root = f"sha256:{hashlib.sha256(capture_bytes).hexdigest()}"
+        capture_roots.append(capture_root)
+        manifest_renditions.append(
+            {
+                "id": rendition["id"],
+                "role": rendition["role"],
+                "transcript": paths["transcript"],
+                "projection": paths["projection"],
+                "scene": paths["scene"],
+                "terminalCapture": paths["terminalCapture"],
+                "captureRoot": capture_root,
+            }
+        )
+    if len(set(capture_roots)) != len(capture_roots):
+        fail("native rendition terminal captures must have distinct roots")
+    rendition_set = {
+        "schema": "kungfu.auditable-demo.rendition-set/v1",
+        "renditions": manifest_renditions,
+        "authority": {
+            "classification": "capture-routing-metadata",
+            "grants": [],
+            "nonAuthorities": [
+                "publication-authority",
+                "runtime-authority",
+                "first-party-identity",
+                "system-identity",
+                "kfd-compliance",
+                "product-system-metadata",
+                "package-metadata",
+                "registry-history",
+                "scan-output",
+                "standalone-generation",
+            ],
+        },
     }
-    (output / "scene.json").write_text(stable_json(scene), encoding="utf-8")
+    (output / "rendition-set.json").write_text(
+        stable_json(rendition_set), encoding="utf-8"
+    )
 
 
 def adapt(
@@ -991,27 +1043,48 @@ def adapt(
             installed, archive, qualified_source
         )
         executable_digest = sha256_file(launcher)
-        capture, raw_terminal_output, exit_code = run_demo(
-            launcher, temporary_root / "home", demo
-        )
-        terminal_output = safe_terminal_output(raw_terminal_output)
-        lines = transcript_lines(
-            coordinate=coordinate,
-            archive_digest=archive_digest,
-            executable_digest=executable_digest,
-            product_version=product_version,
-            terminal_output=terminal_output,
-            capture=capture,
-            exit_code=exit_code,
-            demo=demo,
-        )
-        write_outputs(
-            output,
-            lines,
-            build_projection(lines, capture, exit_code, demo),
-            capture,
-            demo,
-        )
+        raw_captures = []
+        for rendition in demo["renditions"]:
+            capture, raw_terminal_output, exit_code = run_demo(
+                launcher,
+                temporary_root / f"home-{rendition['id']}",
+                demo,
+                rendition["terminal"],
+            )
+            raw_captures.append(
+                {
+                    "rendition": rendition,
+                    "capture": capture,
+                    "raw": raw_terminal_output,
+                    "exitCode": exit_code,
+                }
+            )
+        common_duration_ms = max(item["capture"]["durationMs"] for item in raw_captures)
+        captures = []
+        for item in raw_captures:
+            capture = item["capture"]
+            capture["durationMs"] = common_duration_ms
+            exit_code = item["exitCode"]
+            terminal_output = safe_terminal_output(item["raw"])
+            lines = transcript_lines(
+                coordinate=coordinate,
+                archive_digest=archive_digest,
+                executable_digest=executable_digest,
+                product_version=product_version,
+                terminal_output=terminal_output,
+                capture=capture,
+                exit_code=exit_code,
+                demo=demo,
+            )
+            captures.append(
+                {
+                    "rendition": item["rendition"],
+                    "capture": capture,
+                    "lines": lines,
+                    "projection": build_projection(lines, capture, exit_code, demo),
+                }
+            )
+        write_outputs(output, captures, demo)
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -164,6 +164,7 @@ function fixture(
         ]
       : [
           'printf "\\033[2J\\033[H\\033[1;36mKungfu Agent Work Lab fixture\\033[0m\\r\\n"',
+          'printf "terminal-size="; stty size',
           'printf "\\033[38;2;103;232;165mFresh process continues from governed Work.\\033[0m\\r\\n"',
         ];
   const sentinel = omitSentinel
@@ -334,6 +335,14 @@ test('adapter selects a second catalog demo without changing the capture engine'
         siteSlug: 'agent-work-lab-secondary',
       },
     });
+    catalog.demos[1].renditions[0].scene = structuredClone(
+      catalog.demos[1].scene,
+    );
+    catalog.demos[1].renditions[1].scene = {
+      ...catalog.demos[1].renditions[1].scene,
+      id: 'kungfu-agent-work-lab-secondary-autoplay-720p',
+      title: 'Kungfu Agent Work Lab — secondary capture simulation',
+    };
     const demoCatalog = path.join(root, 'catalog.json');
     json(demoCatalog, catalog);
     const { result, output } = run(root, {
@@ -405,9 +414,14 @@ test('adapter executes only the exact installed archive in a PTY and emits the d
     const { result, output } = run(root);
     assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(fs.readdirSync(output).sort(), [
+      'complete-transcript-720p.txt',
       'complete-transcript.txt',
+      'public-projection-720p.json',
       'public-projection.json',
+      'rendition-set.json',
+      'scene-720p.json',
       'scene.json',
+      'terminal-capture-720p.json',
       'terminal-capture.json',
     ]);
     const transcript = fs.readFileSync(
@@ -456,6 +470,33 @@ test('adapter executes only the exact installed archive in a PTY and emits the d
     ).toString('utf8');
     assert.ok(terminalBytes.includes('\u001b[1;36m'));
     assert.ok(terminalBytes.includes('\u001b[38;2;103;232;165m'));
+    assert.match(terminalBytes, /terminal-size=36 150/u);
+    const responsiveCapture = JSON.parse(
+      fs.readFileSync(path.join(output, 'terminal-capture-720p.json'), 'utf8'),
+    );
+    assert.deepEqual(responsiveCapture.dimensions, { columns: 100, rows: 28 });
+    const responsiveBytes = Buffer.concat(
+      responsiveCapture.events.map((event) =>
+        Buffer.from(event.data, 'base64'),
+      ),
+    ).toString('utf8');
+    assert.match(responsiveBytes, /terminal-size=28 100/u);
+    assert.notEqual(terminalBytes, responsiveBytes);
+    const renditionSet = JSON.parse(
+      fs.readFileSync(path.join(output, 'rendition-set.json'), 'utf8'),
+    );
+    assert.equal(renditionSet.schema, 'kungfu.auditable-demo.rendition-set/v1');
+    assert.deepEqual(
+      renditionSet.renditions.map(({ id, role }) => ({ id, role })),
+      [
+        { id: '1080p', role: 'primary' },
+        { id: '720p', role: 'responsive' },
+      ],
+    );
+    assert.notEqual(
+      renditionSet.renditions[0].captureRoot,
+      renditionSet.renditions[1].captureRoot,
+    );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/auditable-demo-passport.test.mjs
+++ b/scripts/auditable-demo-passport.test.mjs
@@ -139,6 +139,14 @@ test('binds an explicitly selected second demo to its catalog descriptor roots',
         siteSlug: 'agent-work-lab-secondary',
       },
     });
+    catalog.demos[1].renditions[0].scene = structuredClone(
+      catalog.demos[1].scene,
+    );
+    catalog.demos[1].renditions[1].scene = {
+      ...catalog.demos[1].renditions[1].scene,
+      id: 'kungfu-agent-work-lab-secondary-autoplay-720p',
+      title: 'Kungfu Agent Work Lab secondary simulation',
+    };
     const catalogPath = path.join(root, 'catalog.json');
     fs.writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
     const passport = buildPassport(validEnv(), {

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -26,6 +26,10 @@ const WORKFLOW = parse(WORKFLOW_TEXT);
 const RELEASE_WORKFLOW = parse(fs.readFileSync(RELEASE_WORKFLOW_PATH, 'utf8'));
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 const SOURCE_SHA = '1'.repeat(40);
+const NATIVE_RENDITION_BUILDCHAIN_SHA =
+  'afd75d295fcd2d55cfebf621f5ca6d05a9904830';
+const NATIVE_RENDITION_RENDERER_IMAGE =
+  'ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591';
 
 function triggerPlan(overrides = {}) {
   return buildAuditableDemoTriggerPlan({
@@ -326,10 +330,12 @@ test('Gate runtime and renderer are immutable and Passport uses the same runtime
     /^kungfu-systems\/buildchain\/\.github\/workflows\/\.auditable-demo\.yml@([0-9a-f]{40})$/u,
   );
   assert.ok(runtime, 'Gate must use one exact Buildchain commit');
+  assert.equal(runtime[1], NATIVE_RENDITION_BUILDCHAIN_SHA);
   assert.match(
     gate.with['renderer-image'],
     /^ghcr\.io\/kungfu-systems\/build-images\/demo-renderer@sha256:[0-9a-f]{64}$/u,
   );
+  assert.equal(gate.with['renderer-image'], NATIVE_RENDITION_RENDERER_IMAGE);
   assert.equal(
     gate.with['media-profile'],
     'responsive-web-delivery-v1',


### PR DESCRIPTION
## Summary

Generate the responsive auditable-demo media as two independent native terminal captures. The 1080p rendition runs the installed Kungfu CLI in a 150x36 PTY, while the 720p rendition runs it again in a separate 100x28 PTY, so the smaller output contains a genuinely reflowed TUI rather than scaled 1080p pixels.

## Related issue

Follow-up to the auditable-demo responsive media delivery.

## Changes

- declare exact native 1920x1080 and 1280x720 scene/PTY pairs in the demo catalog
- run the installed `kungfu agent-work-lab autoplay` twice with isolated homes and capture roots
- pass the rendition set to the released Buildchain native-rendition Gate
- pin Buildchain PR #2126 and Build Images v1.3.0-alpha.25 by immutable coordinates
- document and test the no-scaling, distinct-content qualification boundary

## Verification

- `./shifu node --test scripts/auditable-demo-adapter.test.mjs scripts/auditable-demo-workflow.test.mjs scripts/auditable-demo-passport.test.mjs` (36 passed)
- `./shifu docs:check` (138 passed)
- `./shifu check:source` (865 tests, 0 failed, 10 platform skips)
- commit hook staged gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a bounded correction to the existing responsive auditable-demo media implementation; it does not alter an architecture authority or public product contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The workflow pins exact Buildchain and renderer-image digests, and the source gate verifies those bindings and generated authority projections.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
