### PR TITLE
fix(release): bind Windows sentinel to exact source input

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,9 +120,9 @@ jobs:
         id: continuity
         shell: pwsh
         env:
-          GITHUB_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
+          KUNGFU_EXACT_SOURCE_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
         run: |
-          .\shifu.cmd node scripts/alpha-promotion-preflight.mjs fast-sentinel --kind windows --out .buildchain/fast-sentinel/windows.json
+          .\shifu.cmd node scripts/alpha-promotion-preflight.mjs fast-sentinel --kind windows --source-commit $env:KUNGFU_EXACT_SOURCE_SHA --out .buildchain/fast-sentinel/windows.json
           $receipt = Get-Content .buildchain/fast-sentinel/windows.json -Raw | ConvertFrom-Json
           "receipt-root=$($receipt.receiptRoot)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "source-sha=$($receipt.sourceSha)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -131,8 +131,8 @@ jobs:
       - name: Independently verify the exact Windows continuity receipt
         shell: pwsh
         env:
-          GITHUB_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
-        run: .\shifu.cmd node scripts/alpha-promotion-preflight.mjs verify-fast-sentinel --receipt .buildchain/fast-sentinel/windows.json --source-commit $env:GITHUB_SHA --platform win32 --architecture x64
+          KUNGFU_EXACT_SOURCE_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || github.event.pull_request.head.sha || github.sha }}
+        run: .\shifu.cmd node scripts/alpha-promotion-preflight.mjs verify-fast-sentinel --receipt .buildchain/fast-sentinel/windows.json --source-commit $env:KUNGFU_EXACT_SOURCE_SHA --platform win32 --architecture x64
 
   auditable-demo-fast-sentinel:
     name: Auditable demo exact-source fast sentinel

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -361,10 +361,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e7e22cc96a21a57c700c66bc85266051c7b859bd9892ef633d5c3df3b70dcace",
+          "definitionDigest": "sha256:f7dc63acebe5c10defce5fac27e65ce16aa95d6c554102da98d441333c100199",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"id:continuity","definitionDigest":"sha256:7b385ea24cf93a1681e845b0b831870419b399aea945e6c093560b4b55ea72ab"},{"index":3,"label":"name:Independently verify the exact Windows continuity receipt","definitionDigest":"sha256:08e15551c227c68b9b0941b5a2af65e795f9ddd6efe1f42a0fc54ce4bfe720b9"}]
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"id:continuity","definitionDigest":"sha256:aae979c9b8b143b19076785a8b475412dfaf38549d5e0a6764fb006a52c72a5d"},{"index":3,"label":"name:Independently verify the exact Windows continuity receipt","definitionDigest":"sha256:02b95433a8c2b062797026a17d1f6579c78ebc31c89a569daf2ec9a93cb4455e"}]
         }
       ]
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:555d77e50e3a4d64cb4952e1377e7ae43f4e1ee0bc87e1955cd5da8858735490"
+          "sourceRoot": "sha256:8ad889d768470da7ca7686ebfbc1f8d7553567b7bbc6e3216a8afdb55e139df1"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -828,5 +828,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:a650b28e9ab271571e85f6728cba52a224db40b72eb41830766f3309945f5328"
+  "registryRoot": "sha256:f3502e0ec4b2c166f96319faaec05de149e37bb9c1e0eee69066b71bcdd33256"
 }

--- a/scripts/alpha-promotion-preflight.mjs
+++ b/scripts/alpha-promotion-preflight.mjs
@@ -774,9 +774,11 @@ function main(argv = process.argv.slice(2)) {
     const output = path.resolve(options.out);
     let result;
     if (options.kind === 'windows') {
+      if (!options['source-commit'])
+        throw new Error('Windows fast-sentinel requires --source-commit');
       const native = executeWindowsContinuityScenario(output);
       result = buildWindowsContinuityFastReceipt({
-        sourceSha: process.env.GITHUB_SHA || '',
+        sourceSha: options['source-commit'],
         nativeReport: native.report,
         nativeExitCode: native.exitCode,
         durationMs: Date.now() - startedAt,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -463,6 +463,17 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
+    /KUNGFU_EXACT_SOURCE_SHA:[\s\S]*fast-sentinel --kind windows --source-commit \$env:KUNGFU_EXACT_SOURCE_SHA[\s\S]*verify-fast-sentinel[\s\S]*--source-commit \$env:KUNGFU_EXACT_SOURCE_SHA/u,
+  );
+  assert.doesNotMatch(
+    build.slice(
+      build.indexOf('  windows-fast-sentinel:'),
+      build.indexOf('  auditable-demo-fast-sentinel:'),
+    ),
+    /^\s*GITHUB_SHA:/mu,
+  );
+  assert.match(
+    build,
     /auditable-demo-fast-sentinel:[\s\S]*runs-on: ubuntu-24\.04/u,
   );
   assert.match(


### PR DESCRIPTION
## Summary

Bind the Windows Alpha continuity sentinel to an explicit exact-source input instead of GitHub's reserved `GITHUB_SHA` variable.

## Related issue

None.

## Changes

- Pass the candidate SHA through `KUNGFU_EXACT_SOURCE_SHA` and `--source-commit`.
- Require the Windows fast-sentinel CLI to receive that explicit source commit.
- Add a workflow regression check that rejects a reserved `GITHUB_SHA` override.
- Refresh the closed-world workflow authority projection.

## Verification

- `node --test scripts/alpha-promotion-preflight.test.mjs` (13/13 passed)
- Missing `--source-commit` fails before executing the native scenario.
- Repository staged pre-commit gate passed, including Gate catalog, 73 dev-required tests, 17 invariant tests, 138 documentation/release-contract tests, KFD checks, and Biome.
- Candidate Build run 30753617780 reproduced the defect: exact checkout/binding `1c28c6e...`, while reserved `GITHUB_SHA` remained PR merge commit `ad7c8c9...`; both native continuity samples passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This release qualification fix preserves the existing exact-source Windows continuity contract and replaces an unreliable reserved environment-variable transport."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs exact-source release evidence transport; it does not widen permissions or publication authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workflow authority projection refreshed and verified
