### PR TITLE
test(agent-session): bound Windows cold-start convergence

### DIFF
--- a/framework/agent-session/tests/mock-product-session.test.mjs
+++ b/framework/agent-session/tests/mock-product-session.test.mjs
@@ -16,15 +16,17 @@ const MOCK = fileURLToPath(
   new URL('../src/mock-provider.mjs', import.meta.url),
 );
 const PROFILE_ROOT = `sha256:${'7'.repeat(64)}`;
+const CONVERGENCE_TIMEOUT_MS = 5000;
+const STARTUP_CONVERGENCE_TIMEOUT_MS = 15000;
 
-async function eventually(probe, label) {
-  const deadline = Date.now() + 5000;
+async function eventually(probe, label, timeoutMs = CONVERGENCE_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const value = await probe();
     if (value) return value;
     await delay(25);
   }
-  throw new Error(`${label} did not converge`);
+  throw new Error(`${label} did not converge within ${timeoutMs}ms`);
 }
 
 async function control(host, session, operation, payload, automatic = true) {
@@ -162,10 +164,14 @@ test('deterministic Mock Agent traverses answer, approval, review, and exit in t
     execution: { env: input.env, cols: 100, rows: 30 },
   });
 
-  await eventually(async () => {
-    const status = await host.invoke({ operation: 'status', session });
-    return status.interactionState === 'ready' ? status : null;
-  }, 'initial ready state');
+  await eventually(
+    async () => {
+      const status = await host.invoke({ operation: 'status', session });
+      return status.interactionState === 'ready' ? status : null;
+    },
+    'initial ready state',
+    STARTUP_CONVERGENCE_TIMEOUT_MS,
+  );
   await control(host, session, 'instruct', { text: 'perform bounded Work' });
   const answer = await eventually(async () => {
     const status = await host.invoke({ operation: 'status', session });


### PR DESCRIPTION
## Summary

- keep the existing 5-second convergence bound for steady-state agent-session transitions
- allow only the initial detached product runtime ready state a bounded 15-second cold-start window
- include the effective timeout in convergence failure diagnostics

## Related issue

Closes #2114

## Verification

- `./shifu test:agent-session-work-attention` (11 passed)
- `node --test framework/agent-session/tests/mock-product-session.test.mjs` repeated 10 times (10/10 passed; 1.2-2.7 seconds per run)
- repository staged gate, including Biome, invariant, documentation, ADR, and Gate catalog checks (passed)

## Qualification context

The exact AWS Windows qualification failure is https://github.com/kungfu-systems/kungfu/actions/runs/30689997715/job/91343093630. A fresh exact-source Windows full qualification will run after protected merge.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Adjust one test-only cold-start bound without changing the agent-session runtime architecture or release contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This test-only change adds no credentials, signing authority, publishing authority, hosted-service access, or public release claim.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoiY3Jvc3MtcGxhdGZvcm0iLCJkZXZIZWFkIjoiY2I1NjZlYjVlN2FhMjczZTBjNTMyY2Q5NWIxNTljZWI0ZWEzYWUyZCIsInB1bGxSZXF1ZXN0SGVhZCI6ImRlODM1N2UyOGZiYzlkZWUzY2I4MWJmMGFjOGQ4YTA5NmZjYWZlMDMiLCJyZXBsYXllZENhbmRpZGF0ZSI6IjY5OGUxNTk5MTQwOWY3OGY5Zjk3NmIzMmIwZDNlMDQ0OTNmNmY1NWEiLCJyZXBsYXllZFRyZWUiOiIzMWEwMjQzOTBiMDlkN2YzYTBhYzQ1MDJkM2IyMzAwNzgwOGY3MTMyIiwicXVldWVBdHRlbXB0IjoiZGU4MzU3ZTI4ZmJjOWRlZTNjYjgxYmYwYWM4ZDhhMDk2ZmNhZmUwM0BjYjU2NmViNWU3YWEyNzNlMGM1MzJjZDk1YjE1OWNlYjRlYTNhZTJkIiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OjliNzA1OTY5ZDcwZTk4ZGRiNGNkZDMwZDYxNDNiNjY1ZTZjMWI3ZWI1ODZlZTI0NDA1ZmUwZTU0NDFiZTliOGUiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1Njo1Y2QyMmFkODFhN2E3NzhmMmU1YmZhZjI5Y2VlOTViNWFlNzliODI0MDRmZGRkM2ViMGI1ZTFhODgwYWNmMmVkIiwic2hhMjU2OjliNzA1OTY5ZDcwZTk4ZGRiNGNkZDMwZDYxNDNiNjY1ZTZjMWI3ZWI1ODZlZTI0NDA1ZmUwZTU0NDFiZTliOGUiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kOTlmM2E5MTY2NzM5ZTBkIiwibGVhc2VSb290Ijoic2hhMjU2OjllMWEzMjhkYmI0YjFjY2ViM2YwMDRlODRiZTMzYmUyMDNlYjUyMmZlNTk2YjIzNGFmNzNmNzA1NWVlNDQ0YTEifQ -->