### PR TITLE
fix(runtime): retry transient Windows state replacement

### DIFF
--- a/framework/core/src/python/kungfu/runtime_service.py
+++ b/framework/core/src/python/kungfu/runtime_service.py
@@ -167,7 +167,15 @@ def _json_write(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", "utf-8")
-    os.replace(tmp, path)
+    replace_attempts = 20 if platform.system() == "Windows" else 1
+    for attempt in range(replace_attempts):
+        try:
+            os.replace(tmp, path)
+            return
+        except PermissionError:
+            if attempt == replace_attempts - 1:
+                raise
+            time.sleep(0.05)
 
 
 def _json_read(path: Path) -> dict[str, Any]:

--- a/framework/core/tests/python/test_runtime_service.py
+++ b/framework/core/tests/python/test_runtime_service.py
@@ -77,6 +77,29 @@ LEASE_FIXTURES = json.loads(
 )
 
 
+def test_windows_json_write_retries_transient_replace_lock(tmp_path, monkeypatch):
+    target = tmp_path / "runtime" / "state.json"
+    original_replace = runtime_service.os.replace
+    attempts = []
+    sleeps = []
+
+    def replace_after_transient_lock(source, destination):
+        attempts.append((source, destination))
+        if len(attempts) == 1:
+            raise PermissionError(5, "Access is denied", str(destination))
+        original_replace(source, destination)
+
+    monkeypatch.setattr(runtime_service.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(runtime_service.os, "replace", replace_after_transient_lock)
+    monkeypatch.setattr(runtime_service.time, "sleep", sleeps.append)
+
+    runtime_service._json_write(target, {"status": "running"})
+
+    assert runtime_service._json_read(target) == {"status": "running"}
+    assert len(attempts) == 2
+    assert sleeps == [0.05]
+
+
 def test_adopted_coordinator_kill_uses_portable_hard_signal(monkeypatch):
     delivered = []
     monkeypatch.setattr(

--- a/framework/maintainability/abstraction-integrity-report.json
+++ b/framework/maintainability/abstraction-integrity-report.json
@@ -6,14 +6,14 @@
   "measurement": {
     "aggregates": {
       "kungfu-cli": 20273,
-      "kungfu-flat-root": 36570,
-      "kungfu-runtime-family": 6152
+      "kungfu-flat-root": 36578,
+      "kungfu-runtime-family": 6160
     },
     "counts": {
       "productionFiles": 229,
-      "productionPhysicalLines": 83267,
+      "productionPhysicalLines": 83275,
       "testFiles": 96,
-      "testPhysicalLines": 45483
+      "testPhysicalLines": 45506
     },
     "hiddenProductionFiles": [],
     "modulesOver1000": [
@@ -87,7 +87,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/runtime_service.py",
-        "physicalLines": 2295
+        "physicalLines": 2303
       },
       {
         "path": "framework/core/src/python/kungfu/runtime_upgrade.py",
@@ -125,7 +125,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/runtime_service.py",
-        "physicalLines": 2295
+        "physicalLines": 2303
       },
       {
         "path": "framework/core/src/python/kungfu/workspace_federation.py",
@@ -236,9 +236,9 @@
         "responsibilities": 114
       },
       {
-        "contentRoot": "sha256:1a6e5e9d98e334120be3130e6e886d53e917208250c2e81f17ce4ecb8a18851c",
+        "contentRoot": "sha256:596b1331379e6c071e84faee38371a4d0135154dcdf7358bea977cfac918aed5",
         "path": "framework/core/src/python/kungfu/runtime_service.py",
-        "physicalLines": 2295,
+        "physicalLines": 2303,
         "responsibilities": 104
       },
       {
@@ -349,17 +349,17 @@
         "test": "platform.system() != 'Windows'"
       },
       {
-        "line": 1515,
+        "line": 1523,
         "path": "framework/core/src/python/kungfu/runtime_service.py",
         "test": "platform.system() == 'Windows'"
       },
       {
-        "line": 1535,
+        "line": 1543,
         "path": "framework/core/src/python/kungfu/runtime_service.py",
         "test": "platform.system() != 'Windows' or getattr(error, 'winerror', None) != 5"
       },
       {
-        "line": 1623,
+        "line": 1631,
         "path": "framework/core/src/python/kungfu/runtime_service.py",
         "test": "platform.system() != 'Windows'"
       },
@@ -370,7 +370,7 @@
       }
     ],
     "schema": "kungfu.python-structure-measurement/v1",
-    "sourceRoot": "sha256:eb71b4c9180e30518c0ed147fe16deef62241591eecaa035a33a7f6f827c4031",
+    "sourceRoot": "sha256:db447763dbdbc750c04391f0d3d2a4db2f2b8ca7eb41e575b7d1ffaf94afb3b5",
     "sourceRoots": {
       "production": [
         "framework/core/src/python"
@@ -446,9 +446,9 @@
     "kungfu.runtime_broker.NativeReadinessAuthority",
     "kungfu.runtime_service.ProcessRuntimeHost"
   ],
-  "reportRoot": "sha256:265024db2617fa11ceb64c6f7debd690bf06558638243e471b1823f081b36041",
+  "reportRoot": "sha256:482bd76d015d62ffc35c0b96ece023607d485daee123824191e7729d05115d7b",
   "schema": "kungfu.abstraction-integrity-report/v1",
-  "sourceRoot": "sha256:eb71b4c9180e30518c0ed147fe16deef62241591eecaa035a33a7f6f827c4031",
+  "sourceRoot": "sha256:db447763dbdbc750c04391f0d3d2a4db2f2b8ca7eb41e575b7d1ffaf94afb3b5",
   "summary": {
     "blockingIssues": 0
   },


### PR DESCRIPTION
## Summary

- retry Windows state-file replacement when a transient reader lock returns WinError 5
- keep non-Windows replacement behavior unchanged
- bound retries to 20 attempts with 50 ms intervals and preserve the final error

## Evidence

Windows burst qualification run 30720421002 completed installation and build, then product-runtime-smoke failed while replacing runtime/supervisor/state.json:

PermissionError: [WinError 5] Access is denied: state.json.tmp -> state.json

The lifecycle controller still completed cleanup with zero cloud residue.

## Validation

- ./shifu build:core
- ./shifu check:source
- runtime_service.py test suite: 40 passed
- runtime upgrade control-plane suite: 134 passed
- targeted transient-lock regression: passed
- ruff format and lint: passed
- git diff --check

## Intent

Bug fix only; no ADR progress or release settlement.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the runtime state contract while making Windows atomic replacement tolerant of a bounded transient reader lock."
}
-->