### PR TITLE
fix(release): update auditable demo gate runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,7 +503,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@afd75d295fcd2d55cfebf621f5ca6d05a9904830 # PR #2126 native rendition qualification
+    uses: kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@31483f9652651d5b7b324fae6864bc4e7ff16fb6 # PR #2217 native rendition path remediation
     with:
       source-ref: ${{ needs.build.outputs.publish-source-sha }}
       source-artifact-name: ${{ needs.resolve-auditable-demo-source.outputs.artifact-name }}
@@ -643,7 +643,7 @@ jobs:
           MEDIA_PROFILE: ${{ needs.auditable-demo.outputs.media-profile }}
           MEDIA_QUALIFICATION_ROOT: ${{ needs.auditable-demo.outputs.media-qualification-root }}
           AUDITABLE_DEMO_ID: ${{ needs.auditable-demo-plan.outputs.demo-id }}
-          BUILDCHAIN_SHA: afd75d295fcd2d55cfebf621f5ca6d05a9904830
+          BUILDCHAIN_SHA: 31483f9652651d5b7b324fae6864bc4e7ff16fb6
           RENDERER_IMAGE: ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:32f5079f14ec0380c27f0df39448cb931e87fe744cc867fbd3d61cfd8a5e18de
         run: ./shifu node scripts/auditable-demo-passport.mjs write --output auditable-demo-release-passport.json
 

--- a/docs/qualification/auditable-demo-artifact-pipeline.md
+++ b/docs/qualification/auditable-demo-artifact-pipeline.md
@@ -73,7 +73,7 @@ they cannot replace the README managed block.
 | --- | --- |
 | Demo renderer | `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:e5ae5002dc0fc267e265dba1068d7476e541dddc9035ccd72cee94dfad872591` |
 | Renderer release | `v1.3.0-alpha.25`, exact version-state source `f327dd2c2879b5fe26982f3d60ddb00b55a64a25`, built from source `8f5581cdffcfbb695c6738de1a8935e3ee8774f2` containing Build Images PR `#350` |
-| Buildchain Gate | `afd75d295fcd2d55cfebf621f5ca6d05a9904830` (Buildchain PR `#2126`, independent native rendition qualification) |
+| Buildchain Gate | `31483f9652651d5b7b324fae6864bc4e7ff16fb6` (Buildchain PR `#2217`, independent native rendition path remediation) |
 | Consumer adapter | `scripts/auditable-demo-adapter.py` from the exact qualified Kungfu source SHA |
 
 Buildchain's reusable build emits

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -281,9 +281,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:ed37673879a43c020efddd957e6dc78767c72c8417042f70c435706b4f50654f",
+          "definitionDigest": "sha256:d114f857e5697f5e51512d96a9591e7bda74bf519cca7d3c0cfc5ecee7ee083c",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@afd75d295fcd2d55cfebf621f5ca6d05a9904830"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.auditable-demo.yml@31483f9652651d5b7b324fae6864bc4e7ff16fb6"],
           "steps": []
         },
         {
@@ -301,10 +301,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:7cdb6c0922b2e7b8ca1c4b951bbb90816831614ecf1a98941b505a6d8bae06ef",
+          "definitionDigest": "sha256:fa14afc75cf3058df521c109a012e0f3c754cbef0f63d21d7c8b97ceea7812c3",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
-          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:a499fcf7582bc254fbd6f18d386b5f7b52527f0ecd59d93d70b90246fb048dd6"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
+          "steps": [{"index":1,"label":"name:Check out exact qualified source","definitionDigest":"sha256:29b1db9963a2029aabffae82fe0ec406fa6ec8d3a522d80493e9e84be9967dbe"},{"index":2,"label":"id:artifact-expiry","definitionDigest":"sha256:b63afe1390635ea616d7c2a9ccc69bfb49f5b8d2ee193c8b8df61800eaad0591"},{"index":3,"label":"name:Write exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:c85e62a2b4adc479152f019e81e53a90717e3ccf6163873252c6d3ff48adfc56"},{"index":4,"label":"name:Upload exact auditable demo Release Passport","authority":"evidence-publication","definitionDigest":"sha256:026dc02ae0372598499bba6aa300fe2c537f6ca694ae3b7d4719a91ca6e4780a"}]
         },
         {
           "id": "auditable-demo-plan",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:70033593b6a9a3c2b851dd18c2fd18598ccfea7dd806c362f6a134152f29c2ab"
+          "sourceRoot": "sha256:ac02a4131db2739d884118d1e4d3e233de0a454090f0f78dca1c005b60aa3715"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:acdf738e1726424173ea9343b0c1455246c09f84574f596a8763facba7f20de9"
+  "registryRoot": "sha256:e1d94fe6d570265fe358d1932deea1a7b7efa840f6aeab71efc5b33bf48e6a82"
 }

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -27,7 +27,7 @@ const RELEASE_WORKFLOW = parse(fs.readFileSync(RELEASE_WORKFLOW_PATH, 'utf8'));
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 const SOURCE_SHA = '1'.repeat(40);
 const NATIVE_RENDITION_BUILDCHAIN_SHA =
-  'afd75d295fcd2d55cfebf621f5ca6d05a9904830';
+  '31483f9652651d5b7b324fae6864bc4e7ff16fb6';
 const NATIVE_RENDITION_RENDERER_IMAGE =
   'ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:32f5079f14ec0380c27f0df39448cb931e87fe744cc867fbd3d61cfd8a5e18de';
 


### PR DESCRIPTION
## Summary

- update the immutable auditable-demo reusable-workflow runtime to Buildchain PR #2217
- bind the Release Passport to the same exact Buildchain revision
- refresh the closed-world workflow authority digests and keep the contract test aligned

## Root evidence

- Buildchain fix: https://github.com/kungfu-systems/buildchain/pull/2217
- exact Buildchain revision: `31483f9652651d5b7b324fae6864bc4e7ff16fb6`
- retained failing final run: https://github.com/kungfu-systems/kungfu/actions/runs/30739014646
- failure repaired: native rendition path objects were passed to path joining by the older pinned runtime
- renderer remains immutable: `ghcr.io/kungfu-systems/build-images/demo-renderer@sha256:32f5079f14ec0380c27f0df39448cb931e87fe744cc867fbd3d61cfd8a5e18de`

## Verification

- `./shifu build:core`
- `./shifu pnpm --filter @kungfu-tech/core run test:tooling` (45/45)
- `./shifu pnpm run test:auditable-demo` (42/42 on the latest protected base)
- `./shifu node scripts/kungfu-workflow-authority.mjs`
- `./shifu node scripts/check-kungfu-gate-catalog.mjs`
- `./shifu check` (changed-scope gate passed)
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair the immutable auditable-demo Gate runtime pin with the independently reviewed native-rendition path fix without changing architecture, publication authority, or platform coverage"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only the immutable qualification runtime pin and derived authority roots. It grants no publication or deployment authority.

## Checklist

- [x] Commit is signed off (DCO)
- [x] Generated workflow authority roots are current
- [x] Candidate is based on the latest protected `dev/v4/v4.0`

Signed-off-by: Keren Dong <keren.dong@kungfu.link>
