### PR TITLE
fix(shifu): scope stdio import to unix

### DIFF
--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -23,7 +23,9 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
+#[cfg(not(windows))]
+use std::process::Stdio;
 
 use shifu_core::{bootstrap, host, json, style};
 


### PR DESCRIPTION
## Summary

Fix protected Windows shifu CI by importing `Stdio` only on non-Windows targets. `promote_desktop` uses it exclusively in the `not(windows)` process-liveness branch.

## Verification

- `cargo clippy --manifest-path crates/shifu/Cargo.toml --all-targets -- -D warnings`
- full staged pre-commit gate, including workspace clippy and unit tests

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This platform-specific lint fix preserves the existing promotion architecture contract"
}
-->

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
