### PR TITLE
fix(tui): preserve packaged extension authority

### DIFF
--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -110,6 +110,7 @@ import {
   resolveTuiCliRuntime,
   resolveTuiProductPaths,
   resolveTuiRuntimeDir,
+  tuiChildCliEnvironment,
 } from './terminal-lifecycle.js';
 import {
   globalWorkContribution,
@@ -210,14 +211,7 @@ async function invokeTuiAgentSession(
 }
 
 function cliEnvironment(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
-  // This process is running inside embedded libnode. Child `kungfu` calls must
-  // re-enter the ordinary CLI instead of recursively selecting the Node host.
-  env.KUNGFU_AS_VARIANT = undefined;
-  env.KUNGFU_DIR = undefined;
-  env.KUNGFU_KFX_CONTRACT = undefined;
-  env.KF_BUNDLED_EXTENSION_ROOT = undefined;
-  return env;
+  return tuiChildCliEnvironment(process.env);
 }
 
 function runtimePaths() {

--- a/framework/tui/src/projects-view.test.ts
+++ b/framework/tui/src/projects-view.test.ts
@@ -230,7 +230,5 @@ test('Project Session discovery follows the current runtime host after Project r
     openProjects,
     /ensureTuiAgentSession\(paths\.runtimeDir\)/,
   );
-  assert.match(source, /env\.KUNGFU_DIR = undefined/);
-  assert.match(source, /env\.KUNGFU_KFX_CONTRACT = undefined/);
-  assert.match(source, /env\.KF_BUNDLED_EXTENSION_ROOT = undefined/);
+  assert.match(source, /return tuiChildCliEnvironment\(process\.env\)/);
 });

--- a/framework/tui/src/terminal-lifecycle.test.ts
+++ b/framework/tui/src/terminal-lifecycle.test.ts
@@ -22,7 +22,25 @@ import {
   existingProjectWorkspaceRoot,
   resolveTuiCoreDir,
   resolveTuiProductPaths,
+  tuiChildCliEnvironment,
 } from './terminal-lifecycle.js';
+
+test('child CLI retains the packaged KFX root without recursive libnode selection', () => {
+  const parent = {
+    KUNGFU_AS_VARIANT: 'node',
+    KUNGFU_DIR: '/product/runtime',
+    KUNGFU_KFX_CONTRACT: '/product/runtime/config/kungfu-kfx.contract.json',
+    KF_BUNDLED_EXTENSION_ROOT: '/product/extensions',
+  };
+
+  const child = tuiChildCliEnvironment(parent);
+
+  assert.equal(child.KUNGFU_AS_VARIANT, undefined);
+  assert.equal(child.KUNGFU_DIR, undefined);
+  assert.equal(child.KUNGFU_KFX_CONTRACT, undefined);
+  assert.equal(child.KF_BUNDLED_EXTENSION_ROOT, '/product/extensions');
+  assert.equal(parent.KUNGFU_AS_VARIANT, 'node');
+});
 
 class FakeOutput extends EventEmitter implements TerminalOutput {
   isTTY = true;

--- a/framework/tui/src/terminal-lifecycle.ts
+++ b/framework/tui/src/terminal-lifecycle.ts
@@ -95,6 +95,18 @@ export function resolveTuiCliRuntime({
   };
 }
 
+export function tuiChildCliEnvironment(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const child = { ...env };
+  // Re-enter the ordinary CLI instead of recursively selecting embedded
+  // libnode, while retaining the installed KFX authority root.
+  child.KUNGFU_AS_VARIANT = undefined;
+  child.KUNGFU_DIR = undefined;
+  child.KUNGFU_KFX_CONTRACT = undefined;
+  return child;
+}
+
 export function resolveTuiProductPaths({
   env,
   resolveCorePackageJson,


### PR DESCRIPTION
## Summary

- preserve KF_BUNDLED_EXTENSION_ROOT when the installed TUI starts an ordinary child CLI
- continue clearing only the embedded libnode selectors that would recurse into the TUI host
- add a direct environment-boundary regression test and keep the source-shape assertion focused on helper delegation

## Related issue

Follow-up remediation for #2100 after Product Build macOS run 30700563464 exposed the installed TUI bootstrap regression introduced with #2124.

## Changes

- centralize child CLI environment construction in terminal-lifecycle
- retain the packaged first-party KFX Suite catalog root
- prove parent environment immutability and selector clearing

## Verification

- ./shifu --filter @kungfu-tech/tui exec tsx --test src/terminal-lifecycle.test.ts src/projects-view.test.ts (18 passed)
- ./shifu --filter @kungfu-tech/tui build (passed)
- repository pre-commit staged gate (passed)
- ./shifu check:source reached 939 passed, 10 skipped, and one environment-only failure because pytest is unavailable on the local PATH
- full TUI suite reached 155 passed and one environment-only cancellation because local Python 3.14 is outside the required Python >=3.13,<3.14 service-host range

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the existing installed TUI extension authority boundary without changing the product or release architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no documentation change required for this regression fix)

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI5LWt1bmdmdS10ZXJtaW5hbC1yZXZpZXctcmVtZWRpYXRpb24iLCJkZWxpdmVyeUNsYXNzIjoiY3Jvc3MtcGxhdGZvcm0iLCJkZXZIZWFkIjoiNjczMDYxY2E2YTY0ZDhjM2ExMWE4ZTIxYWExZTJkYWM0ZTY5OWJkMSIsInB1bGxSZXF1ZXN0SGVhZCI6IjQzNTFmODRkNmM0MzQ3YzE5NTY1YTI2NDEwODExYzhlNjEwYTgyNTciLCJyZXBsYXllZENhbmRpZGF0ZSI6Ijc3Y2I2MWZhYzFmMzU2YzI4ODZmZjM4NmM3ZGNlOGQ3NWExY2VlNzQiLCJyZXBsYXllZFRyZWUiOiJhNjMwMjAzZmZlYjljNWFmZmJiZWVhZTc5OTVmOTBlZjlmNWRlMDY2IiwicXVldWVBdHRlbXB0IjoiNDM1MWY4NGQ2YzQzNDdjMTk1NjVhMjY0MTA4MTFjOGU2MTBhODI1N0A2NzMwNjFjYTZhNjRkOGMzYTExYThlMjFhYTFlMmRhYzRlNjk5YmQxIiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OjNiOTljNTc2ZTc2NWU1Yzg2NTRlNDNjMDZmYTQ1N2ZhMDBhZDRlOTY3YTY5NjFkNmRhMTFlZTE1NjNmNzg0MmEiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1NjowZWExNjQ1ZDljZmUyZTllY2E3MjQyNzk2MjNkMzk3ZTBjMDdjOGU5YWI4N2MyYTFjODkwZmFlM2YyZWZmMzUyIiwic2hhMjU2OjNiOTljNTc2ZTc2NWU1Yzg2NTRlNDNjMDZmYTQ1N2ZhMDBhZDRlOTY3YTY5NjFkNmRhMTFlZTE1NjNmNzg0MmEiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kOTlmM2E5MTY2NzM5ZTBkIiwibGVhc2VSb290Ijoic2hhMjU2OjdkNzllNmQwOTBhZTdlN2UxZTY1ODU4NThhMjIyNjEyNTU0MTBlNDc0NGVkMDUzYTA1ZGVjYTMzZDk3MzdlZDkifQ -->