### PR TITLE
docs(kfd): bind primitive management evidence

### DIFF
--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -247,7 +247,10 @@
         "status": "implemented-candidate-profile",
         "surfaces": [
           "framework/core/src/python/kungfu/assignment_orchestration.py",
-          "docs/qualification/evidence/assignment-organization-rollout/7aae2c562a/report.json"
+          "docs/qualification/evidence/assignment-organization-rollout/7aae2c562a/report.json",
+          "docs/architecture/primitive-management-plane.md",
+          "framework/incubation/incubation-passport.registry.json",
+          "framework/primitive/kungfu-primitive-catalog.contract.json"
         ]
       },
       "verification": {
@@ -260,6 +263,18 @@
           {
             "path": "framework/core/tests/python/test_assignment_orchestration.py",
             "sha256": "sha256:362a6b85e1162bb04566e778c03eb511c65ac57035ad794bb893802aa4e6d28c"
+          },
+          {
+            "path": "docs/architecture/primitive-management-plane.md",
+            "sha256": "sha256:487177ad3247adbfed6fd1ccdecf7c31a7a6c93387bfba98af41cf1256426bcb"
+          },
+          {
+            "path": "framework/incubation/incubation-passport.registry.json",
+            "sha256": "sha256:8cab184f9c708c5fd00324cb420f22972047875b0238b8bf2d10c95e36012dad"
+          },
+          {
+            "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
+            "sha256": "sha256:e2eac134b5ad294a82710318c9c09096d76420d4f3e741e6b547e8b96d2cbc52"
           }
         ]
       },
@@ -279,11 +294,12 @@
       },
       "claimClass": "adoption-candidate",
       "knownLimitations": [
-        "The evidence is bounded to Kungfu's first-party Assignment profile; it does not prove universal primitive need or independent adoption.",
+        "The evidence is bounded to Kungfu's first-party Assignment profile and Primitive Management Plane; it does not prove universal primitive need or independent adoption.",
+        "Incubation passports are the sole intake and the nine-entry catalog is a derived projection; its experimental and candidate admission states are not shipment or KFD-5 promotion.",
         "A passed Buildchain gate does not self-qualify, activate, or ship KFD-5 support."
       ],
       "owner": "kungfu-primitive",
-      "nextGate": "Retain the exact-source gate and release passport, then obtain independent adopter evidence and an explicit release decision before changing shipped support."
+      "nextGate": "Retain the Primitive Management evidence roots and exact-source gate, then obtain independent adopter evidence and an explicit release decision before changing shipped support."
     },
     {
       "id": "KFD-6",
@@ -303,6 +319,36 @@
         "status": "none",
         "evidenceRoots": []
       },
+      "precursorEvidence": {
+        "status": "non-conforming-evidence",
+        "surfaces": [
+          "framework/work-design-advisor/work-design-advisor.contract.json",
+          "framework/work-design-policy-replay/work-design-policy-replay.contract.json",
+          "framework/project-cut/README.md"
+        ],
+        "evidenceRoots": [
+          {
+            "path": "framework/work-design-advisor/work-design-advisor.contract.json",
+            "sha256": "sha256:bbfd014adb84bfce90e20f39978a3cd6129d9c57a56f4564783273db69eb1614"
+          },
+          {
+            "path": "framework/work-design-policy-replay/work-design-policy-replay.contract.json",
+            "sha256": "sha256:caa4f7d38d7efeef985453267d355c2a4dda3737eb83a4bfd5f6cdfbc6f4bc4e"
+          },
+          {
+            "path": "framework/project-cut/README.md",
+            "sha256": "sha256:0d7b91a5d3c04e47175e286763542a7da9e84d4d01b012451d4895b3191dc062"
+          }
+        ],
+        "missingGates": [
+          "plural genesis methods and declared budgets",
+          "fixed-ontology and no-new-primitive baselines",
+          "systematic false-candidate rejection",
+          "held-out promotion separation",
+          "cross-domain transfer"
+        ],
+        "claimBoundary": "Work Design history selection, outcome estimation, and offline policy replay are bounded advisory precursors only. They do not implement, verify, activate, or ship KFD-6 autonomous discovery."
+      },
       "buildchain": {
         "gateStatus": "not-applicable",
         "protocol": "none"
@@ -319,10 +365,11 @@
       },
       "claimClass": "explicit-non-adoption",
       "knownLimitations": [
-        "Kungfu has no bounded KFD-6 causal-experience discovery implementation or evidence."
+        "Kungfu has no conforming KFD-6 causal-experience discovery implementation or verification.",
+        "The retained Work Design precursors do not compare plural genesis methods, run fixed-ontology or no-new-primitive baselines, reject false candidates systematically, separate held-out promotion, or demonstrate transfer."
       ],
       "owner": "unassigned",
-      "nextGate": "Keep unsupported unless a separately admitted causal-experience discovery initiative is approved."
+      "nextGate": "Keep unsupported; admit a separate causal-experience discovery initiative only after the listed missing gates have executable contracts and evidence."
     },
     {
       "id": "KFD-7",

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -247,7 +247,10 @@
         "status": "implemented-candidate-profile",
         "surfaces": [
           "framework/core/src/python/kungfu/assignment_orchestration.py",
-          "docs/qualification/evidence/assignment-organization-rollout/7aae2c562a/report.json"
+          "docs/qualification/evidence/assignment-organization-rollout/7aae2c562a/report.json",
+          "docs/architecture/primitive-management-plane.md",
+          "framework/incubation/incubation-passport.registry.json",
+          "framework/primitive/kungfu-primitive-catalog.contract.json"
         ]
       },
       "verification": {
@@ -260,6 +263,18 @@
           {
             "path": "framework/core/tests/python/test_assignment_orchestration.py",
             "sha256": "sha256:362a6b85e1162bb04566e778c03eb511c65ac57035ad794bb893802aa4e6d28c"
+          },
+          {
+            "path": "docs/architecture/primitive-management-plane.md",
+            "sha256": "sha256:487177ad3247adbfed6fd1ccdecf7c31a7a6c93387bfba98af41cf1256426bcb"
+          },
+          {
+            "path": "framework/incubation/incubation-passport.registry.json",
+            "sha256": "sha256:8cab184f9c708c5fd00324cb420f22972047875b0238b8bf2d10c95e36012dad"
+          },
+          {
+            "path": "framework/primitive/kungfu-primitive-catalog.contract.json",
+            "sha256": "sha256:e2eac134b5ad294a82710318c9c09096d76420d4f3e741e6b547e8b96d2cbc52"
           }
         ]
       },
@@ -279,11 +294,12 @@
       },
       "claimClass": "adoption-candidate",
       "knownLimitations": [
-        "The evidence is bounded to Kungfu's first-party Assignment profile; it does not prove universal primitive need or independent adoption.",
+        "The evidence is bounded to Kungfu's first-party Assignment profile and Primitive Management Plane; it does not prove universal primitive need or independent adoption.",
+        "Incubation passports are the sole intake and the nine-entry catalog is a derived projection; its experimental and candidate admission states are not shipment or KFD-5 promotion.",
         "A passed Buildchain gate does not self-qualify, activate, or ship KFD-5 support."
       ],
       "owner": "kungfu-primitive",
-      "nextGate": "Retain the exact-source gate and release passport, then obtain independent adopter evidence and an explicit release decision before changing shipped support."
+      "nextGate": "Retain the Primitive Management evidence roots and exact-source gate, then obtain independent adopter evidence and an explicit release decision before changing shipped support."
     },
     {
       "id": "KFD-6",
@@ -303,6 +319,36 @@
         "status": "none",
         "evidenceRoots": []
       },
+      "precursorEvidence": {
+        "status": "non-conforming-evidence",
+        "surfaces": [
+          "framework/work-design-advisor/work-design-advisor.contract.json",
+          "framework/work-design-policy-replay/work-design-policy-replay.contract.json",
+          "framework/project-cut/README.md"
+        ],
+        "evidenceRoots": [
+          {
+            "path": "framework/work-design-advisor/work-design-advisor.contract.json",
+            "sha256": "sha256:bbfd014adb84bfce90e20f39978a3cd6129d9c57a56f4564783273db69eb1614"
+          },
+          {
+            "path": "framework/work-design-policy-replay/work-design-policy-replay.contract.json",
+            "sha256": "sha256:caa4f7d38d7efeef985453267d355c2a4dda3737eb83a4bfd5f6cdfbc6f4bc4e"
+          },
+          {
+            "path": "framework/project-cut/README.md",
+            "sha256": "sha256:0d7b91a5d3c04e47175e286763542a7da9e84d4d01b012451d4895b3191dc062"
+          }
+        ],
+        "missingGates": [
+          "plural genesis methods and declared budgets",
+          "fixed-ontology and no-new-primitive baselines",
+          "systematic false-candidate rejection",
+          "held-out promotion separation",
+          "cross-domain transfer"
+        ],
+        "claimBoundary": "Work Design history selection, outcome estimation, and offline policy replay are bounded advisory precursors only. They do not implement, verify, activate, or ship KFD-6 autonomous discovery."
+      },
       "buildchain": {
         "gateStatus": "not-applicable",
         "protocol": "none"
@@ -319,10 +365,11 @@
       },
       "claimClass": "explicit-non-adoption",
       "knownLimitations": [
-        "Kungfu has no bounded KFD-6 causal-experience discovery implementation or evidence."
+        "Kungfu has no conforming KFD-6 causal-experience discovery implementation or verification.",
+        "The retained Work Design precursors do not compare plural genesis methods, run fixed-ontology or no-new-primitive baselines, reject false candidates systematically, separate held-out promotion, or demonstrate transfer."
       ],
       "owner": "unassigned",
-      "nextGate": "Keep unsupported unless a separately admitted causal-experience discovery initiative is approved."
+      "nextGate": "Keep unsupported; admit a separate causal-experience discovery initiative only after the listed missing gates have executable contracts and evidence."
     },
     {
       "id": "KFD-7",

--- a/docs/qualification/kfd-support-matrix.md
+++ b/docs/qualification/kfd-support-matrix.md
@@ -10,8 +10,8 @@ Source implementation is not the same as released support. Verification, Buildch
 | KFD-2 | active r3 | source-supported | implemented | passed | passed | alpha-release-passport | yes | Publish and retain all KFD-2 claim evaluations in the Alpha release passport. |
 | KFD-3 | active r5 | source-supported | implemented | passed | passed | alpha-release-passport | yes | Publish the exact product-declared registry audit and artifact closure in the Alpha release passport. |
 | KFD-4 | active r10 | candidate | implemented-candidate-profile | passed | passed | not-qualified | no | Retain the exact-source gate and release passport, then obtain independent adopter evidence and an explicit release decision before changing shipped support. |
-| KFD-5 | active r7 | candidate | implemented-candidate-profile | passed | passed | not-qualified | no | Retain the exact-source gate and release passport, then obtain independent adopter evidence and an explicit release decision before changing shipped support. |
-| KFD-6 | draft r10 | unsupported | not-implemented | none | not-applicable | not-qualified | no | Keep unsupported unless a separately admitted causal-experience discovery initiative is approved. |
+| KFD-5 | active r7 | candidate | implemented-candidate-profile | passed | passed | not-qualified | no | Retain the Primitive Management evidence roots and exact-source gate, then obtain independent adopter evidence and an explicit release decision before changing shipped support. |
+| KFD-6 | draft r10 | unsupported | not-implemented | none | not-applicable | not-qualified | no | Keep unsupported; admit a separate causal-experience discovery initiative only after the listed missing gates have executable contracts and evidence. |
 | KFD-7 | active r8 | source-supported | implemented | passed | passed | alpha-release-passport | yes | Publish and retain the exact KFD-7 product gate and support projection in the Alpha release passport. |
 | KFD-8 | draft r2 | draft-adopter-evidence | partial | non-conforming-evidence | not-applicable-draft | forbidden-while-draft | no | Keep evidence non-conforming until KFD-8 activation and an adopter qualification contract exist. |
 | KFD-9 | draft r2 | draft-adopter-evidence | partial | non-conforming-evidence | not-applicable-draft | forbidden-while-draft | no | Keep evidence non-conforming until KFD-9 activation and an adopter qualification contract exist. |
@@ -25,8 +25,8 @@ Source implementation is not the same as released support. Verification, Buildch
 - KFD-1, KFD-2, KFD-3, and KFD-7 are the bounded shipped-support set for the current Alpha release declaration.
 - KFD-3 uses Buildchain's product-declared registry audit directly. It currently has 183 declared surfaces and 0 release-Gate-enforced surfaces. Declaration is discoverability; it is not enforcement.
 - KFD-4 passes one bounded observer/contrastive-replay product gate but remains a non-shipped adoption candidate.
-- KFD-5 passes the bounded Assignment adopter gate but remains a non-shipped candidate; Buildchain does not self-qualify or activate it.
-- KFD-6 is explicitly unsupported.
+- KFD-5 passes the bounded Assignment adopter gate and now binds the Primitive Management Plane, sole-intake incubation passports, and derived nine-entry catalog. It remains a non-shipped candidate; Buildchain does not self-qualify or activate it.
+- KFD-6 remains explicitly unsupported. The matrix retains bounded, non-conforming Work Design precursor evidence while keeping implementation, verification, activation, and shipment claims false.
 - KFD-8 through KFD-13 expose only non-conforming draft adopter evidence. They are not shipped support.
 
 ## Inspect this source with Shifu

--- a/scripts/kfd-support-matrix.mjs
+++ b/scripts/kfd-support-matrix.mjs
@@ -224,12 +224,59 @@ function validateMatrix(matrix, { verifyInstalledKfd = true } = {}) {
       `shipped support must remain exactly ${expectedShippedKeys.join(',')}, found ${shippedKeys.join(',') || '<none>'}`,
     );
   }
+  const kfd6 = byKey['kfd-6'];
   if (
-    byKey['kfd-6'].supportStatus !== 'unsupported' ||
-    byKey['kfd-6'].implementation.status !== 'not-implemented' ||
-    byKey['kfd-6'].releaseQualification.shippedSupport
+    kfd6.supportStatus !== 'unsupported' ||
+    kfd6.implementation.status !== 'not-implemented' ||
+    kfd6.implementation.surfaces.length !== 0 ||
+    kfd6.verification.status !== 'none' ||
+    kfd6.verification.evidenceRoots.length !== 0 ||
+    kfd6.buildchain.gateStatus !== 'not-applicable' ||
+    kfd6.releaseQualification.status !== 'not-qualified' ||
+    kfd6.releaseQualification.shippedSupport ||
+    kfd6.releaseQualification.evidenceRoots.length !== 0 ||
+    kfd6.claimClass !== 'explicit-non-adoption'
   ) {
     fail('KFD-6 must remain an explicit unsupported non-adoption');
+  }
+  const kfd6Precursor = kfd6.precursorEvidence;
+  const expectedKfd6PrecursorSurfaces = [
+    'framework/work-design-advisor/work-design-advisor.contract.json',
+    'framework/work-design-policy-replay/work-design-policy-replay.contract.json',
+    'framework/project-cut/README.md',
+  ];
+  const expectedKfd6MissingGates = [
+    'plural genesis methods and declared budgets',
+    'fixed-ontology and no-new-primitive baselines',
+    'systematic false-candidate rejection',
+    'held-out promotion separation',
+    'cross-domain transfer',
+  ];
+  const expectedKfd6ClaimBoundary =
+    'Work Design history selection, outcome estimation, and offline policy replay are bounded advisory precursors only. They do not implement, verify, activate, or ship KFD-6 autonomous discovery.';
+  if (
+    kfd6Precursor?.status !== 'non-conforming-evidence' ||
+    kfd6Precursor.surfaces?.join(',') !==
+      expectedKfd6PrecursorSurfaces.join(',') ||
+    kfd6Precursor.evidenceRoots?.map((entry) => entry.path).join(',') !==
+      expectedKfd6PrecursorSurfaces.join(',') ||
+    kfd6Precursor.missingGates?.join(',') !==
+      expectedKfd6MissingGates.join(',') ||
+    kfd6Precursor.claimBoundary !== expectedKfd6ClaimBoundary
+  ) {
+    fail('KFD-6 precursor evidence must remain bounded and non-conforming');
+  }
+  for (const evidence of kfd6Precursor.evidenceRoots) {
+    const evidencePath = checkoutFile(
+      evidence.path,
+      'KFD-6 precursor evidence',
+    );
+    if (!fs.existsSync(evidencePath)) {
+      fail(`KFD-6 precursor evidence is missing: ${evidence.path}`);
+    }
+    if (sha256File(evidencePath) !== evidence.sha256) {
+      fail(`KFD-6 precursor evidence root drift: ${evidence.path}`);
+    }
   }
   for (const key of ['kfd-4', 'kfd-5']) {
     if (
@@ -258,6 +305,21 @@ function validateMatrix(matrix, { verifyInstalledKfd = true } = {}) {
       expectedKfd4Evidence.join(',')
   ) {
     fail('KFD-4 perspective qualification evidence drifted');
+  }
+  const kfd5 = byKey['kfd-5'];
+  const kfd5SurfaceListRoot = sha256Buffer(
+    kfd5.implementation.surfaces.join('\0'),
+  );
+  const kfd5EvidenceListRoot = sha256Buffer(
+    kfd5.verification.evidenceRoots.map((entry) => entry.path).join('\0'),
+  );
+  if (
+    kfd5SurfaceListRoot !==
+      'sha256:997e161669402b0e6944397a8f017337b3834dd12bc06e214275cc8ebbaab7a8' ||
+    kfd5EvidenceListRoot !==
+      'sha256:b6ea1bdc1dd7af92a25c5bc9004e85eab6386f4225becb196159f8af6509bcf5'
+  ) {
+    fail('KFD-5 Primitive Management evidence drifted');
   }
   for (const key of [
     'kfd-8',
@@ -417,8 +479,8 @@ ${rows}
 - KFD-1, KFD-2, KFD-3, and KFD-7 are the bounded shipped-support set for the current Alpha release declaration.
 - KFD-3 uses Buildchain's product-declared registry audit directly. It currently has ${matrix.kfd3Enforcement.declaredSurfaceCount} declared surfaces and ${matrix.kfd3Enforcement.enforcedSurfaceCount} release-Gate-enforced surfaces. Declaration is discoverability; it is not enforcement.
 - KFD-4 passes one bounded observer/contrastive-replay product gate but remains a non-shipped adoption candidate.
-- KFD-5 passes the bounded Assignment adopter gate but remains a non-shipped candidate; Buildchain does not self-qualify or activate it.
-- KFD-6 is explicitly unsupported.
+- KFD-5 passes the bounded Assignment adopter gate and now binds the Primitive Management Plane, sole-intake incubation passports, and derived nine-entry catalog. It remains a non-shipped candidate; Buildchain does not self-qualify or activate it.
+- KFD-6 remains explicitly unsupported. The matrix retains bounded, non-conforming Work Design precursor evidence while keeping implementation, verification, activation, and shipment claims false.
 - KFD-8 through KFD-13 expose only non-conforming draft adopter evidence. They are not shipped support.
 
 ## Inspect this source with Shifu

--- a/scripts/kfd-support-matrix.test.mjs
+++ b/scripts/kfd-support-matrix.test.mjs
@@ -90,8 +90,22 @@ test('validates the exact KFD-1 through KFD-13 authority', (t) => {
     [
       'docs/qualification/evidence/assignment-organization-rollout/7aae2c562a/report.json',
       'framework/core/tests/python/test_assignment_orchestration.py',
+      'docs/architecture/primitive-management-plane.md',
+      'framework/incubation/incubation-passport.registry.json',
+      'framework/primitive/kungfu-primitive-catalog.contract.json',
     ],
   );
+  const kfd6 = BASE.rows.find((row) => row.key === 'kfd-6');
+  assert.equal(kfd6.supportStatus, 'unsupported');
+  assert.equal(kfd6.implementation.status, 'not-implemented');
+  assert.equal(kfd6.verification.status, 'none');
+  assert.equal(kfd6.precursorEvidence.status, 'non-conforming-evidence');
+  assert.deepEqual(kfd6.precursorEvidence.surfaces, [
+    'framework/work-design-advisor/work-design-advisor.contract.json',
+    'framework/work-design-policy-replay/work-design-policy-replay.contract.json',
+    'framework/project-cut/README.md',
+  ]);
+  assert.equal(kfd6.releaseQualification.shippedSupport, false);
 });
 
 test('fails closed when the KFD-5 candidate loses its passed product gate', (t) => {
@@ -103,6 +117,14 @@ test('fails closed when the KFD-5 candidate loses its passed product gate', (t) 
     result.stderr,
     /kfd-5 must remain a verified, Buildchain-gated, non-shipped candidate/,
   );
+});
+
+test('fails closed when KFD-5 loses Primitive Management evidence', (t) => {
+  const matrix = clone(BASE);
+  matrix.rows[4].verification.evidenceRoots.pop();
+  const result = validateFixture(t, matrix);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /KFD-5 Primitive Management evidence drifted/);
 });
 
 test('fails closed when a KFD row is omitted', (t) => {
@@ -127,6 +149,29 @@ test('fails closed when KFD-6 implies adoption', (t) => {
   const result = validateFixture(t, matrix);
   assert.equal(result.status, 1);
   assert.match(result.stderr, /KFD-6 must remain an explicit unsupported/);
+});
+
+test('fails closed when KFD-6 precursor evidence implies conformance', (t) => {
+  const matrix = clone(BASE);
+  matrix.rows[5].precursorEvidence.status = 'passed';
+  const result = validateFixture(t, matrix);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /precursor evidence must remain bounded and non-conforming/,
+  );
+});
+
+test('fails closed when KFD-6 precursor evidence widens its claim', (t) => {
+  const matrix = clone(BASE);
+  matrix.rows[5].precursorEvidence.claimBoundary =
+    'Work Design implements KFD-6 discovery.';
+  const result = validateFixture(t, matrix);
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /precursor evidence must remain bounded and non-conforming/,
+  );
 });
 
 test('fails closed when draft evidence becomes shipped support', (t) => {


### PR DESCRIPTION
## Summary

Bind current Primitive Management evidence to the KFD-5 non-shipped candidate and retain bounded Work Design precursor evidence for KFD-6 without changing its unsupported status.

## Related issue

None.

## Changes

- Bind the Primitive Management Plane, sole-intake incubation passports, and derived nine-entry catalog to KFD-5 evidence.
- Keep KFD-5 candidate and non-shipped.
- Record exact non-conforming KFD-6 precursor roots and missing gates while keeping implementation, verification, activation, and shipment false.
- Add exact-list and claim-widening fail-closed tests.

## Verification

- ./shifu check:source
- ./shifu check:primitive-authority-boundary
- ./shifu kfd:support-matrix:check
- node --test scripts/kfd-support-matrix.test.mjs

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This evidence-only update does not alter a Kungfu architecture contract or ADR state"
}
-->

## Evolution Map impact

Evolution impact: extends

This adds bounded adoption evidence to the current open Stage without opening, settling, or superseding an authority transition.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change touches source support and release-qualification evidence projections only. It does not publish, deploy, qualify a new release, or widen shipped support.

## Checklist

- [x] Commits are signed off DCO
- [x] Documentation updated if behavior changed