### PR TITLE
fix(release): use product-neutral demo renderer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,7 +510,7 @@ jobs:
       source-artifact-digest: ${{ needs.resolve-auditable-demo-source.outputs.artifact-digest }}
       adapter-path: scripts/auditable-demo-adapter.py
       adapter-arguments-json: ${{ format('["--demo-id",{0}]', toJSON(needs.auditable-demo-plan.outputs.demo-id)) }}
-      renderer-image: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591
+      renderer-image: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:32f5079f14ec0380c27f0df39448cb931e87fe744cc867fbd3d61cfd8a5e18de
       render-media: ${{ needs.auditable-demo-plan.outputs.render-media == 'true' }}
       media-profile: responsive-web-delivery-v1
       artifact-retention-days: 14
@@ -644,7 +644,7 @@ jobs:
           MEDIA_QUALIFICATION_ROOT: ${{ needs.auditable-demo.outputs.media-qualification-root }}
           AUDITABLE_DEMO_ID: ${{ needs.auditable-demo-plan.outputs.demo-id }}
           BUILDCHAIN_SHA: afd75d295fcd2d55cfebf621f5ca6d05a9904830
-          RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591
+          RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:32f5079f14ec0380c27f0df39448cb931e87fe744cc867fbd3d61cfd8a5e18de
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 
       - name: Upload exact auditable demo Release Passport

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -281,7 +281,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:5d96929ec45001d15f36a59c3cbd97342c3ed64e68a048b0c8afbb0f12db8aa7",
+          "definitionDigest": "sha256:ed37673879a43c020efddd957e6dc78767c72c8417042f70c435706b4f50654f",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@afd75d295fcd2d55cfebf621f5ca6d05a9904830"],
           "steps": []
@@ -301,10 +301,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:c7218a748e04f4445bcf7daac7cde19288e7fc3c280b55df7e2d3d5224ac1709",
+          "definitionDigest": "sha256:7cdb6c0922b2e7b8ca1c4b951bbb90816831614ecf1a98941b505a6d8bae06ef",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
-          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:49d631c2178af0fff7a27292912e64fef6d234578c1b7639882bbec0e6fce371"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
+          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:a499fcf7582bc254fbd6f18d386b5f7b52527f0ecd59d93d70b90246fb048dd6"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
         },
         {
           "id": "auditable-demo-plan",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:06b93a39f506b1367318fc508ea856dfbaad8ecc6efaf3980e7485d2a69d51c6"
+          "sourceRoot": "sha256:70033593b6a9a3c2b851dd18c2fd18598ccfea7dd806c362f6a134152f29c2ab"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4f22df3780c46863b4d333e8ceb1de9a00fc877bb2ce0032e1e5b4d685c604b8"
+  "registryRoot": "sha256:acdf738e1726424173ea9343b0c1455246c09f84574f596a8763facba7f20de9"
 }

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -29,7 +29,7 @@ const SOURCE_SHA = '1'.repeat(40);
 const NATIVE_RENDITION_BUILDCHAIN_SHA =
   'afd75d295fcd2d55cfebf621f5ca6d05a9904830';
 const NATIVE_RENDITION_RENDERER_IMAGE =
-  'ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591';
+  'ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:32f5079f14ec0380c27f0df39448cb931e87fe744cc867fbd3d61cfd8a5e18de';
 
 function triggerPlan(overrides = {}) {
   return buildAuditableDemoTriggerPlan({


### PR DESCRIPTION
## Summary

- pin the auditable-demo workflow and Release Passport to the product-neutral renderer from build-images v1.3.0-alpha.26
- refresh the workflow-authority digests and release publication roots
- keep the immutable renderer digest aligned in the workflow contract test

## Root evidence

- renderer: `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:32f5079f14ec0380c27f0df39448cb931e87fe744cc867fbd3d61cfd8a5e18de`
- build-images release: https://github.com/kungfu-systems/build-images/releases/tag/v1.3.0-alpha.26
- source fix: https://github.com/kungfu-systems/build-images/pull/353
- promotion: https://github.com/kungfu-systems/build-images/pull/354
- publication registry root: `sha256:acdf738e1726424173ea9343b0c1455246c09f84574f596a8763facba7f20de9`

## Verification

- `./shifu build:core`
- `./shifu check:source` (965 Node contract tests: 955 passed, 10 skipped, 0 failed; downstream Python and desktop suites passed)
- `./shifu node --test scripts/kungfu-workflow-authority.test.mjs scripts/auditable-demo-workflow.test.mjs`
- `./shifu check:gate-catalog`
- `./shifu check:release-publication-control-plane`
- `./shifu test:release-publication-control-plane`
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair the immutable auditable-demo renderer pin with an independently released product-neutral image without changing architecture, publication authority, or platform coverage"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only the immutable qualification renderer pin and its derived authority roots. It grants no publication or deployment authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Generated authority and publication roots are current

Signed-off-by: Keren Dong <keren.dong+cx@kungfu.link>