### PR TITLE
fix(shifu): gate Stdio import by platform

### DIFF
--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -23,7 +23,9 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
+#[cfg(not(windows))]
+use std::process::Stdio;
 
 use shifu_core::{bootstrap, host, json, style};
 


### PR DESCRIPTION
## Summary

Restore the protected Windows Shifu workspace gate by importing `Stdio` only on non-Windows targets, where the process liveness probe uses it.

## Related issue

Follow-up to the failed Windows check on Alpha candidate PR #2081.

## Changes

- keep `Command` available on every platform
- gate `Stdio` behind `cfg(not(windows))` for the Unix-only process probe

## Verification

- `cargo clippy --manifest-path crates/Cargo.toml -p shifu --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check:staged` (138 documentation/contract tests and all staged Rust lint/unit tests passed)
- DCO commit hook passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a bounded cross-platform compile fix for an existing process probe and does not alter architecture or product behavior."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change restores a required release-path CI gate without weakening it.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no behavior change)
