### PR TITLE
fix(tui): declare Agent Session bundle dependency

### DIFF
--- a/framework/agent-session/tests/native-interactive-client.test.mjs
+++ b/framework/agent-session/tests/native-interactive-client.test.mjs
@@ -28,9 +28,15 @@ test('provider-first source bundle resolves node-pty through the Agent Session p
       () => bundleRequire.resolve('node-pty/lib/index.js'),
       /Cannot find module/u,
     );
-    assert.match(
+    assert.equal(
       bundleRequire.resolve('@kungfu-tech/agent-session/product-client'),
-      /framework\/agent-session\/src\/product-client\.mjs$/u,
+      path.join(
+        ROOT,
+        'framework',
+        'agent-session',
+        'src',
+        'product-client.mjs',
+      ),
     );
     const modulePath = resolveNativeInteractiveNodePty(
       path.join(TUI_DIST, 'agent-session-worker.mjs'),

--- a/framework/tui/package.json
+++ b/framework/tui/package.json
@@ -23,6 +23,7 @@
     "bundle": "node build-bundle.mjs"
   },
   "dependencies": {
+    "@kungfu-tech/agent-session": "workspace:*",
     "@kungfu-tech/api": "workspace:*",
     "@kungfu-tech/core": "workspace:*",
     "@kungfu-tech/kfx": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,9 +607,8 @@ importers:
 
   framework/tui:
     dependencies:
-      '@kungfu-tech/api':
-        specifier: workspace:*
-        version: link:../api
+      '@kungfu-tech/agent-session': {specifier: 'workspace:*', version: 'link:../agent-session'}
+      '@kungfu-tech/api': {specifier: 'workspace:*', version: 'link:../api'}
       '@kungfu-tech/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

- declare the TUI's Agent Session workspace dependency so provider-first bundles resolve product-client
- compare the resolved product-client path portably on Windows and POSIX
- retain the stricter Windows PTY signal semantics that landed independently in PR #2141

## Related issue

Closes #2142

## Evidence

Exact-source Windows full qualification run https://github.com/kungfu-systems/kungfu/actions/runs/30703406223/job/91378391170 passed build-chain verification, live-peer capsule continuity, native cross-process restart, and runtime activation, then failed zero-burden desktop. PR #2141 repaired the Windows node-pty signal failure. This PR repairs the remaining provider-first failure: @kungfu-tech/tui did not declare @kungfu-tech/agent-session, so createRequire from the TUI bundle could not resolve product-client on Windows. The one-job runner terminated with zero EC2, EBS, SSM, or GitHub runner residue.

## Verification

- focused Agent Session regression files after rebase: 13 passed
- TUI bundle: passed
- ./shifu check:staged: passed
- pre-commit repository gate: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Declare the existing Agent Session package dependency required by the provider-first TUI bundle without changing runtime authority, fencing, or release contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This packaging fix adds no credentials, signing authority, publishing authority, hosted-service access, or public release claim.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA3LTI4LWt1bmdmdS1hd3MtdXMtZWxhc3RpYy1ydW5uZXItYnVyc3QtcGxhbmUiLCJkZWxpdmVyeUNsYXNzIjoiY3Jvc3MtcGxhdGZvcm0iLCJkZXZIZWFkIjoiYjkzNGQ5MzZjNWEwZDY1OTIyODNjOGQ4OTMzNmY3YjMwZGI4Mzc4MCIsInB1bGxSZXF1ZXN0SGVhZCI6ImUyZTY3NjUyNDFjYTgwNzRkMDhhY2YzNWY5NDhhOGFiMTcyMzBjYzUiLCJyZXBsYXllZENhbmRpZGF0ZSI6ImQ4ODU1ZGE5ZDU3ODlmZGNkNjUwOTZhZjI1NTMwMWIzOGVmODM2ZjMiLCJyZXBsYXllZFRyZWUiOiI2ZDNlYzU5MTc1OWI0Y2QzNGUxM2EyOThiMjRlZjE0NzQ2NzNhNjAwIiwicXVldWVBdHRlbXB0IjoiZTJlNjc2NTI0MWNhODA3NGQwOGFjZjM1Zjk0OGE4YWIxNzIzMGNjNUBiOTM0ZDkzNmM1YTBkNjU5MjI4M2M4ZDg5MzM2ZjdiMzBkYjgzNzgwIiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OjM1OWRkZjRjYTg2YjIwMDkxY2MwYjI3YTYxOGMyYmExOTg1MTlmOTEzOGRmOTI1N2JkYWE1ZWJhNTgxNDliNWUiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1NjozNTlkZGY0Y2E4NmIyMDA5MWNjMGIyN2E2MThjMmJhMTk4NTE5ZjkxMzhkZjkyNTdiZGFhNWViYTU4MTQ5YjVlIiwic2hhMjU2OjVjZDIyYWQ4MWE3YTc3OGYyZTViZmFmMjljZWU5NWI1YWU3OWI4MjQwNGZkZGQzZWIwYjVlMWE4ODBhY2YyZWQiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kOTlmM2E5MTY2NzM5ZTBkIiwibGVhc2VSb290Ijoic2hhMjU2OmI4NmQ1ZWJmZmYwYjIwYzk2NWM0MWRiYmMwYTdjMmI1NjRlZDRhNmM1YWE5MWNmZDNlYmEyNDEwZjA3MWY4MWQifQ -->