### PR TITLE
fix(maintainability): weld terminal evidence to live authority

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -1310,7 +1310,7 @@
   ],
   "terminalEvidenceProjection": {
     "matrixPath": "framework/maintainability/terminal-evidence-matrix.json",
-    "matrixSchema": "kungfu.maintainability-terminal-evidence-matrix/v2",
+    "matrixSchema": "kungfu.maintainability-terminal-evidence-matrix/v3",
     "predecessorAssignmentId": "2026-07-27-kungfu-maintainability-terminal-closure",
     "predecessorSealedStateRoot": "sha256:41449544ae9f64f6a6e6e7ae69f24c0fd9049e38beef4bba2bbed3e3e730e98c"
   },

--- a/framework/maintainability/terminal-evidence-matrix.json
+++ b/framework/maintainability/terminal-evidence-matrix.json
@@ -1,5 +1,5 @@
 {
-  "schema": "kungfu.maintainability-terminal-evidence-matrix/v2",
+  "schema": "kungfu.maintainability-terminal-evidence-matrix/v3",
   "goalId": "2026-07-29-kungfu-terminal-review-remediation",
   "predecessor": {
     "assignmentId": "2026-07-27-kungfu-maintainability-terminal-closure",
@@ -8,7 +8,7 @@
   "sourceBinding": {
     "repository": "kungfu-systems/kungfu",
     "protectedBranch": "dev/v4/v4.0",
-    "exactHeadRule": "The verifier reads Git HEAD, the protected ref, and a retained GitHub delivery snapshot. Evidence never chooses its own source, pull request, or merge identity.",
+    "exactHeadRule": "The verifier reads Git HEAD and independently observes the protected ref, pull request, approval, terminal-review attestation, workflow runs, jobs, and artifacts through GitHub APIs. Evidence never chooses its own live source, delivery, review, or qualification identity.",
     "alreadyMergedPrerequisites": [
       {
         "pullRequest": 1553,
@@ -21,34 +21,72 @@
     ]
   },
   "terminalEvidence": {
-    "schema": "kungfu.maintainability-terminal-evidence/v2",
+    "schema": "kungfu.maintainability-terminal-evidence/v3",
     "verifier": "framework/maintainability/terminal-evidence.mjs",
-    "sourceWorkflow": ".github/workflows/affected-native-pr.yml",
-    "platformPreflightWorkflow": ".github/workflows/alpha-promotion-preflight.yml",
-    "productWorkflow": ".github/workflows/build.yml",
-    "requiredSourceJobs": [
-      "Candidate source acceptance / check",
-      "affected-native / linux"
+    "runGroups": [
+      {
+        "role": "source",
+        "workflowPath": ".github/workflows/affected-native-pr.yml",
+        "events": ["merge_group"],
+        "requiredJobs": [
+          "Candidate source acceptance / check",
+          "affected-native / linux"
+        ]
+      },
+      {
+        "role": "preflight",
+        "workflowPath": ".github/workflows/alpha-promotion-preflight.yml",
+        "events": ["push", "workflow_dispatch"],
+        "requiredJobs": [
+          "Linux source and Cargo probe",
+          "macOS source and Cargo probe",
+          "Windows source and Cargo probe",
+          "Aggregate exact-source receipt"
+        ]
+      },
+      {
+        "role": "product",
+        "workflowPath": ".github/workflows/build.yml",
+        "events": ["workflow_dispatch"],
+        "requiredJobs": [
+          "build / Linux x64",
+          "build / macOS ARM64",
+          "build / Windows x64"
+        ],
+        "requiredArtifacts": [
+          {"platform": "linux-x64", "nameTemplate": "kungfu-relay-manifest-{platform}-{commit}"},
+          {"platform": "macos-arm64", "nameTemplate": "kungfu-relay-manifest-{platform}-{commit}"},
+          {"platform": "windows-x64", "nameTemplate": "kungfu-relay-manifest-{platform}-{commit}"}
+        ]
+      },
+      {
+        "role": "dev-verify",
+        "workflowPath": ".github/workflows/dev-verify-patrol.yml",
+        "events": ["schedule", "workflow_dispatch"],
+        "requiredJobs": [
+          "verify / Gate profile / macOS ARM64",
+          "verify / Gate profile / Windows x64",
+          "verify / Gate profile / Linux x64"
+        ]
+      },
+      {
+        "role": "agent-patrol",
+        "workflowPath": ".github/workflows/kungfu-agent-patrol.yml",
+        "events": ["schedule", "workflow_dispatch"],
+        "requiredJobs": ["agent-121 / OpenCode Qwen3-Coder patrol"]
+      }
     ],
-    "requiredPreflightPlatforms": [
-      "linux-x64",
-      "macos-arm64",
-      "windows-x64"
-    ],
-    "requiredProductPlatforms": [
-      "linux-x64",
-      "macos-arm64",
-      "windows-x64"
-    ],
-    "artifactIdentityRule": "Every platform run and artifact resolves to the live protected commit. Raw artifact roots recompute from retained bytes; native Assignment and normalized delivery roots recompute with their declared canonical-JSON protocol and are checked against role-specific fields.",
-    "reviewRule": {
+    "pullRequestReviewRule": {
       "reviewer": "kungfu-origin",
-      "decision": "APPROVED",
-      "commit": "exact protected commit",
-      "freshContext": true,
-      "maximumOpenSeverity": "no P0, no P1, and no material P2 in scope"
+      "decision": "APPROVED"
     },
-    "assignmentRule": "The current Assignment request, capture receipt, exact-head completion claim, fit independent native review, accepted close decision, and sealed state are retained under their native canonical roots. Predecessor rows are closed projections of the listed immutable predecessor seal, not actionable work."
+    "terminalReviewRule": {
+      "reviewer": "kungfu-origin",
+      "verdict": "fit",
+      "freshContext": true,
+      "maximumOpenSeverity": "none",
+      "attestationSchema": "kungfu.terminal-review-attestation/v1"
+    }
   },
   "exceptions": [],
   "rows": [

--- a/framework/maintainability/terminal-evidence-matrix.test.mjs
+++ b/framework/maintainability/terminal-evidence-matrix.test.mjs
@@ -7,6 +7,10 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { semanticRoot } from '../project-cut/src/project-cut.mjs';
+import {
+  parseCommandJson,
+  parseTerminalReviewAttestation,
+} from '../terminal-evidence/live-observations.mjs';
 import { digestBytes, verifyTerminalEvidence } from './terminal-evidence.mjs';
 
 const ROOT = path.resolve(
@@ -29,6 +33,7 @@ const REQUIRED_ASSIGNMENTS = [
 ];
 const HEAD = 'a'.repeat(40);
 const OTHER_HEAD = 'b'.repeat(40);
+const TREE = 'c'.repeat(40);
 
 function repositoryPathExists(reference) {
   if (/^https:\/\//u.test(reference)) return true;
@@ -73,35 +78,74 @@ function fixture() {
     });
     return root;
   };
-  const platforms = fixtureMatrix.terminalEvidence.requiredProductPlatforms.map(
-    (platform, index) => {
-      const run = {
-        schema: 'kungfu.terminal-platform-run-snapshot/v1',
-        platform,
-        commit: HEAD,
-        runId: index + 101,
-        conclusion: 'success',
-      };
-      return {
-        platform,
-        commit: HEAD,
-        runId: index + 101,
-        conclusion: 'success',
-        evidenceRoot: retain(`${platform}-run`, run, 'platform-run'),
-        artifacts: [
-          {
-            name: `${platform}-product`,
-            root: retain(
-              `${platform}-product`,
-              Buffer.from(`artifact:${platform}`),
-              'artifact-bytes',
-              'raw-bytes',
-            ),
-          },
-        ],
-      };
-    },
-  );
+  const liveRuns = [];
+  const runs = fixtureMatrix.terminalEvidence.runGroups.map((group, index) => {
+    const runId = index + 101;
+    const jobs = group.requiredJobs.map((name, jobIndex) => ({
+      id: runId * 100 + jobIndex,
+      name,
+      status: 'completed',
+      conclusion: 'success',
+    }));
+    const artifacts = (group.requiredArtifacts || []).map(
+      ({ platform, nameTemplate }, artifactIndex) => {
+        const name = nameTemplate
+          .replaceAll('{platform}', platform)
+          .replaceAll('{commit}', HEAD);
+        const bytes = Buffer.from(`artifact:${platform}`);
+        const root = retain(
+          `${platform}-product`,
+          bytes,
+          'artifact-bytes',
+          'raw-bytes',
+        );
+        return {
+          platform,
+          id: runId * 1000 + artifactIndex,
+          name,
+          root,
+          sizeBytes: bytes.length,
+        };
+      },
+    );
+    const snapshot = {
+      schema: 'kungfu.terminal-run-snapshot/v1',
+      role: group.role,
+      workflowPath: group.workflowPath,
+      runId,
+      runAttempt: 1,
+      event: group.events[0],
+      commit: HEAD,
+      conclusion: 'success',
+    };
+    liveRuns.push({
+      role: group.role,
+      workflowPath: group.workflowPath,
+      runId,
+      runAttempt: 1,
+      event: group.events[0],
+      headSha: HEAD,
+      headBranch: fixtureMatrix.sourceBinding.protectedBranch,
+      status: 'completed',
+      conclusion: 'success',
+      jobs,
+      artifacts: artifacts.map((artifact) => ({
+        id: artifact.id,
+        name: artifact.name,
+        digest: artifact.root,
+        sizeBytes: artifact.sizeBytes,
+        expired: false,
+        workflowRunId: runId,
+        headSha: HEAD,
+      })),
+    });
+    return {
+      ...snapshot,
+      evidenceRoot: retain(`${group.role}-run`, snapshot, 'run-snapshot'),
+      jobs: jobs.map(({ name, conclusion }) => ({ name, conclusion })),
+      artifacts,
+    };
+  });
   const request = {
     schema: 'kungfu.assignment-request/v1',
     retention: {
@@ -138,12 +182,52 @@ function fixture() {
     go_set: [fixtureMatrix.goalId],
     known_gaps: [],
   };
+  const terminalReview = {
+    schema: 'kungfu.terminal-review-report/v1',
+    reviewer: 'kungfu-origin',
+    verdict: 'fit',
+    commit: HEAD,
+    tree: TREE,
+    freshContext: true,
+    maximumOpenSeverity: 'none',
+    findings: [],
+  };
+  const terminalReviewRoot = retain(
+    'terminal-review',
+    terminalReview,
+    'terminal-review-report',
+  );
+  const terminalAttestation = {
+    schema: 'kungfu.terminal-review-attestation/v1',
+    goalId: fixtureMatrix.goalId,
+    commit: HEAD,
+    tree: TREE,
+    reviewer: 'kungfu-origin',
+    verdict: 'fit',
+    freshContext: true,
+    maximumOpenSeverity: 'none',
+    reportRoot: terminalReviewRoot,
+  };
+  const terminalAttestationSnapshot = {
+    schema: 'kungfu.terminal-review-attestation-snapshot/v1',
+    commentId: 4001,
+    author: 'kungfu-origin',
+    createdAt: '2026-08-02T00:01:00Z',
+    updatedAt: '2026-08-02T00:01:00Z',
+    attestation: terminalAttestation,
+  };
+  const terminalAttestationRoot = retain(
+    'terminal-review-attestation',
+    terminalAttestationSnapshot,
+    'terminal-review-attestation-snapshot',
+  );
   const nativeReview = {
     review_id: `review-${'e'.repeat(24)}`,
     review_type: 'independent-completion-review',
     claim_id: completionClaim.claim_id,
     claimant: 'codex/pro-7011/root',
     reviewer: 'kungfu-origin',
+    reviewer_source: terminalReviewRoot,
     verdict: 'fit',
   };
   const independentReviewRoot = semanticRoot(nativeReview);
@@ -165,6 +249,7 @@ function fixture() {
       repository: fixtureMatrix.sourceBinding.repository,
       protectedBranch: fixtureMatrix.sourceBinding.protectedBranch,
       commit: HEAD,
+      tree: TREE,
     },
     delivery: {
       pullRequest: 2001,
@@ -180,26 +265,40 @@ function fixture() {
         },
         'delivery-snapshot',
       ),
+      approval: {
+        reviewId: 3001,
+        reviewer: 'kungfu-origin',
+        decision: 'APPROVED',
+        commit: OTHER_HEAD,
+        root: retain(
+          'github-review',
+          {
+            schema: 'kungfu.terminal-github-review-snapshot/v1',
+            reviewId: 3001,
+            reviewer: 'kungfu-origin',
+            decision: 'APPROVED',
+            commit: OTHER_HEAD,
+          },
+          'github-review-snapshot',
+        ),
+      },
     },
     review: {
       reviewer: 'kungfu-origin',
-      decision: 'APPROVED',
+      verdict: 'fit',
       commit: HEAD,
+      tree: TREE,
       freshContext: true,
-      root: retain(
-        'review',
-        {
-          schema: 'kungfu.terminal-review-snapshot/v1',
-          reviewer: 'kungfu-origin',
-          decision: 'APPROVED',
-          commit: HEAD,
-          freshContext: true,
-        },
-        'review-snapshot',
-      ),
+      maximumOpenSeverity: 'none',
+      root: terminalReviewRoot,
+      attestationRoot: terminalAttestationRoot,
     },
     assignment: {
+      initiativeId: 'kungfu-technical-stewardship',
       assignmentId: fixtureMatrix.goalId,
+      workspaceIdentityRoot: `sha256:${'f'.repeat(64)}`,
+      phase: 'continuation-decided',
+      status: 'active',
       gitCommit: HEAD,
       requestRoot,
       captureReceiptRoot,
@@ -232,32 +331,116 @@ function fixture() {
         'predecessor-seal',
       ),
     },
-    platforms,
+    runs,
     retainedObjects,
   };
   fixtureMatrix.predecessor.sealedStateRoot =
     evidence.predecessor.sealedStateRoot;
-  const verify = (candidate = evidence, live = {}) =>
-    verifyTerminalEvidence(
+  const verify = (candidate = evidence, overrides = {}) => {
+    const baseLive = {
+      schema: 'kungfu.terminal-live-observations/v1',
+      source: {
+        repository: fixtureMatrix.sourceBinding.repository,
+        protectedBranch: fixtureMatrix.sourceBinding.protectedBranch,
+        head: HEAD,
+        headTree: TREE,
+        protectedCommit: HEAD,
+        protectedTree: TREE,
+      },
+      delivery: {
+        pullRequest: 2001,
+        mergeCommit: HEAD,
+        state: 'MERGED',
+        baseRef: fixtureMatrix.sourceBinding.protectedBranch,
+        pullRequestHead: OTHER_HEAD,
+        pullRequestTree: TREE,
+        mergeTree: TREE,
+        approval: {
+          reviewId: 3001,
+          reviewer: 'kungfu-origin',
+          decision: 'APPROVED',
+          commit: OTHER_HEAD,
+          tree: TREE,
+          submittedAt: '2026-08-02T00:00:00Z',
+        },
+      },
+      terminalReview: {
+        commentId: 4001,
+        author: 'kungfu-origin',
+        createdAt: '2026-08-02T00:01:00Z',
+        updatedAt: '2026-08-02T00:01:00Z',
+        ...terminalAttestation,
+      },
+      assignment: {
+        initiativeId: 'kungfu-technical-stewardship',
+        assignmentId: fixtureMatrix.goalId,
+        workspaceIdentityRoot: `sha256:${'f'.repeat(64)}`,
+        phase: 'continuation-decided',
+        status: 'active',
+        requestRoot,
+        captureReceiptRoot,
+        gitCommit: HEAD,
+        completionClaimRoot: semanticRoot(completionClaim),
+        independentReviewRoot,
+        completionDecisionRoot: semanticRoot(decision),
+        sealedStateRoot: evidence.assignment.sealedStateRoot,
+        queryProofRoot: `sha256:${'7'.repeat(64)}`,
+        sealedQueryProofRoot: `sha256:${'7'.repeat(64)}`,
+        reviewer: 'kungfu-origin',
+        reviewerSource: terminalReviewRoot,
+        reviewVerdict: 'fit',
+        decisionAction: 'close',
+        sealVerified: true,
+        nextActions: [],
+        sealedAssignmentId: fixtureMatrix.goalId,
+        sealedPhase: 'continuation-decided',
+        statusCounts: {
+          completion_claims: 1,
+          independent_reviews: 1,
+          continuation_decisions: 1,
+        },
+        sealedCounts: {
+          completion_claims: 1,
+          independent_reviews: 1,
+          continuation_decisions: 1,
+        },
+      },
+      runs: liveRuns,
+    };
+    const live = {
+      ...baseLive,
+      ...overrides,
+      source: { ...baseLive.source, ...(overrides.source || {}) },
+      delivery: {
+        ...baseLive.delivery,
+        ...(overrides.delivery || {}),
+        approval: {
+          ...baseLive.delivery.approval,
+          ...(overrides.delivery?.approval || {}),
+        },
+      },
+      terminalReview: {
+        ...baseLive.terminalReview,
+        ...(overrides.terminalReview || {}),
+      },
+      assignment: {
+        ...baseLive.assignment,
+        ...(overrides.assignment || {}),
+      },
+      runs: overrides.runs || baseLive.runs,
+    };
+    return verifyTerminalEvidence(
       fixtureMatrix,
       candidate,
-      {
-        head: HEAD,
-        protectedCommit: HEAD,
-        delivery: {
-          pullRequest: 2001,
-          mergeCommit: HEAD,
-          state: 'MERGED',
-        },
-        ...live,
-      },
+      live,
       (relative) => {
         const bytes = retainedBytes.get(relative);
         if (!bytes) throw new Error(`missing fixture ${relative}`);
         return bytes;
       },
     );
-  return { evidence, retainedBytes, verify };
+  };
+  return { evidence, liveRuns, retainedBytes, verify };
 }
 
 function clone(value) {
@@ -268,37 +451,55 @@ function issueCodes(report) {
   return new Set(report.issues.map(({ code }) => code));
 }
 
-test('terminal maintainability matrix declares an exact-head v2 contract', () => {
+test('live observation parser preserves object and array authority payloads', () => {
+  assert.deepEqual(
+    parseCommandJson('[tool] prelude\n{"ok":true}\n', 'object'),
+    { ok: true },
+  );
+  assert.deepEqual(
+    parseCommandJson('tool prelude\n[{"id":1},{"id":2}]\n', 'array'),
+    [{ id: 1 }, { id: 2 }],
+  );
+  assert.deepEqual(
+    parseTerminalReviewAttestation('{"schema":"test","ok":true}'),
+    { schema: 'test', ok: true },
+  );
+  assert.equal(parseTerminalReviewAttestation('not json'), undefined);
+});
+
+test('terminal maintainability matrix declares an exact-head v3 contract', () => {
   assert.equal(
     matrix.schema,
-    'kungfu.maintainability-terminal-evidence-matrix/v2',
+    'kungfu.maintainability-terminal-evidence-matrix/v3',
   );
   assert.equal(matrix.sourceBinding.repository, 'kungfu-systems/kungfu');
   assert.equal(matrix.sourceBinding.protectedBranch, 'dev/v4/v4.0');
   assert.equal(
     matrix.terminalEvidence.schema,
-    'kungfu.maintainability-terminal-evidence/v2',
+    'kungfu.maintainability-terminal-evidence/v3',
   );
   assert.equal(repositoryPathExists(matrix.terminalEvidence.verifier), true);
   assert.match(matrix.sourceBinding.exactHeadRule, /reads Git HEAD/u);
   assert.deepEqual(matrix.exceptions, []);
-  for (const workflow of [
-    matrix.terminalEvidence.sourceWorkflow,
-    matrix.terminalEvidence.platformPreflightWorkflow,
-    matrix.terminalEvidence.productWorkflow,
-  ]) {
-    assert.equal(repositoryPathExists(workflow), true, workflow);
+  for (const group of matrix.terminalEvidence.runGroups) {
+    assert.equal(repositoryPathExists(group.workflowPath), true, group.role);
+    assert.ok(group.requiredJobs.length > 0, group.role);
   }
+  assert.deepEqual(
+    matrix.terminalEvidence.runGroups.map(({ role }) => role),
+    ['source', 'preflight', 'product', 'dev-verify', 'agent-patrol'],
+  );
   assert.deepEqual(
     matrix.rows.map((row) => row.assignmentId).sort(),
     [...REQUIRED_ASSIGNMENTS].sort(),
   );
   assert.equal(new Set(matrix.rows.map((row) => row.assignmentId)).size, 7);
-  assert.deepEqual(matrix.terminalEvidence.requiredProductPlatforms, [
-    'linux-x64',
-    'macos-arm64',
-    'windows-x64',
-  ]);
+  assert.deepEqual(
+    matrix.terminalEvidence.runGroups
+      .find(({ role }) => role === 'product')
+      .requiredArtifacts.map(({ platform }) => platform),
+    ['linux-x64', 'macos-arm64', 'windows-x64'],
+  );
   for (const row of matrix.rows) {
     assert.equal(row.disposition, 'closed', row.assignmentId);
     for (const reference of [...row.sourceEvidence, ...row.rawChecks]) {
@@ -320,7 +521,7 @@ test('terminal evidence accepts one exact live protected cut', () => {
 test('live HEAD, protected PR, merge, and review identities fail closed', () => {
   const { evidence, verify } = fixture();
   assert.ok(
-    issueCodes(verify(evidence, { head: OTHER_HEAD })).has(
+    issueCodes(verify(evidence, { source: { head: OTHER_HEAD } })).has(
       'source-head-mismatch',
     ),
   );
@@ -363,9 +564,35 @@ test('live HEAD, protected PR, merge, and review identities fail closed', () => 
   const staleReview = clone(evidence);
   staleReview.review.commit = OTHER_HEAD;
   assert.ok(issueCodes(verify(staleReview)).has('review-head-mismatch'));
+  assert.ok(
+    issueCodes(
+      verify(evidence, { delivery: { approval: { reviewId: 3999 } } }),
+    ).has('pull-review-reviewId-mismatch'),
+  );
+  assert.ok(
+    issueCodes(
+      verify(evidence, {
+        terminalReview: { reportRoot: `sha256:${'8'.repeat(64)}` },
+      }),
+    ).has('review-attestation-root-mismatch'),
+  );
+  assert.ok(
+    issueCodes(
+      verify(evidence, {
+        assignment: { requestRoot: `sha256:${'9'.repeat(64)}` },
+      }),
+    ).has('assignment-live-requestRoot-mismatch'),
+  );
+  assert.ok(
+    issueCodes(
+      verify(evidence, {
+        assignment: { sealedQueryProofRoot: `sha256:${'6'.repeat(64)}` },
+      }),
+    ).has('assignment-seal-query-proof-mismatch'),
+  );
 });
 
-test('retained semantic roles, platform runs, and artifact bytes fail closed', () => {
+test('retained semantic roles, live runs, and artifact bytes fail closed', () => {
   const { evidence, retainedBytes, verify } = fixture();
   const wrongAssignment = clone(evidence);
   wrongAssignment.assignment.requestRoot = digestBytes(
@@ -374,17 +601,74 @@ test('retained semantic roles, platform runs, and artifact bytes fail closed', (
   assert.ok(issueCodes(verify(wrongAssignment)).has('missing-retained-bytes'));
 
   const wrongRun = clone(evidence);
-  wrongRun.platforms[0].runId = 0;
-  assert.ok(issueCodes(verify(wrongRun)).has('invalid-platform-run'));
+  wrongRun.runs[0].runId = 999;
+  assert.ok(issueCodes(verify(wrongRun)).has('run-runId-live-mismatch'));
 
-  const stalePlatform = clone(evidence);
-  stalePlatform.platforms[1].commit = OTHER_HEAD;
-  assert.ok(issueCodes(verify(stalePlatform)).has('platform-head-mismatch'));
+  const wrongWorkflow = clone(evidence);
+  wrongWorkflow.runs[1].workflowPath = '.github/workflows/build.yml';
+  assert.ok(
+    issueCodes(verify(wrongWorkflow)).has('run-workflowPath-live-mismatch'),
+  );
 
-  const artifact = evidence.platforms[2].artifacts[0];
+  const product = evidence.runs.find(({ role }) => role === 'product');
+  const missingArtifacts = clone(evidence);
+  missingArtifacts.runs.find(({ role }) => role === 'product').artifacts = [];
+  assert.ok(
+    issueCodes(verify(missingArtifacts)).has('missing-required-artifact'),
+  );
+
+  const artifact = product.artifacts[2];
   const object = evidence.retainedObjects.find(
     ({ root }) => root === artifact.root,
   );
   retainedBytes.set(object.path, Buffer.from('mutated-artifact'));
   assert.ok(issueCodes(verify(evidence)).has('retained-root-mismatch'));
+});
+
+test('self-consistent declared runs cannot replace GitHub live truth', () => {
+  const { evidence, liveRuns, retainedBytes, verify } = fixture();
+  const candidate = clone(evidence);
+  const source = candidate.runs.find(({ role }) => role === 'source');
+  const retained = candidate.retainedObjects.find(
+    ({ root }) => root === source.evidenceRoot,
+  );
+  const snapshot = JSON.parse(
+    retainedBytes.get(retained.path).toString('utf8'),
+  );
+  snapshot.runId = 999;
+  source.runId = 999;
+  const replacementRoot = semanticRoot(snapshot);
+  source.evidenceRoot = replacementRoot;
+  retained.root = replacementRoot;
+  retainedBytes.set(
+    retained.path,
+    Buffer.from(`${JSON.stringify(snapshot)}\n`),
+  );
+  assert.ok(
+    issueCodes(verify(candidate)).has('run-runId-live-mismatch'),
+    'positive, retained, internally consistent run id must still match live API',
+  );
+
+  const missingJob = clone(liveRuns);
+  missingJob[0].jobs = missingJob[0].jobs.slice(1);
+  assert.ok(
+    issueCodes(verify(evidence, { runs: missingJob })).has(
+      'missing-required-job',
+    ),
+  );
+
+  const wrongDigest = clone(liveRuns);
+  const product = wrongDigest.find(({ role }) => role === 'product');
+  product.artifacts[0].digest = `sha256:${'8'.repeat(64)}`;
+  assert.ok(
+    issueCodes(verify(evidence, { runs: wrongDigest })).has(
+      'artifact-root-live-mismatch',
+    ),
+  );
+
+  const expired = clone(liveRuns);
+  expired.find(({ role }) => role === 'product').artifacts[0].expired = true;
+  assert.ok(
+    issueCodes(verify(evidence, { runs: expired })).has('artifact-expired'),
+  );
 });

--- a/framework/maintainability/terminal-evidence.mjs
+++ b/framework/maintainability/terminal-evidence.mjs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-check
 
-import { spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -10,6 +9,17 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import { semanticRoot } from '../project-cut/src/project-cut.mjs';
+import { collectTerminalLiveObservations } from '../terminal-evidence/live-observations.mjs';
+import {
+  verifyLiveAssignment,
+  verifyLiveRuns,
+} from '../terminal-evidence/live-verification.mjs';
+import {
+  exact,
+  issue,
+  requiredRoot,
+  uniqueBy,
+} from '../terminal-evidence/verification-primitives.mjs';
 
 const ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -17,78 +27,9 @@ const ROOT = path.resolve(
 );
 const MATRIX_PATH = 'framework/maintainability/terminal-evidence-matrix.json';
 const SHA = /^[0-9a-f]{40}$/u;
-const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
 
 function digestBytes(bytes) {
   return `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`;
-}
-
-function issue(code, target, message) {
-  return { code, target, message };
-}
-
-function git(args) {
-  const result = spawnSync('git', args, {
-    cwd: ROOT,
-    encoding: 'utf8',
-    shell: false,
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `git ${args.join(' ')} failed: ${(result.stderr || '').trim()}`,
-    );
-  }
-  return result.stdout.trim();
-}
-
-function requiredRoot(references, value, target, kind, issues) {
-  if (!ROOT_PATTERN.test(value || '')) {
-    issues.push(
-      issue('invalid-root', target, `${target} must be a sha256 root`),
-    );
-    return;
-  }
-  const prior = references.get(value);
-  if (prior && prior.kind !== kind) {
-    issues.push(
-      issue(
-        'retained-role-conflict',
-        target,
-        `${value} cannot represent both ${prior.kind} and ${kind}`,
-      ),
-    );
-    return;
-  }
-  references.set(value, { kind, target });
-}
-
-function exact(value, expected, code, target, issues) {
-  if (value !== expected) {
-    issues.push(
-      issue(
-        code,
-        target,
-        `${target} is ${String(value)}, expected ${expected}`,
-      ),
-    );
-  }
-}
-
-function uniqueBy(values, key, code, issues) {
-  const seen = new Set();
-  for (const value of values || []) {
-    const identity = value?.[key];
-    if (!identity || seen.has(identity)) {
-      issues.push(
-        issue(
-          code,
-          identity || key,
-          `${key} values must be present and unique`,
-        ),
-      );
-    }
-    seen.add(identity);
-  }
 }
 
 function retainedRoot(bytes, object) {
@@ -138,19 +79,85 @@ function verifyRetainedBinding(
         );
       }
       break;
-    case 'review-snapshot':
+    case 'github-review-snapshot':
       mismatch(
         'retained-review-schema',
         'review.schema',
         document?.schema,
-        'kungfu.terminal-review-snapshot/v1',
+        'kungfu.terminal-github-review-snapshot/v1',
       );
-      for (const field of ['reviewer', 'decision', 'commit', 'freshContext']) {
+      for (const field of ['reviewId', 'reviewer', 'decision', 'commit']) {
         mismatch(
           `retained-review-${field}`,
           `review.${field}`,
           document?.[field],
+          evidence.delivery?.approval?.[field],
+        );
+      }
+      break;
+    case 'terminal-review-report':
+      mismatch(
+        'retained-terminal-review-schema',
+        'terminalReview.schema',
+        document?.schema,
+        'kungfu.terminal-review-report/v1',
+      );
+      for (const field of [
+        'reviewer',
+        'verdict',
+        'commit',
+        'tree',
+        'freshContext',
+        'maximumOpenSeverity',
+      ]) {
+        mismatch(
+          `retained-terminal-review-${field}`,
+          `terminalReview.${field}`,
+          document?.[field],
           evidence.review?.[field],
+        );
+      }
+      if ((document?.findings || []).length !== 0) {
+        issues.push(
+          issue(
+            'terminal-review-open-findings',
+            'terminalReview.findings',
+            'terminal review retains open findings',
+          ),
+        );
+      }
+      break;
+    case 'terminal-review-attestation-snapshot':
+      mismatch(
+        'retained-terminal-attestation-schema',
+        'terminalReviewAttestation.schema',
+        document?.schema,
+        'kungfu.terminal-review-attestation-snapshot/v1',
+      );
+      for (const field of ['commentId', 'author', 'createdAt', 'updatedAt']) {
+        mismatch(
+          `retained-terminal-attestation-${field}`,
+          `terminalReviewAttestation.${field}`,
+          document?.[field],
+          live.terminalReview?.[field],
+        );
+      }
+      for (const field of [
+        'schema',
+        'goalId',
+        'commit',
+        'tree',
+        'reviewer',
+        'verdict',
+        'freshContext',
+        'maximumOpenSeverity',
+        'reportRoot',
+      ]) {
+        mismatch(
+          `retained-terminal-attestation-document-${field}`,
+          `terminalReviewAttestation.attestation.${field}`,
+          document?.attestation?.[field],
+          live.terminalReview?.[field],
         );
       }
       break;
@@ -199,7 +206,7 @@ function verifyRetainedBinding(
         'retained-claim-head',
         'assignment.claim.git_commit',
         document?.git_commit,
-        live.head,
+        live.source?.head,
       );
       if (
         !Array.isArray(document?.go_set) ||
@@ -234,13 +241,19 @@ function verifyRetainedBinding(
         'retained-native-reviewer',
         'assignment.review.reviewer',
         document?.reviewer,
-        matrix.terminalEvidence.reviewRule.reviewer,
+        matrix.terminalEvidence.terminalReviewRule.reviewer,
       );
       mismatch(
         'retained-native-review-verdict',
         'assignment.review.verdict',
         document?.verdict,
-        'fit',
+        matrix.terminalEvidence.terminalReviewRule.verdict,
+      );
+      mismatch(
+        'retained-native-review-source',
+        'assignment.review.reviewer_source',
+        document?.reviewer_source,
+        evidence.review?.root,
       );
       break;
     case 'assignment-decision':
@@ -298,29 +311,37 @@ function verifyRetainedBinding(
       }
       break;
     }
-    case 'platform-run': {
-      const platform = (evidence.platforms || []).find(
+    case 'run-snapshot': {
+      const run = (evidence.runs || []).find(
         ({ evidenceRoot }) => evidenceRoot === object.root,
       );
       mismatch(
-        'retained-platform-schema',
-        'platform.schema',
+        'retained-run-schema',
+        'run.schema',
         document?.schema,
-        'kungfu.terminal-platform-run-snapshot/v1',
+        'kungfu.terminal-run-snapshot/v1',
       );
-      for (const field of ['platform', 'commit', 'runId', 'conclusion']) {
+      for (const field of [
+        'role',
+        'workflowPath',
+        'runId',
+        'runAttempt',
+        'event',
+        'commit',
+        'conclusion',
+      ]) {
         mismatch(
-          `retained-platform-${field}`,
-          `platform.${field}`,
+          `retained-run-${field}`,
+          `run.${field}`,
           document?.[field],
-          platform?.[field],
+          run?.[field],
         );
       }
       mismatch(
-        'retained-platform-live-head',
-        'platform.commit',
+        'retained-run-live-head',
+        'run.commit',
         document?.commit,
-        live.head,
+        live.source?.head,
       );
       break;
     }
@@ -362,7 +383,7 @@ export function verifyTerminalEvidence(
   const references = new Map();
   exact(
     matrix.schema,
-    'kungfu.maintainability-terminal-evidence-matrix/v2',
+    'kungfu.maintainability-terminal-evidence-matrix/v3',
     'matrix-schema',
     'matrix.schema',
     issues,
@@ -381,24 +402,53 @@ export function verifyTerminalEvidence(
     'goalId',
     issues,
   );
-
-  if (!SHA.test(live.head || '')) {
+  if ((matrix.exceptions || []).length !== 0) {
     issues.push(
-      issue('invalid-live-head', 'live.head', 'live HEAD is not exact'),
+      issue(
+        'terminal-exception-present',
+        'matrix.exceptions',
+        'terminal closure does not admit exceptions',
+      ),
+    );
+  }
+  exact(
+    live.schema,
+    'kungfu.terminal-live-observations/v1',
+    'live-schema',
+    'live.schema',
+    issues,
+  );
+  if (!SHA.test(live.source?.head || '')) {
+    issues.push(
+      issue('invalid-live-head', 'live.source.head', 'live HEAD is not exact'),
     );
   }
   exact(
     evidence.source?.commit,
-    live.head,
+    live.source?.head,
     'source-head-mismatch',
     'source.commit',
     issues,
   );
   exact(
     evidence.source?.commit,
-    live.protectedCommit,
+    live.source?.protectedCommit,
     'protected-head-mismatch',
     'source.commit',
+    issues,
+  );
+  exact(
+    evidence.source?.tree,
+    live.source?.headTree,
+    'source-tree-mismatch',
+    'source.tree',
+    issues,
+  );
+  exact(
+    live.source?.headTree,
+    live.source?.protectedTree,
+    'protected-tree-mismatch',
+    'live.source.protectedTree',
     issues,
   );
   exact(
@@ -432,7 +482,7 @@ export function verifyTerminalEvidence(
   );
   exact(
     evidence.delivery?.mergeCommit,
-    live.head,
+    live.source?.head,
     'delivery-not-live-head',
     'delivery.mergeCommit',
     issues,
@@ -458,34 +508,185 @@ export function verifyTerminalEvidence(
     'delivery-snapshot',
     issues,
   );
+  exact(
+    live.delivery?.baseRef,
+    matrix.sourceBinding.protectedBranch,
+    'delivery-base-mismatch',
+    'live.delivery.baseRef',
+    issues,
+  );
+  exact(
+    live.delivery?.pullRequestTree,
+    live.source?.headTree,
+    'delivery-tested-tree-mismatch',
+    'live.delivery.pullRequestTree',
+    issues,
+  );
+  exact(
+    live.delivery?.mergeTree,
+    live.source?.headTree,
+    'delivery-merge-tree-mismatch',
+    'live.delivery.mergeTree',
+    issues,
+  );
+  const pullReviewRule = matrix.terminalEvidence.pullRequestReviewRule;
+  for (const field of ['reviewId', 'reviewer', 'decision', 'commit']) {
+    exact(
+      evidence.delivery?.approval?.[field],
+      live.delivery?.approval?.[field],
+      `pull-review-${field}-mismatch`,
+      `delivery.approval.${field}`,
+      issues,
+    );
+  }
+  exact(
+    evidence.delivery?.approval?.reviewer,
+    pullReviewRule.reviewer,
+    'pull-reviewer-mismatch',
+    'delivery.approval.reviewer',
+    issues,
+  );
+  exact(
+    evidence.delivery?.approval?.decision,
+    pullReviewRule.decision,
+    'pull-review-decision-mismatch',
+    'delivery.approval.decision',
+    issues,
+  );
+  exact(
+    live.delivery?.approval?.tree,
+    live.source?.headTree,
+    'pull-review-tree-mismatch',
+    'live.delivery.approval.tree',
+    issues,
+  );
+  requiredRoot(
+    references,
+    evidence.delivery?.approval?.root,
+    'delivery.approval.root',
+    'github-review-snapshot',
+    issues,
+  );
 
+  const terminalReviewRule = matrix.terminalEvidence.terminalReviewRule;
+  exact(
+    live.terminalReview?.schema,
+    terminalReviewRule.attestationSchema,
+    'review-attestation-schema-mismatch',
+    'live.terminalReview.schema',
+    issues,
+  );
+  exact(
+    live.terminalReview?.goalId,
+    matrix.goalId,
+    'review-attestation-goal-mismatch',
+    'live.terminalReview.goalId',
+    issues,
+  );
+  exact(
+    live.terminalReview?.commit,
+    live.source?.head,
+    'review-attestation-head-mismatch',
+    'live.terminalReview.commit',
+    issues,
+  );
+  exact(
+    live.terminalReview?.tree,
+    live.source?.headTree,
+    'review-attestation-tree-mismatch',
+    'live.terminalReview.tree',
+    issues,
+  );
+  exact(
+    live.terminalReview?.author,
+    terminalReviewRule.reviewer,
+    'review-attestation-author-mismatch',
+    'live.terminalReview.author',
+    issues,
+  );
+  exact(
+    live.terminalReview?.reviewer,
+    terminalReviewRule.reviewer,
+    'review-attestation-reviewer-mismatch',
+    'live.terminalReview.reviewer',
+    issues,
+  );
+  exact(
+    live.terminalReview?.verdict,
+    terminalReviewRule.verdict,
+    'review-attestation-verdict-mismatch',
+    'live.terminalReview.verdict',
+    issues,
+  );
+  exact(
+    live.terminalReview?.freshContext,
+    terminalReviewRule.freshContext,
+    'review-attestation-fresh-context-mismatch',
+    'live.terminalReview.freshContext',
+    issues,
+  );
+  exact(
+    live.terminalReview?.maximumOpenSeverity,
+    terminalReviewRule.maximumOpenSeverity,
+    'review-attestation-severity-mismatch',
+    'live.terminalReview.maximumOpenSeverity',
+    issues,
+  );
+  exact(
+    evidence.review?.root,
+    live.terminalReview?.reportRoot,
+    'review-attestation-root-mismatch',
+    'review.root',
+    issues,
+  );
   exact(
     evidence.review?.reviewer,
-    matrix.terminalEvidence.reviewRule.reviewer,
+    terminalReviewRule.reviewer,
     'reviewer-mismatch',
     'review.reviewer',
     issues,
   );
   exact(
-    evidence.review?.decision,
-    matrix.terminalEvidence.reviewRule.decision,
-    'review-decision-mismatch',
-    'review.decision',
+    evidence.review?.verdict,
+    terminalReviewRule.verdict,
+    'review-verdict-mismatch',
+    'review.verdict',
     issues,
   );
   exact(
     evidence.review?.commit,
-    live.head,
+    live.source?.head,
     'review-head-mismatch',
     'review.commit',
     issues,
   );
-  if (evidence.review?.freshContext !== true) {
+  exact(
+    evidence.review?.tree,
+    live.source?.headTree,
+    'review-tree-mismatch',
+    'review.tree',
+    issues,
+  );
+  exact(
+    evidence.review?.freshContext,
+    terminalReviewRule.freshContext,
+    'review-not-fresh',
+    'review.freshContext',
+    issues,
+  );
+  exact(
+    evidence.review?.maximumOpenSeverity,
+    terminalReviewRule.maximumOpenSeverity,
+    'review-open-severity',
+    'review.maximumOpenSeverity',
+    issues,
+  );
+  if (!Number.isInteger(live.terminalReview?.commentId)) {
     issues.push(
       issue(
-        'review-not-fresh',
-        'review.freshContext',
-        'terminal review must be fresh-context',
+        'review-attestation-comment-missing',
+        'live.terminalReview.commentId',
+        'terminal review attestation has no live GitHub comment identity',
       ),
     );
   }
@@ -493,40 +694,18 @@ export function verifyTerminalEvidence(
     references,
     evidence.review?.root,
     'review.root',
-    'review-snapshot',
+    'terminal-review-report',
+    issues,
+  );
+  requiredRoot(
+    references,
+    evidence.review?.attestationRoot,
+    'review.attestationRoot',
+    'terminal-review-attestation-snapshot',
     issues,
   );
 
-  exact(
-    evidence.assignment?.assignmentId,
-    matrix.goalId,
-    'assignment-identity-mismatch',
-    'assignment.assignmentId',
-    issues,
-  );
-  exact(
-    evidence.assignment?.gitCommit,
-    live.head,
-    'assignment-head-mismatch',
-    'assignment.gitCommit',
-    issues,
-  );
-  for (const [field, kind] of [
-    ['requestRoot', 'assignment-request'],
-    ['captureReceiptRoot', 'assignment-capture'],
-    ['completionClaimRoot', 'assignment-claim'],
-    ['independentReviewRoot', 'assignment-review'],
-    ['completionDecisionRoot', 'assignment-decision'],
-    ['sealedStateRoot', 'assignment-seal'],
-  ]) {
-    requiredRoot(
-      references,
-      evidence.assignment?.[field],
-      `assignment.${field}`,
-      kind,
-      issues,
-    );
-  }
+  verifyLiveAssignment(matrix, evidence, live, references, issues);
   exact(
     evidence.predecessor?.assignmentId,
     matrix.predecessor.assignmentId,
@@ -549,61 +728,7 @@ export function verifyTerminalEvidence(
     issues,
   );
 
-  uniqueBy(evidence.platforms, 'platform', 'duplicate-platform', issues);
-  const platforms = new Map(
-    (evidence.platforms || []).map((entry) => [entry.platform, entry]),
-  );
-  for (const required of matrix.terminalEvidence.requiredProductPlatforms) {
-    const platform = platforms.get(required);
-    if (!platform) {
-      issues.push(
-        issue('missing-platform', required, `missing platform ${required}`),
-      );
-      continue;
-    }
-    exact(
-      platform.commit,
-      live.head,
-      'platform-head-mismatch',
-      `${required}.commit`,
-      issues,
-    );
-    if (!Number.isInteger(platform.runId) || platform.runId < 1) {
-      issues.push(
-        issue(
-          'invalid-platform-run',
-          `${required}.runId`,
-          'platform run id must be positive',
-        ),
-      );
-    }
-    if (platform.conclusion !== 'success') {
-      issues.push(
-        issue(
-          'platform-not-successful',
-          required,
-          `platform conclusion is ${platform.conclusion}`,
-        ),
-      );
-    }
-    requiredRoot(
-      references,
-      platform.evidenceRoot,
-      `${required}.evidenceRoot`,
-      'platform-run',
-      issues,
-    );
-    uniqueBy(platform.artifacts, 'name', 'duplicate-artifact', issues);
-    for (const artifact of platform.artifacts || []) {
-      requiredRoot(
-        references,
-        artifact.root,
-        `${required}.artifacts.${artifact.name}`,
-        'artifact-bytes',
-        issues,
-      );
-    }
-  }
+  verifyLiveRuns(matrix, evidence, live, references, issues);
 
   uniqueBy(evidence.retainedObjects, 'root', 'duplicate-retained-root', issues);
   const retained = new Map(
@@ -662,7 +787,8 @@ export function verifyTerminalEvidence(
   return {
     schema: 'kungfu.terminal-evidence-verification/v1',
     verdict: issues.length ? 'fail' : 'pass',
-    sourceCommit: live.head,
+    sourceCommit: live.source?.head,
+    liveObservationRoot: semanticRoot(live),
     verifiedRoots: references.size,
     issues,
   };
@@ -694,21 +820,16 @@ function main() {
   const delivery = JSON.parse(
     fs.readFileSync(path.resolve(options.delivery), 'utf8'),
   );
-  const protectedRef =
-    options.protectedRef ||
-    `refs/remotes/origin/${matrix.sourceBinding.protectedBranch}`;
-  const report = verifyTerminalEvidence(
-    matrix,
-    evidence,
-    {
-      head: git(['rev-parse', 'HEAD']),
-      protectedCommit: git(['rev-parse', protectedRef]),
-      delivery,
-    },
-    (relative) =>
-      fs.readFileSync(
-        path.resolve(path.dirname(evidencePath), String(relative)),
-      ),
+  if (semanticRoot(delivery) !== evidence.delivery?.evidenceRoot) {
+    throw new Error('delivery input does not match the retained delivery root');
+  }
+  const expectedProtectedRef = `refs/remotes/origin/${matrix.sourceBinding.protectedBranch}`;
+  if (options.protectedRef && options.protectedRef !== expectedProtectedRef) {
+    throw new Error(`protected ref must be ${expectedProtectedRef}`);
+  }
+  const live = collectTerminalLiveObservations(matrix, evidence);
+  const report = verifyTerminalEvidence(matrix, evidence, live, (relative) =>
+    fs.readFileSync(path.resolve(path.dirname(evidencePath), String(relative))),
   );
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
   if (report.issues.length) process.exitCode = 1;

--- a/framework/terminal-evidence/live-observations.mjs
+++ b/framework/terminal-evidence/live-observations.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { semanticRoot } from '../project-cut/src/project-cut.mjs';
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
+function command(program, args, cwd = ROOT) {
+  const result = spawnSync(program, args, {
+    cwd,
+    encoding: 'utf8',
+    shell: false,
+    env: process.env,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${program} ${args.join(' ')} failed: ${(
+        result.stderr || result.stdout || ''
+      ).trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function jsonOutput(output, label) {
+  const starts = [];
+  for (const match of output.matchAll(/(?:^|\n)\s*([\[{])/gu)) {
+    starts.push((match.index || 0) + match[0].lastIndexOf(match[1]));
+  }
+  for (const start of starts.reverse()) {
+    try {
+      return JSON.parse(output.slice(start).trim());
+    } catch {
+      // Earlier tool output may contain bracketed log prefixes.
+    }
+  }
+  throw new Error(`${label} did not return a terminal JSON document`);
+}
+
+function git(args) {
+  return command('git', args);
+}
+
+function gh(endpoint) {
+  return jsonOutput(command('gh', ['api', endpoint]), `gh api ${endpoint}`);
+}
+
+function gitTree(commit) {
+  return git(['rev-parse', `${commit}^{tree}`]);
+}
+
+function githubTree(repository, commit) {
+  return gh(`/repos/${repository}/git/commits/${encodeURIComponent(commit)}`)
+    .tree?.sha;
+}
+
+function canonicalSealPath(root) {
+  if (!ROOT_PATTERN.test(root || '')) {
+    throw new Error('Assignment seal root is not exact');
+  }
+  const digest = root.slice('sha256:'.length);
+  const commonDir = path.resolve(ROOT, git(['rev-parse', '--git-common-dir']));
+  return path.join(
+    commonDir,
+    'kungfu',
+    'assignment-states',
+    'sha256',
+    digest.slice(0, 2),
+    digest,
+    'state.json',
+  );
+}
+
+function latest(values, label) {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error(`native Assignment has no ${label}`);
+  }
+  return values.at(-1);
+}
+
+function observeAssignment(matrix, evidence) {
+  const initiativeId = evidence.assignment?.initiativeId;
+  const assignmentId = evidence.assignment?.assignmentId;
+  if (!initiativeId || !assignmentId) {
+    throw new Error(
+      'evidence must identify the native Initiative and Assignment',
+    );
+  }
+  const status = jsonOutput(
+    command(path.join(ROOT, 'shifu'), [
+      'work',
+      'status',
+      '--workspace',
+      ROOT,
+      '--initiative-id',
+      initiativeId,
+      '--assignment-id',
+      assignmentId,
+    ]),
+    'kungfu work status',
+  );
+  const claim = latest(status.completion_claims, 'completion claim');
+  const review = latest(status.independent_reviews, 'independent review');
+  const decision = latest(
+    status.continuation_decisions,
+    'continuation decision',
+  );
+  const sealPath = canonicalSealPath(evidence.assignment?.sealedStateRoot);
+  if (!fs.existsSync(sealPath)) {
+    throw new Error(`canonical Assignment seal is missing: ${sealPath}`);
+  }
+  const verification = jsonOutput(
+    command(path.join(ROOT, 'shifu'), ['work', 'verify-seal', sealPath]),
+    'kungfu work verify-seal',
+  );
+  const seal = JSON.parse(fs.readFileSync(sealPath, 'utf8'));
+  return {
+    initiativeId,
+    assignmentId,
+    workspaceIdentityRoot:
+      status.assignment?.owning_workspace_identity_root || '',
+    phase: status.phase,
+    status: status.assignment?.status || '',
+    requestRoot: status.assignment?.request_root || '',
+    captureReceiptRoot:
+      (status.assignment?.capture_receipt_roots || []).at(-1) || '',
+    gitCommit: claim.git_commit || '',
+    completionClaimRoot: semanticRoot(claim),
+    independentReviewRoot: semanticRoot(review),
+    completionDecisionRoot: semanticRoot(decision),
+    reviewer: review.reviewer || '',
+    reviewerSource: review.reviewer_source || '',
+    reviewVerdict: review.verdict || '',
+    decisionAction: decision.action || '',
+    sealedStateRoot: verification.state_root || '',
+    queryProofRoot: status.query_proof_root || '',
+    sealedQueryProofRoot: seal.query_proof_root || '',
+    sealVerified: verification.ok === true,
+    nextActions: verification.next_actions || [],
+    sealedAssignmentId: seal.assignment?.assignment_id || '',
+    sealedPhase: seal.phase || '',
+    statusCounts: {
+      completion_claims: status.completion_claim_count,
+      independent_reviews: status.independent_review_count,
+      continuation_decisions: status.continuation_decision_count,
+    },
+    sealedCounts: seal.counts || {},
+  };
+}
+
+function observeDelivery(matrix, head, headTree) {
+  const repository = matrix.sourceBinding.repository;
+  const encoded = encodeURIComponent(head);
+  const pulls = gh(`/repos/${repository}/commits/${encoded}/pulls`);
+  const pull = (Array.isArray(pulls) ? pulls : []).find(
+    (candidate) =>
+      candidate?.merged_at &&
+      candidate?.merge_commit_sha === head &&
+      candidate?.base?.ref === matrix.sourceBinding.protectedBranch,
+  );
+  if (!pull) {
+    throw new Error('live protected HEAD has no exact merged pull request');
+  }
+  const pullHead = pull.head?.sha || '';
+  const pullHeadTree = githubTree(repository, pullHead);
+  if (pullHeadTree !== headTree) {
+    throw new Error(
+      'approved pull-request tree differs from live protected tree',
+    );
+  }
+  const rule = matrix.terminalEvidence.pullRequestReviewRule;
+  const reviews = gh(
+    `/repos/${repository}/pulls/${pull.number}/reviews?per_page=100`,
+  );
+  const approval = (Array.isArray(reviews) ? reviews : [])
+    .filter(
+      (review) =>
+        review?.user?.login === rule.reviewer &&
+        review?.state === rule.decision &&
+        githubTree(repository, review.commit_id || '') === headTree,
+    )
+    .sort((left, right) =>
+      String(left.submitted_at).localeCompare(String(right.submitted_at)),
+    )
+    .at(-1);
+  if (!approval) {
+    throw new Error(
+      'exact pull-request tree has no required independent approval',
+    );
+  }
+  return {
+    pullRequest: pull.number,
+    state: pull.state === 'closed' && pull.merged_at ? 'MERGED' : pull.state,
+    baseRef: pull.base?.ref || '',
+    pullRequestHead: pullHead,
+    pullRequestTree: pullHeadTree,
+    mergeCommit: pull.merge_commit_sha || '',
+    mergeTree: githubTree(repository, pull.merge_commit_sha || ''),
+    approval: {
+      reviewId: approval.id,
+      reviewer: approval.user?.login || '',
+      decision: approval.state || '',
+      commit: approval.commit_id || '',
+      tree: githubTree(repository, approval.commit_id || ''),
+      submittedAt: approval.submitted_at || '',
+    },
+  };
+}
+
+function terminalReviewAttestation(body) {
+  try {
+    const value = JSON.parse(String(body || '').trim());
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function observeTerminalReview(matrix, pullRequest, head, headTree) {
+  const repository = matrix.sourceBinding.repository;
+  const rule = matrix.terminalEvidence.terminalReviewRule;
+  const comments = gh(
+    `/repos/${repository}/issues/${pullRequest}/comments?per_page=100`,
+  );
+  const attestation = (Array.isArray(comments) ? comments : [])
+    .map((comment) => ({
+      comment,
+      document: terminalReviewAttestation(comment?.body),
+    }))
+    .filter(
+      ({ comment, document }) =>
+        comment?.user?.login === rule.reviewer &&
+        document?.schema === rule.attestationSchema &&
+        document?.goalId === matrix.goalId &&
+        document?.commit === head &&
+        document?.tree === headTree &&
+        document?.reviewer === rule.reviewer &&
+        document?.verdict === rule.verdict &&
+        document?.freshContext === rule.freshContext &&
+        document?.maximumOpenSeverity === rule.maximumOpenSeverity &&
+        ROOT_PATTERN.test(document?.reportRoot || ''),
+    )
+    .sort(({ comment: left }, { comment: right }) =>
+      String(left.created_at).localeCompare(String(right.created_at)),
+    )
+    .at(-1);
+  if (!attestation) {
+    throw new Error(
+      'live protected cut has no independent terminal review attestation',
+    );
+  }
+  return {
+    commentId: attestation.comment.id,
+    author: attestation.comment.user?.login || '',
+    createdAt: attestation.comment.created_at || '',
+    updatedAt: attestation.comment.updated_at || '',
+    url: attestation.comment.html_url || '',
+    ...attestation.document,
+  };
+}
+
+function observeRun(matrix, declared) {
+  const repository = matrix.sourceBinding.repository;
+  const run = gh(`/repos/${repository}/actions/runs/${declared.runId}`);
+  const jobsPayload = gh(
+    `/repos/${repository}/actions/runs/${declared.runId}/jobs?per_page=100`,
+  );
+  const artifactsPayload = gh(
+    `/repos/${repository}/actions/runs/${declared.runId}/artifacts?per_page=100`,
+  );
+  return {
+    role: declared.role,
+    workflowPath: run.path || '',
+    runId: run.id,
+    runAttempt: run.run_attempt,
+    event: run.event || '',
+    headSha: run.head_sha || '',
+    headBranch: run.head_branch || '',
+    status: run.status || '',
+    conclusion: run.conclusion || '',
+    jobs: (jobsPayload.jobs || []).map((job) => ({
+      id: job.id,
+      name: job.name || '',
+      status: job.status || '',
+      conclusion: job.conclusion || '',
+    })),
+    artifacts: (artifactsPayload.artifacts || []).map((artifact) => ({
+      id: artifact.id,
+      name: artifact.name || '',
+      digest: artifact.digest || '',
+      sizeBytes: artifact.size_in_bytes,
+      expired: artifact.expired === true,
+      workflowRunId: artifact.workflow_run?.id,
+      headSha: artifact.workflow_run?.head_sha || '',
+    })),
+  };
+}
+
+export function collectTerminalLiveObservations(matrix, evidence) {
+  const head = git(['rev-parse', 'HEAD']);
+  const headTree = gitTree(head);
+  const protectedRef = gh(
+    `/repos/${matrix.sourceBinding.repository}/git/ref/heads/${encodeURIComponent(
+      matrix.sourceBinding.protectedBranch,
+    )}`,
+  );
+  const protectedCommit = protectedRef.object?.sha || '';
+  const protectedTree = githubTree(
+    matrix.sourceBinding.repository,
+    protectedCommit,
+  );
+  const delivery = observeDelivery(matrix, head, headTree);
+  return {
+    schema: 'kungfu.terminal-live-observations/v1',
+    observedAt: new Date().toISOString(),
+    source: {
+      repository: matrix.sourceBinding.repository,
+      protectedBranch: matrix.sourceBinding.protectedBranch,
+      head,
+      headTree,
+      protectedCommit,
+      protectedTree,
+    },
+    delivery,
+    terminalReview: observeTerminalReview(
+      matrix,
+      delivery.pullRequest,
+      head,
+      headTree,
+    ),
+    assignment: observeAssignment(matrix, evidence),
+    runs: (evidence.runs || []).map((run) => observeRun(matrix, run)),
+  };
+}
+
+export {
+  jsonOutput as parseCommandJson,
+  terminalReviewAttestation as parseTerminalReviewAttestation,
+};

--- a/framework/terminal-evidence/live-verification.mjs
+++ b/framework/terminal-evidence/live-verification.mjs
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+import {
+  exact,
+  issue,
+  requiredRoot,
+  uniqueBy,
+} from './verification-primitives.mjs';
+
+export function verifyLiveAssignment(
+  matrix,
+  evidence,
+  live,
+  references,
+  issues,
+) {
+  exact(
+    evidence.assignment?.assignmentId,
+    matrix.goalId,
+    'assignment-identity-mismatch',
+    'assignment.assignmentId',
+    issues,
+  );
+  exact(
+    evidence.assignment?.gitCommit,
+    live.source?.head,
+    'assignment-head-mismatch',
+    'assignment.gitCommit',
+    issues,
+  );
+  for (const [field, kind] of [
+    ['requestRoot', 'assignment-request'],
+    ['captureReceiptRoot', 'assignment-capture'],
+    ['completionClaimRoot', 'assignment-claim'],
+    ['independentReviewRoot', 'assignment-review'],
+    ['completionDecisionRoot', 'assignment-decision'],
+    ['sealedStateRoot', 'assignment-seal'],
+  ]) {
+    requiredRoot(
+      references,
+      evidence.assignment?.[field],
+      `assignment.${field}`,
+      kind,
+      issues,
+    );
+  }
+  for (const field of [
+    'initiativeId',
+    'assignmentId',
+    'workspaceIdentityRoot',
+    'phase',
+    'status',
+    'requestRoot',
+    'captureReceiptRoot',
+    'gitCommit',
+    'completionClaimRoot',
+    'independentReviewRoot',
+    'completionDecisionRoot',
+    'sealedStateRoot',
+  ]) {
+    exact(
+      evidence.assignment?.[field],
+      live.assignment?.[field],
+      `assignment-live-${field}-mismatch`,
+      `assignment.${field}`,
+      issues,
+    );
+  }
+  exact(
+    live.assignment?.phase,
+    'continuation-decided',
+    'assignment-not-terminal',
+    'live.assignment.phase',
+    issues,
+  );
+  exact(
+    live.assignment?.sealedPhase,
+    'continuation-decided',
+    'assignment-seal-not-terminal',
+    'live.assignment.sealedPhase',
+    issues,
+  );
+  exact(
+    live.assignment?.sealedAssignmentId,
+    matrix.goalId,
+    'assignment-seal-identity-mismatch',
+    'live.assignment.sealedAssignmentId',
+    issues,
+  );
+  exact(
+    live.assignment?.sealedQueryProofRoot,
+    live.assignment?.queryProofRoot,
+    'assignment-seal-query-proof-mismatch',
+    'live.assignment.sealedQueryProofRoot',
+    issues,
+  );
+  const rule = matrix.terminalEvidence.terminalReviewRule;
+  exact(
+    live.assignment?.reviewer,
+    rule.reviewer,
+    'assignment-live-reviewer-mismatch',
+    'live.assignment.reviewer',
+    issues,
+  );
+  exact(
+    live.assignment?.reviewVerdict,
+    rule.verdict,
+    'assignment-live-review-verdict-mismatch',
+    'live.assignment.reviewVerdict',
+    issues,
+  );
+  exact(
+    live.assignment?.reviewerSource,
+    evidence.review?.root,
+    'assignment-review-source-mismatch',
+    'live.assignment.reviewerSource',
+    issues,
+  );
+  exact(
+    live.assignment?.decisionAction,
+    'close',
+    'assignment-decision-not-close',
+    'live.assignment.decisionAction',
+    issues,
+  );
+  if (live.assignment?.sealVerified !== true) {
+    issues.push(
+      issue(
+        'assignment-seal-unverified',
+        'live.assignment.sealVerified',
+        'canonical native Assignment seal did not verify',
+      ),
+    );
+  }
+  if ((live.assignment?.nextActions || []).length !== 0) {
+    issues.push(
+      issue(
+        'assignment-still-actionable',
+        'live.assignment.nextActions',
+        'terminal native Assignment retains actionable next actions',
+      ),
+    );
+  }
+  for (const field of [
+    'completion_claims',
+    'independent_reviews',
+    'continuation_decisions',
+  ]) {
+    exact(
+      live.assignment?.sealedCounts?.[field],
+      live.assignment?.statusCounts?.[field],
+      'assignment-seal-count-mismatch',
+      `live.assignment.sealedCounts.${field}`,
+      issues,
+    );
+    if ((live.assignment?.statusCounts?.[field] || 0) < 1) {
+      issues.push(
+        issue(
+          'assignment-terminal-chain-incomplete',
+          `live.assignment.statusCounts.${field}`,
+          `terminal Assignment has no ${field}`,
+        ),
+      );
+    }
+  }
+}
+
+function verifyRequiredArtifact(
+  required,
+  artifactRule,
+  declared,
+  observed,
+  live,
+  references,
+  issues,
+) {
+  const name = artifactRule.nameTemplate
+    .replaceAll('{platform}', artifactRule.platform)
+    .replaceAll('{commit}', live.source?.head || '');
+  const declaredArtifact = (declared.artifacts || []).find(
+    (artifact) => artifact.platform === artifactRule.platform,
+  );
+  const observedArtifact = (observed.artifacts || []).find(
+    (artifact) => artifact.name === name,
+  );
+  if (!declaredArtifact || !observedArtifact) {
+    issues.push(
+      issue(
+        'missing-required-artifact',
+        `${required.role}.${artifactRule.platform}`,
+        `required live artifact ${name} is absent`,
+      ),
+    );
+    return;
+  }
+  for (const [field, expected] of [
+    ['id', observedArtifact.id],
+    ['name', name],
+    ['root', observedArtifact.digest],
+    ['sizeBytes', observedArtifact.sizeBytes],
+  ]) {
+    exact(
+      declaredArtifact[field],
+      expected,
+      `artifact-${field}-live-mismatch`,
+      `${required.role}.${artifactRule.platform}.${field}`,
+      issues,
+    );
+  }
+  exact(
+    observedArtifact.workflowRunId,
+    observed.runId,
+    'artifact-run-mismatch',
+    `${required.role}.${artifactRule.platform}.workflowRunId`,
+    issues,
+  );
+  exact(
+    observedArtifact.headSha,
+    live.source?.head,
+    'artifact-head-mismatch',
+    `${required.role}.${artifactRule.platform}.headSha`,
+    issues,
+  );
+  if (observedArtifact.expired === true) {
+    issues.push(
+      issue(
+        'artifact-expired',
+        `${required.role}.${artifactRule.platform}`,
+        `required artifact ${name} has expired`,
+      ),
+    );
+  }
+  requiredRoot(
+    references,
+    declaredArtifact.root,
+    `${required.role}.${artifactRule.platform}.root`,
+    'artifact-bytes',
+    issues,
+  );
+}
+
+export function verifyLiveRuns(matrix, evidence, live, references, issues) {
+  uniqueBy(
+    matrix.terminalEvidence.runGroups,
+    'role',
+    'duplicate-required-run-role',
+    issues,
+  );
+  uniqueBy(evidence.runs, 'role', 'duplicate-run-role', issues);
+  uniqueBy(live.runs, 'role', 'duplicate-live-run-role', issues);
+  const declaredRuns = new Map(
+    (evidence.runs || []).map((entry) => [entry.role, entry]),
+  );
+  const observedRuns = new Map(
+    (live.runs || []).map((entry) => [entry.role, entry]),
+  );
+  for (const required of matrix.terminalEvidence.runGroups || []) {
+    uniqueBy(
+      required.requiredArtifacts,
+      'platform',
+      'duplicate-required-artifact-platform',
+      issues,
+    );
+    const declared = declaredRuns.get(required.role);
+    const observed = observedRuns.get(required.role);
+    if (!declared || !observed) {
+      issues.push(
+        issue(
+          'missing-run-group',
+          required.role,
+          `missing declared or observed ${required.role} run`,
+        ),
+      );
+      continue;
+    }
+    for (const [field, expected] of [
+      ['workflowPath', required.workflowPath],
+      ['runId', observed.runId],
+      ['runAttempt', observed.runAttempt],
+      ['event', observed.event],
+      ['commit', observed.headSha],
+      ['conclusion', observed.conclusion],
+    ]) {
+      exact(
+        declared[field],
+        expected,
+        `run-${field}-live-mismatch`,
+        `${required.role}.${field}`,
+        issues,
+      );
+    }
+    exact(
+      observed.workflowPath,
+      required.workflowPath,
+      'run-workflow-mismatch',
+      `${required.role}.workflowPath`,
+      issues,
+    );
+    exact(
+      observed.headSha,
+      live.source?.head,
+      'run-head-mismatch',
+      `${required.role}.headSha`,
+      issues,
+    );
+    if (!required.events.includes(observed.event)) {
+      issues.push(
+        issue(
+          'run-event-mismatch',
+          `${required.role}.event`,
+          `event ${observed.event} is outside the declared run contract`,
+        ),
+      );
+    }
+    if (!Number.isInteger(observed.runId) || observed.runId < 1) {
+      issues.push(
+        issue(
+          'invalid-run-id',
+          `${required.role}.runId`,
+          'observed run id must be positive',
+        ),
+      );
+    }
+    exact(
+      observed.status,
+      'completed',
+      'run-not-completed',
+      `${required.role}.status`,
+      issues,
+    );
+    exact(
+      observed.conclusion,
+      'success',
+      'run-not-successful',
+      `${required.role}.conclusion`,
+      issues,
+    );
+    requiredRoot(
+      references,
+      declared.evidenceRoot,
+      `${required.role}.evidenceRoot`,
+      'run-snapshot',
+      issues,
+    );
+    uniqueBy(declared.jobs, 'name', 'duplicate-run-job', issues);
+    uniqueBy(observed.jobs, 'name', 'duplicate-live-run-job', issues);
+    const declaredJobs = new Map(
+      (declared.jobs || []).map((job) => [job.name, job]),
+    );
+    const observedJobs = new Map(
+      (observed.jobs || []).map((job) => [job.name, job]),
+    );
+    for (const jobName of required.requiredJobs || []) {
+      const declaredJob = declaredJobs.get(jobName);
+      const observedJob = observedJobs.get(jobName);
+      if (!declaredJob || !observedJob) {
+        issues.push(
+          issue(
+            'missing-required-job',
+            `${required.role}.${jobName}`,
+            `required job ${jobName} is absent`,
+          ),
+        );
+        continue;
+      }
+      exact(
+        declaredJob.conclusion,
+        observedJob.conclusion,
+        'run-job-live-mismatch',
+        `${required.role}.${jobName}`,
+        issues,
+      );
+      exact(
+        observedJob.conclusion,
+        'success',
+        'required-job-not-successful',
+        `${required.role}.${jobName}`,
+        issues,
+      );
+    }
+    uniqueBy(declared.artifacts, 'id', 'duplicate-artifact-id', issues);
+    uniqueBy(declared.artifacts, 'name', 'duplicate-artifact-name', issues);
+    for (const artifactRule of required.requiredArtifacts || []) {
+      verifyRequiredArtifact(
+        required,
+        artifactRule,
+        declared,
+        observed,
+        live,
+        references,
+        issues,
+      );
+    }
+  }
+}

--- a/framework/terminal-evidence/verification-primitives.mjs
+++ b/framework/terminal-evidence/verification-primitives.mjs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// @ts-check
+
+const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
+export function issue(code, target, message) {
+  return { code, target, message };
+}
+
+export function exact(value, expected, code, target, issues) {
+  if (value !== expected) {
+    issues.push(
+      issue(
+        code,
+        target,
+        `${target} is ${String(value)}, expected ${String(expected)}`,
+      ),
+    );
+  }
+}
+
+export function requiredRoot(references, value, target, kind, issues) {
+  if (!ROOT_PATTERN.test(value || '')) {
+    issues.push(
+      issue('invalid-root', target, `${target} must be a sha256 root`),
+    );
+    return;
+  }
+  const prior = references.get(value);
+  if (prior && prior.kind !== kind) {
+    issues.push(
+      issue(
+        'retained-role-conflict',
+        target,
+        `${value} cannot represent both ${prior.kind} and ${kind}`,
+      ),
+    );
+    return;
+  }
+  references.set(value, { kind, target });
+}
+
+export function uniqueBy(values, key, code, issues) {
+  const seen = new Set();
+  for (const value of values || []) {
+    const identity = value?.[key];
+    if (!identity || seen.has(identity)) {
+      issues.push(
+        issue(
+          code,
+          identity || key,
+          `${key} values must be present and unique`,
+        ),
+      );
+    }
+    seen.add(identity);
+  }
+}

--- a/scripts/code-complexity-budget.test.mjs
+++ b/scripts/code-complexity-budget.test.mjs
@@ -592,6 +592,15 @@ test('waiver approval rejects fabricated, unknown, same-authority, and stale rec
   stale.value.approval_receipt.approved_at = '2026-05-01T00:01:00Z';
   stale.value.approval_receipt.expires_at = '2026-08-01T00:00:00Z';
   assert.ok(codes(stale).includes('stale-approval'));
+  assert.ok(
+    codes(fixture.record, fixture.policy, {
+      ...context,
+      evaluationTime: new Date(
+        fixture.record.value.approval_receipt.expires_at,
+      ),
+    }).includes('expired-approval'),
+    'an approval is expired at its exact expires_at boundary',
+  );
 });
 
 test('baseline integrity rejects forged measurements and artifact fields', () => {


### PR DESCRIPTION
## Summary

- Weld terminal evidence verification to live GitHub, Git, and native Assignment authority.
- Require exact protected commit/tree, merged PR, independent approval, workflow jobs, artifact API identity, and downloaded artifact bytes.
- Require a fresh kungfu-origin terminal-review attestation and exact native query-proof/seal binding.
- Cover the exact approval-expiry boundary and helper-proliferation budget.

## Validation

- ./shifu check:source
- ./shifu build:core
- node --test framework/maintainability/terminal-evidence-matrix.test.mjs
- node --test scripts/code-complexity-budget.test.mjs
- node scripts/check-code-complexity.mjs
- node framework/maintainability/semantic-amplification.mjs --check
- git diff --check

No gate weakening or waiver is included.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This verifier hardening changes evidence validation without altering an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change reads GitHub and native Assignment authority only and is covered by fail-closed negative fixtures.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
