### PR TITLE
fix(agent): make control-plane tests platform-neutral

### DIFF
--- a/framework/agent-session/tests/capsule-host.test.mjs
+++ b/framework/agent-session/tests/capsule-host.test.mjs
@@ -165,7 +165,7 @@ test('provider exit closes input before any later write can reach a shell', () =
 });
 
 test('resize and signal target only the current process identity', () => {
-  const { child, current, host } = fixture();
+  const { child, current, host } = fixture(64, 'linux');
   assert.equal(
     host.resize({ ...current, actionId: 'resize-1', cols: 120, rows: 40 })
       .status,

--- a/framework/agent-session/tests/interaction-port.test.mjs
+++ b/framework/agent-session/tests/interaction-port.test.mjs
@@ -43,6 +43,7 @@ function fixture({
   version = '0.144.3',
   queueLimit = 4,
   pause,
+  platform = process.platform,
 } = {}) {
   const child = new FakePtyProcess();
   const host = new AgentSessionCapsuleHost({
@@ -51,6 +52,7 @@ function fixture({
     runtimeIdentity: 'runtime-interaction-1',
     maxOutputBytes: 4096,
     now: () => 1000,
+    platform,
   });
   const started = host.start({
     workConsoleId: 'console-1',
@@ -201,7 +203,7 @@ test('approval and unknown modal states never auto-deliver or auto-queue', () =>
 });
 
 test('interrupt mode sends one fenced signal then waits for ready before text', () => {
-  const { authority, child, port, screen } = fixture();
+  const { authority, child, port, screen } = fixture({ platform: 'linux' });
   screen('Working (3s • esc to interrupt)');
   const held = port.instruct(
     instruction(authority, 'interrupt', { mode: 'interrupt' }),

--- a/framework/agent-session/tests/native-interactive-client.test.mjs
+++ b/framework/agent-session/tests/native-interactive-client.test.mjs
@@ -44,7 +44,10 @@ test('provider-first source bundle resolves node-pty through the Agent Session p
       bundleRequire,
     );
     assert.equal(existsSync(modulePath), true);
-    assert.match(modulePath, /node-pty\/lib\/index\.js$/u);
+    assert.equal(
+      modulePath.endsWith(path.join('node-pty', 'lib', 'index.js')),
+      true,
+    );
   } finally {
     if (previous === undefined) {
       Reflect.deleteProperty(


### PR DESCRIPTION
## Summary

Make the Agent Session control-plane qualification tests explicit about their POSIX signal fixture and path-separator neutral on Windows. This is a test-contract correction; runtime behavior and architecture authority are unchanged.

## Related issue

Follow-up to the exact-source auditable-demo qualification failure in https://github.com/kungfu-systems/kungfu/actions/runs/30708670814

## Changes

- bind generic signal-delivery fixtures to the POSIX platform they exercise
- keep the dedicated Windows negative signal contract unchanged
- compare the bundled `node-pty` module path with `path.join(...)`

## Verification

- `./shifu exec node --test framework/agent-session/tests/capsule-host.test.mjs framework/agent-session/tests/interaction-port.test.mjs framework/agent-session/tests/native-interactive-client.test.mjs` (18 passed)
- `./shifu exec pnpm --filter @kungfu-tech/spec run build`
- `./shifu check`
- staged pre-commit gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This corrects cross-platform test fixtures and path matching without changing runtime behavior or architecture authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: the tests gate exact-source release qualification. The failed exact-source run above and the local focused/full checks provide the bounded evidence.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; behavior is unchanged)