### PR TITLE
fix(agent-session): restore native worker path resolution

### DIFF
--- a/framework/agent-session/src/native-interactive-client.mjs
+++ b/framework/agent-session/src/native-interactive-client.mjs
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createDetachedAgentSessionHost } from './product-client.mjs';

--- a/framework/agent-session/tests/native-interactive-client.test.mjs
+++ b/framework/agent-session/tests/native-interactive-client.test.mjs
@@ -1,7 +1,32 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { ensureNativeInteractiveSessionSurface } from '../src/native-interactive-client.mjs';
+
+test('provider-native bootstrap resolves the default source worker', async () => {
+  const calls = [];
+  const endpoint = await ensureNativeInteractiveSessionSurface({
+    runtimeDir: '/tmp/kungfu-native-default-worker',
+    env: {},
+    createHost(options) {
+      calls.push(options);
+      return {
+        endpoint: '/tmp/native-agent-session.sock',
+        async invoke(request) {
+          assert.deepEqual(request, { operation: 'capabilities' });
+          return { schema: 'kungfu.agent-session.capabilities/v1' };
+        },
+      };
+    },
+  });
+  assert.equal(endpoint, '/tmp/native-agent-session.sock');
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].workerPath,
+    fileURLToPath(new URL('../src/product-worker.mjs', import.meta.url)),
+  );
+});
 
 test('provider-native bootstrap does not resolve or forward node-pty', async () => {
   const calls = [];


### PR DESCRIPTION
## Summary

Restore provider-native Agent Session bootstrap by importing the filesystem predicate already used to resolve the default source worker.

## Related issue

Observed local failure: `native Agent Session bootstrap: existsSync is not defined`.

## Changes

- Import `existsSync` from `node:fs` in the native-interactive bootstrap.
- Add a regression test that resolves and passes the default source worker path.

## Verification

- `./shifu --filter @kungfu-tech/agent-session test` (138/138 passed)
- `./shifu check:source` (passed on exact rebased HEAD)
- `git diff --check`
- Installed-product acceptance on the identical candidate tree: `agentctl run-cli --provider codex --slot pro-qian --execute` entered Codex under Kungfu management.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the existing native Agent Session worker-resolution path without changing its architecture, authority boundary, protocol, or supported provider contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change touches the provider-native CLI bootstrap only to restore its declared worker path; it does not widen provider authority or retain provider transcript bytes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; behavior now matches the existing contract)
