### PR TITLE
fix(agent-session): use junctions for Windows alias tests

### DIFF
--- a/framework/agent-session/tests/product-detached-host.test.mjs
+++ b/framework/agent-session/tests/product-detached-host.test.mjs
@@ -39,7 +39,11 @@ test('filesystem aliases resolve to one detached endpoint', async () => {
   const alias = path.join(parent, 'runtime-alias');
   try {
     await mkdir(runtime);
-    await symlink(runtime, alias, 'dir');
+    await symlink(
+      runtime,
+      alias,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
     assert.deepEqual(
       detachedAgentSessionPaths(alias),
       detachedAgentSessionPaths(runtime),


### PR DESCRIPTION
## Summary

Keep the filesystem-alias control-plane qualification executable on non-elevated Windows runners.

## Related issue

None.

## Changes

- Create the directory alias as a Windows junction on `win32`.
- Preserve the existing directory-symlink contract on POSIX.

## Verification

- `node --test framework/agent-session/tests/product-detached-host.test.mjs` (4/4 passed)
- Repository staged pre-commit gate (passed)
- The candidate Windows qualification failure was reproduced as `EPERM` from directory symlink creation on a non-elevated runner.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This test portability fix preserves the existing filesystem-alias architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; test-only portability fix)