### PR TITLE
fix(agent): retain compile route in installed brief

### DIFF
--- a/framework/core/src/python/kungfu/agent/brief.md
+++ b/framework/core/src/python/kungfu/agent/brief.md
@@ -63,6 +63,7 @@ kungfu agent status --target codex --scope project --json
 kungfu agent install-skill --target codex --scope project --json
 kungfu shifu agent capabilities --json
 kungfu xinfa agent capabilities --json
+kungfu xinfa compile --workspace <repo> --output <atlas-dir> --json
 kungfu agent docs --projection agent --json
 ```
 

--- a/framework/core/tests/python/test_agent_first_entry.py
+++ b/framework/core/tests/python/test_agent_first_entry.py
@@ -45,6 +45,7 @@ def test_brief_and_intent_map_enforce_complete_bounded_first_entry():
 
     assert len(brief.encode("utf-8")) <= 8192
     assert len(brief.splitlines()) <= 120
+    assert "kungfu xinfa compile" in brief
     assert set(intent_map["requiredIntentIds"]) == {
         row["id"] for row in intent_map["intents"]
     }

--- a/framework/maintainability/abstraction-integrity-report.json
+++ b/framework/maintainability/abstraction-integrity-report.json
@@ -13,7 +13,7 @@
       "productionFiles": 229,
       "productionPhysicalLines": 83267,
       "testFiles": 96,
-      "testPhysicalLines": 45482
+      "testPhysicalLines": 45483
     },
     "hiddenProductionFiles": [],
     "modulesOver1000": [
@@ -370,7 +370,7 @@
       }
     ],
     "schema": "kungfu.python-structure-measurement/v1",
-    "sourceRoot": "sha256:1e9e3abcc2a04809662d28e849ce78d6bbaad0768f804152e820b7482b6f28de",
+    "sourceRoot": "sha256:eb71b4c9180e30518c0ed147fe16deef62241591eecaa035a33a7f6f827c4031",
     "sourceRoots": {
       "production": [
         "framework/core/src/python"
@@ -440,9 +440,9 @@
     "kungfu.runtime_broker.NativeReadinessAuthority",
     "kungfu.runtime_service.ProcessRuntimeHost"
   ],
-  "reportRoot": "sha256:d48d310d7e677973fe0d799169a6b0862a4d7e250d95b9bd6ce0196b72abe3f7",
+  "reportRoot": "sha256:0d930b9773c228536c540980864d56efcc753b2b9e1bc72f3f133f00ed250110",
   "schema": "kungfu.abstraction-integrity-report/v1",
-  "sourceRoot": "sha256:1e9e3abcc2a04809662d28e849ce78d6bbaad0768f804152e820b7482b6f28de",
+  "sourceRoot": "sha256:eb71b4c9180e30518c0ed147fe16deef62241591eecaa035a33a7f6f827c4031",
   "summary": {
     "blockingIssues": 0
   },


### PR DESCRIPTION
## Summary

- retain the existing Xinfa compile route in the installed Agent brief
- add a focused regression assertion for the single-entry CLI topology

## Evidence

Windows full qualification run 30713373030 reached Product dist and failed because the installed Agent brief omitted kungfu xinfa compile. The burst instance, SSM registration, runner registration, and attached volumes were all removed after the failed run; lifecycle and diagnostics evidence remain retained.

## Verification

- framework/core/tests/python/test_agent_first_entry.py: 5 passed
- product/scripts/cli-surface-qualification.test.mjs: 6 passed
- ./shifu check:source
- ./shifu build:core
- ./shifu dist, including installed-layout CLI smoke
- ./shifu check:staged

## Evolution impact

None. This restores a previously established public route in the bounded installed brief.

## Governance risk

Low. The change is documentation topology plus a regression assertion.

## Release impact

Restores Windows Product dist qualification without changing runtime semantics or release authority.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the existing Xinfa compile route in the installed Agent brief without changing CLI authority or public release contracts"
}
-->