### PR TITLE
fix(core): align writer safety guard with current API

### DIFF
--- a/framework/core/src/libyijinjing/check-deps.mjs
+++ b/framework/core/src/libyijinjing/check-deps.mjs
@@ -70,8 +70,9 @@ const writerSafetyFragments = new Map([
     [
       'checked_cpu_word_length',
       'require_capacity(data_length)',
-      'length != data.size()',
-      'std::as_bytes(std::span{data})',
+      'auto tx = reserve_frame(trigger_time, carrier_type, data.size());',
+      'tx.copy_bytes(data.data(), data.size());',
+      'tx.commit(data.size());',
     ],
   ],
   [
@@ -79,7 +80,9 @@ const writerSafetyFragments = new Map([
     [
       'contiguous one-dimensional bytes-like buffer',
       'std::span<const std::byte>',
-      'py::overload_cast<int64_t, int32_t, const std::vector<uint8_t> &, uint32_t>',
+      'const auto byte_length = item_count * item_size;',
+      'if (view.ptr == nullptr && byte_length != 0)',
+      'target.write_bytes(trigger_time, carrier_type,',
     ],
   ],
 ]);


### PR DESCRIPTION
## Summary

Keep the yijinjing writer memory-safety source guard aligned with the current span-only, transaction-backed writer API.

## Related issue

None.

## Changes

- Replace retired vector-plus-length writer fragments with the current reserve/copy/commit sequence.
- Bind the Python guard to the checked byte-length, null-address, span, and writer handoff path.

## Verification

- `node framework/core/src/libyijinjing/check-deps.mjs --self-test`
- `node framework/core/src/libyijinjing/check-deps.mjs`
- Repository staged pre-commit gate (passed: 73 dev-required tests, 17 invariant tests, 138 documentation/release-contract tests, Biome)
- Dev Verify run 30749945005 reproduced the stale guard after the legacy overloads were intentionally removed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This guard repair tracks the already-accepted span-only writer interface without changing its architecture or runtime behavior."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs a release qualification guard; it does not alter publication authority or credentials.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; guard-only alignment)
