### PR TITLE
fix(agent-session): expose native follow readiness

### DIFF
--- a/framework/agent-session/src/runtime-port.mjs
+++ b/framework/agent-session/src/runtime-port.mjs
@@ -159,6 +159,10 @@ export class NativeKungfuJournalNoticePort {
     }
   }
 
+  canFollow() {
+    return this.peer.canRequestReadFromPublic();
+  }
+
   drain() {
     const result = this.peer.drainCustomData();
     this.nativeDropped += result.dropped;

--- a/framework/agent-session/tests/runtime-port.native-peer.mjs
+++ b/framework/agent-session/tests/runtime-port.native-peer.mjs
@@ -78,6 +78,7 @@ try {
       process.once('SIGINT', resolve);
     });
   } else {
+    await waitFor(() => port.canFollow(), 'reader coordinator command channel');
     port.follow({
       mode: 'live',
       role: 'system',

--- a/framework/agent-session/tests/runtime-port.test.mjs
+++ b/framework/agent-session/tests/runtime-port.test.mjs
@@ -14,6 +14,7 @@ class FakeWatcher {
     this.runtimeDir = runtimeDir;
     this.started = false;
     this.live = true;
+    this.readRequestReady = true;
     this.usable = true;
     this.issued = [];
     this.incoming = [];
@@ -42,7 +43,11 @@ class FakeWatcher {
 
   requestReadFromPublic(location, fromTime) {
     this.followed = { location, fromTime };
-    return this.live;
+    return this.live && this.readRequestReady;
+  }
+
+  canRequestReadFromPublic() {
+    return this.live && this.readRequestReady;
   }
 
   drainCustomData() {
@@ -160,6 +165,28 @@ test('reader follows a Peer public journal and reconstructs cursor frames', () =
   assert.equal(recovered.frames[0].kind, 'controller-granted');
   assert.equal(recovered.frames[0].payload.leaseId, 'lease-1');
   assert.equal(reader.peer.followed.fromTime, 0n);
+});
+
+test('reader exposes coordinator command readiness separately from liveness', () => {
+  const reader = new NativeKungfuJournalNoticePort({
+    binding,
+    runtimeDir: '/tmp/runtime',
+    peerName: 'capsule-reader-readiness',
+  });
+  reader.peer.readRequestReady = false;
+  assert.equal(reader.health().live, true);
+  assert.equal(reader.canFollow(), false);
+  assert.throws(
+    () =>
+      reader.follow({
+        role: 'system',
+        namespace: 'node',
+        name: 'capsule-writer',
+      }),
+    (error) => error.code === 'peer_not_ready',
+  );
+  reader.peer.readRequestReady = true;
+  assert.equal(reader.canFollow(), true);
 });
 
 test('native queue overflow becomes an explicit gap', () => {

--- a/framework/core/src/bindings/node/binding/watcher.cpp
+++ b/framework/core/src/bindings/node/binding/watcher.cpp
@@ -263,6 +263,11 @@ Napi::Value Watcher::RequestReadFromPublic(const Napi::CallbackInfo &info) {
   return Napi::Boolean::New(info.Env(), true);
 }
 
+Napi::Value Watcher::CanRequestReadFromPublic(const Napi::CallbackInfo &info) {
+  std::lock_guard<std::mutex> lock(writers_mtx_);
+  return Napi::Boolean::New(info.Env(), is_live() and writers_.find(get_coordinator_command_uid()) != writers_.end());
+}
+
 Napi::Value Watcher::DrainCustomData(const Napi::CallbackInfo &info) {
   std::deque<custom_frame_record> drained;
   uint64_t dropped = 0;
@@ -371,6 +376,8 @@ void Watcher::Init(Napi::Env env, Napi::Object exports) {
                                         InstanceMethod("issueCustomData", &Watcher::IssueCustomData),             //
                                         InstanceMethod("issueRawPublic", &Watcher::IssueRawPublic),               //
                                         InstanceMethod("requestReadFromPublic", &Watcher::RequestReadFromPublic), //
+                                        InstanceMethod("canRequestReadFromPublic",                                //
+                                                       &Watcher::CanRequestReadFromPublic),                       //
                                         InstanceMethod("drainCustomData", &Watcher::DrainCustomData),             //
                                         InstanceMethod("runtimeStats", &Watcher::GetRuntimeStats),                //
                                         InstanceMethod("issueMark", &Watcher::IssueMark),                         //

--- a/framework/core/src/bindings/node/binding/watcher.h
+++ b/framework/core/src/bindings/node/binding/watcher.h
@@ -62,6 +62,8 @@ public:
 
   Napi::Value RequestReadFromPublic(const Napi::CallbackInfo &info);
 
+  Napi::Value CanRequestReadFromPublic(const Napi::CallbackInfo &info);
+
   Napi::Value DrainCustomData(const Napi::CallbackInfo &info);
 
   Napi::Value GetRuntimeStats(const Napi::CallbackInfo &info);


### PR DESCRIPTION
## Summary

- expose the native Watcher readiness required to request a public-journal read
- keep `follow()` fail-fast while giving callers a truthful `canFollow()` predicate
- wait for the Coordinator command channel in the cross-process native fixture

## Failure remediated

Exact protected head `d5405d2aba5346ade151803b0ff53a1edc434a6f` failed Windows job `91533907395` in run `30761796264`: the reader observed `isLive()` before its Coordinator command writer existed, then `requestReadFromPublic()` returned false.

## Verification

- `./shifu build:core`
- `node --test framework/agent-session/tests/*.test.mjs` (139/139)
- native mmap-journal+nng roundtrip (4/4)
- `./shifu check:source`
- staged pre-commit repository checks
- `pnpm exec biome check ...`
- `clang-format --dry-run --Werror ...`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Expose the existing Coordinator command-writer readiness condition without changing Agent Session architecture, authority boundaries, transport protocol, or supported platforms."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; this exposes an existing readiness condition)
- [x] Candidate is an exact fork of protected base `d5405d2aba5346ade151803b0ff53a1edc434a6f`

Signed-off-by: Keren Dong <keren.dong@kungfu.link>