### PR TITLE
test(agent-session): widen bounded Windows cold start

### DIFF
--- a/framework/agent-session/tests/mock-product-session.test.mjs
+++ b/framework/agent-session/tests/mock-product-session.test.mjs
@@ -17,16 +17,24 @@ const MOCK = fileURLToPath(
 );
 const PROFILE_ROOT = `sha256:${'7'.repeat(64)}`;
 const CONVERGENCE_TIMEOUT_MS = 5000;
-const STARTUP_CONVERGENCE_TIMEOUT_MS = 15000;
+const STARTUP_CONVERGENCE_TIMEOUT_MS = 60000;
 
-async function eventually(probe, label, timeoutMs = CONVERGENCE_TIMEOUT_MS) {
+async function eventually(
+  probe,
+  label,
+  timeoutMs = CONVERGENCE_TIMEOUT_MS,
+  diagnostic = () => '',
+) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const value = await probe();
     if (value) return value;
     await delay(25);
   }
-  throw new Error(`${label} did not converge within ${timeoutMs}ms`);
+  const detail = diagnostic();
+  throw new Error(
+    `${label} did not converge within ${timeoutMs}ms${detail ? `; ${detail}` : ''}`,
+  );
 }
 
 async function control(host, session, operation, payload, automatic = true) {
@@ -46,6 +54,18 @@ async function control(host, session, operation, payload, automatic = true) {
     automatic,
   });
 }
+
+test('convergence timeout includes its last observed diagnostic', async () => {
+  await assert.rejects(
+    eventually(
+      async () => null,
+      'fixture state',
+      1,
+      () => 'last lifecycle=ready, interaction=busy',
+    ),
+    /fixture state did not converge within 1ms; last lifecycle=ready, interaction=busy/u,
+  );
+});
 
 test('macOS node-pty preparation rejects a linked private support target', async (t) => {
   if (process.platform !== 'darwin') {
@@ -164,13 +184,19 @@ test('deterministic Mock Agent traverses answer, approval, review, and exit in t
     execution: { env: input.env, cols: 100, rows: 30 },
   });
 
+  let lastInitialStatus = null;
   await eventually(
     async () => {
       const status = await host.invoke({ operation: 'status', session });
+      lastInitialStatus = status;
       return status.interactionState === 'ready' ? status : null;
     },
     'initial ready state',
     STARTUP_CONVERGENCE_TIMEOUT_MS,
+    () =>
+      lastInitialStatus
+        ? `last lifecycle=${lastInitialStatus.lifecycleState}, interaction=${lastInitialStatus.interactionState}`
+        : 'no status observed',
   );
   await control(host, session, 'instruct', { text: 'perform bounded Work' });
   const answer = await eventually(async () => {


### PR DESCRIPTION
## Summary

- keep every steady-state agent-session convergence check at 5 seconds
- expand only the initial detached provider readiness guard from 15 to a bounded 60 seconds
- report the last observed lifecycle and interaction state if the startup guard expires
- cover the diagnostic contract with a deterministic timeout test

## Related issue

Closes #2114

## Evidence

The protected exact-source AWS Windows full qualification at https://github.com/kungfu-systems/kungfu/actions/runs/30694185828/job/91354192866 passed install and build, then failed only at `initial ready state did not converge within 15000ms`. Its one-job runner exited cleanly, deleted the JIT parameter after read, terminated the EC2 instance, and left no tagged volume residue.

## Verification

- `./shifu test:agent-session-work-attention` (12 passed)
- `node --test framework/agent-session/tests/mock-product-session.test.mjs` repeated 10 times (10/10 passed)
- `./shifu check:staged` (passed)
- pre-commit repository gate (passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Adjust a test-only bounded cold-start guard and diagnostic without changing Agent Session runtime architecture or release contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This test-only change adds no credentials, signing authority, publishing authority, hosted-service access, or public release claim.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoiY3Jvc3MtcGxhdGZvcm0iLCJkZXZIZWFkIjoiMzkxOTQzNDQ4YmFiNzNjMjM3MmUzZjg4M2Y2OWI5YzMxODg2YmYwMiIsInB1bGxSZXF1ZXN0SGVhZCI6IjU1MzY0ZTFiYjVlNDQ0MjcyOTBjYzhjZjhlODdlZDQ0MmM5NDc2YzgiLCJyZXBsYXllZENhbmRpZGF0ZSI6IjNiMDRkMTY4YmRlNWRlZDc5NDFmMzgxOTlkNDA0Mzc0NDNhODk0MzIiLCJyZXBsYXllZFRyZWUiOiJlOWVlODlhNmRjYzk1Mzk2NmFmYjg4ZjQ4MDdhN2NjZWRmZjg3Yzg5IiwicXVldWVBdHRlbXB0IjoiNTUzNjRlMWJiNWU0NDQyNzI5MGNjOGNmOGU4N2VkNDQyYzk0NzZjOEAzOTE5NDM0NDhiYWI3M2MyMzcyZTNmODgzZjY5YjljMzE4ODZiZjAyIiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OmI1MTExMWRjNmIxZDFlMGI0OGYzY2NmZTE2YThlOTk3NDgxMDAxZTEwMjY2MDMyN2ZjNTViOTM3MzUzZDk5NzMiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1Njo1Y2QyMmFkODFhN2E3NzhmMmU1YmZhZjI5Y2VlOTViNWFlNzliODI0MDRmZGRkM2ViMGI1ZTFhODgwYWNmMmVkIiwic2hhMjU2OmI1MTExMWRjNmIxZDFlMGI0OGYzY2NmZTE2YThlOTk3NDgxMDAxZTEwMjY2MDMyN2ZjNTViOTM3MzUzZDk5NzMiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kOTlmM2E5MTY2NzM5ZTBkIiwibGVhc2VSb290Ijoic2hhMjU2Ojk0ZTRmMjE0ZmFhMGYwYTMxYzc2NmFmODJmMDQzMzU3YjgzZGY3NjEwODY4ZTEwNDg3NzJjMTMwMGFhYWQ0OTIifQ -->