### PR TITLE
fix(ci): issue queue admission lease

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "90a7bf5513b2c912aee1674fda1a8158cdc27d34",
+    "sourceSha": "274a2a7d230bd67933280a5394ac1c6fa5404489",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:a7489f665b391207851189e6da19cd1625d194ec257c72b701229e407cfc454c"
   },

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -59,14 +59,15 @@ jobs:
       checks: read
       contents: write
       pull-requests: write
-      statuses: read
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@978520e86134683f66b607bc70c2d18f623e2410
+      statuses: write
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@1659da98053f8ea8c75471e414b7732e3a491580
     with:
-      buildchain-ref: 978520e86134683f66b607bc70c2d18f623e2410
+      buildchain-ref: 1659da98053f8ea8c75471e414b7732e3a491580
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       required-status-checks: |-
         Candidate source acceptance / check
         affected-native / linux
+      queue-admission-context: Queue admission lease
       ready-label: state/ready
       block-labels: state/blocked,blocked,do-not-merge,work-in-progress
       allowed-head-prefixes: feature/,fix/,chore/,docs/,ci/,refactor/

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -520,9 +520,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5ba5b438e1f3b443dd8e824c55267a6a921472a3fdb65ebbf3c5f1f63c8adf00",
+          "definitionDigest": "sha256:61069f0491d85bc0ea17e8f9ba15c2f30c7f550422baeaf599907187af00a27e",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@978520e86134683f66b607bc70c2d18f623e2410"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@1659da98053f8ea8c75471e414b7732e3a491580"],
           "steps": []
         },
         {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -177,7 +177,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:58762020c81de12f86bd4cf14c1ebd373f983b20930206b0ceb3ccf88beffc27"
+          "sourceRoot": "sha256:ade9634cd160b0f2b407a4100ed94b5cae4d43fcba5aee0acaab7f20f4995ca3"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -846,5 +846,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:5cdcd5acab6a9b99018451d2ffbe4669c5abed13f640b9480456ff93216565ab"
+  "registryRoot": "sha256:e066706c06d6dc9f079176b7dc9336da678515ff2b62a6eb84cab3da9ac57553"
 }

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -13,7 +13,7 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
   const reusableRef = workflow.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/u,
   )?.[1];
-  assert.equal(reusableRef, '978520e86134683f66b607bc70c2d18f623e2410');
+  assert.equal(reusableRef, '1659da98053f8ea8c75471e414b7732e3a491580');
   assert.match(workflow, new RegExp(`buildchain-ref: ${reusableRef}`, 'u'));
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(workflow, /cron: "23,53 \* \* \* \*"/u);
@@ -33,11 +33,13 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
 
 test('Dev auto-merge waits for PR checks and lands through the native queue', () => {
   const requiredChecks = workflow.match(
-    /required-status-checks: \|-\n([\s\S]*?)\n\s+ready-label:/u,
+    /required-status-checks: \|-\n([\s\S]*?)\n\s+queue-admission-context:/u,
   )?.[1];
   assert.match(requiredChecks || '', /Candidate source acceptance \/ check/u);
   assert.match(requiredChecks || '', /affected-native \/ linux/u);
   assert.doesNotMatch(requiredChecks || '', /Queue admission lease/u);
+  assert.match(workflow, /statuses: write/u);
+  assert.match(workflow, /queue-admission-context: Queue admission lease/u);
   assert.match(workflow, /merge-method: rebase/u);
   assert.match(workflow, /landing-mode: queue/u);
   assert.match(


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Operational CI protocol completion for the existing protected Dev merge-queue admission controller; no architecture-decision record or implementation-status projection changes."
}
-->

## Summary

Complete the protected Dev merge-queue admission protocol with an exact-head temporary status lease.

## Changes

- pin Dev PR Auto Merge to Buildchain merge `1659da98053f8ea8c75471e414b7732e3a491580`
- grant the reusable caller scoped commit-status write permission
- pass `Queue admission lease` as the exact-head pre-enqueue context
- refresh workflow authority, publication roots, and KFD source binding

## Verification

- Buildchain PR #2276: 23 PR checks plus merge-group Verify `30779278202`
- `./shifu kfd:buildchain:check`
- `./shifu check:release-publication-control-plane`
- `./shifu check:gate-catalog`
- `./shifu test:alpha-promotion-preflight` (65 tests)
- staged repository gate: passed

## Safety boundary

This changes only Dev PR merge-queue admission. It does not trigger Alpha, stable, tags, packages, or public endpoint publication.