### PR TITLE
fix(verify): cover amp provider discovery default

### DIFF
--- a/tests/fixtures/rewind-demo-cost-adapter/check_cost_adapter.py
+++ b/tests/fixtures/rewind-demo-cost-adapter/check_cost_adapter.py
@@ -142,6 +142,7 @@ res = discover_providers(
         {
             "codex": "/c/codex",
             "claude": "/c/claude",
+            "amp": "/c/amp",
             "opencode": "/c/opencode",
         }
     ),
@@ -150,7 +151,7 @@ res = discover_providers(
 )
 check(
     "discover_providers returns all defaults",
-    set(res) == {"codex", "claude", "opencode"}
+    set(res) == {"codex", "claude", "amp", "opencode"}
     and all(isinstance(v, ProviderDiscovery) for v in res.values()),
 )
 check("all defaults found with injected PATH", all(v.found for v in res.values()))


### PR DESCRIPTION
## Summary

Keep the rewind cost-adapter fixture aligned with the product-owned default provider catalog after `amp` joined that catalog.

## Changes

- inject a synthetic `amp` executable into the no-execution discovery fixture
- require the default discovery result to contain codex, claude, amp, and opencode

## Verification

- `python3 tests/fixtures/rewind-demo-cost-adapter/check_cost_adapter.py tests/fixtures/rewind-demo-cost-adapter`
- full staged pre-commit qualification

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Align a deterministic fixture with the already-implemented provider default; no architecture contract changes"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] The exact previously failing fixture passes
