### PR TITLE
fix(auditable-demo): require native publication renditions

### DIFF
--- a/framework/auditable-demo/catalog.json
+++ b/framework/auditable-demo/catalog.json
@@ -129,13 +129,51 @@
       },
       "scene": {
         "id": "kungfu-project-work-recovery",
-        "width": 1280,
-        "height": 720,
+        "width": 1920,
+        "height": 1080,
         "fps": 15,
         "title": "Kungfu Project Work — retained failures and native settlement",
         "background": "#0B1020",
         "accent": "#67E8A5"
       },
+      "renditions": [
+        {
+          "id": "1080p",
+          "role": "primary",
+          "terminal": {
+            "columns": 150,
+            "rows": 36,
+            "timeoutSeconds": 60
+          },
+          "scene": {
+            "id": "kungfu-project-work-recovery",
+            "width": 1920,
+            "height": 1080,
+            "fps": 15,
+            "title": "Kungfu Project Work — retained failures and native settlement",
+            "background": "#0B1020",
+            "accent": "#67E8A5"
+          }
+        },
+        {
+          "id": "720p",
+          "role": "responsive",
+          "terminal": {
+            "columns": 100,
+            "rows": 28,
+            "timeoutSeconds": 60
+          },
+          "scene": {
+            "id": "kungfu-project-work-recovery-720p",
+            "width": 1280,
+            "height": 720,
+            "fps": 15,
+            "title": "Kungfu Project Work — retained failures and native settlement",
+            "background": "#0B1020",
+            "accent": "#67E8A5"
+          }
+        }
+      ],
       "publication": {
         "readmeFeatured": false,
         "siteSlug": "project-work-recovery"

--- a/scripts/auditable-demo-adapter.test.mjs
+++ b/scripts/auditable-demo-adapter.test.mjs
@@ -335,11 +335,11 @@ test('adapter selects a second catalog demo without changing the capture engine'
         siteSlug: 'agent-work-lab-secondary',
       },
     });
-    catalog.demos[1].renditions[0].scene = structuredClone(
-      catalog.demos[1].scene,
+    catalog.demos.at(-1).renditions[0].scene = structuredClone(
+      catalog.demos.at(-1).scene,
     );
-    catalog.demos[1].renditions[1].scene = {
-      ...catalog.demos[1].renditions[1].scene,
+    catalog.demos.at(-1).renditions[1].scene = {
+      ...catalog.demos.at(-1).renditions[1].scene,
       id: 'kungfu-agent-work-lab-secondary-autoplay-720p',
       title: 'Kungfu Agent Work Lab — secondary capture simulation',
     };

--- a/scripts/auditable-demo-passport.test.mjs
+++ b/scripts/auditable-demo-passport.test.mjs
@@ -139,11 +139,11 @@ test('binds an explicitly selected second demo to its catalog descriptor roots',
         siteSlug: 'agent-work-lab-secondary',
       },
     });
-    catalog.demos[1].renditions[0].scene = structuredClone(
-      catalog.demos[1].scene,
+    catalog.demos.at(-1).renditions[0].scene = structuredClone(
+      catalog.demos.at(-1).scene,
     );
-    catalog.demos[1].renditions[1].scene = {
-      ...catalog.demos[1].renditions[1].scene,
+    catalog.demos.at(-1).renditions[1].scene = {
+      ...catalog.demos.at(-1).renditions[1].scene,
       id: 'kungfu-agent-work-lab-secondary-autoplay-720p',
       title: 'Kungfu Agent Work Lab secondary simulation',
     };

--- a/scripts/update-auditable-demo-readme.mjs
+++ b/scripts/update-auditable-demo-readme.mjs
@@ -122,6 +122,36 @@ function exactArtifact(value, label) {
   };
 }
 
+function optionalRenditionAuthority(value) {
+  if (value === undefined) return null;
+  const frameSets = value?.frameSets;
+  if (
+    value?.policy !== 'independent-native-frame-sets/v1' ||
+    !Array.isArray(frameSets) ||
+    frameSets.length !== 2 ||
+    frameSets[0]?.role !== 'primary' ||
+    frameSets[0]?.width !== 1920 ||
+    frameSets[0]?.height !== 1080 ||
+    !DIGEST_PATTERN.test(frameSets[0]?.captureRoot || '') ||
+    frameSets[1]?.role !== 'responsive' ||
+    frameSets[1]?.width !== 1280 ||
+    frameSets[1]?.height !== 720 ||
+    !DIGEST_PATTERN.test(frameSets[1]?.captureRoot || '') ||
+    frameSets[0].captureRoot === frameSets[1].captureRoot
+  ) {
+    fail('native rendition authority is invalid');
+  }
+  return {
+    policy: value.policy,
+    frameSets: frameSets.map(({ role, width, height, captureRoot }) => ({
+      role,
+      width,
+      height,
+      captureRoot,
+    })),
+  };
+}
+
 export function validatePublicEvidence(value) {
   const version =
     value?.schema === 'kungfu.auditable-demo.public-evidence/v2' ? 2 : 1;
@@ -273,6 +303,9 @@ export function validatePublicEvidence(value) {
       'authorization non-authorities',
     ),
   };
+  const renditionAuthority = optionalRenditionAuthority(
+    value.renditionAuthority,
+  );
   const readmeMedia = {
     path: requiredString(
       value.readmeMedia?.path,
@@ -319,11 +352,12 @@ export function validatePublicEvidence(value) {
     claims: value.claims,
     nonClaims: value.nonClaims,
     authorization,
+    renditionAuthority,
     readmeMedia,
   };
 }
 
-function verifyMediaBundle(mediaDirectory, passport) {
+export function verifyMediaBundle(mediaDirectory, passport) {
   const members = fs
     .readdirSync(mediaDirectory, { withFileTypes: true })
     .map((entry) => {
@@ -433,21 +467,74 @@ function verifyMediaBundle(mediaDirectory, passport) {
       'renderer manifest',
     ).toString('utf8'),
   );
+  const nativeInputs = manifest.inputs?.renditions;
+  const nativeFrameSets = manifest.derivation?.sourceFrameSets;
   if (
     manifest.schema !== 'build-images.auditable-demo-render/v1' ||
     manifest.renderer?.image !== passport.toolchain.rendererImage ||
     manifest.policy?.evidenceClass !== passport.authority.evidenceClass ||
     manifest.policy?.visualClassification !== 'bounded-pty-replay' ||
-    manifest.policy?.runtimeTextAuthority !== 'terminal-capture.json' ||
-    !DIGEST_PATTERN.test(manifest.inputs?.terminalCapture?.root || '') ||
-    manifest.derivation?.policy !==
-      'single-frame-set-deterministic-renditions/v1' ||
-    manifest.derivation?.renditions?.[readmeRendition.path]?.operation !==
-      'lanczos-downscale-from-source-frames'
+    manifest.policy?.runtimeTextAuthority !== 'rendition-set.json' ||
+    manifest.inputs?.renditionSet?.schema !==
+      'kungfu.auditable-demo.rendition-set/v1' ||
+    !DIGEST_PATTERN.test(manifest.inputs?.renditionSet?.root || '') ||
+    manifest.derivation?.authority !== 'rendition-set.json' ||
+    manifest.derivation?.policy !== 'independent-native-frame-sets/v1'
   ) {
-    fail('renderer manifest does not prove the qualified PTY replay');
+    fail('renderer manifest does not prove the qualified native PTY replay');
   }
-  return readmeRendition.bytes;
+  if (
+    !Array.isArray(nativeInputs) ||
+    nativeInputs.length !== 2 ||
+    nativeInputs[0]?.role !== 'primary' ||
+    nativeInputs[0]?.terminalCapture?.dimensions?.columns !== 150 ||
+    nativeInputs[0]?.terminalCapture?.dimensions?.rows !== 36 ||
+    !DIGEST_PATTERN.test(nativeInputs[0]?.terminalCapture?.root || '') ||
+    nativeInputs[1]?.role !== 'responsive' ||
+    nativeInputs[1]?.terminalCapture?.dimensions?.columns !== 100 ||
+    nativeInputs[1]?.terminalCapture?.dimensions?.rows !== 28 ||
+    !DIGEST_PATTERN.test(nativeInputs[1]?.terminalCapture?.root || '') ||
+    nativeInputs[0].terminalCapture.root ===
+      nativeInputs[1].terminalCapture.root
+  ) {
+    fail('renderer inputs do not bind two distinct native terminal captures');
+  }
+  if (
+    !Array.isArray(nativeFrameSets) ||
+    nativeFrameSets.length !== 2 ||
+    nativeFrameSets[0]?.role !== 'primary' ||
+    nativeFrameSets[0]?.width !== 1920 ||
+    nativeFrameSets[0]?.height !== 1080 ||
+    nativeFrameSets[0]?.captureRoot !== nativeInputs[0].terminalCapture.root ||
+    nativeFrameSets[1]?.role !== 'responsive' ||
+    nativeFrameSets[1]?.width !== 1280 ||
+    nativeFrameSets[1]?.height !== 720 ||
+    nativeFrameSets[1]?.captureRoot !== nativeInputs[1].terminalCapture.root
+  ) {
+    fail('renderer derivation does not bind the required native frame sets');
+  }
+  for (const rendition of roles.values()) {
+    const derivation = manifest.derivation?.renditions?.[rendition.path];
+    if (
+      !derivation ||
+      derivation.width !== rendition.width ||
+      derivation.height !== rendition.height ||
+      derivation.operation !== 'native-frame-set-encode'
+    ) {
+      fail(`renderer derivation is invalid for role ${rendition.role}`);
+    }
+  }
+  return {
+    gif: readmeRendition.bytes,
+    nativeFrameSets: nativeFrameSets.map(
+      ({ role, width, height, captureRoot }) => ({
+        role,
+        width,
+        height,
+        captureRoot,
+      }),
+    ),
+  };
 }
 
 export function buildPublicEvidence({
@@ -474,7 +561,7 @@ export function buildPublicEvidence({
   ) {
     fail('Passport artifact is not bound to the exact workflow run');
   }
-  const gif = verifyMediaBundle(mediaDirectory, passport);
+  const { gif, nativeFrameSets } = verifyMediaBundle(mediaDirectory, passport);
   const rootName = passport.root.value.slice(7);
   const mediaPrefix =
     passport.demo.id === 'agent-work-lab' &&
@@ -492,6 +579,10 @@ export function buildPublicEvidence({
       rendererImage: passport.toolchain.rendererImage,
       gate: passport.gate,
       media: passport.media,
+      renditionAuthority: {
+        policy: 'independent-native-frame-sets/v1',
+        frameSets: nativeFrameSets,
+      },
       passport: {
         root: passport.root.value,
         artifact: exactPassportArtifact,
@@ -585,6 +676,10 @@ export function renderAuditableDemoBlock(value) {
     fail('only the catalog-selected README demo can update the managed block');
   }
   const shortSource = evidence.sourceSha.slice(0, 12);
+  const nativeRenditionLine =
+    evidence.renditionAuthority?.policy === 'independent-native-frame-sets/v1'
+      ? 'The 1080p and 720p renditions come from independent native PTY captures, not scaling.'
+      : '';
   return [
     START,
     '## See a fresh Agent continue the same Work',
@@ -603,6 +698,7 @@ export function renderAuditableDemoBlock(value) {
     `The installed \`${evidence.demo.commandLabel}\` command ran in a bounded PTY, the`,
     'required Buildchain Gate qualified its exact capture, and full media rendered only',
     'from that passing Gate.',
+    ...(nativeRenditionLine ? [nativeRenditionLine] : []),
     '',
     `[Method and evidence](docs/qualification/auditable-demo-artifact-pipeline.md) · [source \`${shortSource}\`](https://github.com/kungfu-systems/kungfu/commit/${evidence.sourceSha}) · [workflow run](${evidence.workflowUrl})`,
     '',

--- a/scripts/update-auditable-demo-readme.test.mjs
+++ b/scripts/update-auditable-demo-readme.test.mjs
@@ -14,6 +14,7 @@ import {
   renderAuditableDemoBlock,
   updateReadme,
   validatePublicEvidence,
+  verifyMediaBundle,
   verifyReadmeMediaFile,
 } from './update-auditable-demo-readme.mjs';
 
@@ -235,18 +236,77 @@ test('materializes README evidence only from a verified Passport and exact media
             evidenceClass:
               'exact-installed-artifact-agent-work-lab-autoplay/v1',
             visualClassification: 'bounded-pty-replay',
-            runtimeTextAuthority: 'terminal-capture.json',
+            runtimeTextAuthority: 'rendition-set.json',
           },
           inputs: {
-            terminalCapture: { root: `sha256:${'9'.repeat(64)}` },
+            renditionSet: {
+              schema: 'kungfu.auditable-demo.rendition-set/v1',
+              root: `sha256:${'7'.repeat(64)}`,
+            },
+            renditions: [
+              {
+                role: 'primary',
+                terminalCapture: {
+                  root: `sha256:${'9'.repeat(64)}`,
+                  dimensions: { columns: 150, rows: 36 },
+                },
+              },
+              {
+                role: 'responsive',
+                terminalCapture: {
+                  root: `sha256:${'6'.repeat(64)}`,
+                  dimensions: { columns: 100, rows: 28 },
+                },
+              },
+            ],
           },
           derivation: {
-            policy: 'single-frame-set-deterministic-renditions/v1',
+            authority: 'rendition-set.json',
+            policy: 'independent-native-frame-sets/v1',
+            sourceFrameSets: [
+              {
+                role: 'primary',
+                width: 1920,
+                height: 1080,
+                captureRoot: `sha256:${'9'.repeat(64)}`,
+              },
+              {
+                role: 'responsive',
+                width: 1280,
+                height: 720,
+                captureRoot: `sha256:${'6'.repeat(64)}`,
+              },
+            ],
             renditions: {
+              'demo.mp4': {
+                width: 1920,
+                height: 1080,
+                operation: 'native-frame-set-encode',
+              },
+              'demo.webm': {
+                width: 1920,
+                height: 1080,
+                operation: 'native-frame-set-encode',
+              },
+              'demo-720p.mp4': {
+                width: 1280,
+                height: 720,
+                operation: 'native-frame-set-encode',
+              },
+              'demo-720p.webm': {
+                width: 1280,
+                height: 720,
+                operation: 'native-frame-set-encode',
+              },
               'demo.gif': {
                 width: 1280,
                 height: 720,
-                operation: 'lanczos-downscale-from-source-frames',
+                operation: 'native-frame-set-encode',
+              },
+              'poster.png': {
+                width: 1920,
+                height: 1080,
+                operation: 'native-frame-set-encode',
               },
             },
           },
@@ -377,6 +437,15 @@ test('materializes README evidence only from a verified Passport and exact media
       projection.evidence.authorization,
       passport.authority.authorization,
     );
+    assert.deepEqual(
+      projection.evidence.renditionAuthority.frameSets.map(
+        ({ role, width, height }) => [role, width, height],
+      ),
+      [
+        ['primary', 1920, 1080],
+        ['responsive', 1280, 720],
+      ],
+    );
 
     const passportPath = path.join(repoRoot, 'passport.json');
     const passportArtifactPath = path.join(repoRoot, 'passport-artifact.json');
@@ -407,7 +476,39 @@ test('materializes README evidence only from a verified Passport and exact media
         }),
       /media checksum mismatch/u,
     );
+    fs.writeFileSync(
+      path.join(mediaDirectory, 'demo.gif'),
+      members['demo.gif'],
+    );
+
+    const manifestPath = path.join(mediaDirectory, 'manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    manifest.derivation.renditions['demo.gif'].operation =
+      'lanczos-downscale-from-source-frames';
+    fs.writeFileSync(manifestPath, stableJson(manifest));
+    const reboundChecksums = `${mediaMembersForTest(mediaDirectory)
+      .map(
+        (name) =>
+          `${sha256(fs.readFileSync(path.join(mediaDirectory, name))).slice(7)}  ${name}`,
+      )
+      .join('\n')}\n`;
+    fs.writeFileSync(
+      path.join(mediaDirectory, 'checksums.sha256'),
+      reboundChecksums,
+    );
+    passport.media.root = sha256(Buffer.from(reboundChecksums));
+    assert.throws(
+      () => verifyMediaBundle(mediaDirectory, passport),
+      /renderer derivation is invalid for role readme-compatibility/u,
+    );
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+function mediaMembersForTest(mediaDirectory) {
+  return fs
+    .readdirSync(mediaDirectory)
+    .filter((name) => name !== 'checksums.sha256')
+    .sort();
+}


### PR DESCRIPTION
## Summary

Require the README/publication consumer to accept responsive auditable-demo media only when 1080p and 720p were captured independently at their declared PTY dimensions. This closes the remaining authority gap after the native capture implementation: a scaled derivative or a missing rendition set can no longer become public evidence.

## Related issue

Follow-up to #2080 and the responsive auditable-demo media delivery.

## Changes

- require and verify one `rendition-set.json` with native 1920x1080/150x36 and 1280x720/100x28 captures
- reject shared capture roots, missing native-frame-set operations, and mismatched media coordinates
- project the verified rendition authority into the README evidence block
- register `project-work-recovery` with the same independent native capture contract
- update adapter, Passport, and README materialization coverage for multiple demos

## Verification

- `./shifu node --test scripts/update-auditable-demo-readme.test.mjs scripts/auditable-demo-adapter.test.mjs scripts/auditable-demo-passport.test.mjs` (31 passed)
- `PATH="/tmp/kungfu-source-tools.Av4Rjc/venv/bin:$PATH" ./shifu check:source` (879 core source tests: 869 passed, 10 skipped, 0 failed; all subsequent source-acceptance phases passed)
- `./shifu check` (passed before synchronization)
- commit hook staged gate on current `dev/v4/v4.0` (passed, including 138 documentation tests)
- `git diff --check origin/dev/v4/v4.0...HEAD` (passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a bounded fail-closed correction to the existing responsive auditable-demo publication contract; it does not introduce or replace an architecture authority."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The consumer binds exact Passport, rendition-set, media digests, source/run coordinates, distinct capture roots, and native encoder operations before public materialization.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
