### PR TITLE
fix(release): restore Linux package size headroom

### DIFF
--- a/framework/core/tests/core-platform-package.test.js
+++ b/framework/core/tests/core-platform-package.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 
 const contract = require('../core-platform-package.contract.json');
 const sourcePackage = require('../package.json');
+const stdlibPrune = require('../../../product/stdlib-prune.json');
 const {
   platformPackages,
   resolveExecutable,
@@ -75,6 +76,12 @@ test('platform package budget preserves its bounded bands', () => {
       contract.sizePolicy.compressedHardCeilingBytes,
   );
   assert.equal(contract.sizePolicy.hardCeilingExceptionRequiresReview, true);
+});
+
+test('Linux package prunes the unused dbm accelerator before size enforcement', () => {
+  const dbmAccelerator = 'lib/python3.13/lib-dynload/_dbm*';
+  assert.ok(stdlibPrune.prune.linux.includes(dbmAccelerator));
+  assert.equal(stdlibPrune.prune.darwin.includes(dbmAccelerator), false);
 });
 
 test('Linux Release stripping is explicit and excludes runtimes owned upstream', () => {

--- a/product/stdlib-prune.json
+++ b/product/stdlib-prune.json
@@ -36,6 +36,7 @@
       "lib/python3.13/site-packages/pip",
       "lib/python3.13/site-packages/pip-*.dist-info",
       "lib/python3.13/lib-dynload/_tkinter*",
+      "lib/python3.13/lib-dynload/_dbm*",
       "bin/idle3*",
       "bin/pip*",
       "bin/pydoc3*",


### PR DESCRIPTION
## Summary

- prune the unused CPython 3.13 `_dbm` accelerator from Linux Product packages
- keep Darwin packaging unchanged and preserve the existing 100 MiB hard ceiling
- pin the platform-specific subtraction in the Core package contract test

## Evidence

Exact-source Product runs on protected heads `2f9e421895d277ee81a84fe1c4f0e97556266ecb` and `2cb8880bde0837c5818764ccc05eec0823119459` independently failed the Linux x64 hard ceiling at 105,263,412 and 105,263,398 bytes. An agent-120 reproduction on `2cb8880bde0837c5818764ccc05eec0823119459` produced 105,256,570 bytes. Repacking the same staged tree after removing only `_dbm.cpython-313-x86_64-linux-gnu.so` reduced it to 104,340,040 bytes: 916,530 bytes smaller and 517,560 bytes below the unchanged 104,857,600-byte ceiling. The exact Linux ARM64 archive also contains the same accelerator, so the declarative Linux glob applies consistently to both supported Linux architectures.

Repository search found no runtime use of `dbm`, `shelve`, `_dbm`, or `gdbm`; the extension is unused optional stdlib surface.

## Verification

- `./shifu build:core`: passed from protected base `2cb8880bde0837c5818764ccc05eec0823119459`
- `./shifu check:source`: passed; contract suite 955 passed / 10 skipped / 0 failed, Python suites 40 + 134 passed, desktop suite 73 passed
- `./shifu node --test framework/core/tests/core-platform-package.test.js`: 9 passed
- Biome changed-file check and `git diff --check`: passed
- pre-commit repository gate: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore headroom under an existing Linux package ceiling by removing an unused optional stdlib accelerator without changing release authority or public runtime contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

This bounded packaging repair adds no credential, signing, publishing, hosted-service, identity, or protected-branch authority. It does not raise, waive, or bypass the package-size gate.

## Release impact

Linux Product packages no longer ship the unused CPython `_dbm` extension. Darwin and public command/runtime behavior are unchanged.
