### PR TITLE
fix(agent-session): stabilize Windows PTY qualification

### DIFF
--- a/framework/agent-session/tests/capsule-worker.test.mjs
+++ b/framework/agent-session/tests/capsule-worker.test.mjs
@@ -203,11 +203,14 @@ test('detached Capsule worker survives client loss and reattaches to the same PT
   const reattached = await second.request('status');
   assert.equal(reattached.sessionAttemptId, started.sessionAttemptId);
   assert.equal(reattached.foreground.pid, started.foreground.pid);
+  let replay;
   await waitFor(async () => {
-    const replay = await second.request('snapshot', { requestedSequence: 0 });
-    return replay.receipt.nextSequence > 4096;
-  }, 'synthetic PTY output did not arrive');
-  const replay = await second.request('snapshot', { requestedSequence: 0 });
+    replay = await second.request('snapshot', { requestedSequence: 0 });
+    return (
+      replay.receipt.nextSequence > 4096 &&
+      replay.vt.lines.some((line) => line.includes('approval-needed'))
+    );
+  }, 'synthetic PTY output did not fully converge');
   assert.equal(replay.receipt.gap.reason, 'bounded-retention-overflow');
   assert.equal(replay.vt.activeBuffer, 'primary');
   assert.ok(replay.vt.lines.some((line) => line.includes('approval-needed')));

--- a/framework/agent-session/tests/mock-product-session.test.mjs
+++ b/framework/agent-session/tests/mock-product-session.test.mjs
@@ -47,6 +47,27 @@ async function control(host, session, operation, payload, automatic = true) {
   });
 }
 
+function mockProviderEnvironment() {
+  const environment = { PATH: process.env.PATH ?? '' };
+  if (process.platform !== 'win32') return environment;
+  for (const requested of [
+    'systemroot',
+    'windir',
+    'comspec',
+    'pathext',
+    'temp',
+    'tmp',
+  ]) {
+    const actual = Object.keys(process.env).find(
+      (name) => name.toLowerCase() === requested,
+    );
+    if (actual && typeof process.env[actual] === 'string') {
+      environment[actual] = process.env[actual];
+    }
+  }
+  return environment;
+}
+
 test('macOS node-pty preparation rejects a linked private support target', async (t) => {
   if (process.platform !== 'darwin') {
     t.skip('private spawn-helper preparation is macOS-specific');
@@ -141,7 +162,7 @@ test('deterministic Mock Agent traverses answer, approval, review, and exit in t
     executable: process.execPath,
     argv: [MOCK, '--scenario', 'multi-step'],
     cwd: runtimeDir,
-    env: { PATH: process.env.PATH ?? '' },
+    env: mockProviderEnvironment(),
     runtimeProfileId: 'kungfu.mock-agent.multi-step',
     binding: {
       kind: 'work',


### PR DESCRIPTION
## Summary

- preserve the Windows environment required by ConPTY in the detached Mock Agent qualification
- wait for the complete synthetic approval prompt before asserting the retained VT snapshot
- keep runtime and product semantics unchanged

## Verification

- `./shifu node --test --test-concurrency=1 framework/agent-session/tests/capsule-worker.test.mjs framework/agent-session/tests/mock-product-session.test.mjs` (3 passed)
- staged repository gate passed
- `@kungfu-tech/agent-session` control-plane suite reached 108/109 locally; the only omitted native case requires `framework/core/dist/kungfu/kungfu_node.node` from `./shifu build:core`

## Release impact

Patch-level qualification fix. No public runtime contract changes.