### PR TITLE
fix(ci): bind Windows burst runs to campaign identity

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: AWS US Windows Burst Qualification
+run-name: AWS Windows JIT ${{ inputs.campaign-id }} ${{ inputs.qualification-id }}
 
 on:
   workflow_dispatch:
     inputs:
+      campaign-id:
+        description: "One-shot Windows JIT campaign identity"
+        required: true
       qualification-id:
         description: "One bounded Windows JIT qualification slot"
         required: true
@@ -26,14 +30,14 @@ on:
           - cancellation
           - timeout
       runner-label:
-        description: "Exact unique JIT label created for this run"
+        description: "Exact campaign-scoped JIT label created for this run"
         required: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: aws-us-windows-burst-${{ inputs.qualification-id }}
+  group: aws-us-windows-burst-${{ inputs.campaign-id }}-${{ inputs.qualification-id }}
   cancel-in-progress: false
 
 jobs:
@@ -47,6 +51,7 @@ jobs:
         shell: bash
         env:
           EXPECTED_REPOSITORY: kungfu-systems/kungfu
+          CAMPAIGN_ID: ${{ inputs.campaign-id }}
           QUALIFICATION_ID: ${{ inputs.qualification-id }}
           MODE: ${{ inputs.mode }}
           RUNNER_LABEL: ${{ inputs.runner-label }}
@@ -54,11 +59,12 @@ jobs:
           set -euo pipefail
           test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
           test "${GITHUB_REPOSITORY}" = "${EXPECTED_REPOSITORY}"
+          [[ "${CAMPAIGN_ID}" =~ ^win-[a-z0-9][a-z0-9-]{2,15}$ ]]
           case "${QUALIFICATION_ID}:${MODE}" in
             win-smoke:smoke|win-full-0[1-3]:full|win-cancel:cancellation|win-timeout:timeout) ;;
             *) exit 1 ;;
           esac
-          test "${RUNNER_LABEL}" = "aws-us-ec2-windows-jit-${QUALIFICATION_ID}"
+          test "${RUNNER_LABEL}" = "aws-us-ec2-windows-jit-${CAMPAIGN_ID}-${QUALIFICATION_ID}"
 
       - name: Require write-capable actor
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -82,14 +88,14 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75
     with:
-      buildchain-ref: 376fb92fa014102366111b9aaef4856486c1e499
+      buildchain-ref: 447936a3aa36415a39c75e92fc9b26b0774aeb75
       runner-preset: aws-us-ec2-windows-jit
       aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
       setup-rust: true
       rust-toolchain: "1.96.0"
-      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
+      artifact-name: kungfu-aws-windows-${{ inputs.campaign-id }}-${{ inputs.qualification-id }}
       artifact-paths: |
         product/release/qualification/aws-windows-jit-smoke.json
       expected-artifacts-json: >-
@@ -121,14 +127,14 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75
     with:
-      buildchain-ref: 376fb92fa014102366111b9aaef4856486c1e499
+      buildchain-ref: 447936a3aa36415a39c75e92fc9b26b0774aeb75
       runner-preset: aws-us-ec2-windows-jit
       aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
       setup-rust: true
       rust-toolchain: "1.96.0"
-      artifact-name: kungfu-aws-windows-${{ inputs.qualification-id }}
+      artifact-name: kungfu-aws-windows-${{ inputs.campaign-id }}-${{ inputs.qualification-id }}
       artifact-paths: |
         product/release
       expected-artifacts-json: >-

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -4,7 +4,7 @@
   "owner": "kungfu-ci",
   "retiredAt": "2026-07-30",
   "reactivatedAt": "2026-07-30",
-  "reason": "The v2 callers were retired until the bounded Linux, Windows, and macOS providers landed in reviewed Buildchain v3 authority. Reactivation now fixes both the reusable workflow shell and buildchain-ref to that one immutable reviewed commit.",
+  "reason": "The v2 callers were retired until the bounded Linux, Windows, and macOS providers landed in reviewed Buildchain v3 authority. Each active caller fixes both the reusable workflow shell and buildchain-ref to its immutable reviewed provider commit; the Windows caller additionally requires the persistent one-shot campaign ledger and exact campaign/source binding.",
   "runtimeSafety": {
     "workflowShellReferencesV2": false,
     "buildchainRefInputsV2": false,
@@ -17,6 +17,10 @@
     "reviewedBuildchainV3Source": "376fb92fa014102366111b9aaef4856486c1e499",
     "windowsJitRepairPullRequest": 2083,
     "windowsJitRepairMergeCommit": "376fb92fa014102366111b9aaef4856486c1e499",
+    "windowsCampaignLedgerPullRequest": 2210,
+    "windowsCampaignLedgerMergeCommit": "ab147fa02d4e17937818c89c1269483fa450d986",
+    "windowsCampaignSourceBindingPullRequest": 2212,
+    "windowsCampaignSourceBindingMergeCommit": "447936a3aa36415a39c75e92fc9b26b0774aeb75",
     "v3RequiredInputs": [
       "aws-codebuild-project",
       "aws-ec2-windows-runner-label",
@@ -62,7 +66,9 @@
     "requirementsSatisfied": [
       "Protected Assignment remains owned by kungfu-ci and Buildchain maintainers.",
       "Required runner presets and controller inputs landed in reviewed Buildchain v3.",
-      "Reusable workflow shell and buildchain-ref are pinned to the same immutable reviewed v3 commit.",
+      "Each reusable workflow shell and buildchain-ref pair is pinned to the same immutable reviewed v3 commit.",
+      "Windows admission is one-shot, source-bound, permanently killable, and atomically capped before launch.",
+      "Windows run title and runner label both bind campaign and qualification identity before launch.",
       "Bounded trust, label, non-publication, timeout, cancellation, and cleanup assertions are restored with targeted tests.",
       "Provider policy changes remain outside the caller reactivation."
     ]

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -227,7 +227,7 @@
     {
       "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
       "authority": "qualification",
-      "definitionDigest": "sha256:41b31b1b94638c5dfdc1b0961c5fa7f7a439444f856ecc71ca14c45f30a53172",
+      "definitionDigest": "sha256:981248c822c03424e1b93fa578de67e214445e342b8eacb966b7d49653aa412d",
       "jobs": [
         {
           "id": "cleanup-exercise",
@@ -244,9 +244,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:7a4a2ebf862dd35dd9e946beffdf03dfe0d0d79f7ec475129fe3f294bee20ef4",
+          "definitionDigest": "sha256:a7228f8a3efa9e6b93ddcb5b1f0b4212fa1842c03c2a3ae8774d1dd28d29ad99",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75"],
           "steps": []
         },
         {
@@ -254,9 +254,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:143b06d990a1dca7b6215617af24b2a20b64775d8e174438bf42d5895dbdbcf9",
+          "definitionDigest": "sha256:8b187c791b5b6fc8a5a4c874db6315aa7ba62ba6389c74c6b09e348efb1b480d",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75"],
           "steps": []
         },
         {
@@ -264,10 +264,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:ed8c39bd07f1a530e41ec91142529b5b5c6e0e345a59f8ffaf6077a779518192",
+          "definitionDigest": "sha256:7c89de0c8a4167b3fe88de845455406f90cfe73b7f188c3271d993d53358c767",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd"],
-          "steps": [{"index":1,"label":"name:Require canonical repository, mode, and label","definitionDigest":"sha256:c79ae3993e76974650848389ab59d62f355ae08734717d349c6ea7e144182999"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]
+          "steps": [{"index":1,"label":"name:Require canonical repository, mode, and label","definitionDigest":"sha256:bfd821a228fbc60a9e65f9ae5722d70bb4acc0b3356e5cd6fb499347d0e27e3b"},{"index":2,"label":"name:Require write-capable actor","definitionDigest":"sha256:3430783a3e543bfdbe6f96ad0be249927e372191c7e2cc5d8c540c14be66d68f"}]
         }
       ]
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -111,7 +111,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:9828639e188badfc8a1f2ddfe17ea1d07ba9e737d15289a981a0a9db3906bbbd"
+          "sourceRoot": "sha256:230bcbae47325a380301077232bad5a9b26a0c0d164a8961b92290f63fde6008"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:eb2138871147f4ab71da8f2b3d8bf0c97b32c26b03f1131764af5368387e0d04"
+  "registryRoot": "sha256:f77d0aab5cc2c6fee2eb2c54780a79fd6d69eede47257553ed5f55d5370b4da8"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -191,7 +191,7 @@ test('AWS CodeBuild qualification rejects static and release credentials', () =>
   }
 });
 
-test('reactivated AWS burst workflows pin one reviewed Buildchain v3 source', () => {
+test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sources', () => {
   const retirement = JSON.parse(
     fs.readFileSync(
       path.join(
@@ -215,6 +215,21 @@ test('reactivated AWS burst workflows pin one reviewed Buildchain v3 source', ()
     retirement.evidence.windowsJitRepairMergeCommit,
     buildchainSource,
   );
+  const windowsBuildchainSource =
+    retirement.evidence.windowsCampaignSourceBindingMergeCommit;
+  assert.equal(retirement.evidence.windowsCampaignLedgerPullRequest, 2210);
+  assert.equal(
+    retirement.evidence.windowsCampaignLedgerMergeCommit,
+    'ab147fa02d4e17937818c89c1269483fa450d986',
+  );
+  assert.equal(
+    retirement.evidence.windowsCampaignSourceBindingPullRequest,
+    2212,
+  );
+  assert.equal(
+    windowsBuildchainSource,
+    '447936a3aa36415a39c75e92fc9b26b0774aeb75',
+  );
 
   for (const name of [
     'aws-us-linux-burst-qualification.yml',
@@ -225,6 +240,10 @@ test('reactivated AWS burst workflows pin one reviewed Buildchain v3 source', ()
       path.join(repositoryRoot, '.github/workflows', name),
       'utf8',
     );
+    const expectedBuildchainSource =
+      name === 'aws-us-windows-burst-qualification.yml'
+        ? windowsBuildchainSource
+        : buildchainSource;
     assert.match(workflow, /workflow_dispatch:/);
     assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
     if (name === 'aws-us-windows-burst-qualification.yml') {
@@ -235,13 +254,14 @@ test('reactivated AWS burst workflows pin one reviewed Buildchain v3 source', ()
     const shellPins =
       workflow.match(
         new RegExp(
-          `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${buildchainSource}`,
+          `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${expectedBuildchainSource}`,
           'g',
         ),
       ) || [];
     const runtimePins =
-      workflow.match(new RegExp(`buildchain-ref: ${buildchainSource}`, 'g')) ||
-      [];
+      workflow.match(
+        new RegExp(`buildchain-ref: ${expectedBuildchainSource}`, 'g'),
+      ) || [];
     assert.ok(shellPins.length >= 1);
     assert.equal(runtimePins.length, shellPins.length);
     assert.doesNotMatch(workflow, /train\/v2|buildchain-ref:\s*[\r\n]/);
@@ -292,6 +312,15 @@ test('AWS Windows burst workflow preserves bounded full and cleanup exercises', 
     'utf8',
   );
   assert.match(workflow, /name: AWS US Windows Burst Qualification/);
+  assert.match(
+    workflow,
+    /run-name: AWS Windows JIT \$\{\{ inputs\.campaign-id \}\} \$\{\{ inputs\.qualification-id \}\}/,
+  );
+  assert.match(workflow, /campaign-id:\n {8}description:/);
+  assert.match(
+    workflow,
+    /group: aws-us-windows-burst-\$\{\{ inputs\.campaign-id \}\}-\$\{\{ inputs\.qualification-id \}\}/,
+  );
   assert.match(workflow, /permissions:\n {2}contents: read/);
   assert.equal(
     (
@@ -313,6 +342,14 @@ test('AWS Windows burst workflow preserves bounded full and cleanup exercises', 
   assert.match(workflow, /win-full-0\[1-3\]:full/);
   assert.match(workflow, /win-cancel:cancellation/);
   assert.match(workflow, /win-timeout:timeout/);
+  assert.match(
+    workflow,
+    /\[\[ "\$\{CAMPAIGN_ID\}" =~ \^win-\[a-z0-9\]\[a-z0-9-\]\{2,15\}\$ \]\]/,
+  );
+  assert.match(
+    workflow,
+    /aws-us-ec2-windows-jit-\$\{CAMPAIGN_ID\}-\$\{QUALIFICATION_ID\}/,
+  );
   assert.match(workflow, /timeout-minutes:/);
   assert.match(workflow, /\n {2}smoke:\n/);
   assert.match(workflow, /\n {2}full:\n/);


### PR DESCRIPTION
## Summary

Bind every Windows burst dispatch to an explicit one-shot campaign identity across the GitHub run title, concurrency key, runner label, artifacts, and the reviewed Buildchain controller source.

This closes the caller-side gap after Buildchain PRs #2210 and #2212. The workflow remains manually disabled because the current Windows campaign exceeded its hard budget.

## Related issue

Atlas goal 2026-07-28-kungfu-aws-us-elastic-runner-burst-plane

## Changes

- require and validate a bounded campaign-id
- bind the exact display title and JIT runner label to campaign plus qualification identity
- pin the Windows caller to reviewed Buildchain merge 447936a3aa36415a39c75e92fc9b26b0774aeb75
- refresh workflow and release-publication authority roots
- retain exact PR and merge evidence in the burst retirement gate

## Verification

- ./shifu check:source
- ./shifu node --test scripts/buildchain-install.test.mjs
- ./shifu check:release-publication-control-plane
- ./shifu node scripts/kungfu-workflow-authority.mjs
- git diff origin/dev/v4/v4.0...HEAD --check
- Windows workflow readback: disabled_manually
- AWS US provider-tagged active EC2 instances and volumes: zero

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fail-closed CI repair narrows an existing provider workflow and updates generated authority roots without altering an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change adds fail-closed campaign/source binding only. It does not enable or dispatch provider capacity.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed