### PR TITLE
fix(runtime): preserve peer readiness snapshots

### DIFF
--- a/framework/core/src/python/kungfu/peer_lifecycle.py
+++ b/framework/core/src/python/kungfu/peer_lifecycle.py
@@ -19,6 +19,7 @@ import re
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, Mapping
@@ -63,9 +64,26 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 def _write_json(path: Path, value: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", "utf-8")
-    os.replace(temporary, path)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as output:
+            temporary = Path(output.name)
+            output.write(json.dumps(value, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
 
 
 def _canonical_digest(value: Mapping[str, Any]) -> str:
@@ -462,6 +480,32 @@ def _product_entry_command() -> list[str]:
     ]
 
 
+def _wait_for_ensure_status(
+    runtime: str,
+    peer_id: str,
+    timeout: float,
+    *,
+    host_process: subprocess.Popen[Any] | None = None,
+) -> dict[str, Any]:
+    """Wait for a live host to finish its asynchronous readiness transition."""
+
+    deadline = time.monotonic() + timeout
+    while True:
+        current = status(runtime, peer_id)
+        if current["healthy"] or current["lifecycleState"] in {
+            "crash-loop",
+            "ended",
+            "lost-control",
+            "ownership-unknown",
+        }:
+            return current
+        if host_process is not None and host_process.poll() is not None:
+            return current
+        if time.monotonic() >= deadline:
+            return current
+        time.sleep(0.1)
+
+
 def ensure(
     spec: Mapping[str, Any],
     runtime_dir: str | os.PathLike[str],
@@ -559,18 +603,8 @@ def ensure(
                 "process-identity-unavailable",
                 "Peer host process start identity was unavailable",
             )
-    deadline = time.monotonic() + readiness_wait
-    while time.monotonic() < deadline:
-        current_status = status(runtime, peer_id)
-        if current_status["healthy"] or current_status["lifecycleState"] in {
-            "crash-loop",
-            "lost-control",
-            "ownership-unknown",
-        }:
-            break
-        time.sleep(0.1)
     return {
-        **status(runtime, peer_id),
+        **_wait_for_ensure_status(runtime, peer_id, readiness_wait, host_process=child),
         "changed": True,
         "adopted": False,
         "command": command,

--- a/framework/core/tests/python/test_peer_lifecycle.py
+++ b/framework/core/tests/python/test_peer_lifecycle.py
@@ -31,6 +31,26 @@ def _spec(*, process_exit="restart", durable_state="declared", max_restarts=3):
     }
 
 
+def test_json_write_is_atomic_across_interleaved_writers(tmp_path, monkeypatch):
+    target = tmp_path / "runtime" / "state.json"
+    original_replace = peer_lifecycle.os.replace
+    interleaved = False
+
+    def replace_with_interleaved_writer(source, destination):
+        nonlocal interleaved
+        if not interleaved:
+            interleaved = True
+            peer_lifecycle._write_json(target, {"writer": "nested"})
+        original_replace(source, destination)
+
+    monkeypatch.setattr(peer_lifecycle.os, "replace", replace_with_interleaved_writer)
+
+    peer_lifecycle._write_json(target, {"writer": "outer"})
+
+    assert peer_lifecycle._read_json(target) == {"writer": "outer"}
+    assert list(target.parent.glob(f".{target.name}.*.tmp")) == []
+
+
 def test_plan_is_stable_and_never_uses_a_shell(tmp_path):
     first = peer_lifecycle.plan(_spec(), tmp_path)
     second = peer_lifecycle.plan(_spec(), tmp_path)
@@ -161,6 +181,45 @@ def test_ensure_fails_closed_on_pid_reuse(tmp_path, monkeypatch):
         peer_lifecycle.ensure(_spec(), runtime_dir, wait_seconds=0)
 
     assert failure.value.code == "ownership-unknown"
+
+
+def test_ensure_stops_waiting_when_a_new_host_exits(tmp_path, monkeypatch):
+    stopped = {
+        "healthy": False,
+        "lifecycleState": "starting",
+    }
+
+    class ExitedHost:
+        def poll(self):
+            return 2
+
+    monkeypatch.setattr(peer_lifecycle, "status", lambda *_args: stopped)
+
+    result = peer_lifecycle._wait_for_ensure_status(
+        str(tmp_path), "test.probe", 30, host_process=ExitedHost()
+    )
+
+    assert result is stopped
+
+
+def test_ensure_wait_returns_the_observed_ready_snapshot(tmp_path, monkeypatch):
+    ready = {"healthy": True, "lifecycleState": "ready"}
+    transient_empty_read = {"healthy": False, "lifecycleState": "stopped"}
+    statuses = [ready, transient_empty_read]
+    calls = 0
+
+    def next_status(_runtime_dir, _peer_id):
+        nonlocal calls
+        current = statuses[min(calls, len(statuses) - 1)]
+        calls += 1
+        return current
+
+    monkeypatch.setattr(peer_lifecycle, "status", next_status)
+
+    result = peer_lifecycle._wait_for_ensure_status(str(tmp_path), "test.probe", 30)
+
+    assert result is ready
+    assert calls == 1
 
 
 def test_stale_host_generation_cannot_stop_new_owner(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- give every peer lifecycle JSON writer a unique same-directory temporary file before atomic replacement
- return the exact terminal status observed by `ensure` instead of performing a second race-prone read
- stop waiting when a newly launched host exits or reaches the explicit `ended` terminal state
- cover interleaved writers, host exit, and Ready-then-empty-read deterministically

## Related issue

Closes #2134

## Evidence

The exact-source AWS Windows full qualification at https://github.com/kungfu-systems/kungfu/actions/runs/30700558110/job/91370858331 passed install, native build, and `agent-session-capsule-continuity`, then failed `native-cross-process-restart` with `Peer lifecycle host did not reach Ready: stopped`. The coordinator log shows the native Peer registered immediately before the transient stopped projection.

The same focused changes were already developed inside open PR #1997 but are not ancestors of protected `dev/v4/v4.0`. This PR lands only those two runtime files and their deterministic tests so the Windows qualification can proceed without importing unrelated packager-retirement scope.

## Verification

- peer lifecycle Python suite: 21 passed, 1 Windows-only test skipped on macOS
- ruff format check: passed
- `./shifu check:staged`: passed
- pre-commit repository gate: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair atomic lifecycle observation and concurrent state-file publication without changing the fenced Peer lifecycle architecture or release contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This runtime correctness change adds no credentials, signing authority, publishing authority, hosted-service access, or public release claim.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoiY3Jvc3MtcGxhdGZvcm0iLCJkZXZIZWFkIjoiMjMzNmYyMTIxNzMzOWI0ZDFhMGQ0NjUzNzdiY2E5ZTFkMjMxMDgwNiIsInB1bGxSZXF1ZXN0SGVhZCI6ImVlM2IwOGMzMDQyMGQ0OTkxZTU1ZmQ0YjVlNTNhODA3ZjEwOGE2NWIiLCJyZXBsYXllZENhbmRpZGF0ZSI6IjdhYjM2ZTJjOTJjMjlhYzYyMGIxMTViODAxZDY4N2U2MzQyNGJmMjkiLCJyZXBsYXllZFRyZWUiOiI0NmY5MTY2OGYyZGNhMGQ0OGM3ZTkyODM3ZWM3NmFiYjhiMzg3MWNlIiwicXVldWVBdHRlbXB0IjoiZWUzYjA4YzMwNDIwZDQ5OTFlNTVmZDRiNWU1M2E4MDdmMTA4YTY1YkAyMzM2ZjIxMjE3MzM5YjRkMWEwZDQ2NTM3N2JjYTllMWQyMzEwODA2IiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OmQxYzk5NjczZjc5YzU5MmUyNDEzNjIwMDdjMWM5MDZjZTI1MWQyMjEzNjQyZGZjNTk2OWNmOTk4MGQ1NWE2NGEiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1Njo1Y2QyMmFkODFhN2E3NzhmMmU1YmZhZjI5Y2VlOTViNWFlNzliODI0MDRmZGRkM2ViMGI1ZTFhODgwYWNmMmVkIiwic2hhMjU2OmQxYzk5NjczZjc5YzU5MmUyNDEzNjIwMDdjMWM5MDZjZTI1MWQyMjEzNjQyZGZjNTk2OWNmOTk4MGQ1NWE2NGEiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kOTlmM2E5MTY2NzM5ZTBkIiwibGVhc2VSb290Ijoic2hhMjU2OjU0MjUzYWQ1ZWZlMmI3MGY0MTM0MDJjNDEyYTFmNjcyNTBhNDVhODRlMDQyMzYwNDFkZmEwYjdiZDg2OTdjNmUifQ -->