### PR TITLE
fix(source): close protected checkout write paths

### DIFF
--- a/framework/maintainability/readonly-source-routes.json
+++ b/framework/maintainability/readonly-source-routes.json
@@ -12,7 +12,19 @@
       "command": "./shifu check:source",
       "classification": "read-only-source",
       "implementation": "scripts/source-acceptance.mjs",
-      "transitiveWriters": [],
+      "runtimeImplementation": "scripts/readonly-source-toolchain.mjs",
+      "writerOwner": "source-acceptance-runtime",
+      "transitiveWriters": [
+        "disposable OS test directories only"
+      ],
+      "deniedCheckoutWriters": [
+        "_tmp_*",
+        ".buildchain/diagnostics/*.tmp-*",
+        ".pnpm-store/**",
+        "generated-fixtures/**",
+        "nested-task-output/**"
+      ],
+      "recovery": "move disposable writes to the declared OS runtime root; run legitimate materialization in an isolated worktree and exclude it from ./shifu check:source",
       "network": false,
       "dependencyInstallation": false
     },

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -3,9 +3,9 @@
   "verdict": "pass",
   "authoritySemantics": "navigation-only-projection-over-existing-authorities",
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
-  "manifestRoot": "sha256:a4a33a8743dd4c2d30b88f19834fda45c9dda0ac972239cfdb9aa6b4ffba2b18",
+  "manifestRoot": "sha256:0e4ae531ff0b740fcaae8098cec1b5efaa2122c85bf7be3913130e0860c3663a",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:e535083e53336889ecad0613f837e395e4d215b7ac570bd827aa67e3fa6683ec",
+  "sourceRoot": "sha256:7cfa5af1bbd0060a203e8ce4bf5aa24c3785de894cf1a1129912868199815415",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -641,17 +641,17 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 2419,
+          "currentLines": 2110,
           "baselineLines": 2514,
-          "currentRoot": "sha256:e05159e93a4ff42eced680189f9fd1e2654ca6f8197941f5eae3eea9fd1bd9f5",
+          "currentRoot": "sha256:2c38f87b407f98e7e6f6cc62e7d2314b9cf5db8b65bb5c5d1b394f9e5c17e37c",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
         {
           "path": "product/scripts/runtime-pin-snapshot.mjs",
-          "currentLines": 242,
+          "currentLines": 518,
           "baselineLines": null,
-          "currentRoot": "sha256:cdfd975c2ede6cf3654d1b55df37e0578ef03a061a8dd59f99170937b8dd3a00",
+          "currentRoot": "sha256:f89ecaa859a3b968ceaec79a210986edb9e8e841fe81ea390bc9b5d90b99fee1",
           "baselineRoot": null,
           "changedSinceBaseline": true
         }
@@ -1380,14 +1380,14 @@
       "rollback": "Move the read-only evidence helpers back and preserve the existing re-export surface."
     },
     {
-      "id": "product-assembly-lifecycle",
+      "id": "product-assembly-runtime",
       "original": [
         "product/scripts/dist.mjs"
       ],
-      "boundary": "Lifecycle ordering and product target guards form one pure assembly plan; product mechanics, platform adapters, and release behavior remain in dist.mjs.",
+      "boundary": "Source pins, platform package selection, no-optional acquisition, and lifecycle ordering form one explicit-input assembly runtime; product mechanics and release behavior remain in dist.mjs.",
       "target": "product/scripts/runtime-pin-snapshot.mjs",
-      "owner": "product/release",
-      "dependencyInvariant": "The plan receives all mechanics explicitly, preserves the existing Buildchain event order, and exposes no second CLI or product authority.",
+      "owner": "product/release-assembly-runtime",
+      "dependencyInvariant": "The runtime receives repository paths, command execution, logging, environment, package resolution, and product mechanics explicitly; it preserves Buildchain event order and exposes no CLI, publication, or second product authority.",
       "tests": [
         "product/scripts/dist.test.mjs",
         "framework/maintainability/semantic-amplification.test.mjs"
@@ -1937,7 +1937,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 2419,
+        "metric": 2110,
         "threshold": 2450,
         "finding": null
       },

--- a/framework/maintainability/semantic-amplification.manifest.json
+++ b/framework/maintainability/semantic-amplification.manifest.json
@@ -1200,14 +1200,14 @@
       "rollback": "Move the read-only evidence helpers back and preserve the existing re-export surface."
     },
     {
-      "id": "product-assembly-lifecycle",
+      "id": "product-assembly-runtime",
       "original": [
         "product/scripts/dist.mjs"
       ],
-      "boundary": "Lifecycle ordering and product target guards form one pure assembly plan; product mechanics, platform adapters, and release behavior remain in dist.mjs.",
+      "boundary": "Source pins, platform package selection, no-optional acquisition, and lifecycle ordering form one explicit-input assembly runtime; product mechanics and release behavior remain in dist.mjs.",
       "target": "product/scripts/runtime-pin-snapshot.mjs",
-      "owner": "product/release",
-      "dependencyInvariant": "The plan receives all mechanics explicitly, preserves the existing Buildchain event order, and exposes no second CLI or product authority.",
+      "owner": "product/release-assembly-runtime",
+      "dependencyInvariant": "The runtime receives repository paths, command execution, logging, environment, package resolution, and product mechanics explicitly; it preserves Buildchain event order and exposes no CLI, publication, or second product authority.",
       "tests": [
         "product/scripts/dist.test.mjs",
         "framework/maintainability/semantic-amplification.test.mjs"

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -37,7 +37,10 @@ import { normalizeCopiedSymlinks } from './portable-symlinks.mjs';
 import { productReleaseChannelConfig } from './release-channel-trust.mjs';
 import {
   assertSupportedProductHost,
+  createPlatformDependencyRuntime,
+  esbuildPlatformBinaryPath,
   readTrunkRuntimePinSnapshot,
+  requiresManagedEsbuildPlatform,
   runProductAssembly,
 } from './runtime-pin-snapshot.mjs';
 import {
@@ -49,6 +52,7 @@ import {
   resolveDesktopLocalArtifact,
 } from './upgrade-manifest.mjs';
 export { desktopUpdaterArtifact };
+export { esbuildPlatformBinaryPath, requiresManagedEsbuildPlatform };
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -200,49 +204,6 @@ function labelSlug(label) {
     .replace(/^\.+|\.+$/g, '');
 }
 
-function libnodePlatformPackageName() {
-  const packages = {
-    'darwin-arm64': '@kungfu-tech/libnode-darwin-arm64',
-    'linux-x64': '@kungfu-tech/libnode-linux-x64',
-    'linux-arm64': '@kungfu-tech/libnode-linux-arm64',
-    'win32-x64': '@kungfu-tech/libnode-win32-x64',
-  };
-  return packages[`${process.platform}-${process.arch}`];
-}
-
-function rollupPlatformPackageName() {
-  const libc = linuxLibc();
-  const packages = {
-    'darwin-arm64': '@rollup/rollup-darwin-arm64',
-    [`linux-arm64-${libc}`]: `@rollup/rollup-linux-arm64-${libc}`,
-    [`linux-x64-${libc}`]: `@rollup/rollup-linux-x64-${libc}`,
-    'win32-arm64': '@rollup/rollup-win32-arm64-msvc',
-    'win32-ia32': '@rollup/rollup-win32-ia32-msvc',
-    'win32-x64': '@rollup/rollup-win32-x64-msvc',
-  };
-  return packages[
-    `${process.platform}-${process.arch}${libc ? `-${libc}` : ''}`
-  ];
-}
-
-function esbuildPlatformPackageName() {
-  const packages = {
-    'darwin-arm64': '@esbuild/darwin-arm64',
-    'linux-x64': '@esbuild/linux-x64',
-    'linux-arm64': '@esbuild/linux-arm64',
-    'win32-x64': '@esbuild/win32-x64',
-  };
-  return packages[`${process.platform}-${process.arch}`];
-}
-
-function linuxLibc() {
-  if (process.platform !== 'linux') {
-    return '';
-  }
-  const report = process.report?.getReport?.();
-  return report?.header?.glibcVersionRuntime ? 'gnu' : 'musl';
-}
-
 export function installArgs(
   noOptional = process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL === '1',
 ) {
@@ -253,289 +214,19 @@ export function installArgs(
   return args;
 }
 
-function canResolve(packageName) {
-  try {
-    require.resolve(`${packageName}/package.json`);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function canResolveFrom(packageName, paths) {
-  try {
-    require.resolve(`${packageName}/package.json`, { paths });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function packageVersionFrom(packageName, paths) {
-  return readJson(require.resolve(`${packageName}/package.json`, { paths }))
-    .version;
-}
-
-function rollupPackagePathsFromGui() {
-  const vitePackageJson = require.resolve('vite/package.json', {
-    paths: [GUI_DIR],
-  });
-  const viteDir = path.dirname(vitePackageJson);
-  const rollupPackageJson = require.resolve('rollup/package.json', {
-    paths: [viteDir],
-  });
-  return [path.dirname(rollupPackageJson), viteDir];
-}
-
-function rollupVersionFromGui() {
-  return packageVersionFrom('rollup', rollupPackagePathsFromGui());
-}
-
-function packageJsonPath(nodePath, packageName) {
-  return path.join(nodePath, ...packageName.split('/'), 'package.json');
-}
-
-function appendNodePath(env, nodePaths) {
-  const nextNodePath = [...nodePaths, env.NODE_PATH || '']
-    .filter(Boolean)
-    .join(path.delimiter);
-  return nextNodePath ? { ...env, NODE_PATH: nextNodePath } : env;
-}
-
-function ensureNoOptionalPlatformPackage({
-  kind,
-  packageName,
-  version,
-  installRoot,
-}) {
-  const nodePath = path.join(installRoot, 'node_modules');
-  const installedPackageJson = packageJsonPath(nodePath, packageName);
-  const installedVersion = fs.existsSync(installedPackageJson)
-    ? readJson(installedPackageJson).version
-    : undefined;
-  if (installedVersion !== version) {
-    fs.rmSync(installRoot, { recursive: true, force: true });
-    fs.mkdirSync(installRoot, { recursive: true });
-    run(
-      `install ${kind} platform package`,
-      'npm',
-      [
-        'install',
-        '--no-save',
-        '--package-lock=false',
-        '--ignore-scripts',
-        // Platform packages can be published after a runner cached an older
-        // packument. Revalidate metadata through the configured registry so a
-        // warm cache cannot turn a real version into a false ETARGET.
-        '--prefer-online',
-        '--prefix',
-        installRoot,
-        `${packageName}@${version}`,
-      ],
-      {
-        phase: 'dependencies',
-        event: `product.${kind}.platform.install`,
-        attributes: {
-          packageName,
-          version,
-        },
-      },
-    );
-  } else {
-    buildchainLogger.mark(`product.${kind}.platform.cached`, {
-      phase: 'dependencies',
-      attributes: {
-        packageName,
-        version,
-      },
-    });
-  }
-
-  buildchainLogger.mark(`product.${kind}.platform.ready`, {
-    phase: 'dependencies',
-    attributes: {
-      packageName,
-      version,
-    },
-  });
-  return nodePath;
-}
-
-export function esbuildPlatformBinaryPath(packageRoot, platform) {
-  return path.join(
-    packageRoot,
-    platform === 'win32' ? 'esbuild.exe' : path.join('bin', 'esbuild'),
-  );
-}
-
-export function requiresManagedEsbuildPlatform({
-  noOptional,
-  hostVersion,
-  platformVersion,
-}) {
-  return noOptional && platformVersion !== hostVersion;
-}
-
-function ensureEsbuildRuntime({ slot, paths }) {
-  const packageJson = require.resolve('esbuild/package.json', { paths });
-  const esbuildVersion = readJson(packageJson).version;
-  const resolvePaths = [path.dirname(packageJson)];
-  const packageName = esbuildPlatformPackageName();
-  if (!packageName) {
-    throw new Error(
-      `unsupported esbuild platform: ${process.platform}-${process.arch}`,
-    );
-  }
-  let platformPackageJson;
-  try {
-    platformPackageJson = require.resolve(`${packageName}/package.json`, {
-      paths: resolvePaths,
-    });
-  } catch {
-    platformPackageJson = undefined;
-  }
-  const resolvedPlatformVersion = platformPackageJson
-    ? readJson(platformPackageJson).version
-    : undefined;
-  if (
-    requiresManagedEsbuildPlatform({
-      noOptional: process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL === '1',
-      hostVersion: esbuildVersion,
-      platformVersion: resolvedPlatformVersion,
-    })
-  ) {
-    const nodePath = ensureNoOptionalPlatformPackage({
-      kind: `esbuild.${slot}`,
-      packageName,
-      version: esbuildVersion,
-      installRoot: path.join(
-        ROOT,
-        '.buildchain',
-        'esbuild-platform',
-        slot,
-        `${process.platform}-${process.arch}`,
-      ),
-    });
-    platformPackageJson = packageJsonPath(nodePath, packageName);
-    resolvePaths.unshift(path.dirname(nodePath));
-  }
-  if (!platformPackageJson) {
-    throw new Error(`missing ${packageName} for esbuild ${esbuildVersion}`);
-  }
-  const platformVersion = readJson(platformPackageJson).version;
-  if (platformVersion !== esbuildVersion) {
-    throw new Error(
-      `esbuild host ${esbuildVersion} does not match ${packageName} ${platformVersion}`,
-    );
-  }
-  const binaryPath = esbuildPlatformBinaryPath(
-    path.dirname(platformPackageJson),
-    process.platform,
-  );
-  if (!fs.existsSync(binaryPath)) {
-    throw new Error(`missing ${packageName} binary: ${binaryPath}`);
-  }
-  return {
-    packageJson,
-    packageName,
-    resolvePaths,
-    binaryPath,
-  };
-}
-
-function guiEsbuildPackagePaths() {
-  const electronVitePackageJson = require.resolve(
-    'electron-vite/package.json',
-    { paths: [GUI_DIR] },
-  );
-  return [path.dirname(electronVitePackageJson)];
-}
-
-function buildchainSourceBuildEnv() {
-  if (process.env.KUNGFU_BUILDCHAIN_NO_OPTIONAL !== '1') {
-    buildchainLogger.mark('product.libnode.platform.optional', {
-      phase: 'dependencies',
-      attributes: {
-        noOptional: false,
-      },
-    });
-    return process.env;
-  }
-
-  const packageName = libnodePlatformPackageName();
-  if (!packageName) {
-    throw new Error(
-      `unsupported libnode platform: ${process.platform}-${process.arch}`,
-    );
-  }
-  const nodePaths = [];
-  if (canResolve(packageName)) {
-    buildchainLogger.mark('product.libnode.platform.resolved', {
-      phase: 'dependencies',
-      attributes: {
-        packageName,
-        source: 'workspace-node-path',
-      },
-    });
-  }
-
-  const corePackage = readJson(
-    path.join(ROOT, 'framework', 'core', 'package.json'),
-  );
-  const libnodeVersion = corePackage.devDependencies?.['@kungfu-tech/libnode'];
-  if (!libnodeVersion) {
-    throw new Error('framework/core must declare @kungfu-tech/libnode');
-  }
-
-  const installRoot = path.join(
-    ROOT,
-    '.buildchain',
-    'libnode-platform',
-    `${process.platform}-${process.arch}`,
-  );
-  if (!canResolve(packageName)) {
-    nodePaths.push(
-      ensureNoOptionalPlatformPackage({
-        kind: 'libnode',
-        packageName,
-        version: libnodeVersion,
-        installRoot,
-      }),
-    );
-  }
-
-  const rollupPackageName = rollupPlatformPackageName();
-  if (!rollupPackageName) {
-    throw new Error(
-      `unsupported rollup platform: ${process.platform}-${process.arch}`,
-    );
-  }
-  if (canResolveFrom(rollupPackageName, rollupPackagePathsFromGui())) {
-    buildchainLogger.mark('product.rollup.platform.resolved', {
-      phase: 'dependencies',
-      attributes: {
-        packageName: rollupPackageName,
-        source: 'workspace-node-path',
-      },
-    });
-  } else {
-    nodePaths.push(
-      ensureNoOptionalPlatformPackage({
-        kind: 'rollup',
-        packageName: rollupPackageName,
-        version: rollupVersionFromGui(),
-        installRoot: path.join(
-          ROOT,
-          '.buildchain',
-          'rollup-platform',
-          `${process.platform}-${process.arch}`,
-        ),
-      }),
-    );
-  }
-
-  return appendNodePath(process.env, nodePaths);
-}
+const platformDependencyRuntime = createPlatformDependencyRuntime({
+  root: ROOT,
+  guiDir: GUI_DIR,
+  readJson,
+  run,
+  logger: buildchainLogger,
+  requireFn: require,
+});
+const {
+  buildchainSourceBuildEnv,
+  ensureEsbuildRuntime,
+  guiEsbuildPackagePaths,
+} = platformDependencyRuntime;
 
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -15,12 +15,10 @@ import {
   cliArchiveLayout,
   copyTree,
   desktopUpdaterArtifact,
-  esbuildPlatformBinaryPath,
   installArgs,
   installedKungfuInvocation,
   isShippedKfdSupport,
   kfxBundleExternalModules,
-  requiresManagedEsbuildPlatform,
   runInstalledKungfuAgentHubSmoke,
   runInstalledKungfuAssignmentAdmissionSmoke,
   runInstalledKungfuCommand,
@@ -32,6 +30,12 @@ import {
   productReleaseChannelConfig,
   releaseChannelKeyId,
 } from './release-channel-trust.mjs';
+import {
+  PLATFORM_DEPENDENCY_RUNTIME_OWNER,
+  esbuildPlatformBinaryPath,
+  platformDependencyPackageName,
+  requiresManagedEsbuildPlatform,
+} from './runtime-pin-snapshot.mjs';
 import {
   INTEL_MACOS_DIAGNOSTIC,
   PRODUCT_ASSEMBLY_STAGE_IDS,
@@ -860,10 +864,17 @@ test('CLI staging carries the Xinfa contract and verification engine', () => {
 
 test('installed SDK keeps esbuild external and carries its native runtime', () => {
   const dist = fs.readFileSync(new URL('./dist.mjs', import.meta.url), 'utf8');
+  const runtime = fs.readFileSync(
+    new URL('./runtime-pin-snapshot.mjs', import.meta.url),
+    'utf8',
+  );
   assert.match(dist, /external: \['esbuild'\]/);
   assert.match(dist, /'esbuild',\s+esbuildRuntime\.resolvePaths/);
-  assert.match(dist, /function esbuildPlatformPackageName\(\)/);
-  assert.match(dist, /function ensureEsbuildRuntime\(\{ slot, paths \}\)/);
+  assert.match(runtime, /esbuild: \{/);
+  assert.match(
+    runtime,
+    /const ensureEsbuildRuntime = \(\{ slot, paths \}\) =>/,
+  );
   assert.match(
     dist,
     /process\.env\.ESBUILD_BINARY_PATH = esbuildRuntime\.binaryPath/,
@@ -884,12 +895,12 @@ test('Buildchain stages exact esbuild binaries per product surface', () => {
     assert.match(dist, new RegExp(`slot: '${slot}'`));
   }
   assert.match(dist, /esbuild-platform',\s+slot/);
-  assert.match(dist, /installedVersion !== version/);
+  assert.match(dist, /installed !== version/);
   assert.match(dist, /requiresManagedEsbuildPlatform/);
   assert.match(dist, /resolvePaths\.unshift\(path\.dirname\(nodePath\)\)/);
   assert.match(
     dist,
-    /esbuild host \$\{esbuildVersion\} does not match \$\{packageName\} \$\{platformVersion\}/,
+    /esbuild host \$\{version\} does not match \$\{packageName\} \$\{platformVersion\}/,
   );
   assert.match(dist, /buildKfx\(kfxPackages, sdkBuildEnv\)/);
   assert.match(dist, /'bundle tui',[\s\S]+?env: tuiBuildEnv/);
@@ -920,9 +931,37 @@ test('product assembly stages have one ordered lifecycle owner', () => {
 });
 
 test('platform package installs revalidate registry metadata', () => {
+  const runtime = fs.readFileSync(
+    new URL('./runtime-pin-snapshot.mjs', import.meta.url),
+    'utf8',
+  );
+  assert.match(runtime, /'--prefer-online'/);
+  assert.doesNotMatch(runtime, /'--prefer-offline'/);
+});
+
+test('platform dependency lifecycle has one named owner and restores dist headroom', () => {
   const dist = fs.readFileSync(new URL('./dist.mjs', import.meta.url), 'utf8');
-  assert.match(dist, /'--prefer-online'/);
-  assert.doesNotMatch(dist, /'--prefer-offline'/);
+  assert.equal(
+    PLATFORM_DEPENDENCY_RUNTIME_OWNER,
+    'product/release-assembly-runtime',
+  );
+  assert.ok(dist.split(/\r?\n/u).length <= 2200);
+  assert.match(dist, /createPlatformDependencyRuntime\(\{/u);
+  assert.doesNotMatch(dist, /function ensureNoOptionalPlatformPackage/u);
+});
+
+test('platform dependency owner preserves macOS, Linux, and Windows package identities', () => {
+  const fixtures = [
+    ['libnode', 'darwin', 'arm64', '', '@kungfu-tech/libnode-darwin-arm64'],
+    ['rollup', 'linux', 'x64', 'gnu', '@rollup/rollup-linux-x64-gnu'],
+    ['esbuild', 'win32', 'x64', '', '@esbuild/win32-x64'],
+  ];
+  for (const [kind, platform, architecture, libc, expected] of fixtures) {
+    assert.equal(
+      platformDependencyPackageName(kind, { platform, architecture, libc }),
+      expected,
+    );
+  }
 });
 
 test('esbuild platform binary follows the native package layout', () => {

--- a/product/scripts/runtime-pin-snapshot.mjs
+++ b/product/scripts/runtime-pin-snapshot.mjs
@@ -14,6 +14,282 @@ const SUPPORTED_PRODUCT_TARGETS = new Set([
   'win32/x64',
 ]);
 
+export const PLATFORM_DEPENDENCY_RUNTIME_OWNER =
+  'product/release-assembly-runtime';
+
+const PLATFORM_DEPENDENCY_PACKAGES = {
+  libnode: {
+    'darwin-arm64': '@kungfu-tech/libnode-darwin-arm64',
+    'linux-x64': '@kungfu-tech/libnode-linux-x64',
+    'linux-arm64': '@kungfu-tech/libnode-linux-arm64',
+    'win32-x64': '@kungfu-tech/libnode-win32-x64',
+  },
+  rollup: {
+    'darwin-arm64': '@rollup/rollup-darwin-arm64',
+    'linux-arm64-gnu': '@rollup/rollup-linux-arm64-gnu',
+    'linux-arm64-musl': '@rollup/rollup-linux-arm64-musl',
+    'linux-x64-gnu': '@rollup/rollup-linux-x64-gnu',
+    'linux-x64-musl': '@rollup/rollup-linux-x64-musl',
+    'win32-arm64': '@rollup/rollup-win32-arm64-msvc',
+    'win32-ia32': '@rollup/rollup-win32-ia32-msvc',
+    'win32-x64': '@rollup/rollup-win32-x64-msvc',
+  },
+  esbuild: {
+    'darwin-arm64': '@esbuild/darwin-arm64',
+    'linux-x64': '@esbuild/linux-x64',
+    'linux-arm64': '@esbuild/linux-arm64',
+    'win32-x64': '@esbuild/win32-x64',
+  },
+};
+
+export function platformDependencyPackageName(
+  kind,
+  { platform, architecture, libc = '' },
+) {
+  const suffix = kind === 'rollup' && libc ? `-${libc}` : '';
+  return PLATFORM_DEPENDENCY_PACKAGES[kind]?.[
+    `${platform}-${architecture}${suffix}`
+  ];
+}
+
+export function esbuildPlatformBinaryPath(packageRoot, platform) {
+  return path.join(
+    packageRoot,
+    platform === 'win32' ? 'esbuild.exe' : path.join('bin', 'esbuild'),
+  );
+}
+
+export function requiresManagedEsbuildPlatform({
+  noOptional,
+  hostVersion,
+  platformVersion,
+}) {
+  return noOptional && platformVersion !== hostVersion;
+}
+
+// Explicit inputs keep package acquisition subordinate to product assembly:
+// this owner selects and prepares platform dependencies, but cannot sequence,
+// publish, or qualify a product on its own.
+export function createPlatformDependencyRuntime({
+  root,
+  guiDir,
+  readJson,
+  run,
+  logger,
+  requireFn,
+  env = process.env,
+  platform = process.platform,
+  architecture = process.arch,
+  report = process.report,
+}) {
+  const platformIdentity = () => `${platform}-${architecture}`;
+  const linuxLibc = () => {
+    if (platform !== 'linux') return '';
+    return report?.getReport?.()?.header?.glibcVersionRuntime ? 'gnu' : 'musl';
+  };
+  const platformPackage = (kind) =>
+    platformDependencyPackageName(kind, {
+      platform,
+      architecture,
+      libc: linuxLibc(),
+    });
+  const canResolve = (packageName, paths) => {
+    try {
+      requireFn.resolve(`${packageName}/package.json`, paths ? { paths } : {});
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const packageJsonPath = (nodePath, packageName) =>
+    path.join(nodePath, ...packageName.split('/'), 'package.json');
+  const rollupPaths = () => {
+    const vite = requireFn.resolve('vite/package.json', { paths: [guiDir] });
+    const viteDir = path.dirname(vite);
+    const rollup = requireFn.resolve('rollup/package.json', {
+      paths: [viteDir],
+    });
+    return [path.dirname(rollup), viteDir];
+  };
+  const appendNodePath = (baseEnv, nodePaths) => {
+    const value = [...nodePaths, baseEnv.NODE_PATH || '']
+      .filter(Boolean)
+      .join(path.delimiter);
+    return value ? { ...baseEnv, NODE_PATH: value } : baseEnv;
+  };
+  const ensurePackage = ({ kind, packageName, version, installRoot }) => {
+    const nodePath = path.join(installRoot, 'node_modules');
+    const packageJson = packageJsonPath(nodePath, packageName);
+    const installed = fs.existsSync(packageJson)
+      ? readJson(packageJson).version
+      : undefined;
+    if (installed !== version) {
+      fs.rmSync(installRoot, { recursive: true, force: true });
+      fs.mkdirSync(installRoot, { recursive: true });
+      run(
+        `install ${kind} platform package`,
+        'npm',
+        [
+          'install',
+          '--no-save',
+          '--package-lock=false',
+          '--ignore-scripts',
+          '--prefer-online',
+          '--prefix',
+          installRoot,
+          `${packageName}@${version}`,
+        ],
+        {
+          phase: 'dependencies',
+          event: `product.${kind}.platform.install`,
+          attributes: { packageName, version },
+        },
+      );
+    } else {
+      logger.mark(`product.${kind}.platform.cached`, {
+        phase: 'dependencies',
+        attributes: { packageName, version },
+      });
+    }
+    logger.mark(`product.${kind}.platform.ready`, {
+      phase: 'dependencies',
+      attributes: { packageName, version },
+    });
+    return nodePath;
+  };
+  const ensureEsbuildRuntime = ({ slot, paths }) => {
+    const packageJson = requireFn.resolve('esbuild/package.json', { paths });
+    const version = readJson(packageJson).version;
+    const resolvePaths = [path.dirname(packageJson)];
+    const packageName = platformPackage('esbuild');
+    if (!packageName)
+      throw new Error(`unsupported esbuild platform: ${platformIdentity()}`);
+    let platformJson;
+    try {
+      platformJson = requireFn.resolve(`${packageName}/package.json`, {
+        paths: resolvePaths,
+      });
+    } catch {
+      platformJson = undefined;
+    }
+    if (
+      requiresManagedEsbuildPlatform({
+        noOptional: env.KUNGFU_BUILDCHAIN_NO_OPTIONAL === '1',
+        hostVersion: version,
+        platformVersion: platformJson
+          ? readJson(platformJson).version
+          : undefined,
+      })
+    ) {
+      const nodePath = ensurePackage({
+        kind: `esbuild.${slot}`,
+        packageName,
+        version,
+        installRoot: path.join(
+          root,
+          '.buildchain',
+          'esbuild-platform',
+          slot,
+          platformIdentity(),
+        ),
+      });
+      platformJson = packageJsonPath(nodePath, packageName);
+      resolvePaths.unshift(path.dirname(nodePath));
+    }
+    if (!platformJson)
+      throw new Error(`missing ${packageName} for esbuild ${version}`);
+    const platformVersion = readJson(platformJson).version;
+    if (platformVersion !== version)
+      throw new Error(
+        `esbuild host ${version} does not match ${packageName} ${platformVersion}`,
+      );
+    const binaryPath = esbuildPlatformBinaryPath(
+      path.dirname(platformJson),
+      platform,
+    );
+    if (!fs.existsSync(binaryPath))
+      throw new Error(`missing ${packageName} binary: ${binaryPath}`);
+    return { packageJson, packageName, resolvePaths, binaryPath };
+  };
+  const guiEsbuildPackagePaths = () => {
+    const electronVite = requireFn.resolve('electron-vite/package.json', {
+      paths: [guiDir],
+    });
+    return [path.dirname(electronVite)];
+  };
+  const buildchainSourceBuildEnv = () => {
+    if (env.KUNGFU_BUILDCHAIN_NO_OPTIONAL !== '1') {
+      logger.mark('product.libnode.platform.optional', {
+        phase: 'dependencies',
+        attributes: { noOptional: false },
+      });
+      return env;
+    }
+    const libnode = platformPackage('libnode');
+    if (!libnode)
+      throw new Error(`unsupported libnode platform: ${platformIdentity()}`);
+    const nodePaths = [];
+    if (canResolve(libnode))
+      logger.mark('product.libnode.platform.resolved', {
+        phase: 'dependencies',
+        attributes: { packageName: libnode, source: 'workspace-node-path' },
+      });
+    const corePackage = readJson(
+      path.join(root, 'framework', 'core', 'package.json'),
+    );
+    const libnodeVersion =
+      corePackage.devDependencies?.['@kungfu-tech/libnode'];
+    if (!libnodeVersion)
+      throw new Error('framework/core must declare @kungfu-tech/libnode');
+    if (!canResolve(libnode))
+      nodePaths.push(
+        ensurePackage({
+          kind: 'libnode',
+          packageName: libnode,
+          version: libnodeVersion,
+          installRoot: path.join(
+            root,
+            '.buildchain',
+            'libnode-platform',
+            platformIdentity(),
+          ),
+        }),
+      );
+    const rollup = platformPackage('rollup');
+    if (!rollup)
+      throw new Error(`unsupported rollup platform: ${platformIdentity()}`);
+    const paths = rollupPaths();
+    if (canResolve(rollup, paths))
+      logger.mark('product.rollup.platform.resolved', {
+        phase: 'dependencies',
+        attributes: { packageName: rollup, source: 'workspace-node-path' },
+      });
+    else {
+      const rollupJson = requireFn.resolve('rollup/package.json', { paths });
+      nodePaths.push(
+        ensurePackage({
+          kind: 'rollup',
+          packageName: rollup,
+          version: readJson(rollupJson).version,
+          installRoot: path.join(
+            root,
+            '.buildchain',
+            'rollup-platform',
+            platformIdentity(),
+          ),
+        }),
+      );
+    }
+    return appendNodePath(env, nodePaths);
+  };
+  return {
+    owner: PLATFORM_DEPENDENCY_RUNTIME_OWNER,
+    buildchainSourceBuildEnv,
+    ensureEsbuildRuntime,
+    guiEsbuildPackagePaths,
+  };
+}
+
 export function assertSupportedProductHost({
   platform = process.platform,
   architecture = process.arch,

--- a/scripts/check-readonly-source-routes.mjs
+++ b/scripts/check-readonly-source-routes.mjs
@@ -18,6 +18,14 @@ const REQUIRED_AGENT_DISCOVERY = [
   'kungfu agent status --target <agent> --json',
   'kungfu agent work inspect --ref <ref> --json',
 ];
+const REQUIRED_SOURCE_ACCEPTANCE_DENIALS = [
+  '_tmp_*',
+  '.buildchain/diagnostics/*.tmp-*',
+  '.pnpm-store/**',
+  'generated-fixtures/**',
+  'nested-task-output/**',
+];
+const SOURCE_ACCEPTANCE_WRITER_OWNER = 'source-acceptance-runtime';
 
 function sourceCommand(command) {
   const normalized = command
@@ -69,6 +77,31 @@ export function validateReadonlyRouteInventory(
     }
     if (!route.implementation || !exists(path.join(ROOT, route.implementation)))
       diagnostics.push({ code: 'route-implementation', id: route.id || '' });
+    if (route.id === 'source-acceptance') {
+      if (
+        !route.runtimeImplementation ||
+        !exists(path.join(ROOT, route.runtimeImplementation))
+      )
+        diagnostics.push({
+          code: 'source-runtime-implementation',
+          id: route.id,
+        });
+      if (route.writerOwner !== SOURCE_ACCEPTANCE_WRITER_OWNER)
+        diagnostics.push({ code: 'source-writer-owner', id: route.id });
+      if (!String(route.recovery || '').includes('OS runtime root'))
+        diagnostics.push({ code: 'source-writer-recovery', id: route.id });
+      const denied = new Set(route.deniedCheckoutWriters || []);
+      for (const writer of REQUIRED_SOURCE_ACCEPTANCE_DENIALS) {
+        if (!denied.has(writer))
+          diagnostics.push({
+            code: 'source-writer-denial',
+            id: route.id,
+            writer,
+            owner: SOURCE_ACCEPTANCE_WRITER_OWNER,
+            recovery: route.recovery || '',
+          });
+      }
+    }
   }
   const declaredSource = new Set(
     routes

--- a/scripts/check-readonly-source-routes.test.mjs
+++ b/scripts/check-readonly-source-routes.test.mjs
@@ -29,3 +29,27 @@ test('unclassified, writing, or missing routes fail closed', () => {
   assert.ok(codes.includes('read-route-side-effect'));
   assert.ok(codes.includes('route-implementation'));
 });
+
+test('source acceptance requires exact writer ownership, recovery, and checkout denials', () => {
+  const broken = structuredClone(inventory);
+  const source = broken.routes.find(
+    (route) => route.id === 'source-acceptance',
+  );
+  source.writerOwner = 'nested-task';
+  source.recovery = '';
+  source.deniedCheckoutWriters = [];
+  const diagnostics = validateReadonlyRouteInventory(broken);
+  const codes = diagnostics.map((item) => item.code);
+  assert.ok(codes.includes('source-writer-owner'));
+  assert.ok(codes.includes('source-writer-recovery'));
+  assert.equal(
+    diagnostics.filter((item) => item.code === 'source-writer-denial').length,
+    5,
+  );
+  for (const item of diagnostics.filter(
+    (diagnostic) => diagnostic.code === 'source-writer-denial',
+  )) {
+    assert.equal(item.owner, 'source-acceptance-runtime');
+    assert.equal(item.recovery, '');
+  }
+});

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -611,14 +611,27 @@ test('runtime guard rejects a direct task and accepts Shifu provenance', () => {
   assert.equal(accepted.status, 0);
 });
 
-test('package manager cannot run a guarded root task without a canonical Shifu correction', () => {
-  const corepack = process.platform === 'win32' ? 'corepack.cmd' : 'corepack';
-  const direct = spawnSync(corepack, ['pnpm', 'run', 'check:entry-contract'], {
-    cwd: ROOT,
-    encoding: 'utf8',
-    env: { ...process.env, SHIFU_ENTRYPOINT: '' },
-    shell: process.platform === 'win32',
-  });
+test('package task guard rejects direct package-manager provenance without repository writes', (t) => {
+  const runtimeRoot =
+    process.env.KUNGFU_SOURCE_ACCEPTANCE_RUNTIME_ROOT || os.tmpdir();
+  const fixture = fs.mkdtempSync(
+    path.join(runtimeRoot, 'kungfu-package-manager-guard-'),
+  );
+  t.after(() => fs.rmSync(fixture, { recursive: true, force: true }));
+  const direct = spawnSync(
+    process.execPath,
+    [path.join(ROOT, 'scripts', 'require-shifu.mjs'), 'check:entry-contract'],
+    {
+      cwd: fixture,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        SHIFU_ENTRYPOINT: '',
+        npm_command: 'run-script',
+        npm_lifecycle_event: 'check:entry-contract',
+      },
+    },
+  );
   const output = `${direct.stdout}\n${direct.stderr}`;
   assert.equal(direct.status, 1);
   assert.match(output, /Direct package-manager invocation is unsupported/);
@@ -627,4 +640,5 @@ test('package manager cannot run a guarded root task without a canonical Shifu c
     /\[shifu-entry\] Run: \.\/shifu (?:install|check:entry-contract)(?:\r?\n|$)/,
   );
   assert.doesNotMatch(output, /\[shifu-entry\] Run: (?:corepack|node|pnpm)\b/);
+  assert.deepEqual(fs.readdirSync(fixture), []);
 });

--- a/scripts/readonly-agent-bootstrap.test.mjs
+++ b/scripts/readonly-agent-bootstrap.test.mjs
@@ -75,6 +75,16 @@ function executableOnPath(name) {
   throw new Error(`${name} is not available on PATH`);
 }
 
+function declaredExecutable(name, candidate) {
+  if (!candidate) return null;
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return candidate;
+  } catch {
+    throw new Error(`${name} is not executable: ${candidate}`);
+  }
+}
+
 function snapshotSource(root) {
   const rows = [];
   const visit = (directory) => {
@@ -189,9 +199,11 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
   assert.equal(cloned.status, 0, cloned.stderr);
   const base = sourceMergeBase();
   const corePytest = path.join(ROOT, 'framework/core/.venv/bin/pytest');
-  const pytest = fs.existsSync(corePytest)
-    ? corePytest
-    : executableOnPath('pytest');
+  const pytest =
+    declaredExecutable(
+      'KUNGFU_READONLY_PYTEST',
+      process.env.KUNGFU_READONLY_PYTEST,
+    ) || (fs.existsSync(corePytest) ? corePytest : executableOnPath('pytest'));
   const fixedBase = spawnSync(
     git,
     ['update-ref', 'refs/heads/dev/v4/v4.0', base.sha],

--- a/scripts/readonly-agent-bootstrap.test.mjs
+++ b/scripts/readonly-agent-bootstrap.test.mjs
@@ -101,6 +101,36 @@ function snapshotSource(root) {
   return rows;
 }
 
+function sourceAuditRoot(rows) {
+  const hash = crypto.createHash('sha256');
+  for (const row of rows) hash.update(row).update('\0');
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function boundedDiagnosticTail(...values) {
+  const [stderr] = values;
+  if (stderr) return stderr.slice(-24 * 1024);
+  const output = values.filter(Boolean).join('\n');
+  const lines = output.split(/\r?\n/u);
+  const failingTestsIndex = lines.findLastIndex(
+    (line) => line.trim() === '✖ failing tests:',
+  );
+  if (failingTestsIndex >= 0)
+    return lines
+      .slice(failingTestsIndex, failingTestsIndex + 120)
+      .join('\n')
+      .slice(0, 24 * 1024);
+  const failureSummaryIndex = lines.findLastIndex((line) =>
+    /^(?:ℹ fail [1-9]|# fail [1-9])/u.test(line.trimStart()),
+  );
+  if (failureSummaryIndex >= 0)
+    return lines
+      .slice(Math.max(0, failureSummaryIndex - 8), failureSummaryIndex + 40)
+      .join('\n')
+      .slice(0, 24 * 1024);
+  return output.slice(-24 * 1024);
+}
+
 function makeReadOnly(root) {
   const directories = [];
   const visit = (directory) => {
@@ -522,6 +552,7 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
   }
 
   const before = snapshotSource(fixture);
+  const beforeAuditRoot = sourceAuditRoot(before);
   const protectedRef = base.sha;
   makeReadOnly(fixture);
   fs.chmodSync(home, 0o555);
@@ -631,11 +662,18 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
   assert.equal(
     sourceAcceptance.status,
     0,
-    `check:source:\n${[sourceAcceptance.stderr, sourceAcceptance.stdout]
-      .filter(Boolean)
-      .join('\n')}`,
+    `check:source (bounded tail):\n${boundedDiagnosticTail(
+      sourceAcceptance.stderr,
+      sourceAcceptance.stdout,
+    )}`,
   );
-  assert.deepEqual(snapshotSource(fixture), before);
+  const after = snapshotSource(fixture);
+  const afterAuditRoot = sourceAuditRoot(after);
+  assert.deepEqual(after, before);
+  assert.equal(afterAuditRoot, beforeAuditRoot);
+  console.log(
+    `[readonly-source] filesystem-write-audit before=${beforeAuditRoot} after=${afterAuditRoot} byteUnchanged=true`,
+  );
   assert.equal(fs.existsSync(toolLog), false, 'bootstrap tool was invoked');
   assert.deepEqual(fs.readdirSync(home), [], 'read-only route wrote into HOME');
   assert.equal(

--- a/scripts/readonly-source-toolchain.mjs
+++ b/scripts/readonly-source-toolchain.mjs
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-check
 
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
 
 // A bounded YAML 1.2 reader for committed GitHub workflow contracts. It covers
 // mappings, sequences, quoted/plain scalars, flow collections, and literal or
@@ -311,4 +316,156 @@ export function optionalAjv2020() {
     else throw error;
   }
   return cachedAjv;
+}
+
+export const SOURCE_ACCEPTANCE_RUNTIME_OWNER = 'source-acceptance-runtime';
+export const SOURCE_ACCEPTANCE_RECOVERY =
+  'move disposable writes to the declared OS runtime root; run legitimate materialization in an isolated worktree and exclude it from ./shifu check:source';
+
+function digestRows(rows) {
+  const hash = crypto.createHash('sha256');
+  for (const row of rows) hash.update(row).update('\0');
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function gitNull(root, args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'buffer',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status !== 0)
+    throw new Error(
+      `git ${args.join(' ')} failed: ${String(result.stderr || '').trim()}`,
+    );
+  return result.stdout.toString('utf8').split('\0').filter(Boolean);
+}
+
+function pathInside(root, target) {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== '..' &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function resolveThroughExistingAncestor(target) {
+  let cursor = path.resolve(target);
+  const suffix = [];
+  while (!fs.existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) break;
+    suffix.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+  return path.resolve(fs.realpathSync(cursor), ...suffix);
+}
+
+export function assertExternalSourceAcceptanceTarget(
+  checkoutRoot,
+  target,
+  label = 'write target',
+) {
+  const canonicalCheckout = fs.realpathSync(checkoutRoot);
+  const canonicalTarget = resolveThroughExistingAncestor(target);
+  if (pathInside(canonicalCheckout, canonicalTarget))
+    throw new Error(
+      `${label} is inside the protected checkout; owner=${SOURCE_ACCEPTANCE_RUNTIME_OWNER}; recovery=${SOURCE_ACCEPTANCE_RECOVERY}`,
+    );
+  return canonicalTarget;
+}
+
+export function sourceCheckoutSnapshot(root) {
+  const rows = (kind, paths) =>
+    paths.sort().map((relative) => {
+      const absolute = path.join(root, relative);
+      const stat = fs.lstatSync(absolute);
+      const bytes = stat.isSymbolicLink()
+        ? Buffer.from(fs.readlinkSync(absolute))
+        : fs.readFileSync(absolute);
+      return `${kind}:${stat.isSymbolicLink() ? 'link' : 'file'}:${relative}:${crypto
+        .createHash('sha256')
+        .update(bytes)
+        .digest('hex')}`;
+    });
+  const tracked = gitNull(root, ['ls-files', '-z']);
+  const untracked = gitNull(root, [
+    'ls-files',
+    '--others',
+    '--exclude-standard',
+    '-z',
+  ]);
+  return {
+    trackedTreeRoot: digestRows(rows('tracked', tracked)),
+    untrackedInventoryRoot: digestRows(rows('untracked', untracked)),
+    trackedCount: tracked.length,
+    untrackedCount: untracked.length,
+  };
+}
+
+export function assertSourceCheckoutUnchanged(before, after) {
+  for (const key of ['trackedTreeRoot', 'untrackedInventoryRoot'])
+    if (before[key] !== after[key])
+      throw new Error(
+        `protected checkout ${key} changed during source acceptance; owner=${SOURCE_ACCEPTANCE_RUNTIME_OWNER}; recovery=${SOURCE_ACCEPTANCE_RECOVERY}`,
+      );
+}
+
+export function prepareSourceAcceptanceRuntime(
+  checkoutRoot,
+  baseEnv = process.env,
+) {
+  // tsx opens an IPC socket below TMPDIR. Darwin's Unix-domain socket path is
+  // short enough that the normal per-user os.tmpdir() prefix can overflow it,
+  // so POSIX source acceptance owns a deliberately short OS runtime root.
+  // Windows has no Unix socket path limit and retains its runner/system temp.
+  const runtimeParent =
+    process.platform === 'win32' ? baseEnv.RUNNER_TEMP || os.tmpdir() : '/tmp';
+  const osTemp = assertExternalSourceAcceptanceTarget(
+    checkoutRoot,
+    runtimeParent,
+    'OS temporary root',
+  );
+  const runtimeRoot = fs.mkdtempSync(path.join(osTemp, 'kf-sa-'));
+  const directories = Object.fromEntries(
+    [
+      'tmp',
+      'cache',
+      'state',
+      'corepack',
+      'pnpm-home',
+      'npm-cache',
+      'diagnostics',
+    ].map((name) => [name, path.join(runtimeRoot, name)]),
+  );
+  for (const directory of Object.values(directories))
+    fs.mkdirSync(directory, { recursive: true });
+  return {
+    owner: SOURCE_ACCEPTANCE_RUNTIME_OWNER,
+    recovery: SOURCE_ACCEPTANCE_RECOVERY,
+    runtimeRoot,
+    env: {
+      ...baseEnv,
+      TMPDIR: directories.tmp,
+      TMP: directories.tmp,
+      TEMP: directories.tmp,
+      XDG_CACHE_HOME: directories.cache,
+      XDG_STATE_HOME: directories.state,
+      COREPACK_HOME: directories.corepack,
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+      PNPM_HOME: directories['pnpm-home'],
+      npm_config_cache: directories['npm-cache'],
+      NPM_CONFIG_CACHE: directories['npm-cache'],
+      SHIFU_CACHE_RECEIPT: path.join(
+        directories.diagnostics,
+        'shifu-cache-resolution.json',
+      ),
+      KUNGFU_SOURCE_ACCEPTANCE_RUNTIME_ROOT: runtimeRoot,
+    },
+    cleanup() {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    },
+  };
 }

--- a/scripts/shifu-gate-executor.test.mjs
+++ b/scripts/shifu-gate-executor.test.mjs
@@ -549,6 +549,7 @@ test('task actions re-enter an existing lightweight Shifu task beside an active 
       SHIFU_CACHE_PROFILE_REF: profilePath,
       SHIFU_CACHE_PROFILE_DIGEST: sha256(profileBytes),
       SHIFU_CACHE_SCOPE: 'self-hosted-runner',
+      SHIFU_CACHE_RECEIPT: path.join(directory, 'shifu-cache-resolution.json'),
       RUNNER_NAME: runnerName,
       SHIFU_CACHE_ACTIVE: undefined,
       SHIFU_CACHE_BYPASS: undefined,

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -11,6 +11,11 @@ import {
   checkDevChannelAuthority,
   devMergeBaseCandidates,
 } from './candidate-timeline-events.cjs';
+import {
+  assertSourceCheckoutUnchanged,
+  prepareSourceAcceptanceRuntime,
+  sourceCheckoutSnapshot,
+} from './readonly-source-toolchain.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CPP = /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/;
@@ -897,12 +902,12 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
 }
 
 /** @param {Command} step */
-function run(step) {
+function run(step, sourceEnv = process.env) {
   console.log(`\n[source-acceptance] ${step.label}`);
   console.log(`[source-acceptance] $ ${step.command} ${step.args.join(' ')}`);
   const result = spawnSync(step.command, step.args, {
     cwd: step.cwd || ROOT,
-    env: step.env || process.env,
+    env: { ...sourceEnv, ...(step.env || {}) },
     stdio: 'inherit',
   });
   if (result.error || result.status !== 0) {
@@ -921,25 +926,46 @@ function run(step) {
 }
 
 function main() {
-  const files = sourceChangedFiles();
-  console.log(`[source-acceptance] changed files: ${files.length}`);
-  if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE !== '1') {
-    assertYijinjingWriterInterface();
-    console.log('[source-acceptance] yijinjing writer interface passed');
-  }
-  const devChannels = checkDevChannelAuthority();
+  const before = sourceCheckoutSnapshot(ROOT);
+  const runtime = prepareSourceAcceptanceRuntime(ROOT);
   console.log(
-    `\n[source-acceptance] dev channel authority\n${JSON.stringify(devChannels, null, 2)}`,
+    `[source-acceptance] trackedTreeRoot=${before.trackedTreeRoot} untrackedInventoryRoot=${before.untrackedInventoryRoot}`,
   );
-  if (devChannels.verdict !== 'pass')
-    throw new Error('dev channel authority failed');
-  if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE === '1') {
-    console.warn(
-      '[source-acceptance] cold read-only lane: the installed TypeScript dependency graph is absent; normal source acceptance and CI enforce tooling type checks.',
+  let failure;
+  try {
+    const files = sourceChangedFiles();
+    console.log(`[source-acceptance] changed files: ${files.length}`);
+    if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE !== '1') {
+      assertYijinjingWriterInterface();
+      console.log('[source-acceptance] yijinjing writer interface passed');
+    }
+    const devChannels = checkDevChannelAuthority();
+    console.log(
+      `\n[source-acceptance] dev channel authority\n${JSON.stringify(devChannels, null, 2)}`,
     );
+    if (devChannels.verdict !== 'pass')
+      throw new Error('dev channel authority failed');
+    if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE === '1') {
+      console.warn(
+        '[source-acceptance] cold read-only lane: the installed TypeScript dependency graph is absent; normal source acceptance and CI enforce tooling type checks.',
+      );
+    }
+    for (const step of sourceAcceptancePlan(files, sourceMergeBase().sha))
+      run(step, runtime.env);
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      const after = sourceCheckoutSnapshot(ROOT);
+      assertSourceCheckoutUnchanged(before, after);
+      console.log(
+        `[source-acceptance] zero-write trackedTreeRoot=${after.trackedTreeRoot} untrackedInventoryRoot=${after.untrackedInventoryRoot}`,
+      );
+    } finally {
+      runtime.cleanup();
+    }
   }
-  for (const step of sourceAcceptancePlan(files, sourceMergeBase().sha))
-    run(step);
+  if (failure) throw failure;
   console.log('\n[source-acceptance] build-free source gate passed');
 }
 

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -9,6 +9,11 @@ import { fileURLToPath } from 'node:url';
 
 import { scanTree } from './no-bash-guard.mjs';
 import {
+  SOURCE_ACCEPTANCE_RUNTIME_OWNER,
+  assertExternalSourceAcceptanceTarget,
+  prepareSourceAcceptanceRuntime,
+} from './readonly-source-toolchain.mjs';
+import {
   assertKfdEvidenceSourceBinding,
   findGitTreeEquivalentAncestor,
   isLocalQualificationRuntime,
@@ -21,6 +26,79 @@ import {
 } from './source-acceptance.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('source acceptance owns one external runtime for every writable tool surface', (t) => {
+  const runtime = prepareSourceAcceptanceRuntime(ROOT);
+  t.after(runtime.cleanup);
+  assert.equal(runtime.owner, SOURCE_ACCEPTANCE_RUNTIME_OWNER);
+  if (process.platform !== 'win32') {
+    assert.equal(
+      runtime.runtimeRoot.startsWith('/private/tmp/kf-sa-') ||
+        runtime.runtimeRoot.startsWith('/tmp/kf-sa-'),
+      true,
+    );
+    assert.equal(runtime.env.TMPDIR.length < 80, true);
+  }
+  for (const key of [
+    'TMPDIR',
+    'XDG_CACHE_HOME',
+    'XDG_STATE_HOME',
+    'COREPACK_HOME',
+    'PNPM_HOME',
+    'npm_config_cache',
+    'SHIFU_CACHE_RECEIPT',
+  ]) {
+    assert.doesNotThrow(() =>
+      assertExternalSourceAcceptanceTarget(ROOT, runtime.env[key], key),
+    );
+  }
+});
+
+test('repo-local temporary, cache, fixture, and nested task writers fail before mutation', (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-source-writer-denial-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+  const checkout = path.join(temporary, 'checkout');
+  fs.mkdirSync(checkout);
+  const sentinel = path.join(checkout, 'sentinel');
+  fs.writeFileSync(sentinel, 'unchanged\n');
+  for (const relative of [
+    '_tmp_guard',
+    '.buildchain/diagnostics/shifu-cache-resolution.json.tmp-1',
+    '.pnpm-store/state.json',
+    'generated-fixtures/result.json',
+    'nested-task-output/receipt.json',
+  ]) {
+    assert.throws(
+      () =>
+        assertExternalSourceAcceptanceTarget(
+          checkout,
+          path.join(checkout, relative),
+          relative,
+        ),
+      /owner=source-acceptance-runtime; recovery=/u,
+    );
+    assert.equal(fs.existsSync(path.join(checkout, relative)), false);
+  }
+  const checkoutAlias = path.join(temporary, 'checkout-alias');
+  fs.symlinkSync(
+    checkout,
+    checkoutAlias,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+  assert.throws(
+    () =>
+      assertExternalSourceAcceptanceTarget(
+        checkout,
+        path.join(checkoutAlias, 'aliased-output'),
+        'aliased-output',
+      ),
+    /owner=source-acceptance-runtime; recovery=/u,
+  );
+  assert.equal(fs.existsSync(path.join(checkout, 'aliased-output')), false);
+  assert.equal(fs.readFileSync(sentinel, 'utf8'), 'unchanged\n');
+});
 
 test('no-bash guard ignores local Kungfu qualification runtimes', (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-no-bash-'));


### PR DESCRIPTION
Close protected source-acceptance write paths, retain an auditable byte-for-byte cold read-only fixture, and restore product assembly maintainability headroom without changing public product or architecture contracts.

Supersedes #2204 after the protected base advanced.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Close protected source-acceptance write paths and restore product assembly maintainability headroom without changing public product or architecture contracts."
}
-->