### PR TITLE
fix(tui): settle contextual project restore

### DIFF
--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -24,7 +24,6 @@ import {
   reduceControlPlaneInput,
   resolveProductStartupSurface,
   shouldStartContextualProjectRestore,
-  useStartupProductSurface,
 } from './profile-shell.js';
 import {
   PROJECTS_QUICK_COMMANDS,
@@ -156,7 +155,7 @@ function ContextualProjectRestoreHarness({
   navigation?: Promise<ProductSurface>;
 }) {
   const [surface, setSurfaceState] = React.useState<ProductSurface>('loading');
-  const startupSurface = useStartupProductSurface(surface);
+  const startupSurface = React.useRef(surface).current;
   const surfaceRef = React.useRef(surface);
   const [loading, setLoading] = React.useState(false);
   const [restored, setRestored] = React.useState(false);

--- a/framework/tui/src/control-plane.test.ts
+++ b/framework/tui/src/control-plane.test.ts
@@ -15,6 +15,7 @@ import {
   ControlPlaneBar,
   ControlPlaneOverlay,
   type ControlPlaneState,
+  type ProductSurface,
   QUICK_COMMANDS,
   contextualProjectRestoreCanCommit,
   createControlPlaneInputFence,
@@ -23,6 +24,7 @@ import {
   reduceControlPlaneInput,
   resolveProductStartupSurface,
   shouldStartContextualProjectRestore,
+  useStartupProductSurface,
 } from './profile-shell.js';
 import {
   PROJECTS_QUICK_COMMANDS,
@@ -134,6 +136,78 @@ class CaptureOutput extends Writable {
     this.chunks.push(String(chunk));
     callback();
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function ContextualProjectRestoreHarness({
+  selected,
+  inventory,
+  navigation,
+}: {
+  selected: Promise<void>;
+  inventory: Promise<void>;
+  navigation?: Promise<ProductSurface>;
+}) {
+  const [surface, setSurfaceState] = React.useState<ProductSurface>('loading');
+  const startupSurface = useStartupProductSurface(surface);
+  const surfaceRef = React.useRef(surface);
+  const [loading, setLoading] = React.useState(false);
+  const [restored, setRestored] = React.useState(false);
+  const setSurface = React.useCallback((next: ProductSurface) => {
+    surfaceRef.current = next;
+    setSurfaceState(next);
+  }, []);
+
+  React.useEffect(() => {
+    if (!navigation) return;
+    void navigation.then(setSurface);
+  }, [navigation, setSurface]);
+
+  React.useEffect(() => {
+    if (
+      !shouldStartContextualProjectRestore({
+        playbackMode: false,
+        surface: startupSurface,
+        emptyState: false,
+        startupProjectRoot: '/tmp/project',
+      })
+    ) {
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    void selected
+      .then(async () => {
+        if (!active || !contextualProjectRestoreCanCommit(surfaceRef.current)) {
+          return;
+        }
+        setSurface('project-work');
+        await inventory;
+        if (!active || surfaceRef.current !== 'project-work') return;
+        setRestored(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [inventory, selected, setSurface, startupSurface]);
+
+  return React.createElement(
+    Text,
+    null,
+    `${surface}:${loading ? 'loading' : 'settled'}:${
+      restored ? 'restored' : 'pending'
+    }`,
+  );
 }
 
 test('opens Help, slash commands, and product search from the focused input', () => {
@@ -509,6 +583,71 @@ test('explicit product navigation cancels contextual Project restoration', () =>
       `${surface} must revoke a pending restore before React rerenders`,
     );
   }
+});
+
+test('contextual Project restore survives its owned async surface transition', async () => {
+  const output = new CaptureOutput();
+  const selected = deferred<void>();
+  const inventory = deferred<void>();
+  const instance = render(
+    React.createElement(ContextualProjectRestoreHarness, {
+      selected: selected.promise,
+      inventory: inventory.promise,
+    }),
+    {
+      stdout: output as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      debug: true,
+    },
+  );
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  selected.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.match(output.chunks.join(''), /project-work:loading:pending/);
+
+  inventory.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const frame = output.chunks.join('');
+  instance.unmount();
+  instance.cleanup();
+
+  assert.match(frame, /project-work:settled:restored/);
+});
+
+test('explicit navigation cancels async Project restore and settles loading', async () => {
+  const output = new CaptureOutput();
+  const selected = deferred<void>();
+  const inventory = deferred<void>();
+  const navigation = deferred<ProductSurface>();
+  const instance = render(
+    React.createElement(ContextualProjectRestoreHarness, {
+      selected: selected.promise,
+      inventory: inventory.promise,
+      navigation: navigation.promise,
+    }),
+    {
+      stdout: output as unknown as NodeJS.WriteStream,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      debug: true,
+    },
+  );
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  navigation.resolve('projects');
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.match(output.chunks.join(''), /projects:loading:pending/);
+
+  selected.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  const frame = output.chunks.join('');
+  instance.unmount();
+  instance.cleanup();
+
+  assert.match(frame, /projects:settled:pending/);
+  assert.doesNotMatch(frame, /project-work/);
 });
 
 test('the real Ink control plane covers the product canvas and keeps a fixed input bar', async () => {

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -79,6 +79,7 @@ import {
   resolveProductStartupSurface,
   shouldStartContextualProjectRestore,
   splitHorizontalPointerActionAtPoint,
+  useStartupProductSurface,
 } from './profile-shell.js';
 import {
   KUNGFU_EMPTY_WORK_NEBULA_PATTERN,
@@ -980,6 +981,7 @@ function ProductHost({
   const [surface, setSurfaceState] = React.useState<ProductSurface>(
     initialProductSurface({ playbackMode, firstLaunch, emptyState }),
   );
+  const startupSurface = useStartupProductSurface(surface);
   const startupAnimationEnabled = React.useMemo(
     () => terminalAnimationsEnabled(process.env),
     [],
@@ -1178,7 +1180,7 @@ function ProductHost({
     if (
       !shouldStartContextualProjectRestore({
         playbackMode,
-        surface,
+        surface: startupSurface,
         emptyState,
         startupProjectRoot,
       })
@@ -1271,7 +1273,7 @@ function ProductHost({
     projects,
     setSurface,
     startupProjectRoot,
-    surface,
+    startupSurface,
   ]);
   const autoplay = React.useMemo(
     () =>

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -79,7 +79,6 @@ import {
   resolveProductStartupSurface,
   shouldStartContextualProjectRestore,
   splitHorizontalPointerActionAtPoint,
-  useStartupProductSurface,
 } from './profile-shell.js';
 import {
   KUNGFU_EMPTY_WORK_NEBULA_PATTERN,
@@ -981,7 +980,7 @@ function ProductHost({
   const [surface, setSurfaceState] = React.useState<ProductSurface>(
     initialProductSurface({ playbackMode, firstLaunch, emptyState }),
   );
-  const startupSurface = useStartupProductSurface(surface);
+  const startupSurface = React.useRef(surface).current;
   const startupAnimationEnabled = React.useMemo(
     () => terminalAnimationsEnabled(process.env),
     [],

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import {
   CLOSED_CONTROL_PLANE,
   type ControlPlaneState,
+  type ProductSurface,
   QUICK_COMMANDS,
   type QuickCommand,
 } from './control-plane-state.js';
@@ -87,6 +88,12 @@ export type ProfileShellLayout = {
   navigationWidth: number;
   evidenceWidth: number;
 };
+
+export function useStartupProductSurface(
+  surface: ProductSurface,
+): ProductSurface {
+  return React.useRef(surface).current;
+}
 
 export function resolveProfileShellLayout(
   dimensions: TerminalDimensions,

--- a/framework/tui/src/profile-shell.tsx
+++ b/framework/tui/src/profile-shell.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import {
   CLOSED_CONTROL_PLANE,
   type ControlPlaneState,
-  type ProductSurface,
   QUICK_COMMANDS,
   type QuickCommand,
 } from './control-plane-state.js';
@@ -88,12 +87,6 @@ export type ProfileShellLayout = {
   navigationWidth: number;
   evidenceWidth: number;
 };
-
-export function useStartupProductSurface(
-  surface: ProductSurface,
-): ProductSurface {
-  return React.useRef(surface).current;
-}
 
 export function resolveProfileShellLayout(
   dimensions: TerminalDimensions,


### PR DESCRIPTION
## Summary

Fix TUI startup restoration for a contextual Project so the restore is not cancelled by its own `loading` to `project-work` surface transition.

## Related issue

None.

## Changes

- Freeze the startup surface used to decide whether contextual Project restoration owns the initial request.
- Keep the live surface as the fail-closed commit gate for explicit user navigation.
- Add real Ink/React async regressions for the owned transition and explicit-navigation cancellation, including loading settlement.

## Verification

- `./shifu --filter @kungfu-tech/tui exec tsx --test src/control-plane.test.ts` (26/26)
- `./shifu build:cli`
- `./shifu test:kfx-profile-suite`
- `./shifu check:staged`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores the existing contextual Project startup lifecycle and does not alter an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; this restores intended behavior)