### PR TITLE
test(rewind): align provider discovery fixture

### DIFF
--- a/tests/fixtures/rewind-demo-cost-adapter/check_cost_adapter.py
+++ b/tests/fixtures/rewind-demo-cost-adapter/check_cost_adapter.py
@@ -2,8 +2,8 @@
 #
 # Parse-layer assertions for the cost adapters. Proves three things without a
 # journal or the native binding:
-#   1. provider discovery locates Codex (PATH + macOS app bundle), Claude, and
-#      OpenCode and records misses diagnosably, touching no credential;
+#   1. provider discovery locates Codex (PATH + macOS app bundle), Claude, Amp,
+#      and OpenCode and records misses diagnosably, touching no credential;
 #   2. the Codex `exec --json` adapter accumulates turn.completed usage into an
 #      EXACT_RUN snapshot with no fabricated dollar cost;
 #   3. the Claude `--print --output-format json` adapter carries the real
@@ -142,6 +142,7 @@ res = discover_providers(
         {
             "codex": "/c/codex",
             "claude": "/c/claude",
+            "amp": "/c/amp",
             "opencode": "/c/opencode",
         }
     ),
@@ -150,7 +151,7 @@ res = discover_providers(
 )
 check(
     "discover_providers returns all defaults",
-    set(res) == {"codex", "claude", "opencode"}
+    set(res) == {"codex", "claude", "amp", "opencode"}
     and all(isinstance(v, ProviderDiscovery) for v in res.values()),
 )
 check("all defaults found with injected PATH", all(v.found for v in res.values()))


### PR DESCRIPTION
## Summary

- include Amp in the cost-adapter fixture's injected default provider set
- align the expected default discovery keys with the current provider catalog
- restore product.verify-full on the exact Alpha candidate source after Dev Verify run 30701665047 exposed the stale assertion

## Verification

- PYTHONDONTWRITEBYTECODE=1 node tests/fixtures/rewind-demo-cost-adapter/run.mjs
- repository pre-commit staged gate, including 73 latency contract tests, 17 invariant tests, 138 documentation tests, Ruff format, and Ruff lint

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Align a parse-only fixture with the existing provider catalog without changing runtime behavior, architecture, or release authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation remains correct; this is a test-only contract alignment
