### PR TITLE
feat(product): refine onboarding navigation

### DIFF
--- a/docs/adr/KF-ADR-019fb2de-4a59-7bf4-8231-b32b62aa7e9b.md
+++ b/docs/adr/KF-ADR-019fb2de-4a59-7bf4-8231-b32b62aa7e9b.md
@@ -11,7 +11,7 @@ period: 2026-07-30
 theme: project-work-agent-first-layer
 confidence: high
 evidence_grade: B
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1991, https://github.com/kungfu-systems/kungfu/pull/2147, https://github.com/kungfu-systems/kungfu/pull/2185, https://github.com/kungfu-systems/kungfu/pull/2208]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1991, https://github.com/kungfu-systems/kungfu/pull/2147, https://github.com/kungfu-systems/kungfu/pull/2185, https://github.com/kungfu-systems/kungfu/pull/2208, https://github.com/kungfu-systems/kungfu/pull/2225]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1991
 qualification_refs: [framework/product/project-work-agent.contract.json, scripts/check-project-work-agent-product.test.mjs, framework/core/tests/python/test_projects.py, framework/core/tests/python/test_run_product_path.py, framework/core/tests/python/test_cli_progressive_help.py, framework/core/tests/python/test_assignment_review_equivalence.py, crates/trunk/src/help.rs, framework/api/tests/onboarding.test.ts, framework/tui/src/projects-view.test.ts, framework/tui/src/starter-project-view.test.ts, framework/tui/src/project-tour-view.test.ts, framework/tui/src/agent-work-lab-view.test.ts, framework/gui/src/agent-work-lab.test.ts, extensions/work-dashboard/tests/work-control-profile.test.ts, extensions/work-dashboard/tests/project-work-run.test.ts]
 last_reviewed: 2026-08-02
@@ -58,6 +58,8 @@ the exact brief prompt, and complete shared onboarding only after durable Work
 starts or binds. Completed or dismissed onboarding opens Core Work directly;
 it does not require Lab inspection, KFX admission, or native renderer startup.
 KFX execution and Work settlement retain their independent fail-closed gates.
+After first use, low-frequency onboarding re-entry belongs in the GUI Help menu
+and the TUI `/onboarding` command rather than permanent daily-work chrome.
 
 Every interactive surface presents the same golden path:
 

--- a/framework/gui/src/main/index.ts
+++ b/framework/gui/src/main/index.ts
@@ -87,6 +87,7 @@ import {
   isKungfuCliInstalled,
   uninstallKungfuCliFromPath,
 } from './installCli';
+import { productHelpMenuItems } from './product-help-menu';
 import {
   PRODUCT_NAME,
   productAboutPanelOptions,
@@ -1151,11 +1152,11 @@ function buildMenu() {
         });
       },
     },
-    {
-      label: 'Getting Started with Your Agent',
-      click: () => navigateShell({ target: 'onboarding' }),
-    },
   ];
+  const helpSubmenu = productHelpMenuItems({
+    openOnboarding: () => navigateShell({ target: 'onboarding' }),
+    openExternal: (url) => void shell.openExternal(url),
+  });
   const planDeps: KfxPlanDeps = {
     fs: {
       existsSync,
@@ -1223,6 +1224,7 @@ function buildMenu() {
       ],
     },
     { role: 'windowMenu' },
+    { role: 'help', submenu: helpSubmenu },
   ];
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));

--- a/framework/gui/src/main/product-help-menu.ts
+++ b/framework/gui/src/main/product-help-menu.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const PRODUCT_HELP_LINKS = [
+  {
+    label: 'GitHub Repository',
+    url: 'https://github.com/kungfu-systems/kungfu',
+  },
+  { label: 'Kungfu Website', url: 'https://kungfu.tech' },
+  { label: 'Developer Platform', url: 'https://libkungfu.dev' },
+] as const;
+
+export type ProductHelpMenuItem = {
+  label?: string;
+  type?: 'separator';
+  click?: () => void;
+};
+
+export function productHelpMenuItems({
+  openOnboarding,
+  openExternal,
+}: {
+  openOnboarding: () => void;
+  openExternal: (url: string) => void;
+}): ProductHelpMenuItem[] {
+  return [
+    { label: 'Onboarding', click: openOnboarding },
+    { type: 'separator' },
+    ...PRODUCT_HELP_LINKS.map(({ label, url }) => ({
+      label,
+      click: () => openExternal(url),
+    })),
+  ];
+}

--- a/framework/gui/src/product-search.test.ts
+++ b/framework/gui/src/product-search.test.ts
@@ -3,6 +3,10 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import {
+  PRODUCT_HELP_LINKS,
+  productHelpMenuItems,
+} from './main/product-help-menu';
 
 const source = readFileSync(
   new URL('./renderer/src/main.tsx', import.meta.url),
@@ -38,6 +42,47 @@ test('the title-bar search shares Help, Command, Work, and view sources', () => 
   assert.match(source, /Search Help, Commands, Work/);
   assert.doesNotMatch(source, /Search views/);
   assert.doesNotMatch(source, /<datalist/);
+});
+
+test('the title-bar product menu reserves permanent chrome for daily work', () => {
+  assert.doesNotMatch(
+    source,
+    /id: 'onboarding',[\s\S]*title: 'Getting Started'/,
+  );
+  assert.doesNotMatch(source, /onOpenOnboarding/);
+  assert.match(source, /id: 'all-work'/);
+  assert.match(source, /id: 'projects'/);
+  assert.match(source, /id: 'agent-work-lab'/);
+});
+
+test('the Help menu keeps onboarding available without permanent shell chrome', () => {
+  let onboardingOpened = 0;
+  const externalUrls: string[] = [];
+  const items = productHelpMenuItems({
+    openOnboarding: () => {
+      onboardingOpened += 1;
+    },
+    openExternal: (url) => externalUrls.push(url),
+  });
+
+  assert.deepEqual(
+    items.map((item) => item.label ?? item.type),
+    [
+      'Onboarding',
+      'separator',
+      'GitHub Repository',
+      'Kungfu Website',
+      'Developer Platform',
+    ],
+  );
+
+  items[0]?.click?.();
+  for (const item of items.slice(2)) item.click?.();
+  assert.equal(onboardingOpened, 1);
+  assert.deepEqual(
+    externalUrls,
+    PRODUCT_HELP_LINKS.map((entry) => entry.url),
+  );
 });
 
 test('Cmd or Ctrl K focuses the same search plane without executing CLI results', () => {

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -263,7 +263,6 @@ function ShellTitleBar({
   onSearchChange,
   onSearchActivate,
   onOpenSettings,
-  onOpenOnboarding,
   onOpenAllWork,
   currentProjectTitle,
   onOpenCurrentProject,
@@ -284,7 +283,6 @@ function ShellTitleBar({
   onSearchChange: (value: string) => void;
   onSearchActivate: (result: ProductSearchResult) => void;
   onOpenSettings: () => void;
-  onOpenOnboarding: () => void;
   onOpenAllWork: () => void;
   currentProjectTitle: string;
   onOpenCurrentProject?: () => void;
@@ -644,13 +642,6 @@ function ShellTitleBar({
               }}
             >
               {[
-                {
-                  id: 'onboarding',
-                  title: 'Getting Started',
-                  icon: '→',
-                  active: activeViewId === 'onboarding',
-                  action: onOpenOnboarding,
-                },
                 {
                   id: 'all-work',
                   title: 'All Work',
@@ -2225,12 +2216,6 @@ function App() {
         onSearchChange={setSearchText}
         onSearchActivate={activateSearchResult}
         onOpenSettings={() => setSettingsOpen(true)}
-        onOpenOnboarding={() => {
-          setLabOpen(false);
-          setProjectsOpen(false);
-          setCoreWorkOpen(false);
-          setOnboardingOpen(true);
-        }}
         onOpenAllWork={() => openWorkSurface()}
         currentProjectTitle={
           currentProjectDisplayName

--- a/framework/tui/src/agent-work-lab-view.test.ts
+++ b/framework/tui/src/agent-work-lab-view.test.ts
@@ -17,6 +17,7 @@ import React from 'react';
 import {
   AGENT_WORK_LAB_POINTER_ACTIONS,
   AGENT_WORK_LAB_QUICK_COMMANDS,
+  AgentFirstOnboardingView,
   AgentWorkLabHost,
   AgentWorkLabView,
   agentWorkLabActionReturnsToControls,
@@ -30,6 +31,7 @@ import {
   agentWorkLabStarterReceiptInput,
   isAgentWorkLabReportReturnInput,
   nextAgentWorkLabFocus,
+  tuiOnboardingActionFromInput,
 } from './agent-work-lab-view.js';
 import {
   appendWorkbenchSessionLines,
@@ -117,6 +119,120 @@ class CaptureOutput extends EventEmitter {
     return true;
   };
 }
+
+test('Getting Started copies the one-line Agent prompt with one key and confirms it', async () => {
+  const output = new CaptureOutput();
+  const actions: string[] = [];
+  const props = {
+    dimensions: { columns: 80, rows: 24 },
+    state: {
+      version: 1,
+      status: 'completed' as const,
+      route: 'agent' as const,
+      labCompleted: false,
+      tourCompleted: false,
+      completedAt: '2026-08-02T00:00:00.000Z',
+    },
+    command:
+      '/Applications/Kungfu.app/Contents/Resources/bin/kungfu agent brief',
+    prompt: 'Run the local brief, then guide me through my first Work.',
+    onAction: (action: string) => actions.push(action),
+  };
+  const instance = render(
+    React.createElement(AgentFirstOnboardingView, props),
+    {
+      stdout: output as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      debug: true,
+    },
+  );
+
+  try {
+    await waitUntil(
+      () =>
+        output.chunks
+          .join('')
+          .includes('[C/c] Copy this one-line Agent prompt'),
+      'the copy action label',
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 80));
+    process.stdin.emit('data', Buffer.from('1'));
+    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+    assert.equal(actions.length, 0);
+    process.stdin.emit('data', Buffer.from('C'));
+    await waitUntil(() => actions.includes('copy'), 'the copy action');
+    instance.rerender(
+      React.createElement(AgentFirstOnboardingView, {
+        ...props,
+        notice: {
+          ok: true,
+          title: 'ONE-LINE AGENT PROMPT COPIED',
+          detail: 'Paste it into your Agent in another window.',
+          next: 'Optional: [Enter] start · [L/l] Lab · [T/t] Tour.',
+        },
+      }),
+    );
+    await waitUntil(
+      () => output.chunks.join('').includes('ONE-LINE AGENT PROMPT COPIED'),
+      'the copy confirmation',
+    );
+    process.stdin.emit('data', Buffer.from('\r'));
+    await waitUntil(() => actions.includes('continue'), 'the continue action');
+  } finally {
+    instance.unmount();
+    instance.cleanup();
+    process.stdin.pause();
+  }
+
+  const frame = output.chunks.join('');
+  assert.match(frame, /\[C\/c\] Copy this one-line Agent prompt/u);
+  assert.match(frame, /\[Enter\] Continue to Kungfu/u);
+  assert.match(frame, /\[L\/l\] Agent Work Lab/u);
+  assert.match(frame, /\[T\/t\] Guided Project Tour/u);
+  assert.match(frame, /Paste it into your Agent in another window\./u);
+  assert.match(frame, /Optional: \[Enter\] start/u);
+  assert.deepEqual(actions, ['copy', 'continue']);
+});
+
+test('Getting Started uses case-insensitive mnemonic keys instead of step numbers', () => {
+  assert.deepEqual(
+    ['c', 'C', '\r', 'l', 'L', 't', 'T', 's', 'S'].map(
+      tuiOnboardingActionFromInput,
+    ),
+    [
+      'copy',
+      'copy',
+      'continue',
+      'lab',
+      'lab',
+      'tour',
+      'tour',
+      'dismiss',
+      'dismiss',
+    ],
+  );
+  for (const retiredKey of ['1', '2', '3', 'w', 'W']) {
+    assert.equal(tuiOnboardingActionFromInput(retiredKey), null);
+  }
+});
+
+test('Getting Started visually distinguishes its prompt and actionable keys', () => {
+  const source = readFileSync(
+    new URL('./agent-work-lab-view.tsx', import.meta.url),
+    'utf8',
+  );
+  const onboarding = source.slice(
+    source.indexOf('function OnboardingShortcutLine'),
+    source.indexOf('export type TuiAgentWorkLabMode'),
+  );
+  assert.match(onboarding, /backgroundColor="yellow"/u);
+  assert.equal(
+    onboarding.includes('key={`prompt:${row}`} color="cyan" bold'),
+    true,
+  );
+  assert.match(onboarding, /opaqueWidth=\{noticeColumns\}/u);
+});
 
 async function waitUntil(
   condition: () => boolean,

--- a/framework/tui/src/agent-work-lab-view.test.ts
+++ b/framework/tui/src/agent-work-lab-view.test.ts
@@ -186,6 +186,8 @@ test('Getting Started copies the one-line Agent prompt with one key and confirms
   }
 
   const frame = output.chunks.join('');
+  assert.match(frame, /Keep your agent\. Give it durable Work\./u);
+  assert.match(frame, /kungfu run\s+codex\|claude\|opencode\|amp/u);
   assert.match(frame, /\[C\/c\] Copy this one-line Agent prompt/u);
   assert.match(frame, /\[Enter\] Continue to Kungfu/u);
   assert.match(frame, /\[L\/l\] Agent Work Lab/u);

--- a/framework/tui/src/agent-work-lab-view.tsx
+++ b/framework/tui/src/agent-work-lab-view.tsx
@@ -96,38 +96,91 @@ function wrapOnboardingText(value: string, width: number): string[] {
 }
 
 export type TuiOnboardingAction =
-  | 'agent'
+  | 'copy'
   | 'lab'
   | 'tour'
   | 'continue'
   | 'dismiss';
+
+export type TuiOnboardingNotice = {
+  ok: boolean;
+  title: string;
+  detail: string;
+  next: string;
+};
+
+export function tuiOnboardingActionFromInput(
+  value: string,
+): TuiOnboardingAction | 'quit' | null {
+  if (value === 'q' || value === 'Q' || value === '\u0003') return 'quit';
+  if (value === 'c' || value === 'C') return 'copy';
+  if (value === '\r' || value === '\n') return 'continue';
+  if (value === 'l' || value === 'L') return 'lab';
+  if (value === 't' || value === 'T') return 'tour';
+  if (value === 's' || value === 'S') return 'dismiss';
+  return null;
+}
+
+function OnboardingShortcutLine({
+  value,
+  opaqueWidth,
+}: {
+  value: string;
+  opaqueWidth?: number;
+}) {
+  const content =
+    opaqueWidth === undefined
+      ? value
+      : ` ${value}`.slice(0, opaqueWidth).padEnd(opaqueWidth);
+  return (
+    <Text
+      color={opaqueWidth === undefined ? undefined : 'white'}
+      backgroundColor={opaqueWidth === undefined ? undefined : 'blue'}
+      wrap="truncate-end"
+    >
+      {content.split(/(\[[^\]]+\])/u).map((part, index) =>
+        /^\[[^\]]+\]$/u.test(part) ? (
+          <Text
+            key={`${index}:${part}`}
+            bold
+            color="black"
+            backgroundColor="yellow"
+          >
+            {part}
+          </Text>
+        ) : (
+          part
+        ),
+      )}
+    </Text>
+  );
+}
 
 export function AgentFirstOnboardingView({
   dimensions,
   state,
   command,
   prompt,
-  notice = '',
+  notice,
   onAction,
 }: {
   dimensions: TerminalDimensions;
   state: KungfuOnboardingState;
   command: string;
   prompt: string;
-  notice?: string;
+  notice?: TuiOnboardingNotice;
   onAction: (action: TuiOnboardingAction) => void;
 }) {
   const { exit } = useApp();
+  const noticePanelWidth = Math.max(24, Math.min(72, dimensions.columns - 4));
+  const noticeColumns = Math.max(1, noticePanelWidth - 2);
+  const noticeLine = (value: string) =>
+    ` ${value}`.slice(0, noticeColumns).padEnd(noticeColumns);
   React.useEffect(() => {
     const onData = (chunk: Buffer | string) => {
-      const value = String(chunk);
-      if (value === 'q' || value === 'Q' || value === '\u0003') exit();
-      else if (value === '1' || value === '\r' || value === '\n')
-        onAction('agent');
-      else if (value === '2') onAction('lab');
-      else if (value === '3') onAction('tour');
-      else if (value === 'w') onAction('continue');
-      else if (value === 's') onAction('dismiss');
+      const action = tuiOnboardingActionFromInput(String(chunk));
+      if (action === 'quit') exit();
+      else if (action) onAction(action);
     };
     process.stdin.on('data', onData);
     return () => {
@@ -146,36 +199,93 @@ export function AgentFirstOnboardingView({
       <Text color="green" bold>
         KUNGFU · AGENT-FIRST ENTRY
       </Text>
-      <Text bold>Keep your agent. Give it durable Work.</Text>
+      <Text bold>Start in either place. Use one path, or both.</Text>
       <Text wrap="wrap">
-        Kungfu does not require a new chat or daily workspace. Start by teaching
-        the agent you already use how to preserve Projects, Work, attempts,
-        review, and settlement across sessions.
+        Copy Kungfu into the Agent you already use, continue directly into the
+        Kungfu UI, or explore first. Copying is helpful, never required.
       </Text>
       <TitledBorderWindow
         columns={Math.max(20, dimensions.columns - 2)}
-        title="1 · COPY THIS TO YOUR EXISTING AGENT"
+        title="OPTION A · BRING KUNGFU TO YOUR AGENT"
         borderColor="green"
         paddingX={1}
         rows={[
-          ...wrapOnboardingText(prompt, Math.max(16, dimensions.columns - 8)),
-          '',
           ...wrapOnboardingText(
-            `Exact local command: ${command}`,
+            prompt,
             Math.max(16, dimensions.columns - 8),
-          ),
-          '[1/Enter] I’ll use my Agent',
+          ).map((row) => (
+            <Text key={`prompt:${row}`} color="cyan" bold>
+              {row}
+            </Text>
+          )),
+          <Text key="prompt-command-gap"> </Text>,
+          ...wrapOnboardingText(
+            `The copied prompt includes this exact local command: ${command}`,
+            Math.max(16, dimensions.columns - 8),
+          ).map((row) => (
+            <Text key={`command:${row}`} dimColor>
+              {row}
+            </Text>
+          )),
+          <OnboardingShortcutLine
+            key="copy-shortcut"
+            value="[C/c] Copy this one-line Agent prompt"
+          />,
         ]}
       />
-      <Text>
-        Optional: [2] Agent Work Lab · [3] Guided Project Tour · [w] Work now ·
-        [s] Don’t show again
-      </Text>
-      <Text dimColor>
-        Keep using kungfu run codex|claude|opencode|amp. GUI/TUI are optional
-        control surfaces. Current route: {state.route}.
-      </Text>
-      {notice ? <Text color="yellow">{notice}</Text> : null}
+      <TitledBorderWindow
+        columns={Math.max(20, dimensions.columns - 2)}
+        title="OPTION B · START IN KUNGFU"
+        borderColor="cyan"
+        paddingX={1}
+        rows={[
+          <Text key="continue-copy">
+            Open the local Work control plane. No copy or paste is required.
+          </Text>,
+          <OnboardingShortcutLine
+            key="continue-shortcut"
+            value="[Enter] Continue to Kungfu"
+          />,
+        ]}
+      />
+      <OnboardingShortcutLine value="Explore first: [L/l] Agent Work Lab · [T/t] Guided Project Tour" />
+      <OnboardingShortcutLine
+        value={`Return any time with /onboarding · [S/s] Don’t show again · Current route: ${state.route}`}
+      />
+      {notice ? (
+        <Box
+          position="absolute"
+          width={noticePanelWidth}
+          height={6}
+          marginTop={Math.max(2, Math.floor((dimensions.rows - 6) / 2))}
+          marginLeft={Math.max(
+            2,
+            Math.floor((dimensions.columns - noticePanelWidth) / 2),
+          )}
+          borderStyle="double"
+          borderColor={notice.ok ? 'green' : 'red'}
+          flexDirection="column"
+          overflow="hidden"
+        >
+          <Text
+            bold
+            color={notice.ok ? 'black' : 'white'}
+            backgroundColor={notice.ok ? 'green' : 'red'}
+          >
+            {noticeLine(notice.title)}
+          </Text>
+          <Text color="white" backgroundColor="blue">
+            {noticeLine(notice.detail)}
+          </Text>
+          <OnboardingShortcutLine
+            value={notice.next}
+            opaqueWidth={noticeColumns}
+          />
+          <Text color="white" backgroundColor="blue" dimColor>
+            {noticeLine('Closes automatically in 4 seconds.')}
+          </Text>
+        </Box>
+      ) : null}
     </Box>
   );
 }

--- a/framework/tui/src/agent-work-lab-view.tsx
+++ b/framework/tui/src/agent-work-lab-view.tsx
@@ -95,6 +95,8 @@ function wrapOnboardingText(value: string, width: number): string[] {
   return lines;
 }
 
+const AGENT_SHELL_ENTRY = 'kungfu run codex|claude|opencode|amp';
+
 export type TuiOnboardingAction =
   | 'copy'
   | 'lab'
@@ -199,10 +201,11 @@ export function AgentFirstOnboardingView({
       <Text color="green" bold>
         KUNGFU · AGENT-FIRST ENTRY
       </Text>
-      <Text bold>Start in either place. Use one path, or both.</Text>
+      <Text bold>Keep your agent. Give it durable Work.</Text>
       <Text wrap="wrap">
-        Copy Kungfu into the Agent you already use, continue directly into the
-        Kungfu UI, or explore first. Copying is helpful, never required.
+        Start in either place. Copy Kungfu into the Agent you already use,
+        continue directly into the Kungfu UI, or explore first. Copying is
+        helpful, never required.
       </Text>
       <TitledBorderWindow
         columns={Math.max(20, dimensions.columns - 2)}
@@ -220,7 +223,7 @@ export function AgentFirstOnboardingView({
           )),
           <Text key="prompt-command-gap"> </Text>,
           ...wrapOnboardingText(
-            `The copied prompt includes this exact local command: ${command}`,
+            `Exact local command: ${command}`,
             Math.max(16, dimensions.columns - 8),
           ).map((row) => (
             <Text key={`command:${row}`} dimColor>
@@ -241,6 +244,9 @@ export function AgentFirstOnboardingView({
         rows={[
           <Text key="continue-copy">
             Open the local Work control plane. No copy or paste is required.
+          </Text>,
+          <Text key="shell-entry" dimColor>
+            Keep your normal Agent workflow: {AGENT_SHELL_ENTRY}
           </Text>,
           <OnboardingShortcutLine
             key="continue-shortcut"

--- a/framework/tui/src/control-plane-state.ts
+++ b/framework/tui/src/control-plane-state.ts
@@ -64,6 +64,7 @@ export type ProductQuickCommandAction =
   | 'work'
   | 'projects'
   | 'lab'
+  | 'onboarding'
   | 'home'
   | 'quit';
 
@@ -119,6 +120,13 @@ export const QUICK_COMMANDS: QuickCommand<ProductQuickCommandAction>[] = [
     title: 'Open Lab',
     summary: 'Open the installed identity-neutral work experiment suite.',
     action: 'lab',
+  },
+  {
+    id: 'onboarding',
+    command: '/onboarding',
+    title: 'Open Getting Started',
+    summary: 'Reopen the Agent-first onboarding guide at any time.',
+    action: 'onboarding',
   },
   {
     id: 'home',

--- a/framework/tui/src/control-plane-state.ts
+++ b/framework/tui/src/control-plane-state.ts
@@ -158,6 +158,29 @@ export function resolveProductStartupSurface({
   return projectResumeSettled ? 'all-work' : null;
 }
 
+export function shouldStartContextualProjectRestore({
+  playbackMode,
+  surface,
+  emptyState,
+  startupProjectRoot,
+}: {
+  playbackMode: boolean;
+  surface: string;
+  emptyState: boolean;
+  startupProjectRoot?: string;
+}): boolean {
+  return (
+    !playbackMode &&
+    contextualProjectRestoreCanCommit(surface) &&
+    !emptyState &&
+    Boolean(startupProjectRoot)
+  );
+}
+
+export function contextualProjectRestoreCanCommit(surface: string): boolean {
+  return surface === 'loading';
+}
+
 export function directWorkspaceNavigationFromInput(
   current: ControlPlaneState,
   input: string,

--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -16,11 +16,13 @@ import {
   ControlPlaneOverlay,
   type ControlPlaneState,
   QUICK_COMMANDS,
+  contextualProjectRestoreCanCommit,
   createControlPlaneInputFence,
   directWorkspaceNavigationFromInput,
   quickCommandMatches,
   reduceControlPlaneInput,
   resolveProductStartupSurface,
+  shouldStartContextualProjectRestore,
 } from './profile-shell.js';
 import {
   PROJECTS_QUICK_COMMANDS,
@@ -481,6 +483,30 @@ test('startup opens only the current .kungfu Project and otherwise shows All Wor
     }),
     'all-work',
   );
+});
+
+test('explicit product navigation cancels contextual Project restoration', () => {
+  const startup = {
+    playbackMode: false,
+    emptyState: false,
+    startupProjectRoot: '/tmp/project',
+  };
+  assert.equal(
+    shouldStartContextualProjectRestore({ ...startup, surface: 'loading' }),
+    true,
+  );
+  for (const surface of ['lab', 'projects', 'all-work', 'onboarding']) {
+    assert.equal(
+      shouldStartContextualProjectRestore({ ...startup, surface }),
+      false,
+      `${surface} must not be replaced by a late Project restore`,
+    );
+    assert.equal(
+      contextualProjectRestoreCanCommit(surface),
+      false,
+      `${surface} must revoke a pending restore before React rerenders`,
+    );
+  }
 });
 
 test('the real Ink control plane covers the product canvas and keeps a fixed input bar', async () => {

--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -276,11 +276,13 @@ test('keeps quick commands bounded to declared product actions', () => {
       'work',
       'projects',
       'lab',
+      'onboarding',
       'home',
       'quit',
     ],
   );
   assert.equal(quickCommandMatches('/new')[0]?.action, 'new-work');
+  assert.equal(quickCommandMatches('/onboarding')[0]?.action, 'onboarding');
   assert.equal(quickCommandMatches('/rm -rf').length, 0);
 });
 
@@ -543,6 +545,7 @@ test('the real Ink control plane covers the product canvas and keeps a fixed inp
   instance.cleanup();
   assert.match(frame, /KUNGFU · HELP/);
   assert.match(frame, /focused input accepts text/);
+  assert.match(frame, /Getting Started: \/onboarding/);
   assert.match(frame, /Help open/);
   assert.match(frame, /HELP.*Esc Back/s);
   assert.match(frame, /╭/);

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -67,11 +67,13 @@ import {
   PlaybackBar,
   QUICK_COMMANDS,
   type TerminalDimensions,
+  contextualProjectRestoreCanCommit,
   createControlPlaneInputFence,
   directWorkspaceNavigationFromInput,
   quickCommandMatches,
   reduceControlPlaneInput,
   resolveProductStartupSurface,
+  shouldStartContextualProjectRestore,
   splitHorizontalPointerActionAtPoint,
 } from './profile-shell.js';
 import {
@@ -928,6 +930,15 @@ function StartingHost({
   );
 }
 
+type ProductSurface =
+  | 'loading'
+  | 'onboarding'
+  | 'lab'
+  | 'all-work'
+  | 'projects'
+  | 'project-work'
+  | 'project-assignment';
+
 function ProductHost({
   lab,
   dimensions,
@@ -970,15 +981,7 @@ function ProductHost({
   const [startup, setStartup] = React.useState<
     AgentWorkLabStartupRoute | undefined
   >(playbackMode ? PENDING_STARTUP : undefined);
-  const [surface, setSurface] = React.useState<
-    | 'loading'
-    | 'onboarding'
-    | 'lab'
-    | 'all-work'
-    | 'projects'
-    | 'project-work'
-    | 'project-assignment'
-  >(
+  const [surface, setSurfaceState] = React.useState<ProductSurface>(
     playbackMode
       ? 'lab'
       : firstLaunch
@@ -995,9 +998,10 @@ function ProductHost({
     playbackMode || firstLaunch || emptyState || !startupAnimationEnabled,
   );
   const surfaceRef = React.useRef(surface);
-  React.useEffect(() => {
-    surfaceRef.current = surface;
-  }, [surface]);
+  const setSurface = React.useCallback((next: ProductSurface) => {
+    surfaceRef.current = next;
+    setSurfaceState(next);
+  }, []);
   const projects = React.useMemo(
     () => openTuiProjects(!projectTourRoot, Boolean(projectTourRoot)),
     [projectTourRoot],
@@ -1182,12 +1186,16 @@ function ProductHost({
   }, [lab, playbackMode, startup, surface]);
   React.useEffect(() => {
     if (
-      playbackMode ||
-      surface === 'onboarding' ||
-      emptyState ||
-      !startupProjectRoot
-    )
+      !shouldStartContextualProjectRestore({
+        playbackMode,
+        surface,
+        emptyState,
+        startupProjectRoot,
+      })
+    ) {
       return;
+    }
+    if (!startupProjectRoot) return;
     let active = true;
     const request = openProjectRequest.current + 1;
     openProjectRequest.current = request;
@@ -1195,7 +1203,9 @@ function ProductHost({
     void projects
       .select(startupProjectRoot)
       .then(async (receipt) => {
-        if (!active) return;
+        if (!active || !contextualProjectRestoreCanCommit(surfaceRef.current)) {
+          return;
+        }
         const selected = receipt as {
           workspace: ProjectWorkspaceSelection;
         };
@@ -1208,13 +1218,19 @@ function ProductHost({
           registry_path: '',
           selected: selected.workspace,
         } as unknown as ProjectTemplateWorkspaceSelection);
-        surfaceRef.current = 'project-work';
         setSurface('project-work');
         const inventory = await projects.works(
           selected.workspace.workspace_root,
         );
         const work = inventory.activeWork;
-        if (!active || request !== openProjectRequest.current || !work) return;
+        if (
+          !active ||
+          request !== openProjectRequest.current ||
+          surfaceRef.current !== 'project-work' ||
+          !work
+        ) {
+          return;
+        }
         const workspace = {
           schema: 'kungfu.workspace.registry/v1',
           last_workspace_id: selected.workspace.workspace_id,
@@ -1231,6 +1247,13 @@ function ProductHost({
             requestPath: work.requestPath,
           },
         });
+        if (
+          !active ||
+          request !== openProjectRequest.current ||
+          surfaceRef.current !== 'project-work'
+        ) {
+          return;
+        }
         setStarterProject({ workspace, work, works: inventory.works });
         setStarterWorkReceipt(resumed.workReceipt);
         setStarterReviewReceipt(resumed.reviewReceipt);
@@ -1251,7 +1274,15 @@ function ProductHost({
     return () => {
       active = false;
     };
-  }, [emptyState, lab, playbackMode, projects, startupProjectRoot, surface]);
+  }, [
+    emptyState,
+    lab,
+    playbackMode,
+    projects,
+    setSurface,
+    startupProjectRoot,
+    surface,
+  ]);
   const autoplay = React.useMemo(
     () =>
       autoDemo
@@ -1288,6 +1319,7 @@ function ProductHost({
     playbackMode,
     openedProject,
     projectResumeSettled,
+    setSurface,
     startupProjectRoot,
     startupIntroSettled,
     surface,
@@ -1484,7 +1516,7 @@ function ProductHost({
         );
       }
     },
-    [dispatchLabAction, onboardingState, persistOnboarding],
+    [dispatchLabAction, onboardingState, persistOnboarding, setSurface],
   );
   const acknowledgeLabAction = React.useCallback((id: number) => {
     setLabActionRequest((current) =>
@@ -1572,18 +1604,18 @@ function ProductHost({
           }
         });
     },
-    [lab, setControlNow],
+    [lab, setControlNow, setSurface],
   );
   const openGlobalWork = React.useCallback(() => {
     setControlNow({ ...CLOSED_CONTROL_PLANE, focus: 'workspace' });
     setSurface('all-work');
-  }, [setControlNow]);
+  }, [setControlNow, setSurface]);
   const openHome = React.useCallback(() => {
     setControlNow({ ...CLOSED_CONTROL_PLANE, focus: 'workspace' });
     if (starterProject) setSurface('project-assignment');
     else if (openedProject) setSurface('project-work');
     else setSurface('all-work');
-  }, [openedProject, setControlNow, starterProject]);
+  }, [openedProject, setControlNow, setSurface, starterProject]);
   const activateControl = React.useCallback(() => {
     const current = controlRef.current;
     if (current.mode === 'commands') {
@@ -1744,6 +1776,7 @@ function ProductHost({
     openedProject,
     projects,
     setControlNow,
+    setSurface,
   ]);
   const activateControlRef = React.useRef(activateControl);
   activateControlRef.current = activateControl;
@@ -1848,6 +1881,7 @@ function ProductHost({
     openedProject,
     productNavActions,
     setControlNow,
+    setSurface,
     size,
   ]);
 
@@ -1873,6 +1907,7 @@ function ProductHost({
     openHome,
     openedProject,
     playbackMode,
+    setSurface,
     surface,
   ]);
 

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -54,9 +54,11 @@ import {
   AgentWorkLabHost,
   type AgentWorkLabSuiteAction,
   type TuiOnboardingAction,
+  type TuiOnboardingNotice,
   agentWorkLabActionReturnsToControls,
   readTuiOnboardingState,
 } from './agent-work-lab-view.js';
+import { copyTextToClipboard } from './clipboard/index.js';
 import { scrollListSelection } from './list-window/index.js';
 import { boundedIndex, decodeShellKey } from './navigation.js';
 import {
@@ -968,7 +970,13 @@ function ProductHost({
       const paths = runtimePaths();
       return readTuiOnboardingState(paths.configHome);
     });
-  const [onboardingNotice, setOnboardingNotice] = React.useState('');
+  const [onboardingNotice, setOnboardingNotice] =
+    React.useState<TuiOnboardingNotice>();
+  React.useEffect(() => {
+    if (!onboardingNotice) return undefined;
+    const timer = setTimeout(() => setOnboardingNotice(undefined), 4_000);
+    return () => clearTimeout(timer);
+  }, [onboardingNotice]);
   const firstLaunch =
     !playbackMode && !emptyState && shouldShowKungfuOnboarding(onboardingState);
   const startupProjectRoot = React.useMemo(
@@ -1365,6 +1373,14 @@ function ProductHost({
         keywords: ['qualification', 'handoff', 'session'],
         action: { kind: 'open-view', viewId: 'lab' },
       },
+      {
+        id: 'view.onboarding',
+        kind: 'view',
+        title: 'Getting Started',
+        summary: 'Reopen the Agent-first onboarding guide at any time.',
+        keywords: ['onboarding', 'agent', 'guide', 'first'],
+        action: { kind: 'open-view', viewId: 'onboarding' },
+      },
     ],
     [],
   );
@@ -1451,9 +1467,12 @@ function ProductHost({
         { env: invocation.env, maxBuffer: 2 * 1024 * 1024 },
         (error) => {
           if (error) {
-            setOnboardingNotice(
-              `Could not save Getting Started state: ${error.message}`,
-            );
+            setOnboardingNotice({
+              ok: false,
+              title: 'GETTING STARTED STATE NOT SAVED',
+              detail: error.message,
+              next: 'Press Enter to continue without saving this state.',
+            });
             setControlNow({
               ...CLOSED_CONTROL_PLANE,
               focus: 'workspace',
@@ -1461,7 +1480,7 @@ function ProductHost({
             });
             return;
           }
-          setOnboardingNotice('');
+          setOnboardingNotice(undefined);
           setOnboardingState(next);
           onSaved?.();
         },
@@ -1488,10 +1507,25 @@ function ProductHost({
   );
   const handleOnboardingAction = React.useCallback(
     (action: TuiOnboardingAction) => {
-      if (action === 'agent') {
-        persistOnboarding(
-          finishKungfuOnboarding(onboardingState, { route: 'agent' }),
-          () => setSurface('all-work'),
+      if (action === 'copy') {
+        const receipt = copyTextToClipboard(agentFirstEntry.prompt, {
+          exec: (file, args, options) =>
+            execFileSync(file, args, { ...options, encoding: 'utf8' }),
+        });
+        setOnboardingNotice(
+          receipt.ok
+            ? {
+                ok: true,
+                title: 'ONE-LINE AGENT PROMPT COPIED',
+                detail: 'Paste it into your Agent in another window.',
+                next: 'Optional: [Enter] start · [L/l] Lab · [T/t] Tour.',
+              }
+            : {
+                ok: false,
+                title: 'COPY PROMPT FAILED',
+                detail: receipt.error,
+                next: 'Optional: [Enter] start · [L/l] Lab · [T/t] Tour.',
+              },
         );
       } else if (action === 'lab') {
         persistOnboarding(
@@ -1516,7 +1550,13 @@ function ProductHost({
         );
       }
     },
-    [dispatchLabAction, onboardingState, persistOnboarding, setSurface],
+    [
+      agentFirstEntry.prompt,
+      dispatchLabAction,
+      onboardingState,
+      persistOnboarding,
+      setSurface,
+    ],
   );
   const acknowledgeLabAction = React.useCallback((id: number) => {
     setLabActionRequest((current) =>
@@ -1688,6 +1728,9 @@ function ProductHost({
       } else if (command.action === 'lab') {
         setSurface('lab');
         closeControl('workspace');
+      } else if (command.action === 'onboarding') {
+        setSurface('onboarding');
+        closeControl('workspace');
       } else if (command.action === 'home') {
         openHome();
         closeControl('workspace');
@@ -1749,6 +1792,8 @@ function ProductHost({
     } else if (result.action.kind === 'open-view') {
       if (result.action.viewId === 'work') {
         openGlobalWork();
+      } else if (result.action.viewId === 'onboarding') {
+        setSurface('onboarding');
       } else {
         setSurface(result.action.viewId === 'lab' ? 'lab' : 'projects');
       }
@@ -1895,7 +1940,6 @@ function ProductHost({
         if (openedProject) openHome();
         else setSurface('projects');
       } else if (value === '3') setSurface('lab');
-      else if (value === '4') setSurface('onboarding');
     };
     process.stdin.on('data', onData);
     return () => {
@@ -2212,7 +2256,6 @@ function ProductHost({
             <Text color={labOpen ? 'cyan' : undefined} bold={labOpen}>
               [3] Agent Work Lab
             </Text>
-            <Text>[4] Getting Started</Text>
           </Box>
         </Box>
       ) : null}

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -32,11 +32,13 @@ import type { WorkLoopShellModel } from './work-loop-contribution.js';
 export {
   CLOSED_CONTROL_PLANE,
   QUICK_COMMANDS,
+  contextualProjectRestoreCanCommit,
   createControlPlaneInputFence,
   directWorkspaceNavigationFromInput,
   quickCommandMatches,
   reduceControlPlaneInput,
   resolveProductStartupSurface,
+  shouldStartContextualProjectRestore,
 } from './control-plane-state.js';
 export type {
   ControlPlaneInputFence,

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -1670,12 +1670,15 @@ export function ControlPlaneOverlay({
               Mouse requires terminal click reporting. In iTerm2, allow mouse
               clicks and drags for the active Profile.
             </Text>
+            <Text color="yellow">Getting Started: /onboarding</Text>
             <Box marginTop={1} flexDirection="column">
-              {quickCommands.slice(0, Math.max(1, rowBudget)).map((command) => (
-                <Text key={command.id} color="yellow" wrap="truncate-end">
-                  {command.command.padEnd(10)} {command.title}
-                </Text>
-              ))}
+              {quickCommands
+                .slice(0, Math.max(1, rowBudget - 1))
+                .map((command) => (
+                  <Text key={command.id} color="yellow" wrap="truncate-end">
+                    {command.command.padEnd(10)} {command.title}
+                  </Text>
+                ))}
             </Box>
           </>
         ) : null}


### PR DESCRIPTION
## Summary

Refine the first-use product navigation after local GUI and TUI acceptance. Keep onboarding available through explicit Help and /onboarding entry points while reserving persistent chrome for daily Work.

## Related issue

None.

## Changes

- keep TUI Getting Started actions mnemonic, visually distinct, and available through /onboarding
- move GUI Onboarding into the native Help menu
- add GitHub, product website, and developer platform links to Help
- preserve first-launch onboarding and existing Work, Lab, and Tour entry behavior

## Verification

- ./shifu test:agent-work-lab
- ./shifu --filter @kungfu-tech/tui exec tsx --test <absolute product-search.test.ts>
- ./shifu build:app
- full pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019fb2de-4a59-7bf4-8231-b32b62aa7e9b"],
  "summary": "Refine the accepted agent-first onboarding navigation across TUI and GUI surfaces",
  "verification": ["Agent Work Lab product suite", "GUI product-search menu tests", "GUI production build", "full pre-commit gate"]
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation is already bound by the accepted onboarding ADR