### PR TITLE
fix(agent-session): stabilize Windows PTY qualification

### DIFF
--- a/framework/agent-session/src/capsule-host.mjs
+++ b/framework/agent-session/src/capsule-host.mjs
@@ -32,6 +32,7 @@ export class AgentSessionCapsuleHost {
     ptyReadiness = { ready: true, diagnostic: null },
     maxOutputBytes = 256 * 1024,
     now = () => Date.now(),
+    platform = process.platform,
   }) {
     if (!pty || typeof pty.spawn !== 'function') {
       throw new Error(
@@ -47,6 +48,7 @@ export class AgentSessionCapsuleHost {
     }
     this.maxOutputBytes = maxOutputBytes;
     this.now = now;
+    this.platform = platform;
     this.session = null;
   }
 
@@ -308,7 +310,14 @@ export class AgentSessionCapsuleHost {
     if (session.inputAdmission !== 'open') {
       throw new Error('provider process has already ended');
     }
-    session.child.kill(signal);
+    if (this.platform === 'win32') {
+      if (signal !== 'SIGTERM') {
+        throw new Error(`signal '${signal}' is not supported on Windows`);
+      }
+      session.child.kill();
+    } else {
+      session.child.kill(signal);
+    }
     return this.#controlReceipt('signal', action, { signal });
   }
 

--- a/framework/agent-session/tests/capsule-host.test.mjs
+++ b/framework/agent-session/tests/capsule-host.test.mjs
@@ -38,7 +38,7 @@ class FakePtyProcess extends EventEmitter {
   }
 }
 
-function fixture(maxOutputBytes = 64) {
+function fixture(maxOutputBytes = 64, platform = process.platform) {
   const child = new FakePtyProcess();
   let now = 1000;
   const host = new AgentSessionCapsuleHost({
@@ -47,6 +47,7 @@ function fixture(maxOutputBytes = 64) {
     runtimeIdentity: 'runtime-test-1',
     maxOutputBytes,
     now: () => now++,
+    platform,
   });
   const status = host.start({
     workConsoleId: 'console-1',
@@ -185,6 +186,24 @@ test('resize and signal target only the current process identity', () => {
         signal: 'SIGKILL',
       }),
     /not allowed/u,
+  );
+});
+
+test('Windows termination uses the node-pty kill contract without claiming unsupported signals', () => {
+  const { child, current, host } = fixture(64, 'win32');
+  assert.equal(
+    host.signal({ ...current, actionId: 'end-1', signal: 'SIGTERM' }).status,
+    'applied',
+  );
+  assert.deepEqual(child.signals, [undefined]);
+  assert.throws(
+    () =>
+      host.signal({
+        ...current,
+        actionId: 'interrupt-1',
+        signal: 'SIGINT',
+      }),
+    /signal 'SIGINT' is not supported on Windows/u,
   );
 });
 

--- a/framework/agent-session/tests/capsule-worker.test.mjs
+++ b/framework/agent-session/tests/capsule-worker.test.mjs
@@ -203,11 +203,14 @@ test('detached Capsule worker survives client loss and reattaches to the same PT
   const reattached = await second.request('status');
   assert.equal(reattached.sessionAttemptId, started.sessionAttemptId);
   assert.equal(reattached.foreground.pid, started.foreground.pid);
+  let replay;
   await waitFor(async () => {
-    const replay = await second.request('snapshot', { requestedSequence: 0 });
-    return replay.receipt.nextSequence > 4096;
-  }, 'synthetic PTY output did not arrive');
-  const replay = await second.request('snapshot', { requestedSequence: 0 });
+    replay = await second.request('snapshot', { requestedSequence: 0 });
+    return (
+      replay.receipt.nextSequence > 4096 &&
+      replay.vt.lines.some((line) => line.includes('approval-needed'))
+    );
+  }, 'synthetic PTY output did not fully converge');
   assert.equal(replay.receipt.gap.reason, 'bounded-retention-overflow');
   assert.equal(replay.vt.activeBuffer, 'primary');
   assert.ok(replay.vt.lines.some((line) => line.includes('approval-needed')));

--- a/framework/agent-session/tests/peer-transport.test.mjs
+++ b/framework/agent-session/tests/peer-transport.test.mjs
@@ -46,7 +46,11 @@ class FakePtyProcess extends EventEmitter {
   }
 }
 
-function fixture({ maxFrames = 256, maxOutputBytes = 1024 } = {}) {
+function fixture({
+  maxFrames = 256,
+  maxOutputBytes = 1024,
+  platform = 'linux',
+} = {}) {
   let clock = 1000;
   const child = new FakePtyProcess();
   const host = new AgentSessionCapsuleHost({
@@ -55,6 +59,7 @@ function fixture({ maxFrames = 256, maxOutputBytes = 1024 } = {}) {
     runtimeIdentity: 'workspace-runtime-1',
     maxOutputBytes,
     now: () => clock,
+    platform,
   });
   const started = host.start({
     workConsoleId: 'console-1',
@@ -217,6 +222,35 @@ test('interrupt signal is idempotent and uses the same controller and foreground
         expectedForeground: { ...foreground, processStartIdentity: 'stale' },
       }),
     (error) => error.code === 'foreground_mismatch',
+  );
+});
+
+test('Windows transport rejects an unsupported interrupt without recording fake delivery', () => {
+  const { current, foreground, port, transport } = fixture({
+    platform: 'win32',
+  });
+  transport.acquireControl({
+    leaseId: 'lease-gui',
+    holderId: 'gui',
+    planRoot: 'plan-gui',
+  });
+  assert.throws(
+    () =>
+      transport.submitSignal({
+        ...current,
+        actionId: 'interrupt-1',
+        inputId: 'interrupt-input-1',
+        signal: 'SIGINT',
+        leaseId: 'lease-gui',
+        holderId: 'gui',
+        coordinatorEpoch: '3',
+        expectedForeground: foreground,
+      }),
+    /signal 'SIGINT' is not supported on Windows/u,
+  );
+  assert.equal(
+    port.frames.some((frame) => frame.kind === 'interrupt-delivered'),
+    false,
   );
 });
 


### PR DESCRIPTION
## Summary

- wait for complete retained VT convergence before asserting the synthetic approval prompt
- map Windows termination to node-pty's no-argument kill contract
- reject unsupported Windows interrupt claims without recording fake delivery
- keep pure transport signal tests platform-neutral while retaining explicit Windows negative coverage

## Verification

- exact-source four-platform Alpha preflight `30705550951` passed for `4dee773b2a68b7c18340adddd4a6a07e557a2e4f`
- focused Agent Session host, worker, Mock Product, and peer transport suites passed 24/24 before commit
- staged repository gate passed for all three commits
- Windows full run `30702267508` passed build, base verification 73/73, all three 90-second fuzz campaigns, and the repaired Mock Product termination path; the remaining pure-test platform leak is fixed in the final commit

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair Windows PTY qualification and termination portability without changing Agent Session architecture or public release contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This bounded portability fix adds no credentials, signing authority, publishing authority, hosted-service access, identity-derived permission, or public release claim.

## Release impact

Patch-level Windows portability and deterministic qualification fix. No public contract changes.
