### PR TITLE
fix(updater): align local artifact release identity

### DIFF
--- a/framework/core/src/python/kungfu/runtime_upgrade.py
+++ b/framework/core/src/python/kungfu/runtime_upgrade.py
@@ -1055,6 +1055,7 @@ _MANIFEST_CUT_FIELDS = {
     "platformSliceRoot",
     "cutTransition",
     "artifacts",
+    "localArtifact",
     "qualificationEvidenceRef",
 }
 

--- a/framework/core/tests/python/test_release_cut.py
+++ b/framework/core/tests/python/test_release_cut.py
@@ -361,6 +361,13 @@ def test_manifest_identity_root_excludes_only_cut_projection_fields() -> None:
         "releaseCutRoot": _root("1"),
         "platformSliceRoot": _root("2"),
         "cutTransition": {"cutTransitionRoot": _root("3")},
+        "artifacts": [{"kind": "desktop", "digest": _root("4")}],
+        "localArtifact": {
+            "kind": "desktop-local",
+            "format": "directory",
+            "digest": _root("5"),
+        },
+        "qualificationEvidenceRef": _root("6"),
     }
     expected = release_cut.content_root(
         {


### PR DESCRIPTION
## Summary

Keep Python native updater manifest identity calculation aligned with the Node release manifest builder when a finalized desktop manifest carries localArtifact.

## Related issue

None. Found during the first controlled local native updater cutover.

## Changes

- Exclude localArtifact from the manifest identity projection, matching the Node producer contract.
- Extend the Python release-cut test so artifacts, localArtifact, and qualification evidence remain bound by the Release Cut rather than the manifest identity root.

## Verification

- PYTHONPATH=src/python:build/Release uv run --frozen pytest -q tests/python/test_release_cut.py
- node --test product/scripts/upgrade-manifest.test.mjs
- Real generated macOS manifest validates with identical declared and computed manifestIdentityRoot.
- Repository staged gate passed during commit.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores parity between two existing implementations of the Product Release Cut manifest identity contract without changing the architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: the patch only aligns local release identity validation. It does not publish, mutate channels, sign public artifacts, or alter product names.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; implementation parity fix only)