### PR TITLE
ci: pin Windows burst campaign to USD 80 controller

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -88,9 +88,9 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@ae9bd5385cfb8060fb2574521121f1a798e83c6f
     with:
-      buildchain-ref: 447936a3aa36415a39c75e92fc9b26b0774aeb75
+      buildchain-ref: ae9bd5385cfb8060fb2574521121f1a798e83c6f
       runner-preset: aws-us-ec2-windows-jit
       aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
       setup-rust: true
@@ -127,9 +127,9 @@ jobs:
       contents: read
       issues: write
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@ae9bd5385cfb8060fb2574521121f1a798e83c6f
     with:
-      buildchain-ref: 447936a3aa36415a39c75e92fc9b26b0774aeb75
+      buildchain-ref: ae9bd5385cfb8060fb2574521121f1a798e83c6f
       runner-preset: aws-us-ec2-windows-jit
       aws-ec2-windows-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -4,7 +4,7 @@
   "owner": "kungfu-ci",
   "retiredAt": "2026-07-30",
   "reactivatedAt": "2026-07-30",
-  "reason": "The v2 callers were retired until the bounded Linux, Windows, and macOS providers landed in reviewed Buildchain v3 authority. Each active caller fixes both the reusable workflow shell and buildchain-ref to its immutable reviewed provider commit; the Windows caller additionally requires the persistent one-shot campaign ledger and exact campaign/source binding.",
+  "reason": "The v2 callers were retired until the bounded Linux, Windows, and macOS providers landed in reviewed Buildchain v3 authority. Each active caller fixes both the reusable workflow shell and buildchain-ref to its immutable reviewed provider commit; the Windows caller additionally requires the persistent one-shot campaign ledger, exact campaign/source binding, and the USD 80 phase cap with a frozen spend baseline.",
   "runtimeSafety": {
     "workflowShellReferencesV2": false,
     "buildchainRefInputsV2": false,
@@ -21,6 +21,8 @@
     "windowsCampaignLedgerMergeCommit": "ab147fa02d4e17937818c89c1269483fa450d986",
     "windowsCampaignSourceBindingPullRequest": 2212,
     "windowsCampaignSourceBindingMergeCommit": "447936a3aa36415a39c75e92fc9b26b0774aeb75",
+    "windowsUsd80PhaseCapPullRequest": 2229,
+    "windowsUsd80PhaseCapMergeCommit": "ae9bd5385cfb8060fb2574521121f1a798e83c6f",
     "v3RequiredInputs": [
       "aws-codebuild-project",
       "aws-ec2-windows-runner-label",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -244,9 +244,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a7228f8a3efa9e6b93ddcb5b1f0b4212fa1842c03c2a3ae8774d1dd28d29ad99",
+          "definitionDigest": "sha256:497f621e09e4a581eedbca81e4eb9a46a2d3bdc708bb8bbe0a052bcccf82b2e9",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@ae9bd5385cfb8060fb2574521121f1a798e83c6f"],
           "steps": []
         },
         {
@@ -254,9 +254,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:8b187c791b5b6fc8a5a4c874db6315aa7ba62ba6389c74c6b09e348efb1b480d",
+          "definitionDigest": "sha256:1a12155f1eb2c1dd7fa4736dea290d591261ba1e8b504bbd60977ce92f4815a2",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@447936a3aa36415a39c75e92fc9b26b0774aeb75"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@ae9bd5385cfb8060fb2574521121f1a798e83c6f"],
           "steps": []
         },
         {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -111,7 +111,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:230bcbae47325a380301077232bad5a9b26a0c0d164a8961b92290f63fde6008"
+          "sourceRoot": "sha256:88b57065059170bdb8cc76941b5bc66e2663efaa43c7e165aeda9b89f5f501e3"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:7501ef2ece31dec264fd3ce720010a465f9ad7848cd58244d62af0e70d8880e2"
+  "registryRoot": "sha256:4f22df3780c46863b4d333e8ceb1de9a00fc877bb2ce0032e1e5b4d685c604b8"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -230,6 +230,13 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     windowsBuildchainSource,
     '447936a3aa36415a39c75e92fc9b26b0774aeb75',
   );
+  assert.equal(retirement.evidence.windowsUsd80PhaseCapPullRequest, 2229);
+  const windowsUsd80PhaseCapSource =
+    retirement.evidence.windowsUsd80PhaseCapMergeCommit;
+  assert.equal(
+    windowsUsd80PhaseCapSource,
+    'ae9bd5385cfb8060fb2574521121f1a798e83c6f',
+  );
 
   for (const name of [
     'aws-us-linux-burst-qualification.yml',
@@ -242,7 +249,7 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     );
     const expectedBuildchainSource =
       name === 'aws-us-windows-burst-qualification.yml'
-        ? windowsBuildchainSource
+        ? windowsUsd80PhaseCapSource
         : buildchainSource;
     assert.match(workflow, /workflow_dispatch:/);
     assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);


### PR DESCRIPTION
Pin the manual-only Windows burst workflow to reviewed Buildchain v3 commit `ae9bd5385cfb8060fb2574521121f1a798e83c6f`, which adds the frozen Cost Explorer baseline and atomic USD 80 campaign cap. Refresh the closed workflow authority and release publication roots, and retain the prior source-binding evidence as immutable history. The workflow remains disabled; macOS is unchanged and disabled.

Validation: focused Buildchain install tests 11/11, Kungfu gate catalog, release publication control plane, JSON/diff hygiene, and the full staged pre-commit gate passed. The local full source run reached 953 passes and exposed one fixed old-SHA expectation plus one host-only missing `pytest` prerequisite; protected CI provides the standard-environment replay.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Operationally pin an existing manual-only Windows qualification caller to the reviewed USD 80 bounded Buildchain controller without changing product, protocol, or publication authority."}
-->