### PR TITLE
feat(profile): expose lifecycle command contract

### DIFF
--- a/framework/core/src/python/kungfu/profile_composition.py
+++ b/framework/core/src/python/kungfu/profile_composition.py
@@ -168,6 +168,7 @@ def manager(runtime_dir: str | Path) -> dict[str, Any]:
         profiles.append(projected)
     return {
         "schema": MANAGER_SCHEMA,
+        "lifecycleCommandContract": profile_sdk.lifecycle_command_contract(),
         "runtimeDir": lifecycle.get("runtime_dir", str(runtime_dir)),
         "cutSystemTime": lifecycle.get("cut_system_time", 0),
         "profiles": profiles,

--- a/framework/core/src/python/kungfu/profile_lifecycle_commands.py
+++ b/framework/core/src/python/kungfu/profile_lifecycle_commands.py
@@ -1,0 +1,443 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rooted Profile lifecycle command templates derived from the CLI catalog."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Mapping
+
+from kungfu import agent as agent_pack
+from kungfu.profile_sdk_support import ProfileSdkError, _root
+
+
+COMMAND_CONTRACT_SCHEMA = "kungfu.profile-lifecycle-command-contract/v1"
+_PLACEHOLDER = re.compile(r"^\{([a-z][a-z0-9_]*)\}$")
+_SHELL_TOKENS = {"sh", "bash", "zsh", "cmd", "powershell", "-c", "/c"}
+_PLACEHOLDER_TYPES = {
+    "binary": "executable-path",
+    "profile_id": "profile-id",
+    "source": "directory-path",
+    "before_root": "sha256-root",
+    "plan_file": "json-file-path",
+    "authorization_file": "json-file-path",
+    "expected_plan_id": "sha256-root",
+    "choice": "approval-choice",
+    "authorized_by": "actor-id",
+}
+
+
+def _is_root(value: Any) -> bool:
+    if not isinstance(value, str) or not value.startswith("sha256:"):
+        return False
+    digest = value.removeprefix("sha256:")
+    return len(digest) == 64 and all(char in "0123456789abcdef" for char in digest)
+
+
+_OPERATIONS = (
+    {
+        "id": "profile.capabilities",
+        "kind": "capabilities",
+        "surface": "kungfu.cli.commands.profile.capabilities",
+        "arguments": (),
+        "preconditions": (),
+        "output": "kungfu.agent-profile-sdk/v1",
+        "receipt": "none",
+        "impact": "Read the installed Profile SDK and lifecycle command contract.",
+        "recovery": "Refresh the installed product if the contract root is unavailable.",
+    },
+    {
+        "id": "profile.list",
+        "kind": "list",
+        "surface": "kungfu.cli.commands.profile.list.profiles",
+        "arguments": (),
+        "preconditions": (),
+        "output": "kungfu.profile-lifecycle/v1",
+        "receipt": "none",
+        "impact": "Read the current Core-owned Profile lifecycle projection.",
+        "recovery": "Inspect lifecycle diagnostics without applying a mutation.",
+    },
+    {
+        "id": "profile.manager",
+        "kind": "manager",
+        "surface": "kungfu.cli.commands.profile.manager",
+        "arguments": (),
+        "preconditions": (),
+        "output": "kungfu.profile-manager/v1",
+        "receipt": "none",
+        "impact": "Read lifecycle, source health, and composition projections.",
+        "recovery": "Use Profile inspect to isolate a degraded source projection.",
+    },
+    {
+        "id": "profile.inspect",
+        "kind": "inspect",
+        "surface": "kungfu.cli.commands.profile.inspect",
+        "arguments": ("{profile_id}",),
+        "preconditions": ("profile_id-present",),
+        "output": "kungfu.profile-lifecycle/v1",
+        "receipt": "none",
+        "impact": "Read one exact Profile source or lifecycle state.",
+        "recovery": "List Profiles and retry with one unambiguous Profile id.",
+    },
+    {
+        "id": "profile.plan.upgrade",
+        "kind": "plan",
+        "surface": "kungfu.cli.commands.profile.plan",
+        "arguments": (
+            "upgrade",
+            "{source}",
+            "--expected-current-root",
+            "{before_root}",
+        ),
+        "preconditions": ("source-exists", "before_root-matches-current"),
+        "output": "kungfu.profile-agent-plan/v1",
+        "receipt": "none",
+        "impact": "Plan an upgrade at an exact current root without applying it.",
+        "recovery": "Refresh Profile state and re-plan when the current root changes.",
+    },
+    {
+        "id": "profile.apply",
+        "kind": "apply",
+        "surface": "kungfu.cli.commands.profile.apply",
+        "arguments": (
+            "{plan_file}",
+            "--authorization-file",
+            "{authorization_file}",
+        ),
+        "preconditions": (
+            "plan_file-root-verified",
+            "authorization_file-binds-plan",
+        ),
+        "output": "kungfu.profile-lifecycle-receipt/v1",
+        "receipt": "kungfu.profile-lifecycle-receipt/v1",
+        "impact": "Apply an authorized, still-current Profile lifecycle plan.",
+        "recovery": "Inspect the receipt and current state before planning a rollback.",
+    },
+    {
+        "id": "profile.authorize-upgrade",
+        "kind": "authorize-lifecycle",
+        "surface": "kungfu.cli.commands.profile.authorize.lifecycle",
+        "arguments": (
+            "upgrade",
+            "{source}",
+            "--expected-plan-id",
+            "{expected_plan_id}",
+            "--choice",
+            "{choice}",
+            "--authorized-by",
+            "{authorized_by}",
+        ),
+        "preconditions": (
+            "source-exists",
+            "expected_plan_id-matches-current",
+            "choice-explicit",
+            "authorized_by-externally-verified",
+        ),
+        "output": "kungfu.profile-lifecycle-receipt/v1",
+        "receipt": "kungfu.profile-lifecycle-receipt/v1",
+        "impact": "Re-plan, authorize, and apply one exact Profile upgrade.",
+        "recovery": "Re-plan after stale-root failure; use a reviewed rollback plan after mutation.",
+    },
+)
+
+
+def _fail(message: str, **details: Any) -> None:
+    raise ProfileSdkError("lifecycle-command-contract-invalid", message, **details)
+
+
+def _surface_index(catalog: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    surfaces = catalog.get("surfaces")
+    if not isinstance(surfaces, list):
+        _fail("CLI catalog surfaces are unavailable")
+    return {
+        str(row.get("id")): row
+        for row in surfaces
+        if isinstance(row, Mapping) and row.get("id")
+    }
+
+
+def _authority_projection(
+    lifecycle_authority: Mapping[str, Any],
+    sdk_contract: Mapping[str, Any],
+    cli_catalog: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "lifecycle": {
+            "schema": lifecycle_authority.get("schema"),
+            "authority": lifecycle_authority.get("authority"),
+            "root": _root(lifecycle_authority),
+        },
+        "sdk": {
+            "schema": sdk_contract.get("schema"),
+            "id": sdk_contract.get("id"),
+            "version": sdk_contract.get("version"),
+            "root": sdk_contract.get("root"),
+        },
+        "cli": {
+            "schema": cli_catalog.get("schema"),
+            "contractRoot": cli_catalog.get("contractRoot"),
+            "catalogRoot": cli_catalog.get("catalogRoot"),
+            "surfaceRoot": cli_catalog.get("surfaceRoot"),
+        },
+    }
+
+
+def command_contract(
+    lifecycle_authority: Mapping[str, Any],
+    sdk_contract: Mapping[str, Any],
+    cli_catalog: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the canonical command contract from installed authority projections."""
+
+    catalog = cli_catalog or agent_pack.cli_surface_catalog()
+    surfaces = _surface_index(catalog)
+    commands = []
+    for spec in _OPERATIONS:
+        surface = surfaces.get(str(spec["surface"]))
+        if surface is None:
+            _fail(
+                "declared command is absent from the CLI catalog", operation=spec["id"]
+            )
+        canonical_path = str(surface.get("canonical_path") or "").split()
+        if canonical_path[:2] != ["kungfu", "profile"]:
+            _fail("CLI catalog path is not a Profile command", operation=spec["id"])
+        mutation_class = str(surface.get("mutation_class") or "")
+        mutation = mutation_class == "write"
+        argv = ["{binary}", *canonical_path[1:], *spec["arguments"], "--json"]
+        placeholders = []
+        for token in argv:
+            match = _PLACEHOLDER.fullmatch(token)
+            if match:
+                name = match.group(1)
+                placeholders.append({"name": name, "type": _PLACEHOLDER_TYPES[name]})
+        commands.append(
+            {
+                "id": spec["id"],
+                "kind": spec["kind"],
+                "surfaceId": spec["surface"],
+                "commandPath": canonical_path,
+                "argv": argv,
+                "placeholders": placeholders,
+                "mutation": mutation,
+                "mutationClass": mutation_class,
+                "approvalPolicy": copy.deepcopy(surface.get("approval_policy")),
+                "preconditions": list(spec["preconditions"]),
+                "outputSchema": spec["output"],
+                "receiptSchema": spec["receipt"],
+                "impact": spec["impact"],
+                "diagnostics": {
+                    "format": "kungfu.profile-diagnosis/v1",
+                    "stderr": "diagnostic-only",
+                },
+                "recovery": spec["recovery"],
+            }
+        )
+    body = {
+        "schema": COMMAND_CONTRACT_SCHEMA,
+        "version": 1,
+        "authorities": _authority_projection(
+            lifecycle_authority, sdk_contract, catalog
+        ),
+        "placeholderTypes": copy.deepcopy(_PLACEHOLDER_TYPES),
+        "commands": commands,
+    }
+    contract = {**body, "contractRoot": _root(body)}
+    validate_command_contract(
+        contract,
+        cli_catalog=catalog,
+        lifecycle_authority=lifecycle_authority,
+        sdk_contract=sdk_contract,
+    )
+    return contract
+
+
+def validate_command_contract(
+    contract: Mapping[str, Any],
+    *,
+    cli_catalog: Mapping[str, Any] | None = None,
+    lifecycle_authority: Mapping[str, Any] | None = None,
+    sdk_contract: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Fail closed on drift, shell templates, or authority/mutation mismatch."""
+
+    value = copy.deepcopy(dict(contract))
+    recorded_root = value.pop("contractRoot", None)
+    if value.get("schema") != COMMAND_CONTRACT_SCHEMA or recorded_root != _root(value):
+        _fail("Profile lifecycle command contract root mismatch")
+    catalog = cli_catalog or agent_pack.cli_surface_catalog()
+    surfaces = _surface_index(catalog)
+    expected_authorities = value.get("authorities")
+    if value.get("placeholderTypes") != _PLACEHOLDER_TYPES:
+        _fail("command placeholder types do not match the installed contract")
+    if not isinstance(expected_authorities, Mapping):
+        _fail("command contract authority roots are unavailable")
+    lifecycle_projection = expected_authorities.get("lifecycle") or {}
+    sdk_projection = expected_authorities.get("sdk") or {}
+    cli_projection = expected_authorities.get("cli") or {}
+    if not all(
+        _is_root(candidate)
+        for candidate in (
+            lifecycle_projection.get("root"),
+            sdk_projection.get("root"),
+            cli_projection.get("contractRoot"),
+            cli_projection.get("catalogRoot"),
+            cli_projection.get("surfaceRoot"),
+        )
+    ):
+        _fail("command contract authority roots are incomplete")
+    if lifecycle_authority is not None and sdk_contract is not None:
+        expected = _authority_projection(lifecycle_authority, sdk_contract, catalog)
+        if expected_authorities != expected:
+            _fail("command contract authority roots do not match installed authorities")
+    commands = value.get("commands")
+    if not isinstance(commands, list) or not commands:
+        _fail("command contract has no commands")
+    seen: set[str] = set()
+    for command in commands:
+        if not isinstance(command, Mapping):
+            _fail("command declaration must be an object")
+        operation_id = str(command.get("id") or "")
+        if not operation_id or operation_id in seen:
+            _fail(
+                "command operation ids must be stable and unique",
+                operation=operation_id,
+            )
+        seen.add(operation_id)
+        surface = surfaces.get(str(command.get("surfaceId") or ""))
+        if surface is None:
+            _fail(
+                "command surface is absent from the CLI catalog", operation=operation_id
+            )
+        path = str(surface.get("canonical_path") or "").split()
+        if command.get("commandPath") != path:
+            _fail("command path does not match the CLI catalog", operation=operation_id)
+        mutation_class = str(surface.get("mutation_class") or "")
+        expected_mutation = mutation_class == "write"
+        if (
+            command.get("mutationClass") != mutation_class
+            or command.get("mutation") is not expected_mutation
+        ):
+            _fail(
+                "command mutation metadata conflicts with the CLI catalog",
+                operation=operation_id,
+            )
+        if command.get("approvalPolicy") != surface.get("approval_policy"):
+            _fail(
+                "command approval policy conflicts with the CLI catalog",
+                operation=operation_id,
+            )
+        argv = command.get("argv")
+        if not isinstance(argv, list) or argv[: len(path)] != ["{binary}", *path[1:]]:
+            _fail(
+                "command argv does not begin with its canonical CLI path",
+                operation=operation_id,
+            )
+        declared_placeholders = {
+            row.get("name")
+            for row in command.get("placeholders") or []
+            if isinstance(row, Mapping)
+            and row.get("type")
+            == value.get("placeholderTypes", {}).get(row.get("name"))
+        }
+        found_placeholders: set[str] = set()
+        for token in argv:
+            if (
+                not isinstance(token, str)
+                or not token
+                or any(char.isspace() for char in token)
+            ):
+                _fail(
+                    "command argv must contain structured tokens",
+                    operation=operation_id,
+                )
+            if token.lower() in _SHELL_TOKENS:
+                _fail(
+                    "shell evaluation is forbidden in command argv",
+                    operation=operation_id,
+                )
+            match = _PLACEHOLDER.fullmatch(token)
+            if match:
+                name = match.group(1)
+                if name not in _PLACEHOLDER_TYPES:
+                    _fail(
+                        "command uses an unknown placeholder",
+                        operation=operation_id,
+                        placeholder=name,
+                    )
+                found_placeholders.add(name)
+            elif "{" in token or "}" in token:
+                _fail("placeholders must occupy one argv token", operation=operation_id)
+        if declared_placeholders != found_placeholders:
+            _fail(
+                "command placeholder declarations do not match argv",
+                operation=operation_id,
+            )
+        preconditions = command.get("preconditions")
+        if not isinstance(preconditions, list):
+            _fail("command preconditions must be explicit", operation=operation_id)
+        approval = command.get("approvalPolicy") or {}
+        if expected_mutation and (
+            not preconditions or approval.get("mode") in (None, "", "none")
+        ):
+            _fail(
+                "mutating commands require approval and preconditions",
+                operation=operation_id,
+            )
+        for field in (
+            "outputSchema",
+            "receiptSchema",
+            "impact",
+            "diagnostics",
+            "recovery",
+        ):
+            if command.get(field) in (None, "", {}):
+                _fail(
+                    "command metadata is incomplete",
+                    operation=operation_id,
+                    field=field,
+                )
+    return dict(contract)
+
+
+def render_command(
+    contract: Mapping[str, Any],
+    operation_id: str,
+    bindings: Mapping[str, str],
+    *,
+    allow_mutation: bool = False,
+) -> list[str]:
+    """Render one structured argv vector, fencing mutation by default."""
+
+    validate_command_contract(contract)
+    command = next(
+        (row for row in contract["commands"] if row.get("id") == operation_id), None
+    )
+    if command is None:
+        _fail("unknown command operation", operation=operation_id)
+    if command.get("mutation") is True and not allow_mutation:
+        raise ProfileSdkError(
+            "lifecycle-command-mutation-rejected",
+            "mutating Profile commands require an explicit higher-authority caller",
+            operation=operation_id,
+        )
+    rendered = []
+    for token in command["argv"]:
+        match = _PLACEHOLDER.fullmatch(token)
+        if not match:
+            rendered.append(token)
+            continue
+        name = match.group(1)
+        replacement = bindings.get(name)
+        if (
+            not isinstance(replacement, str)
+            or not replacement
+            or any(char in replacement for char in "{}\n\r\0")
+        ):
+            _fail(
+                "command binding is missing or unsafe",
+                operation=operation_id,
+                placeholder=name,
+            )
+        rendered.append(replacement)
+    return rendered

--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -21,6 +21,7 @@ from typing import Any, Mapping
 from kungfu import agent as agent_pack
 from kungfu import runtime_broker
 from kungfu import kfx_contract
+from kungfu import profile_lifecycle_commands
 from kungfu.storage import service as storage_service
 from kungfu.profile_sdk_support import (
     ACTION_PLAN_SCHEMA as ACTION_PLAN_SCHEMA,
@@ -86,16 +87,23 @@ def capabilities() -> dict[str, Any]:
     contract_bytes = agent_pack.document_text("profile-sdk.contract.json").encode(
         "utf-8"
     )
+    lifecycle_authority = storage_service.profile_lifecycle("", "contract")
+    sdk_authority = {
+        "schema": sdk_contract["schema"],
+        "id": sdk_contract["id"],
+        "version": sdk_contract["version"],
+        "root": "sha256:" + _sha256(contract_bytes),
+    }
+    lifecycle_command_contract = profile_lifecycle_commands.command_contract(
+        lifecycle_authority,
+        sdk_authority,
+        agent_pack.cli_surface_catalog(),
+    )
     return {
         "schema": SDK_SCHEMA,
         "contract": kfx_contract.contract_metadata(),
         "profileSchema": kfx_contract.profile_suite_schema(),
-        "sdkContract": {
-            "schema": sdk_contract["schema"],
-            "id": sdk_contract["id"],
-            "version": sdk_contract["version"],
-            "root": "sha256:" + _sha256(contract_bytes),
-        },
+        "sdkContract": sdk_authority,
         "schemas": {
             "brief": sdk_contract["briefSchema"],
             "decisionCard": sdk_contract["decisionCardSchema"],
@@ -113,7 +121,8 @@ def capabilities() -> dict[str, Any]:
         },
         "sourcePlanSchema": SOURCE_PLAN_SCHEMA,
         "actionRegistrySchema": ACTION_REGISTRY_SCHEMA,
-        "lifecycleAuthority": storage_service.profile_lifecycle("", "contract"),
+        "lifecycleAuthority": lifecycle_authority,
+        "lifecycleCommandContract": lifecycle_command_contract,
         "operations": [
             "capabilities",
             "examples",
@@ -156,6 +165,7 @@ def capabilities() -> dict[str, Any]:
             "assessment-authorize",
             "manager",
             "authorize-lifecycle",
+            "lifecycle-command-contract",
             "export",
             "import",
         ],
@@ -171,6 +181,12 @@ def capabilities() -> dict[str, Any]:
             "selfCertification": False,
         },
     }
+
+
+def lifecycle_command_contract() -> dict[str, Any]:
+    """Return the same installed command contract projected by capabilities."""
+
+    return capabilities()["lifecycleCommandContract"]
 
 
 def examples() -> dict[str, Any]:

--- a/framework/core/tests/python/test_profile_lifecycle_command_contract.py
+++ b/framework/core/tests/python/test_profile_lifecycle_command_contract.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from kungfu import agent as agent_pack
+from kungfu import profile_lifecycle_commands, profile_sdk
+from kungfu.cli.commands import __registry__  # noqa: F401
+from kungfu.cli.commands import kfc
+from kungfu.profile_sdk_support import _root
+
+
+def _contract():
+    return profile_sdk.capabilities()["lifecycleCommandContract"]
+
+
+def _reroot(contract):
+    body = copy.deepcopy(contract)
+    body.pop("contractRoot", None)
+    contract["contractRoot"] = _root(body)
+    return contract
+
+
+def _command(contract, operation_id):
+    return next(row for row in contract["commands"] if row["id"] == operation_id)
+
+
+def test_contract_is_deterministic_rooted_and_shared_by_installed_projections(tmp_path):
+    first = _contract()
+    second = _contract()
+    body = copy.deepcopy(first)
+    recorded = body.pop("contractRoot")
+
+    assert first == second
+    assert first["schema"] == "kungfu.profile-lifecycle-command-contract/v1"
+    assert recorded == _root(body)
+    assert profile_sdk.lifecycle_command_contract() == first
+
+    runner = CliRunner()
+    capabilities = runner.invoke(
+        kfc, ["--home", str(tmp_path / "home"), "profile", "capabilities", "--json"]
+    )
+    manager = runner.invoke(
+        kfc, ["--home", str(tmp_path / "home"), "profile", "manager", "--json"]
+    )
+    assert capabilities.exit_code == 0, capabilities.output
+    assert manager.exit_code == 0, manager.output
+    assert json.loads(capabilities.output)["lifecycleCommandContract"] == first
+    assert json.loads(manager.output)["lifecycleCommandContract"] == first
+
+
+def test_reader_and_plan_commands_render_as_argv_while_writes_are_fenced():
+    contract = _contract()
+    bindings = {
+        "binary": "/task/bin/kungfu",
+        "profile_id": "example.week-day",
+        "source": "/task/profiles/week-day",
+        "before_root": "sha256:" + "1" * 64,
+    }
+
+    assert profile_lifecycle_commands.render_command(
+        contract, "profile.manager", bindings
+    ) == ["/task/bin/kungfu", "profile", "manager", "--json"]
+    assert profile_lifecycle_commands.render_command(
+        contract, "profile.plan.upgrade", bindings
+    ) == [
+        "/task/bin/kungfu",
+        "profile",
+        "plan",
+        "upgrade",
+        "/task/profiles/week-day",
+        "--expected-current-root",
+        "sha256:" + "1" * 64,
+        "--json",
+    ]
+    assert _command(contract, "profile.manager")["mutation"] is False
+    assert _command(contract, "profile.plan.upgrade")["mutation"] is False
+    assert _command(contract, "profile.apply")["mutation"] is True
+    assert _command(contract, "profile.authorize-upgrade")["mutation"] is True
+    with pytest.raises(profile_sdk.ProfileSdkError) as raised:
+        profile_lifecycle_commands.render_command(
+            contract,
+            "profile.apply",
+            {
+                "binary": "/task/bin/kungfu",
+                "plan_file": "/task/plan.json",
+                "authorization_file": "/task/authorization.json",
+            },
+        )
+    assert raised.value.diagnosis["code"] == "lifecycle-command-mutation-rejected"
+
+
+def test_contract_rejects_stale_root_unknown_placeholder_and_shell_argv():
+    stale = _contract()
+    stale["version"] = 2
+    with pytest.raises(profile_sdk.ProfileSdkError):
+        profile_lifecycle_commands.validate_command_contract(stale)
+
+    unknown = _contract()
+    command = _command(unknown, "profile.manager")
+    command["argv"].append("{unknown}")
+    command["placeholders"].append({"name": "unknown", "type": "text"})
+    _reroot(unknown)
+    with pytest.raises(profile_sdk.ProfileSdkError, match="unknown placeholder"):
+        profile_lifecycle_commands.validate_command_contract(unknown)
+
+    shell = _contract()
+    command = _command(shell, "profile.manager")
+    command["argv"] = ["{binary}", "profile", "manager", "sh", "-c", "date"]
+    _reroot(shell)
+    with pytest.raises(profile_sdk.ProfileSdkError, match="shell evaluation"):
+        profile_lifecycle_commands.validate_command_contract(shell)
+
+
+def test_contract_rejects_mutation_approval_precondition_and_catalog_drift():
+    mislabeled = _contract()
+    _command(mislabeled, "profile.apply")["mutation"] = False
+    _reroot(mislabeled)
+    with pytest.raises(profile_sdk.ProfileSdkError, match="mutation metadata"):
+        profile_lifecycle_commands.validate_command_contract(mislabeled)
+
+    approval = _contract()
+    _command(approval, "profile.apply")["approvalPolicy"] = {
+        "mode": "none",
+        "caller_confirmation_required": False,
+        "preconditions": [],
+    }
+    _reroot(approval)
+    with pytest.raises(profile_sdk.ProfileSdkError, match="approval policy"):
+        profile_lifecycle_commands.validate_command_contract(approval)
+
+    precondition = _contract()
+    _command(precondition, "profile.apply")["preconditions"] = []
+    _reroot(precondition)
+    with pytest.raises(profile_sdk.ProfileSdkError, match="require approval"):
+        profile_lifecycle_commands.validate_command_contract(precondition)
+
+    catalog = copy.deepcopy(agent_pack.cli_surface_catalog())
+    catalog["surfaces"] = [
+        row
+        for row in catalog["surfaces"]
+        if row["id"] != "kungfu.cli.commands.profile.manager"
+    ]
+    with pytest.raises(
+        profile_sdk.ProfileSdkError, match="absent from the CLI catalog"
+    ):
+        profile_lifecycle_commands.command_contract(
+            profile_sdk.capabilities()["lifecycleAuthority"],
+            profile_sdk.capabilities()["sdkContract"],
+            catalog,
+        )
+
+
+def test_cli_reads_and_plans_only_inside_the_supplied_home(tmp_path):
+    real_home_sentinel = tmp_path / "outside-home-sentinel"
+    real_home_sentinel.write_text("unchanged", encoding="utf-8")
+    home = tmp_path / "isolated-home"
+    runner = CliRunner()
+
+    capabilities = runner.invoke(
+        kfc, ["--home", str(home), "profile", "capabilities", "--json"]
+    )
+    listing = runner.invoke(kfc, ["--home", str(home), "profile", "list", "--json"])
+    assert capabilities.exit_code == 0, capabilities.output
+    assert listing.exit_code == 0, listing.output
+    assert json.loads(listing.output)["profiles"] == []
+    assert real_home_sentinel.read_text(encoding="utf-8") == "unchanged"
+    assert (
+        _command(
+            json.loads(capabilities.output)["lifecycleCommandContract"], "profile.list"
+        )["mutation"]
+        is False
+    )

--- a/package.json
+++ b/package.json
@@ -316,6 +316,8 @@
     "test:native-kfx-admission": "node scripts/require-shifu.mjs test:native-kfx-admission && node scripts/run-native-kfx-admission-tests.mjs",
     "check:kfx-identity-neutral-authority": "node scripts/require-shifu.mjs check:kfx-identity-neutral-authority && node scripts/run-native-kfx-admission-tests.mjs --identity-neutral-only",
     "test:profile-lifecycle": "node scripts/require-shifu.mjs test:profile-lifecycle && node scripts/run-profile-lifecycle-tests.mjs",
+    "fix:profile-lifecycle-command-contract": "node scripts/require-shifu.mjs fix:profile-lifecycle-command-contract && uv run --project framework/core --frozen ruff format framework/core/src/python/kungfu/profile_lifecycle_commands.py framework/core/src/python/kungfu/profile_sdk.py framework/core/src/python/kungfu/profile_composition.py framework/core/tests/python/test_profile_lifecycle_command_contract.py && biome check --write scripts/run-profile-lifecycle-tests.mjs scripts/qualify-profile-lifecycle-command-contract.mjs",
+    "qualify:profile-lifecycle-command-contract": "node scripts/require-shifu.mjs qualify:profile-lifecycle-command-contract && node scripts/qualify-profile-lifecycle-command-contract.mjs",
     "test:agent-profile-sdk": "node scripts/require-shifu.mjs test:agent-profile-sdk && node scripts/run-agent-profile-sdk-tests.mjs",
     "test:agent-console-contract": "node scripts/require-shifu.mjs test:agent-console-contract && node scripts/run-agent-console-contract-tests.mjs",
     "test:runtime-upgrade": "node scripts/require-shifu.mjs test:runtime-upgrade && node scripts/run-runtime-upgrade-tests.mjs",

--- a/scripts/qualify-profile-lifecycle-command-contract.mjs
+++ b/scripts/qualify-profile-lifecycle-command-contract.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// shifu-entry-contract: qualify the built wheel through ./shifu only.
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const root = process.cwd();
+const wheelDir = path.join(
+  root,
+  'framework',
+  'core',
+  'build',
+  'python',
+  'dist',
+);
+const qualificationRoot = path.join(
+  root,
+  'framework',
+  'core',
+  'build',
+  'qualification',
+  'profile-lifecycle-command-contract',
+);
+
+function fail(message) {
+  console.error(`[profile-command-contract] ${message}`);
+  process.exit(1);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    env: process.env,
+    ...options,
+  });
+  if (result.error || result.status !== 0) {
+    if (result.stdout) process.stderr.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    fail(
+      result.error
+        ? `${command} failed: ${result.error.message}`
+        : `${command} exited ${result.status}`,
+    );
+  }
+  return result.stdout;
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function semanticRoot(value) {
+  return `sha256:${crypto.createHash('sha256').update(canonical(value)).digest('hex')}`;
+}
+
+if (!fs.existsSync(wheelDir))
+  fail('built wheel directory is unavailable; run ./shifu build:core');
+const wheels = fs
+  .readdirSync(wheelDir)
+  .filter((name) => /^kungfu-.*\.whl$/u.test(name))
+  .sort();
+if (wheels.length !== 1)
+  fail(`expected one built Kungfu wheel, found ${wheels.length}`);
+
+fs.mkdirSync(qualificationRoot, { recursive: true });
+const environment = fs.mkdtempSync(path.join(qualificationRoot, 'installed-'));
+const python = path.join(
+  environment,
+  process.platform === 'win32' ? 'Scripts' : 'bin',
+  process.platform === 'win32' ? 'python.exe' : 'python',
+);
+const binary = path.join(
+  environment,
+  process.platform === 'win32' ? 'Scripts' : 'bin',
+  process.platform === 'win32' ? 'kungfu.cmd' : 'kungfu',
+);
+const wheel = path.join(wheelDir, wheels[0]);
+run('uv', ['venv', environment, '--python', '3.13']);
+run('uv', ['pip', 'install', '--python', python, wheel]);
+if (process.platform === 'win32') {
+  fs.writeFileSync(binary, `@echo off\r\n"${python}" -m kungfu %*\r\n`, 'utf8');
+} else {
+  fs.writeFileSync(
+    binary,
+    `#!/bin/sh\nexec ${JSON.stringify(python)} -m kungfu "$@"\n`,
+    { encoding: 'utf8', mode: 0o755 },
+  );
+}
+
+const home = path.join(environment, 'home');
+const capabilities = JSON.parse(
+  run(binary, ['--home', home, 'profile', 'capabilities', '--json']),
+);
+const manager = JSON.parse(
+  run(binary, ['--home', home, 'profile', 'manager', '--json']),
+);
+const contract = capabilities.lifecycleCommandContract;
+if (contract?.schema !== 'kungfu.profile-lifecycle-command-contract/v1')
+  fail('installed capabilities omit the lifecycle command contract');
+if (canonical(manager.lifecycleCommandContract) !== canonical(contract))
+  fail(
+    'installed capabilities and manager project different command contracts',
+  );
+const { contractRoot: recordedRoot, ...body } = contract;
+if (recordedRoot !== semanticRoot(body))
+  fail('installed command contract root mismatch');
+
+const commands = new Map(contract.commands.map((row) => [row.id, row]));
+for (const id of [
+  'profile.capabilities',
+  'profile.inspect',
+  'profile.list',
+  'profile.manager',
+  'profile.plan.upgrade',
+]) {
+  if (commands.get(id)?.mutation !== false)
+    fail(`reader/plan command is not mutation-free: ${id}`);
+}
+for (const id of ['profile.apply', 'profile.authorize-upgrade']) {
+  if (commands.get(id)?.mutation !== true)
+    fail(`mutating command is not fenced: ${id}`);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      schema: 'kungfu.profile-lifecycle-command-contract-qualification/v1',
+      status: 'qualified',
+      wheel,
+      binary,
+      contractRoot: recordedRoot,
+      commandCount: contract.commands.length,
+      readerPlanCount: contract.commands.filter((row) => row.mutation === false)
+        .length,
+      mutationCount: contract.commands.filter((row) => row.mutation === true)
+        .length,
+      home,
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/run-profile-lifecycle-tests.mjs
+++ b/scripts/run-profile-lifecycle-tests.mjs
@@ -9,6 +9,48 @@ import path from 'node:path';
 import process from 'node:process';
 
 const buildDir = path.join(process.cwd(), 'framework', 'core', 'build');
+const coreDir = path.join(process.cwd(), 'framework', 'core');
+const pythonEnvironment =
+  process.env.UV_PROJECT_ENVIRONMENT || path.join(coreDir, '.venv');
+const python =
+  process.platform === 'win32'
+    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
+    : path.join(pythonEnvironment, 'bin', 'python');
+const ninjaName = process.platform === 'win32' ? 'ninja.exe' : 'ninja';
+const managedNinja = process.env.UV_PROJECT_ENVIRONMENT
+  ? path.join(
+      process.env.UV_PROJECT_ENVIRONMENT,
+      process.platform === 'win32' ? 'Scripts' : 'bin',
+      ninjaName,
+    )
+  : path.join(
+      coreDir,
+      '.venv',
+      process.platform === 'win32' ? 'Scripts' : 'bin',
+      ninjaName,
+    );
+const configure = spawnSync(
+  'cmake',
+  [
+    '-S',
+    coreDir,
+    '-B',
+    buildDir,
+    `-DCMAKE_MAKE_PROGRAM=${managedNinja}`,
+    `-DPYTHON_EXECUTABLE=${python}`,
+  ],
+  { cwd: process.cwd(), stdio: 'inherit' },
+);
+if (configure.error || configure.status !== 0) {
+  if (configure.error)
+    console.error(
+      `[profile-lifecycle-test] configure: ${configure.error.message}`,
+    );
+  console.error(
+    '[profile-lifecycle-test] failed to rebind the configured tree to the current Shifu toolchain',
+  );
+  process.exit(configure.status ?? 2);
+}
 // shifu-entry-contract: this task builds the exact native target before use.
 const build = spawnSync(
   'cmake',
@@ -73,13 +115,6 @@ if (result.error || result.status !== 0) {
   process.exit(result.status ?? 1);
 }
 
-const pythonEnvironment =
-  process.env.UV_PROJECT_ENVIRONMENT ||
-  path.join(process.cwd(), 'framework', 'core', '.venv');
-const python =
-  process.platform === 'win32'
-    ? path.join(pythonEnvironment, 'Scripts', 'python.exe')
-    : path.join(pythonEnvironment, 'bin', 'python');
 const pythonPath = [
   path.join(process.cwd(), 'framework', 'core', 'build', 'Release'),
   path.join(process.cwd(), 'framework', 'core', 'src', 'python'),
@@ -102,6 +137,14 @@ const pythonResult = spawnSync(
       'tests',
       'python',
       'test_profile_lifecycle_cli.py',
+    ),
+    path.join(
+      process.cwd(),
+      'framework',
+      'core',
+      'tests',
+      'python',
+      'test_profile_lifecycle_command_contract.py',
     ),
     '-q',
   ],


### PR DESCRIPTION
## Summary

Expose one canonical, rooted Profile lifecycle command contract so installed readers can render safe argv templates without guessing CLI syntax or acquiring lifecycle authority.

## Related issue

Atlas Assignment `2026-08-02-kungfu-profile-lifecycle-command-contract`.

## Changes

- derive a deterministic `kungfu.profile-lifecycle-command-contract/v1` from the governed Profile lifecycle, SDK, and CLI catalog authorities
- project the same rooted contract through Profile capabilities and Profile Manager
- separate five reader/plan operations from two mutation operations with typed placeholders, preconditions, approval, receipt, diagnostics, impact, and recovery metadata
- reject stale roots, shell execution, unknown placeholders, authority drift, and reader/mutation misclassification
- add focused source tests and exact installed-wheel qualification
- rebind the Profile lifecycle test runner to stable managed Ninja/Python paths instead of ephemeral Shifu overlays

## Verification

- `./shifu test:profile-lifecycle` (5 native scenarios, 7 Python tests, Node binding)
- `./shifu test:agent-profile-sdk` (64 passed)
- `./shifu check:cli-catalog-parity`
- `./shifu fix:profile-lifecycle-command-contract`
- `./shifu qualify:profile-lifecycle-command-contract`
- installed contract root: `sha256:029ad932d7a8f3df20b885c5ea11f6242e72f7816a8ccfe4f988aecb55788433`
- Atlas installed compatibility reports `command_projection=declared`, five reader plans, two fenced mutations
- repository staged pre-commit/source gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This additive machine-readable projection exposes the existing Profile lifecycle and governed CLI contracts without changing lifecycle authority, approval semantics, or command behavior."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change adds qualification evidence and a machine-readable installed contract; it does not grant publication or Profile mutation authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Focused source and installed-artifact qualification passed
- [x] Documentation impact evaluated; the contract is self-describing and ADR-neutral