### PR TITLE
fix(agent): preserve native UI continuity

### DIFF
--- a/framework/agent-session/src/native-interactive-client.mjs
+++ b/framework/agent-session/src/native-interactive-client.mjs
@@ -40,7 +40,21 @@ export function resolveNativeInteractiveNodePty(
     'lib',
     'index.js',
   );
-  const candidates = [requested ? path.resolve(requested) : null, bundled];
+  const sourcePackage = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    'agent-session',
+    'node_modules',
+    'node-pty',
+    'lib',
+    'index.js',
+  );
+  const candidates = [
+    requested ? path.resolve(requested) : null,
+    bundled,
+    sourcePackage,
+  ];
   try {
     const productClient = moduleRequire.resolve(
       '@kungfu-tech/agent-session/product-client',

--- a/framework/agent-session/tests/native-interactive-client.test.mjs
+++ b/framework/agent-session/tests/native-interactive-client.test.mjs
@@ -14,7 +14,7 @@ const ROOT = path.resolve(
 );
 const TUI_DIST = path.join(ROOT, 'framework', 'tui', 'dist');
 
-test('provider-first source bundle resolves node-pty through the Agent Session package', async () => {
+test('provider-first source bundle resolves node-pty from the sibling Agent Session package', async () => {
   const runtimeDir = await mkdtemp(
     path.join(os.tmpdir(), 'kungfu-native-provider-first-'),
   );
@@ -38,10 +38,15 @@ test('provider-first source bundle resolves node-pty through the Agent Session p
         'product-client.mjs',
       ),
     );
+    const unavailableRequire = {
+      resolve() {
+        throw new Error('package lookup unavailable');
+      },
+    };
     const modulePath = resolveNativeInteractiveNodePty(
       path.join(TUI_DIST, 'agent-session-worker.mjs'),
       runtimeDir,
-      bundleRequire,
+      unavailableRequire,
     );
     assert.equal(existsSync(modulePath), true);
     assert.equal(

--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 import threading
 import time
-from typing import Any, Callable, Mapping, Protocol, Sequence
+from typing import Any, Callable, Mapping, Sequence
 import uuid
 
 import kungfu
@@ -48,10 +48,6 @@ _SENSITIVE_COMMAND_NAME = (
     r"(?:api[-_]?key|access[-_]?key|token|secret|password|passwd|"
     r"authorization|cookie|credential|signature)"
 )
-
-
-class _ReturnCodeResult(Protocol):
-    returncode: int
 
 
 def bind_current_native_work(
@@ -692,7 +688,7 @@ def run_native_interactive(
     workspace_root: str,
     work_ref: Mapping[str, Any] | None,
     work_selection: Mapping[str, Any],
-    process_runner: Callable[..., _ReturnCodeResult] | None = None,
+    process_runner: Callable[..., session_surface.ReturnCodeResult] | None = None,
     session_invoker: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None,
     session_endpoint: str | None = None,
     work_observer: Callable[[Mapping[str, Any] | None], Mapping[str, Any]]
@@ -802,21 +798,9 @@ def run_native_interactive(
                     {"operation": "show", "session": dict(session_ref)}
                 )
                 binding = current.get("binding") or {}
-                if binding.get("kind") == "work" and binding.get("workRef"):
-                    active_work_ref = binding["workRef"]
-                    observed = dict(
-                        work_observer(active_work_ref) if work_observer else {}
-                    )
-                else:
-                    # Session liveness and Work observation are independent.
-                    # A workspace assistant has no Work projection yet, but the
-                    # launcher can still prove that its provider process is
-                    # alive while it waits for an in-UI bind.
-                    observed = {
-                        "state": "fresh",
-                        "work": None,
-                        "diagnostic": None,
-                    }
+                observed = session_surface.native_heartbeat_observation(
+                    binding, work_observer
+                )
                 session_invoker(
                     {
                         "operation": "heartbeat-native",
@@ -851,7 +835,7 @@ def run_native_interactive(
         heartbeat_thread.start()
 
     argv = [*interactive_launch_argv(profile), *adapter["argv"]]
-    completed: _ReturnCodeResult | None = None
+    completed: session_surface.ReturnCodeResult | None = None
     try:
         if process_runner is None:
             # Spawn the terminal owner before starting any Python observer

--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -802,16 +802,21 @@ def run_native_interactive(
                     {"operation": "show", "session": dict(session_ref)}
                 )
                 binding = current.get("binding") or {}
-                if binding.get("kind") != "work" or not binding.get("workRef"):
-                    # A workspace assistant has no Work state to heartbeat yet.
-                    # Keep polling the read-only Session projection until the
-                    # provider binds from inside its fully established UI; this
-                    # avoids pushing Work observations through the provider's
-                    # trust/startup boundary.
-                    stop_heartbeat.wait(heartbeat_seconds)
-                    continue
-                active_work_ref = binding["workRef"]
-                observed = dict(work_observer(active_work_ref) if work_observer else {})
+                if binding.get("kind") == "work" and binding.get("workRef"):
+                    active_work_ref = binding["workRef"]
+                    observed = dict(
+                        work_observer(active_work_ref) if work_observer else {}
+                    )
+                else:
+                    # Session liveness and Work observation are independent.
+                    # A workspace assistant has no Work projection yet, but the
+                    # launcher can still prove that its provider process is
+                    # alive while it waits for an in-UI bind.
+                    observed = {
+                        "state": "fresh",
+                        "work": None,
+                        "diagnostic": None,
+                    }
                 session_invoker(
                     {
                         "operation": "heartbeat-native",

--- a/framework/core/src/python/kungfu/agent/runtime_profiles.py
+++ b/framework/core/src/python/kungfu/agent/runtime_profiles.py
@@ -400,6 +400,7 @@ MOCK_SCENARIOS = (
 BACKENDS = ("tmux", "direct")
 CWD_POLICIES = ("workspace-root", "home", "inherit")
 _VERSION_TIMEOUT_SECONDS = 5.0
+_PROVIDER_VERSION_TIMEOUT_SECONDS = {"amp": 15.0}
 _SEMANTIC_VERSION = re.compile(
     r"(?<![0-9])([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)(?![0-9])"
 )
@@ -408,6 +409,10 @@ _SEMANTIC_VERSION = re.compile(
 def _parse_semantic_version(output: str) -> str | None:
     match = _SEMANTIC_VERSION.search(output)
     return match.group(1) if match else None
+
+
+def _version_timeout_seconds(provider: str) -> float:
+    return _PROVIDER_VERSION_TIMEOUT_SECONDS.get(provider, _VERSION_TIMEOUT_SECONDS)
 
 
 def _profile_id(provider: str, path_class: str, path: str) -> str:
@@ -649,14 +654,19 @@ def _discover_configured_adapter(
         if path in seen or not exists(path):
             continue
         seen.add(path)
+        provider = str(adapter["id"])
         version = (
             version_probe(path)
             if version_probe is not None
-            else _probe_version(path, discovery["versionArgv"])
+            else _probe_version(
+                path,
+                discovery["versionArgv"],
+                timeout_seconds=_version_timeout_seconds(provider),
+            )
         )
         results.append(
             ProviderDiscovery(
-                provider=str(adapter["id"]),
+                provider=provider,
                 found=True,
                 path=path,
                 path_class=path_class,
@@ -667,13 +677,18 @@ def _discover_configured_adapter(
     return results
 
 
-def _probe_version(executable: str, version_argv: list[str]) -> str | None:
+def _probe_version(
+    executable: str,
+    version_argv: list[str],
+    *,
+    timeout_seconds: float = _VERSION_TIMEOUT_SECONDS,
+) -> str | None:
     try:
         result = subprocess.run(
             [executable, *(str(value) for value in version_argv)],
             capture_output=True,
             text=True,
-            timeout=_VERSION_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
             check=False,
         )
     except (OSError, subprocess.SubprocessError):
@@ -877,7 +892,7 @@ def verify_profile(profile: Mapping[str, Any]) -> dict[str, Any]:
                 [executable, *probe_argv],
                 capture_output=True,
                 text=True,
-                timeout=_VERSION_TIMEOUT_SECONDS,
+                timeout=_version_timeout_seconds(provider),
                 check=False,
                 env=(
                     {**os.environ, "KUNGFU_AS_VARIANT": "node"}

--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -7,9 +7,23 @@ from pathlib import Path
 import shutil
 import socket
 import sys
+from typing import Protocol
 
 
 MAX_RESPONSE_BYTES = 1024 * 1024
+
+
+class ReturnCodeResult(Protocol):
+    returncode: int
+
+
+def native_heartbeat_observation(binding, work_observer=None):
+    """Separate provider liveness from an optional bound Work projection."""
+
+    work_ref = binding.get("workRef") if binding.get("kind") == "work" else None
+    if work_ref:
+        return dict(work_observer(work_ref) if work_observer else {})
+    return {"state": "fresh", "work": None, "diagnostic": None}
 
 
 def endpoint_for_runtime(runtime_dir):

--- a/framework/core/src/python/kungfu/projects/__init__.py
+++ b/framework/core/src/python/kungfu/projects/__init__.py
@@ -381,6 +381,24 @@ def _captured_work(candidate: Path) -> dict[str, Any] | None:
     }
 
 
+def _live_work_phase(target: Path, work: dict[str, Any]) -> str | None:
+    runtime_dir = target / ".kungfu" / "runtime"
+    if not runtime_dir.is_dir():
+        return None
+    try:
+        from kungfu.cli.commands import assignment as assignment_commands
+
+        status = assignment_commands._status(
+            str(runtime_dir),
+            work["initiativeId"],
+            work["assignmentId"],
+        )
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError):
+        return None
+    phase = str(status.get("phase") or "").strip()
+    return phase if phase in orchestration.PHASES else None
+
+
 def work_inventory(path: str | Path) -> dict[str, Any]:
     target = Path(path).expanduser().resolve()
     if not target.is_dir():
@@ -412,6 +430,8 @@ def work_inventory(path: str | Path) -> dict[str, Any]:
                 settled=bool(settled),
                 stateRoot=selected["state_root"],
             )
+        elif phase := _live_work_phase(target, work):
+            next_work.update(phase=phase, settled=False)
         projected.append(next_work)
     body = {
         "schema": WORK_INVENTORY_SCHEMA,

--- a/framework/core/tests/python/test_agent_console_contract.py
+++ b/framework/core/tests/python/test_agent_console_contract.py
@@ -435,6 +435,29 @@ def test_runtime_profile_verification_returns_a_semantic_provider_version(
     assert result["version"] == expected
 
 
+def test_amp_runtime_profile_verification_allows_a_bounded_cold_start(
+    monkeypatch,
+):
+    observed = {}
+
+    def probe(*args, **kwargs):
+        observed["timeout"] = kwargs["timeout"]
+        return SimpleNamespace(returncode=0, stdout="0.0.1785586633\n", stderr="")
+
+    monkeypatch.setattr(runtime_profiles.subprocess, "run", probe)
+
+    result = runtime_profiles.verify_profile(
+        {
+            "id": "amp.path.test",
+            "provider": "amp",
+            "launch": {"executable": sys.executable},
+        }
+    )
+
+    assert result["ok"] is True
+    assert observed["timeout"] == 15.0
+
+
 def test_third_party_runtime_verification_accepts_bounded_opaque_version(
     monkeypatch,
 ):
@@ -1392,7 +1415,7 @@ def test_bare_native_launches_get_unique_workspace_consoles(monkeypatch, tmp_pat
     )
 
 
-def test_unbound_native_attempt_polls_binding_without_work_heartbeat(
+def test_unbound_native_attempt_heartbeats_session_without_work_observation(
     monkeypatch, tmp_path
 ):
     requests = []
@@ -1459,7 +1482,20 @@ def test_unbound_native_attempt_polls_binding_without_work_heartbeat(
 
     operations = [request["operation"] for request in requests]
     assert operations.count("show") >= 2
-    assert "heartbeat-native" not in operations
+    heartbeats = [
+        request for request in requests if request["operation"] == "heartbeat-native"
+    ]
+    assert len(heartbeats) >= 2
+    assert all(
+        heartbeat["observation"]
+        == {
+            "state": "fresh",
+            "staleAfterMs": 5000,
+            "work": None,
+            "diagnostic": None,
+        }
+        for heartbeat in heartbeats
+    )
     assert operations.count("end-native") == 1
 
 

--- a/framework/core/tests/python/test_projects.py
+++ b/framework/core/tests/python/test_projects.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -417,3 +418,74 @@ def test_project_work_inventory_lists_multiple_captured_work_without_writing(tmp
     summary = projects.catalog(config_home=str(config_home))["projects"][0]
     assert summary["workCount"] == 2
     assert summary["updatedAt"].endswith("Z")
+
+
+def test_project_work_inventory_projects_live_executing_phase(tmp_path):
+    project = tmp_path / "ordinary-project"
+    project.mkdir()
+    target = resolve_workspace_target(
+        "capture-only",
+        str(project),
+        cwd=str(project),
+    )
+    request = {
+        "schema": "kungfu.assignment-request/v1",
+        "source": {
+            "kind": "kungfu-product",
+            "surface": "project-work-composer",
+        },
+        "retention": {
+            "policy": "explicit-expiry-retain-bytes-v1",
+            "expiresAt": None,
+        },
+        "workDefinition": {
+            "goal_id": "assignment-example",
+            "mission_id": "project-work-example",
+            "title": "Example Work",
+            "objective": "Produce a reviewable result",
+            "acceptance_criteria": ["The result is reviewable"],
+        },
+    }
+    orchestration.capture_assignment_request(request, target)
+    runtime = project / ".kungfu" / "runtime"
+    _activate_work_control(runtime)
+    mission_control.create_initiative(
+        str(runtime),
+        initiative_id="project-work-example",
+        title="Project Work Example",
+        intent="Retain live Work state in the Project view",
+        actor="local-user",
+    )
+    mission_control.create_assignment(
+        str(runtime),
+        initiative_id="project-work-example",
+        assignment_id="assignment-example",
+        title="Example Work",
+        objective="Produce a reviewable result",
+        actor="local-user",
+    )
+    mission_control.claim_assignment_execution(
+        str(runtime),
+        initiative_id="project-work-example",
+        assignment_id="assignment-example",
+        owner="local-user",
+        agent="native-agent",
+        slot="interactive",
+        lease_id="lease-example",
+        lease_expires_at=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        authorized_by="local-user",
+    )
+    mission_control.advance_assignment_phase(
+        str(runtime),
+        initiative_id="project-work-example",
+        assignment_id="assignment-example",
+        to_phase="executing",
+        actor="native-agent",
+        reason="begin retained Project Work",
+    )
+
+    inventory = projects.work_inventory(project)
+
+    assert inventory["activeWork"]["phase"] == "executing"
+    assert inventory["activeWork"]["settled"] is False
+    assert inventory["writeOccurred"] is False

--- a/framework/gui/src/product-search.test.ts
+++ b/framework/gui/src/product-search.test.ts
@@ -8,6 +8,10 @@ const source = readFileSync(
   new URL('./renderer/src/main.tsx', import.meta.url),
   'utf8',
 );
+const projectsPanelSource = readFileSync(
+  new URL('./renderer/src/projects-panel/index.tsx', import.meta.url),
+  'utf8',
+);
 const workViewSource = readFileSync(
   new URL(
     '../../../extensions/work-dashboard/src/view/index.tsx',
@@ -75,7 +79,11 @@ test('Core Work remains a first-class shell surface without an admitted Work KFX
   assert.match(source, /onOpenAllWork=\{\(\) => openWorkSurface\(\)\}/);
   assert.match(
     source,
-    /coreWorkOpen \|\| retainedCoreSurfaces\.has\('core-work'\)[\s\S]*<ProjectWorkControlView projects=\{projects\} shell=\{shell\} \/>/,
+    /<RetainedCoreSurfaceStack[\s\S]*work=\{[\s\S]*<ProjectWorkControlView projects=\{projects\} shell=\{shell\} \/>/,
+  );
+  assert.match(
+    projectsPanelSource,
+    /visible === 'core-work' \|\| retained\.has\('core-work'\)/,
   );
   assert.match(
     source,
@@ -84,22 +92,31 @@ test('Core Work remains a first-class shell surface without an admitted Work KFX
 });
 
 test('visited core product surfaces stay mounted while hidden', () => {
-  assert.match(source, /const \[retainedCoreSurfaces,/);
+  assert.match(source, /useRetainedCoreSurfaces\(\{/);
   assert.match(
-    source,
-    /projectsOpen \|\| retainedCoreSurfaces\.has\('projects'\)/,
+    projectsPanelSource,
+    /visible === 'projects' \|\| retained\.has\('projects'\)/,
   );
   assert.match(
-    source,
-    /labOpen \|\| retainedCoreSurfaces\.has\('agent-work-lab'\)/,
+    projectsPanelSource,
+    /visible === 'agent-work-lab' \|\| retained\.has\('agent-work-lab'\)/,
   );
   assert.match(
-    source,
-    /coreWorkOpen \|\| retainedCoreSurfaces\.has\('core-work'\)/,
+    projectsPanelSource,
+    /visible === 'core-work' \|\| retained\.has\('core-work'\)/,
   );
-  assert.match(source, /display: projectsOpen \? 'block' : 'none'/);
-  assert.match(source, /display: labOpen \? 'block' : 'none'/);
-  assert.match(source, /display: coreWorkOpen \? 'block' : 'none'/);
+  assert.match(
+    projectsPanelSource,
+    /display: visible === 'projects' \? 'block' : 'none'/,
+  );
+  assert.match(
+    projectsPanelSource,
+    /display: visible === 'agent-work-lab' \? 'block' : 'none'/,
+  );
+  assert.match(
+    projectsPanelSource,
+    /display: visible === 'core-work' \? 'block' : 'none'/,
+  );
 });
 
 test('Project navigation preserves the current Project while the catalog is explicit', () => {

--- a/framework/maintainability/abstraction-integrity-report.json
+++ b/framework/maintainability/abstraction-integrity-report.json
@@ -11,9 +11,9 @@
     },
     "counts": {
       "productionFiles": 229,
-      "productionPhysicalLines": 83275,
+      "productionPhysicalLines": 83313,
       "testFiles": 96,
-      "testPhysicalLines": 45506
+      "testPhysicalLines": 45614
     },
     "hiddenProductionFiles": [],
     "modulesOver1000": [
@@ -23,7 +23,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/run_agent.py",
-        "physicalLines": 1693
+        "physicalLines": 1682
       },
       {
         "path": "framework/core/src/python/kungfu/agent/work_profile.py",
@@ -140,10 +140,10 @@
         "responsibilities": 31
       },
       {
-        "contentRoot": "sha256:d07c4e97a5ac6f6fd016ae6ea3a16c11842b28a8bc575caa8b0dfb8999c74b8b",
+        "contentRoot": "sha256:7a3c6444a3ae6bad4b1002cb230ea01372955b3900e666eb990eedf8e596d03d",
         "path": "framework/core/src/python/kungfu/agent/run_agent.py",
-        "physicalLines": 1693,
-        "responsibilities": 37
+        "physicalLines": 1682,
+        "responsibilities": 36
       },
       {
         "contentRoot": "sha256:97cdedccf1b1d0f9b5201e865c6bd41c67afeb41c94ecffac5c145fc0905113c",
@@ -269,7 +269,7 @@
     "parseErrors": [],
     "platformBranches": [
       {
-        "line": 20,
+        "line": 34,
         "path": "framework/core/src/python/kungfu/agent/session_surface.py",
         "test": "sys.platform == 'win32'"
       },
@@ -370,7 +370,7 @@
       }
     ],
     "schema": "kungfu.python-structure-measurement/v1",
-    "sourceRoot": "sha256:db447763dbdbc750c04391f0d3d2a4db2f2b8ca7eb41e575b7d1ffaf94afb3b5",
+    "sourceRoot": "sha256:5447ade66cf54d5b7f17813c0677bc38f7dea7e6ecde3374945fd18223df899f",
     "sourceRoots": {
       "production": [
         "framework/core/src/python"
@@ -446,9 +446,9 @@
     "kungfu.runtime_broker.NativeReadinessAuthority",
     "kungfu.runtime_service.ProcessRuntimeHost"
   ],
-  "reportRoot": "sha256:482bd76d015d62ffc35c0b96ece023607d485daee123824191e7729d05115d7b",
+  "reportRoot": "sha256:fd6b8aa5df24b0b9028104449838e98860f7364f5528e4ceb41dd667bb605d96",
   "schema": "kungfu.abstraction-integrity-report/v1",
-  "sourceRoot": "sha256:db447763dbdbc750c04391f0d3d2a4db2f2b8ca7eb41e575b7d1ffaf94afb3b5",
+  "sourceRoot": "sha256:5447ade66cf54d5b7f17813c0677bc38f7dea7e6ecde3374945fd18223df899f",
   "summary": {
     "blockingIssues": 0
   },


### PR DESCRIPTION
## Summary

Preserve provider-native UI continuity across Codex, OpenCode, and Amp while keeping Work authority explicit.

## Changes

- Keep unbound native sessions observable and fresh without claiming a Work.
- Allow Amp cold-start version discovery enough time to complete.
- Resolve packaged node-pty from provider-first Agent Session bundles.
- Project live Work phases into the TUI inventory.
- Align the retained Core Work surface test with its extracted renderer component.

## Verification

- `./shifu check`
- Native UI acceptance with Codex, OpenCode, and Amp: launch, injected Kungfu context, Work binding and concurrency guard, observer freshness, TUI projection, and normal exit.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores existing native Agent UI continuity and observer behavior without changing an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The provider CLI boundary remains provider-native: Kungfu injects context and observes liveness without capturing terminal transcript bytes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed, or not required for this bounded bug fix
- [x] Tests added or updated for behavior changes