### PR TITLE
docs(readme): align the Agent handoff narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Kungfu
 
-**Your agent shouldn't start over when the chat ends.**
+**Your agents don't hand off the work. You do.**
 
-Kungfu helps a fresh agent continue the same work without asking you to explain
-it all again. It does this from declared project sources, makes missing or
-conflicting context visible, and preserves enough structure to continue without
-reconstructing everything from conversation history.
+Every switch means copying context, re-explaining decisions, chasing updates,
+and checking what got lost. Kungfu keeps the same work moving, no matter which
+agent takes over.
+
+Use the best Agent when it matters. Use a cheaper one when it does not. Keep the
+same Work across Codex, Claude, OpenCode, Amp, or your own execution surface.
 
 > **Kungfu UNGFU™** · Never Guess. Facts Unfold. [Why this signature
 > exists](docs/concepts/why-kungfu.md).
@@ -14,8 +16,9 @@ Before asking an agent to use Kungfu, make sure the `kungfu` command is on its
 `PATH`. [Set up the Kungfu command](docs/guides/installing-cli.md#make-kungfu-available-in-path),
 then paste this one sentence into the agent you already use:
 
-> Run `kungfu agent brief`, then guide me through my first Project and Work.
-> Keep me in my current agent, and use Kungfu as the durable Work layer.
+```text
+Run `kungfu agent brief`, then guide me through my first Project and Work. Keep me in my current agent, and use Kungfu as the durable Work layer.
+```
 
 Keep working in that agent when you are ready:
 
@@ -35,7 +38,7 @@ A successful agent process is retained for independent review; it does not
 complete Work by itself.
 
 <!-- kungfu:auditable-demo:agent-work-lab-autoplay:start -->
-## See a fresh Agent continue the same Work
+## See the Work survive an Agent change
 
 **One Work. Two fresh Agent processes. No copied chat.**
 
@@ -80,8 +83,8 @@ Project you can keep using. After onboarding, bare `kungfu` opens Work directly.
 
 ## What Kungfu preserves
 
-- **Work continuity.** A fresh Agent can recover what was done, what remains,
-  and which Work it is continuing.
+- **Work continuity.** Change the Agent without losing what was done, what
+  remains, or which Work is continuing.
 - **Verified project understanding.** Declared sources, important omissions,
   conflicts, decisions, and uncertainty remain visible instead of being guessed.
 - **Inspectable history.** People and Agents can see what happened, what the
@@ -97,13 +100,13 @@ See the [continuity handoff](https://kungfu.tech/#continuity-demo) and
 The current result is preparatory fixture evidence—not a provider comparison,
 multi-day durability or retention result, or FO10 qualification.
 
-## Keep using the agents you already have
+## Change the Agent, not the Work
 
-`kungfu run <agent>` is the scriptable golden path, not a required replacement
-for Codex, Claude Code, VS Code, terminals, or other agent surfaces. The
-provider-neutral low-level launcher remains available as the advanced
-`kungfu run agent` command. Registered third-party PTY Agents use
-`kungfu run agent --agent <profile-id>` and the bounded
+`kungfu run <agent>` is the scriptable golden path across Codex, Claude Code,
+OpenCode, Amp, and other Agent surfaces. Kungfu does not replace those surfaces;
+it keeps the Work behind them. The provider-neutral low-level launcher remains
+available as the advanced `kungfu run agent` command. Registered third-party
+PTY Agents use `kungfu run agent --agent <profile-id>` and the bounded
 [native adapter contract](docs/guides/native-agent-adapters.md). The same local
 contracts and Work state remain available through the Kungfu TUI, GUI, CLI,
 and APIs.
@@ -254,7 +257,17 @@ and prepared package-manager adapters are not public release artifacts.
 
 ### Kungfu in the Agent Supply Chain
 
-Kungfu is also the founding runtime proof for an open Agent Supply Chain:
+Kungfu lights the first loop by keeping Work alive across the Agents a person
+already uses. The Agent experiences explicit capabilities, inspectable evidence,
+and durable Work—then can recognize and ask for those qualities elsewhere.
+
+That creates a possible market loop: Agents recommend within human or Hub
+authority, builders receive a demand signal, and more Agent-native products can
+ship the same qualities. Those products can restart the loop without Kungfu.
+This is an adoption thesis, not a claim of broad external demand or a multi-Hub
+market. [See the Agent Supply Chain loop](https://kungfu.tech/agent-supply-chain/).
+
+The technical chain is:
 
 ```text
 KFD-3 discovery -> Buildchain artifact evidence -> KFD-2 assessment


### PR DESCRIPTION
## Summary

Align the root README with the current kungfu.tech narrative: people should be able to change Agents without becoming the manual handoff bus.

Keep the first-contact path concise, explain the Agent Supply Chain flywheel without overstating adoption, and render the one-sentence Agent brief prompt as a GitHub-copyable code block.

## Related issue

None.

## Changes

- Lead with the multi-Agent handoff problem and the cost-aware Agent choice.
- Reframe continuity around changing the Agent while preserving the same Work.
- Add a bounded explanation of how Kungfu can light the first Agent Supply Chain loop.
- Convert the first Agent prompt to a fenced text block for GitHub native copy support.

## Verification

- `./shifu docs:check`
- Commit-time repository checks
- GitHub GFM Markdown API rendering confirmed the prompt is emitted as a `pre/code` block
- `./shifu check:source` reached 961 passing tests and 10 platform skips; its only local failure was the cold-fixture prerequisite `pytest is not available on PATH`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This documentation-only change updates first-contact product narrative and does not alter an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates public product positioning and links to the existing official Agent Supply Chain page. It does not rename Kungfu, packages, release identities, or domains. Documentation and trademark gates passed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed