### PR TITLE
test(agent-session): make hosted portability fixtures neutral

### DIFF
--- a/framework/agent-session/tests/capsule-host.test.mjs
+++ b/framework/agent-session/tests/capsule-host.test.mjs
@@ -38,7 +38,7 @@ class FakePtyProcess extends EventEmitter {
   }
 }
 
-function fixture(maxOutputBytes = 64, platform = process.platform) {
+function fixture(maxOutputBytes = 64, platform = 'linux') {
   const child = new FakePtyProcess();
   let now = 1000;
   const host = new AgentSessionCapsuleHost({

--- a/framework/agent-session/tests/interaction-port.test.mjs
+++ b/framework/agent-session/tests/interaction-port.test.mjs
@@ -43,6 +43,7 @@ function fixture({
   version = '0.144.3',
   queueLimit = 4,
   pause,
+  platform = 'linux',
 } = {}) {
   const child = new FakePtyProcess();
   const host = new AgentSessionCapsuleHost({
@@ -51,6 +52,7 @@ function fixture({
     runtimeIdentity: 'runtime-interaction-1',
     maxOutputBytes: 4096,
     now: () => 1000,
+    platform,
   });
   const started = host.start({
     workConsoleId: 'console-1',

--- a/framework/agent-session/tests/native-interactive-client.test.mjs
+++ b/framework/agent-session/tests/native-interactive-client.test.mjs
@@ -44,7 +44,12 @@ test('provider-first source bundle resolves node-pty through the Agent Session p
       bundleRequire,
     );
     assert.equal(existsSync(modulePath), true);
-    assert.match(modulePath, /node-pty\/lib\/index\.js$/u);
+    assert.equal(path.basename(modulePath), 'index.js');
+    assert.equal(path.basename(path.dirname(modulePath)), 'lib');
+    assert.equal(
+      path.basename(path.dirname(path.dirname(modulePath))),
+      'node-pty',
+    );
   } finally {
     if (previous === undefined) {
       Reflect.deleteProperty(


### PR DESCRIPTION
## Summary

- keep POSIX signal fixtures deterministic instead of inheriting the hosted runner platform
- let interaction-port tests opt into an explicit platform while defaulting to the reviewed POSIX contract
- validate the resolved node-pty path by path components on both Windows and POSIX

## Evidence

The exact Windows hosted Product qualification exposed three test-only portability failures after the production Windows PTY contract had already landed: two POSIX SIGINT fixtures inherited win32, and one valid node-pty path was compared with POSIX separators. Production signal semantics remain unchanged and fail closed for unsupported Windows signals.

## Verification

- ./shifu build:core: passed on protected base 77129be119d47ef467ec79e02164f778563ffe6b
- Agent Session suite with installed-version probes skipped: 122 passed, 0 failed
- focused three-file Biome check: passed
- pre-commit repository gate: passed
- full-repository lint reports four pre-existing errors outside this patch

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Make existing hosted test fixtures cross-platform without changing runtime authority, signal behavior, fencing, or release contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This test-only repair adds no credentials, signing authority, publishing authority, hosted-service access, or public release claim.