### PR TITLE
fix(agent-session): create detached worker socket directory

### DIFF
--- a/framework/agent-session/src/private-runtime-directory.mjs
+++ b/framework/agent-session/src/private-runtime-directory.mjs
@@ -1,0 +1,22 @@
+import { lstatSync, mkdirSync } from 'node:fs';
+
+export function ensurePrivateRuntimeDirectory(directory) {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const stat = lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(
+      `Agent Session runtime path '${directory}' is not a real directory`,
+    );
+  }
+  const uid = process.getuid?.();
+  if (uid !== undefined && stat.uid !== uid) {
+    throw new Error(
+      `Agent Session runtime path '${directory}' is not owned by this user`,
+    );
+  }
+  if (process.platform !== 'win32' && (stat.mode & 0o077) !== 0) {
+    throw new Error(
+      `Agent Session runtime path '${directory}' must not be group/world accessible`,
+    );
+  }
+}

--- a/framework/agent-session/src/product-client.mjs
+++ b/framework/agent-session/src/product-client.mjs
@@ -5,7 +5,6 @@ import {
   cpSync,
   existsSync,
   lstatSync,
-  mkdirSync,
   readFileSync,
   realpathSync,
   unlinkSync,
@@ -16,6 +15,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
+import { ensurePrivateRuntimeDirectory } from './private-runtime-directory.mjs';
 import { invokeAgentSessionSurfaceRpc } from './product-rpc.mjs';
 
 const require = createRequire(import.meta.url);
@@ -48,7 +48,7 @@ export function prepareAgentSessionNodePty({ runtimeDir, modulePath } = {}) {
     'node-pty',
   );
   if (!existsSync(targetRoot)) {
-    ensurePrivateDirectory(path.dirname(targetRoot));
+    ensurePrivateRuntimeDirectory(path.dirname(targetRoot));
     cpSync(packageRoot, targetRoot, { recursive: true });
   }
   const targetStat = lstatSync(targetRoot);
@@ -121,27 +121,6 @@ export function detachedAgentSessionPaths(runtimeDir) {
     registry: path.join(directory, 'work-console-registry.json'),
     startupLock: path.join(directory, 'worker-start.lock'),
   };
-}
-
-function ensurePrivateDirectory(directory) {
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
-  const stat = lstatSync(directory);
-  if (!stat.isDirectory() || stat.isSymbolicLink()) {
-    throw new Error(
-      `Agent Session runtime path '${directory}' is not a real directory`,
-    );
-  }
-  const uid = process.getuid?.();
-  if (uid !== undefined && stat.uid !== uid) {
-    throw new Error(
-      `Agent Session runtime path '${directory}' is not owned by this user`,
-    );
-  }
-  if (process.platform !== 'win32' && (stat.mode & 0o077) !== 0) {
-    throw new Error(
-      `Agent Session runtime path '${directory}' must not be group/world accessible`,
-    );
-  }
 }
 
 function transientConnection(error) {
@@ -220,8 +199,10 @@ export function createDetachedAgentSessionHost({
   async function ensureWorker() {
     if (starting) return starting;
     starting = (async () => {
-      ensurePrivateDirectory(paths.directory);
-      if (paths.socketDirectory) ensurePrivateDirectory(paths.socketDirectory);
+      ensurePrivateRuntimeDirectory(paths.directory);
+      if (paths.socketDirectory) {
+        ensurePrivateRuntimeDirectory(paths.socketDirectory);
+      }
       const deadline = now() + STARTUP_LOCK_STALE_MS + CONNECT_TIMEOUT_MS;
       let lastError = null;
       while (now() < deadline) {

--- a/framework/agent-session/src/product-worker.mjs
+++ b/framework/agent-session/src/product-worker.mjs
@@ -6,6 +6,7 @@ import {
   CodexAppServerProductRuntime,
   codexAppServerProductEnabled,
 } from './codex-app-server-product.mjs';
+import { ensurePrivateRuntimeDirectory } from './private-runtime-directory.mjs';
 import { bindAgentSessionSurfaceRpc } from './product-rpc.mjs';
 import { InProcessAgentSessionProductRuntime } from './product-runtime.mjs';
 import { AgentSessionProductSurface } from './product-surface.mjs';
@@ -28,6 +29,9 @@ export async function runAgentSessionProductWorker({
     );
   }
   mkdirSync(path.dirname(metadata), { recursive: true, mode: 0o700 });
+  if (process.platform !== 'win32') {
+    ensurePrivateRuntimeDirectory(path.dirname(endpoint));
+  }
   const runtime = new InProcessAgentSessionProductRuntime({
     pty,
     loadPty: createCapsuleNodePtyLoader({

--- a/framework/agent-session/tests/capsule-transport-runtime.test.mjs
+++ b/framework/agent-session/tests/capsule-transport-runtime.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -44,10 +44,22 @@ test('Capsule node-pty resolution is lazy and reports an optional capability', (
 test('the detached control core starts without node-pty for native sessions', async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), 'kungfu-native-core-'));
   const paths = detachedAgentSessionPaths(root);
+  const socketRoot =
+    process.platform === 'win32'
+      ? null
+      : await mkdtemp(
+          path.join(
+            process.platform === 'darwin' ? '/tmp' : os.tmpdir(),
+            'kungfu-native-core-socket-',
+          ),
+        );
+  if (socketRoot) await rm(socketRoot, { recursive: true, force: true });
   let worker;
   try {
     worker = await runAgentSessionProductWorker({
-      endpoint: paths.endpoint,
+      endpoint: socketRoot
+        ? path.join(socketRoot, 'core.sock')
+        : paths.endpoint,
       metadata: paths.metadata,
       registryPath: paths.registry,
       ptyModule: '/definitely/missing/node-pty.js',
@@ -57,9 +69,13 @@ test('the detached control core starts without node-pty for native sessions', as
       worker.surface.capabilities().registryAuthority.includes('v3'),
       true,
     );
+    if (socketRoot) {
+      assert.equal((await stat(socketRoot)).mode & 0o777, 0o700);
+    }
     assert.deepEqual(worker.runtime.list(), []);
   } finally {
     await worker?.close();
     await rm(root, { recursive: true, force: true });
+    if (socketRoot) await rm(socketRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Repair detached Agent Session worker startup on POSIX hosts when the derived Unix socket parent does not yet exist. Supersedes #2221 with an exact fork of protected base `513679396ec24f59f538692a6febae876e89e8ad`, as required by the serialized queue-admission contract.

## Related issue

- Retained macOS qualification failure: https://github.com/kungfu-systems/kungfu/actions/runs/30745479637
- Retained Linux qualification failure: https://github.com/kungfu-systems/kungfu/actions/runs/30745482705

## Changes

- extract the existing private runtime-directory validation into one shared helper
- create and validate the detached worker socket parent before POSIX bind
- reproduce a missing socket parent and require recreation with mode 0700

## Verification

- candidate tree `f5af290955f9bec9c314b06202afb2e3895055e0` exactly matches the locally tested latest-base tree
- `./shifu --filter @kungfu-tech/agent-session test:control-plane` (136/136 on the identical tree)
- `./shifu exec biome check ...` (4 files)
- `./shifu exec uv run --project framework/core --frozen node --test scripts/readonly-agent-bootstrap.test.mjs` (1/1)
- staged pre-commit gate passed
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair POSIX detached-worker socket setup without changing the Agent Session architecture, authority boundary, protocol, or supported platform matrix"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; behavior now matches the existing contract)
- [x] Candidate is an exact fork of protected base `513679396ec24f59f538692a6febae876e89e8ad`

Signed-off-by: Keren Dong <keren.dong@kungfu.link>