### PR TITLE
fix(release): keep retained source builds local

### DIFF
--- a/product/scripts/upgrade-manifest.mjs
+++ b/product/scripts/upgrade-manifest.mjs
@@ -20,6 +20,7 @@ import {
 import { contentRoot } from './release-channel-index.mjs';
 
 export const UNQUALIFIED_RELEASE_EVIDENCE = 'unqualified-local-build';
+const BUILDCHAIN_RETAINED_EVIDENCE = 'buildchain-retained:';
 const DOCUMENTATION_URL = 'https://www.kungfu.tech/docs/guides/upgrading';
 const RELEASE_SCHEMA = 'kungfu.product-upgrade.manifest/v1';
 const RELEASE_CUT_SCHEMA = 'kungfu.product-release-cut/v1';
@@ -196,18 +197,20 @@ export function bindProductReleaseCut(
       .map((value) => value.trim())
       .filter(Boolean),
     sourceSettlementRoot = process.env.KF_SOURCE_SETTLEMENT_ROOT,
+    sourceBuild = process.env.KUNGFU_BUILDCHAIN_SOURCE_BUILD === '1',
   } = {},
 ) {
   const base = cutFreeManifest(manifest);
   const manifestIdentityRoot = contentRoot(manifestIdentity(base));
+  const localOnlyEvidence = (value) =>
+    String(value || '').startsWith(UNQUALIFIED_RELEASE_EVIDENCE) ||
+    (sourceBuild &&
+      String(value || '').startsWith(BUILDCHAIN_RETAINED_EVIDENCE));
   const localEvidence =
-    String(base.qualificationEvidenceRef || '').startsWith(
-      UNQUALIFIED_RELEASE_EVIDENCE,
-    ) ||
+    localOnlyEvidence(base.qualificationEvidenceRef) ||
     (base.artifacts || []).some(
       (artifact) =>
-        !artifact.signature ||
-        artifact.signature === UNQUALIFIED_RELEASE_EVIDENCE,
+        !artifact.signature || localOnlyEvidence(artifact.signature),
     );
   const trustDomain = localEvidence ? 'shifu-local' : 'public';
   const qualificationEvidenceRoots = sortedRoots([
@@ -315,6 +318,7 @@ export function buildBundledUpgradeManifest({
     UNQUALIFIED_RELEASE_EVIDENCE,
   qualificationEvidenceRef = process.env.KF_UPGRADE_QUALIFICATION_REF ||
     `${UNQUALIFIED_RELEASE_EVIDENCE}:${revision}`,
+  sourceBuild = process.env.KUNGFU_BUILDCHAIN_SOURCE_BUILD === '1',
 }) {
   assertPlatform(platform, architecture);
   if (!fs.statSync(runtimeRoot).isDirectory()) {
@@ -326,37 +330,40 @@ export function buildBundledUpgradeManifest({
   });
   const runtimeBuildId = `runtime-${version}-${runtimeDigest.slice(0, 16)}`;
   const frontendBuildId = `product-${version}-${revision.slice(0, 12)}-${runtimeDigest.slice(0, 16)}`;
-  return bindProductReleaseCut({
-    schema: RELEASE_SCHEMA,
-    productVersion: version,
-    releaseChannel,
-    sourceCommit: revision,
-    runtimeBuildId,
-    runtimeArtifactDigest: `sha256:${runtimeDigest}`,
-    runtimeEntrypoint: runtimeEntrypoint(platform),
-    frontendBuildId,
-    controlProtocolRange: { min: 1, max: 1 },
-    peerWireProtocolRange: { min: 1, max: 1 },
-    journalSchemaReadRange: { min: 1, max: 1 },
-    journalSchemaWriteVersion: 1,
-    migrationClass: 'none',
-    rollbackClass: 'automatic',
-    minimumSupportedFrontend: version,
-    minimumSupportedRuntime: version,
-    platform,
-    architecture,
-    artifacts: [
-      {
-        kind: 'runtime',
-        url: 'app-resource://kungfu',
-        size: treeSize(runtimeRoot, { filter: releaseRuntimePath }),
-        digest: `sha256:${runtimeDigest}`,
-        signature: runtimeSignature,
-      },
-    ],
-    qualificationEvidenceRef,
-    documentationUrl: DOCUMENTATION_URL,
-  });
+  return bindProductReleaseCut(
+    {
+      schema: RELEASE_SCHEMA,
+      productVersion: version,
+      releaseChannel,
+      sourceCommit: revision,
+      runtimeBuildId,
+      runtimeArtifactDigest: `sha256:${runtimeDigest}`,
+      runtimeEntrypoint: runtimeEntrypoint(platform),
+      frontendBuildId,
+      controlProtocolRange: { min: 1, max: 1 },
+      peerWireProtocolRange: { min: 1, max: 1 },
+      journalSchemaReadRange: { min: 1, max: 1 },
+      journalSchemaWriteVersion: 1,
+      migrationClass: 'none',
+      rollbackClass: 'automatic',
+      minimumSupportedFrontend: version,
+      minimumSupportedRuntime: version,
+      platform,
+      architecture,
+      artifacts: [
+        {
+          kind: 'runtime',
+          url: 'app-resource://kungfu',
+          size: treeSize(runtimeRoot, { filter: releaseRuntimePath }),
+          digest: `sha256:${runtimeDigest}`,
+          signature: runtimeSignature,
+        },
+      ],
+      qualificationEvidenceRef,
+      documentationUrl: DOCUMENTATION_URL,
+    },
+    { sourceBuild },
+  );
 }
 
 export function buildCliUpgradeManifest({

--- a/product/scripts/upgrade-manifest.test.mjs
+++ b/product/scripts/upgrade-manifest.test.mjs
@@ -193,6 +193,47 @@ test('bundled manifest binds exact runtime bytes and source product identity', (
   }
 });
 
+test('Buildchain source-build evidence remains publication-ineligible', () => {
+  const f = fixture();
+  try {
+    const evidence =
+      'buildchain-retained:product/release/qualification/kungfu-upgrade-qualification-evidence.json';
+    const options = {
+      ...f,
+      platform: 'win32',
+      architecture: 'x64',
+      revision: '1'.repeat(40),
+      runtimeSignature: `${evidence}#runtime`,
+      qualificationEvidenceRef: evidence,
+    };
+    const sourceBuild = buildBundledUpgradeManifest({
+      ...options,
+      sourceBuild: true,
+    });
+    assert.deepEqual(sourceBuild.releaseCut.publicationPolicy, {
+      trustDomain: 'shifu-local',
+      publicationEligible: false,
+      immutable: true,
+      eligibleChannels: [],
+    });
+
+    const publicBuild = buildBundledUpgradeManifest({
+      ...options,
+      sourceBuild: false,
+    });
+    assert.equal(
+      publicBuild.releaseCut.publicationPolicy.trustDomain,
+      'public',
+    );
+    assert.equal(
+      publicBuild.releaseCut.publicationPolicy.publicationEligible,
+      true,
+    );
+  } finally {
+    fs.rmSync(f.root, { recursive: true, force: true });
+  }
+});
+
 test('combined release rejects a CLI and desktop identity split', () => {
   const root = `sha256:${'1'.repeat(64)}`;
   assert.doesNotThrow(() =>


### PR DESCRIPTION
## Summary

- classify `buildchain-retained:` evidence as local-only inside the explicit Buildchain source-build boundary
- keep those Product Release Cuts on `shifu-local` with publication disabled so Shifu can register the exact dev build
- preserve public trust-domain behavior outside source builds
- replace revoked PR #2101 with a new exact head based on protected `6984066f684bf0e40eb18e686ea65b89d75f1312`

## Related issue

Closes #2100
Supersedes #2101 after its exact-head queue lease was revoked on dequeue.

## Verification

- `node --test product/scripts/upgrade-manifest.test.mjs` (10 passed)
- `cargo test -p shifu` from `crates/` (45 passed)
- repository staged gate (passed)
- byte-for-byte source blob match with independently reviewed PR #2101 implementation

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct source-build Release Cut trust classification without changing the release architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This change narrows publication eligibility for explicit source builds. It adds no credentials, signing authority, publishing authority, hosted-service access, or public release claim.
