### PR TITLE
fix(shifu): register qualified product cuts

### DIFF
--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -47,6 +47,7 @@ use crate::artifact_catalog::product_mainline_ref;
 use crate::native_update::{
     artifact_sha256, installed_release_cut_root, local_artifact_identity_valid, valid_sha256_root,
 };
+use crate::util;
 
 /// The buildchain self-describe contract shifu asks for the repo's KFD-3
 /// registry location. shifu holds no copy of that layout path: the layout is
@@ -281,6 +282,7 @@ struct LocalReleaseEvidence {
     product_version: String,
     release_cut_root: String,
     platform_slice_root: String,
+    release_trust_domain: String,
 }
 
 /// Read the repo's KFD-3 registry and return the registration plan for
@@ -394,25 +396,16 @@ fn plan_at(root: &Path, path: &Path, task: &str) -> Option<DistributionPlan> {
             .filter(|a| !a.kind.is_empty() && !a.path_glob.is_empty())
             .collect();
         if dist.str_of("releaseCompanions") == "standard" {
-            let (runtime, upgrade_runtime) = match env::consts::OS {
-                "macos" => ("darwin", "darwin"),
-                "windows" => ("windows", "win32"),
-                other => (other, other),
-            };
-            let archive = if env::consts::OS == "windows" {
-                "zip"
-            } else {
-                "tar.gz"
-            };
+            let (archive_glob, manifest_glob) = util::standard_companion_globs(env::consts::OS);
             artifacts.extend([
                 DeclaredArtifact {
                     kind: "cli-archive".to_string(),
-                    path_glob: format!("product/release/cli/*cli-{runtime}-*.{archive}"),
+                    path_glob: archive_glob,
                     sha256: String::new(),
                 },
                 DeclaredArtifact {
                     kind: "upgrade-manifest".to_string(),
-                    path_glob: format!("product/release/cli/*upgrade-*-{upgrade_runtime}-*.json"),
+                    path_glob: manifest_glob,
                     sha256: String::new(),
                 },
             ]);
@@ -595,7 +588,10 @@ pub fn register(root: &Path, plan: &DistributionPlan) {
                 "KUNGFU_BUILD_PLATFORM_SLICE_ROOT={}",
                 quote(&release.platform_slice_root)
             ),
-            "KUNGFU_BUILD_RELEASE_TRUST_DOMAIN='shifu-local'".to_string(),
+            format!(
+                "KUNGFU_BUILD_RELEASE_TRUST_DOMAIN={}",
+                quote(&release.release_trust_domain)
+            ),
         ]);
     }
     meta.push(String::new());
@@ -663,10 +659,12 @@ fn local_release_evidence(
     let policy = release_cut
         .get("publicationPolicy")
         .ok_or_else(|| "Product Release Cut has no publication policy".to_string())?;
-    if policy.str_of("trustDomain") != "shifu-local"
-        || policy.get("publicationEligible") != Some(&json::Json::Bool(false))
-    {
-        return Err("registered dev build is not publication-ineligible".to_string());
+    let trust_domain = policy.str_of("trustDomain");
+    let Some(json::Json::Bool(publication_eligible)) = policy.get("publicationEligible") else {
+        return Err("registered build has no publication eligibility".to_string());
+    };
+    if !util::registration_policy_is_coherent(trust_domain, *publication_eligible) {
+        return Err("registered build has an incoherent publication policy".to_string());
     }
     let (local_path, local_declaration, local_sha) = local_artifact
         .ok_or_else(|| "registered dev build has no local desktop artifact".to_string())?;
@@ -708,6 +706,7 @@ fn local_release_evidence(
         product_version: document.str_of("productVersion").to_string(),
         release_cut_root: release_cut_root.to_string(),
         platform_slice_root: platform_slice_root.to_string(),
+        release_trust_domain: trust_domain.to_string(),
     }))
 }
 
@@ -976,8 +975,8 @@ mod tests {
                   "releaseCut": {{
                     "releaseCutRoot": "sha256:{cut}",
                     "publicationPolicy": {{
-                      "trustDomain": "shifu-local",
-                      "publicationEligible": false
+                      "trustDomain": "public",
+                      "publicationEligible": true
                     }}
                   }},
                   "localArtifact": {{
@@ -1035,7 +1034,7 @@ mod tests {
             "KUNGFU_BUILD_PLATFORM_SLICE_ROOT='sha256:{}'",
             "d".repeat(64)
         )));
-        assert!(meta.contains("KUNGFU_BUILD_RELEASE_TRUST_DOMAIN='shifu-local'"));
+        assert!(meta.contains("KUNGFU_BUILD_RELEASE_TRUST_DOMAIN='public'"));
         // Content hash of b"artifact-bytes", recorded for provenance.
         assert!(meta.contains(
             "KUNGFU_BUILD_SHA256='6521df166eb07efaf36eba5b6bedefd9d6a252e9c80bab1c99653700ec71473c'"

--- a/crates/shifu/src/util.rs
+++ b/crates/shifu/src/util.rs
@@ -10,6 +10,34 @@ use std::process::{Command, Stdio};
 
 pub use shifu_core::host::{find_on_path, kungfu_cache_dir, unique_temp_dir, xdg_dir};
 
+pub fn standard_companion_globs(platform: &str) -> (String, String) {
+    let archive_platform = match platform {
+        "macos" => "darwin",
+        other => other,
+    };
+    let manifest_platform = match platform {
+        "macos" => "darwin",
+        "windows" => "win32",
+        other => other,
+    };
+    let archive = if platform == "windows" {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    (
+        format!("product/release/cli/*cli-{archive_platform}-*.{archive}"),
+        format!("product/release/cli/*upgrade-*-{manifest_platform}-*.json"),
+    )
+}
+
+pub fn registration_policy_is_coherent(trust_domain: &str, publication_eligible: bool) -> bool {
+    matches!(
+        (trust_domain, publication_eligible),
+        ("shifu-local", false) | ("public", true)
+    )
+}
+
 pub fn die(msg: &str) -> ! {
     eprintln!("shifu: {msg}");
     std::process::exit(1);
@@ -49,5 +77,44 @@ pub fn exec_or_exit(mut cmd: Command) -> ! {
             Ok(status) => std::process::exit(status.code().unwrap_or(1)),
             Err(err) => die(&format!("failed to run {:?}: {err}", cmd.get_program())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{registration_policy_is_coherent, standard_companion_globs};
+
+    #[test]
+    fn standard_companions_preserve_platform_names() {
+        assert_eq!(
+            standard_companion_globs("windows"),
+            (
+                "product/release/cli/*cli-windows-*.zip".to_string(),
+                "product/release/cli/*upgrade-*-win32-*.json".to_string(),
+            )
+        );
+        assert_eq!(
+            standard_companion_globs("macos"),
+            (
+                "product/release/cli/*cli-darwin-*.tar.gz".to_string(),
+                "product/release/cli/*upgrade-*-darwin-*.json".to_string(),
+            )
+        );
+        assert_eq!(
+            standard_companion_globs("linux"),
+            (
+                "product/release/cli/*cli-linux-*.tar.gz".to_string(),
+                "product/release/cli/*upgrade-*-linux-*.json".to_string(),
+            )
+        );
+    }
+
+    #[test]
+    fn registration_policy_requires_a_coherent_trust_domain() {
+        assert!(registration_policy_is_coherent("shifu-local", false));
+        assert!(registration_policy_is_coherent("public", true));
+        assert!(!registration_policy_is_coherent("public", false));
+        assert!(!registration_policy_is_coherent("shifu-local", true));
+        assert!(!registration_policy_is_coherent("unknown", false));
     }
 }


### PR DESCRIPTION
## Summary

- allow the Shifu product registrar to retain a Product Release Cut when its publication policy is coherent for either local or public trust
- preserve the actual release trust domain in catalog metadata instead of hard-coding shifu-local
- keep platform-specific standard companion glob logic centralized and covered for Windows, macOS, and Linux

## Related issue

- Native Assignment 2026-07-29-kungfu-terminal-review-remediation

## Root cause

The protected Product build creates a qualified public Product Release Cut under Buildchain retained evidence. The registrar accepted only shifu-local plus publicationEligible=false, so a successful macOS dist ended with registered build is not publication-ineligible and runtime product-catalog qualification found no build.

## Verification

- cargo test --manifest-path crates/Cargo.toml -p shifu: 47/47 passed
- test:shifu-kfd-readonly: 44/44 passed
- code complexity budget: passed; 16/16 budget tests passed
- complete staged pre-commit source acceptance passed, including cargo fmt, cargo clippy -D warnings, cargo test --workspace, documentation and ADR contracts, invariant gates, Shifu and KFD contracts
- commit is based on protected head 07a5ef3e4548ed636edcb26d7b0603342ceb814d

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores catalog registration for an already-qualified Product Release Cut and changes no architecture contract or release channel topology."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change accepts only the two coherent trust and publication eligibility pairs. It grants no new publication authority and rejects incoherent or unknown policy combinations.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed