### PR TITLE
fix(ci): read Windows JIT label from step environment

### DIFF
--- a/.github/workflows/aws-us-windows-burst-qualification.yml
+++ b/.github/workflows/aws-us-windows-burst-qualification.yml
@@ -181,7 +181,7 @@ jobs:
             throw "missing EC2 instance identity"
           }
           $labels = $env:BUILDCHAIN_RUNNER_LABELS_JSON | ConvertFrom-Json
-          if ($EXPECTED_LABEL -notin $labels) {
+          if ($env:EXPECTED_LABEL -notin $labels) {
             throw "JIT label mismatch"
           }
           "instance=$($env:AWS_EC2_INSTANCE_ID)"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -234,10 +234,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:23b52a3000961fce92fce68508453a36ebbaefdb4808d41d478d6d24486a4865",
+          "definitionDigest": "sha256:3c83aee139d47df4e5275310ed936b20db7ef169aa06973f5371d0d8198d87ab",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": [],
-          "steps": [{"index":1,"label":"name:Confirm exact JIT runner identity","definitionDigest":"sha256:115bfd9234736a1da607e61a0bb1be98a191d35f0da57ad4bb419a447069b9d2"},{"index":2,"label":"name:Hold until the declared cleanup trigger","definitionDigest":"sha256:ebc15529c500b6f0e216a2a2ede2ade66d1f685f9b824e67cf3a5382af07cf84"}]
+          "steps": [{"index":1,"label":"name:Confirm exact JIT runner identity","definitionDigest":"sha256:c698b5435dd0cd908946051f13616670d9639cf4f482f0c5d313d1b6242c25b9"},{"index":2,"label":"name:Hold until the declared cleanup trigger","definitionDigest":"sha256:ebc15529c500b6f0e216a2a2ede2ade66d1f685f9b824e67cf3a5382af07cf84"}]
         },
         {
           "id": "full",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -111,7 +111,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:88b57065059170bdb8cc76941b5bc66e2663efaa43c7e165aeda9b89f5f501e3"
+          "sourceRoot": "sha256:bbaa81705979fe216eca197a7439ee1f5173d2c480cb7011d8d643b0ebc7cb50"
         },
         {
           "path": ".github/workflows/build.yml",
@@ -835,5 +835,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:010deca6019f4d9b0f2da5d13fbf0da5069e777629437ea02d1e807cfdb22b82"
+  "registryRoot": "sha256:6bb77301ab19b2e232ea5ce0604091559f6228435c5ed59907d2a86d49f13ab5"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -262,6 +262,8 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
       assert.match(workflow, /jobs:\n {2}trust:/);
       assert.match(workflow, /runs-on: ubuntu-24\.04/);
       assert.match(workflow, /Require write-capable actor/);
+      assert.match(workflow, /\$env:EXPECTED_LABEL -notin \$labels/);
+      assert.doesNotMatch(workflow, /if \(\$EXPECTED_LABEL -notin \$labels\)/);
     }
     const shellPins =
       workflow.match(


### PR DESCRIPTION
## Summary

- read `EXPECTED_LABEL` from the PowerShell step environment
- add a regression that rejects the unset local-variable form
- refresh workflow-authority and publication roots

## Why

The Windows JIT worker inherited its root `.env` correctly. The timeout job failed before its hold step because the workflow referenced `$EXPECTED_LABEL`, an unset PowerShell local variable, instead of `$env:EXPECTED_LABEL`.

## Validation

- `./shifu check:source` (passed with the locked Core environment before the clean rebase; the exact four-file diff and generated roots were unchanged by rebase)
- `node --test scripts/buildchain-install.test.mjs`
- `node scripts/kungfu-workflow-authority.mjs`
- `node scripts/check-kungfu-gate-catalog.mjs`
- `node framework/release/publication-control-plane.mjs check`

No release or campaign activation.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct an incorrect PowerShell variable reference in the existing Windows JIT qualification workflow; no architecture or public contract changes."
}
-->