### PR TITLE
feat(ci): coalesce dev qualification patrol

### DIFF
--- a/.github/workflows/dev-qualification-patrol.yml
+++ b/.github/workflows/dev-qualification-patrol.yml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Dev Qualification Patrol
+
+on:
+  workflow_run:
+    workflows:
+      - Alpha promotion preflight
+      - Dev Verify Patrol
+      - Build
+      - Release - New Version
+      - Release native components
+    types: [completed]
+  schedule:
+    # Offset recovery for delayed or missed workflow_run delivery.
+    - cron: "7,22,37,52 * * * *"
+  workflow_dispatch:
+    inputs:
+      buildchain-ref:
+        description: "Temporary exact Buildchain SHA for trusted controller validation"
+        required: false
+        default: ""
+      dry-run:
+        description: "Observe current qualification state without dispatch or retry"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  patrol:
+    uses: kungfu-systems/buildchain/.github/workflows/dev-qualification-patrol.yml@49da2cd118b04d502fd90deaa57acaf83b0eaed7
+    with:
+      buildchain-ref: ${{ inputs.buildchain-ref || '49da2cd118b04d502fd90deaa57acaf83b0eaed7' }}
+      source-branch: ${{ github.event.repository.default_branch }}
+      dev-workflow-path: .github/workflows/dev-verify-patrol.yml
+      preflight-workflow-path: .github/workflows/alpha-promotion-preflight.yml
+      priority-workflows-json: >-
+        [".github/workflows/build.yml",".github/workflows/release-new-version.yml",".github/workflows/release-shifu.yml"]
+      dispatch-inputs-json: >-
+        {"buildchain-ref":"${{ inputs.buildchain-ref || '49da2cd118b04d502fd90deaa57acaf83b0eaed7' }}"}
+      max-attempts: 2
+      mutation-authorized: ${{ github.event_name != 'workflow_dispatch' }}
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+    secrets:
+      qualification-token: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -16,13 +16,14 @@
 name: Dev Verify Patrol
 
 on:
-  schedule:
-    # Daily at 20:00 UTC, which is 04:00 Asia/Shanghai on the following day.
-    - cron: "0 20 * * *"
   workflow_dispatch:
     inputs:
       buildchain-ref:
         description: "Temporary Buildchain train or exact SHA for trusted manual validation"
+        required: false
+        default: ""
+      source-sha:
+        description: "Controller-observed Dev SHA; must equal the dispatch event SHA"
         required: false
         default: ""
 
@@ -30,7 +31,30 @@ permissions:
   contents: read
 
 jobs:
+  bind-source:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      source-sha: ${{ steps.source.outputs.source-sha }}
+    steps:
+      - name: Bind workflow event to requested Dev source
+        id: source
+        shell: bash
+        env:
+          EVENT_SHA: ${{ github.sha }}
+          REQUESTED_SHA: ${{ inputs.source-sha }}
+        run: |
+          set -euo pipefail
+          [[ "$EVENT_SHA" =~ ^[0-9a-f]{40}$ ]]
+          if [ -n "$REQUESTED_SHA" ]; then
+            [[ "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+            test "$REQUESTED_SHA" = "$EVENT_SHA"
+          fi
+          echo "source-sha=$EVENT_SHA" >> "$GITHUB_OUTPUT"
+
   verify:
+    needs: bind-source
     permissions:
       contents: read
       id-token: write
@@ -42,6 +66,7 @@ jobs:
       # cache hits are optional: every source/runtime checkout verifies the
       # locked SHA and falls back to GitHub when a retained bundle is stale.
       buildchain-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}
+      source-ref: ${{ needs.bind-source.outputs.source-sha }}
       checkout-cache-mode: auto
       checkout-cache-fallback: github
       rust-toolchain: "1.96.0"
@@ -70,7 +95,8 @@ jobs:
   report:
     needs: verify
     # Always run so the tracking issue is closed on green and opened/refreshed
-    # on red. This workflow only triggers on schedule / workflow_dispatch.
+    # on red. This workflow is dispatched only through the qualification
+    # controller or a trusted manual diagnostic.
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -79,7 +105,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       RESULT: ${{ needs.verify.result }}
-      HEAD_SHA: ${{ github.sha }}
+      HEAD_SHA: ${{ needs.verify.outputs.source-sha }}
       DEV_BRANCH: ${{ github.event.repository.default_branch }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       AUTOMATION_LABELS: "kind/internal,area/buildchain,source/automation,state/blocked"
@@ -119,7 +145,7 @@ jobs:
           body="$(cat <<EOF
           <!-- kungfu-attention-source: automation -->
 
-          The daily dev verify patrol found \`${DEV_BRANCH}\` failing.
+          The Dev qualification patrol found \`${DEV_BRANCH}\` failing.
 
           - Commit: \`${short_sha}\`
           - Run: ${RUN_URL}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -538,26 +538,53 @@
       ]
     },
     {
+      "path": ".github/workflows/dev-qualification-patrol.yml",
+      "authority": "qualification",
+      "definitionDigest": "sha256:00a0ae69c1caa91a8ecd32b4df7a10bf462d43aa699fce4d348af02583b63ea3",
+      "jobs": [
+        {
+          "id": "patrol",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:57a029cf8190b4df23acdab9ba2607199f768e86544ea020c57a29dd22ca41be",
+          "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-qualification-patrol.yml@49da2cd118b04d502fd90deaa57acaf83b0eaed7"],
+          "steps": []
+        }
+      ]
+    },
+    {
       "path": ".github/workflows/dev-verify-patrol.yml",
       "authority": "diagnostic",
-      "definitionDigest": "sha256:9b20d3c16112715b00b0ffdee667d118cb14f2f47f5a45d0821c7ddb56e9a6ea",
+      "definitionDigest": "sha256:cc4961063e8a7b0203c82d559e625a3d5a52eaa539b6815ab0cb6062a29a71d0",
       "jobs": [
+        {
+          "id": "bind-source",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:241876aaad1b05e78ec556d7a9d6c685cd146fe82bd02033bbed1ecffdb66801",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": [],
+          "steps": [{"index":1,"label":"id:source","definitionDigest":"sha256:062a9a480710a64e08b7ebcdd0f2ac4cee8c97503dde5a8b5704ed7d8b7206e0"}]
+        },
         {
           "id": "report",
           "authority": "diagnostic",
           "publication": "none",
           "receipt": "none",
-          "definitionDigest": "sha256:a05982a2c1f611924354bf60fa038b8de9e34188f638622bb1edc0c8032b9610",
+          "definitionDigest": "sha256:2f624de37d5d71ac909f04bd17f59e21f48c515ed7d44fd6db9ff4a0eecdc783",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": [],
-          "steps": [{"index":1,"label":"name:Sync tracking issue with patrol result","authority":"diagnostic-write","definitionDigest":"sha256:9a52c75f071708a68e46fe539e4714efde77cec2ec7d571f8e17c28fca4800b0"}]
+          "steps": [{"index":1,"label":"name:Sync tracking issue with patrol result","authority":"diagnostic-write","definitionDigest":"sha256:f33e4ab9673c51d1a245249276274a2af1f662756bcc213c502405a136cf9a76"}]
         },
         {
           "id": "verify",
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:aaf8f6119c6eae36fe5c7052ecd568541a6170d799db0fe92a849de9652f18ab",
+          "definitionDigest": "sha256:5c48dc34b7eab862016e0fe250421066fc17139476cec001f545eaa2f92f2d5c",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984"],
           "steps": []

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -82,6 +82,8 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/dev-gate-latency-patrol.yml` | `collect` | diagnostic | evidence | diagnostic | token:read | none | 6 |
 | `.github/workflows/dev-pr-auto-merge.yml` | `admission` | qualification | none | diagnostic | token:write, repo-secret:KUNGFU_GITHUB_TOKEN | none | 0 |
 | `.github/workflows/dev-pr-auto-merge.yml` | `resolve-target` | qualification | none | diagnostic | token:none | none | 1 |
+| `.github/workflows/dev-qualification-patrol.yml` | `patrol` | qualification | none | diagnostic | token:write, repo-secret:KUNGFU_GITHUB_TOKEN | none | 0 |
+| `.github/workflows/dev-verify-patrol.yml` | `bind-source` | qualification | none | diagnostic | token:read | none | 1 |
 | `.github/workflows/dev-verify-patrol.yml` | `report` | diagnostic | none | none | token:write | none | 1 |
 | `.github/workflows/dev-verify-patrol.yml` | `verify` | qualification | none | qualifying | token:write, oidc | none | 0 |
 | `.github/workflows/docs-check.yml` | `docs-check` | qualification | none | diagnostic | token:read | none | 3 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -187,6 +187,16 @@
           "sourceRoot": "sha256:639f670a1fa0f6418fc142c01e82a024ff2ce530b0ebd6db9857e63944ac9117"
         },
         {
+          "path": ".github/workflows/dev-qualification-patrol.yml",
+          "classification": "qualification",
+          "owner": "kungfu-release",
+          "surfaceIds": [
+            "product-alpha",
+            "product-stable"
+          ],
+          "sourceRoot": "sha256:a94f7b5c47883a70231ab1ca9b202cf0e7c15089d163410e0888b937c57d2c1f"
+        },
+        {
           "path": ".github/workflows/stable-candidate-patrol.yml",
           "classification": "qualification",
           "owner": "kungfu-release",
@@ -203,7 +213,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:d9231b9aa95aab8e6986209b194ceab7f6129c8ca4d5267b6ba2af80071966f8"
+          "sourceRoot": "sha256:fad9a5a41a0f91fdf60e3f7eea658906e8c133a5fb5d5cbaeb3abc5af11d6bf8"
         },
         {
           "path": ".github/workflows/docs-check.yml",
@@ -836,5 +846,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e2f70af837b34c8b99c73da6d4244e9f288e51c73682d2e45580c4ecd327d129"
+  "registryRoot": "sha256:a911c02f9b2d30feba4c4b059e65e79d58fd98847b3cfe4c26bdd413d3bcba8c"
 }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -235,7 +235,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   );
   assert.equal(controllers.length, 10);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
-  assert.equal(result.workflowAuthority.workflows.length, 33);
+  assert.equal(result.workflowAuthority.workflows.length, 34);
   const agentPatrol = result.workflowAuthority.workflows.find(
     (workflow) => workflow.path === '.github/workflows/kungfu-agent-patrol.yml',
   );

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -11,11 +11,15 @@ function workflow(name) {
   return fs.readFileSync(path.join(ROOT, '.github/workflows', name), 'utf8');
 }
 
-test('Dev Patrol runs at 04:00 Asia/Shanghai with an explicit UTC contract', () => {
+test('Dev Patrol is exact-source dispatch-only behind the qualification controller', () => {
   const source = workflow('dev-verify-patrol.yml');
-  assert.match(source, /04:00 Asia\/Shanghai/u);
-  assert.match(source, /cron: "0 20 \* \* \*"/u);
-  assert.doesNotMatch(source, /cron: "23 3 \* \* \*"/u);
+  assert.doesNotMatch(source, /schedule:/u);
+  assert.match(source, /source-sha:/u);
+  assert.match(source, /test "\$REQUESTED_SHA" = "\$EVENT_SHA"/u);
+  assert.match(
+    source,
+    /source-ref: \$\{\{ needs\.bind-source\.outputs\.source-sha \}\}/u,
+  );
   assert.match(
     source,
     /buildchain-ref: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.buildchain-ref \|\| '' \}\}/u,
@@ -24,6 +28,34 @@ test('Dev Patrol runs at 04:00 Asia/Shanghai with an explicit UTC contract', () 
     source,
     /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| '[0-9a-f]{40}' \}\}/u,
   );
+});
+
+test('qualification patrol coalesces the latest Dev SHA behind release priority', () => {
+  const source = workflow('dev-qualification-patrol.yml');
+  const reusableRef = source.match(
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-qualification-patrol\.yml@([0-9a-f]{40})/u,
+  )?.[1];
+  assert.match(reusableRef || '', /^[0-9a-f]{40}$/u);
+  assert.match(source, /workflow_run:/u);
+  assert.match(source, /Alpha promotion preflight/u);
+  assert.match(source, /Dev Verify Patrol/u);
+  assert.match(source, /Release - New Version/u);
+  assert.match(source, /Release native components/u);
+  assert.match(source, /cron: "7,22,37,52 \* \* \* \*"/u);
+  assert.match(
+    source,
+    /priority-workflows-json:[\s\S]*build\.yml[\s\S]*release-new-version\.yml[\s\S]*release-shifu\.yml/u,
+  );
+  assert.match(source, /max-attempts: 2/u);
+  assert.match(
+    source,
+    /mutation-authorized: \$\{\{ github\.event_name != 'workflow_dispatch' \}\}/u,
+  );
+  assert.match(
+    source,
+    /qualification-token: \$\{\{ secrets\.KUNGFU_GITHUB_TOKEN \}\}/u,
+  );
+  assert.doesNotMatch(source, /npm publish|gh release create|git tag/iu);
 });
 
 test('candidate patrol is a thin Buildchain caller with exact channel and evidence inputs', () => {


### PR DESCRIPTION
## Summary

Replace the daily heavy Dev Verify schedule with an event-driven qualification controller that coalesces rapid Dev updates, yields to Alpha and release work, and binds every heavy run to the exact observed source SHA.

## Related issue

None.

## Changes

- add the Dev Qualification Patrol wake-up and recovery controller
- make Dev Verify dispatch-only with an exact source binding job
- pass the exact source SHA into the Buildchain Gate profile and report evidence
- pin the reusable controller to merged Buildchain commit 49da2cd118b04d502fd90deaa57acaf83b0eaed7
- register the new workflow in workflow authority and publication control-plane projections
- cover coalescing, release priority, bounded retry wiring, no-publication boundaries, and the 34-workflow closed-world count

## Verification

- `./shifu check:gate-catalog`
- `node --test scripts/check-kungfu-gate-catalog.test.mjs` (24 passed)
- full `./shifu check:source` passed on the semantically identical v3 head
- v4 pre-commit staged gate passed on exact Dev base `6c3768f6fc`, including updated KFD support-matrix evidence
- live read-only controller observation returned `waiting-priority` and performed no mutation while release work was active
- Buildchain PR #2268 passed 23 protected checks and merge-queue verification

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Operational CI qualification scheduling and retry governance on a ci/* branch; no architecture-decision record or implementation-status projection changes."
}
-->

## Governance risk check

Does this PR touch any of these boundaries?

- [x] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The controller receives the repository qualification token only at the reusable workflow boundary. It may observe Actions, dispatch Dev Verify, or rerun failed jobs under the Buildchain classifier; it cannot publish Alpha, releases, packages, tags, or public endpoints. Manual dispatch is read-only.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
