### PR TITLE
fix(core): link JSON headers into wasm host

### DIFF
--- a/framework/core/src/libwasm/CMakeLists.txt
+++ b/framework/core/src/libwasm/CMakeLists.txt
@@ -125,7 +125,8 @@ target_include_directories(kungfu_wasm_host PRIVATE include ../libkungfu/include
 target_compile_options(kungfu_wasm_host PRIVATE
   $<$<CONFIG:Release>:${COMPILER_OPTIMIZE_ON_OPTIONS}>)
 target_link_libraries(kungfu_wasm_host PRIVATE
-  ${LIBKUNGFU_NAME} ${KUNGFU_PUBLIC_ABI_TARGET} kungfu_compile_contract ${CMAKE_DL_LIBS})
+  ${LIBKUNGFU_NAME} ${KUNGFU_PUBLIC_ABI_TARGET} kungfu_compile_contract
+  nlohmann_json::nlohmann_json ${CMAKE_DL_LIBS})
 
 add_custom_target(kungfu_libwasm_self_test
   COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:kungfu_wasm_host>/libwasm"


### PR DESCRIPTION
## Summary

- link `nlohmann_json::nlohmann_json` into the production Wasmtime host target
- make the host target inherit the canonical JSON include surface during a clean core build
- preserve runtime and command semantics; this is a build dependency correction only

## Verification

- `./shifu check:source`
- `./shifu build:core`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This target-scoped build dependency correction restores the already-defined Wasmtime host include surface and does not alter an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; no behavior change)

## Atlas work

Assignment: `2026-08-03-atlas-assignment-profile-admission-closure`
Exact source head: `3646b93b3e466b5d7930f2de19161c04f5bf1808`
