### PR TITLE
fix(cli): use canonical product name in help

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+        "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -79,7 +79,7 @@
       "pointer": {
         "kind": "file",
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "5278a6073ac9c013d1d9496800878d6c4d1bad91971b79ffa5e0c450ef987b09"
+        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
       },
       "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
     },
@@ -117,11 +117,11 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+        "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/first-value.contract.json",
@@ -145,7 +145,7 @@
       },
       {
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "5278a6073ac9c013d1d9496800878d6c4d1bad91971b79ffa5e0c450ef987b09"
+        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
       },
       {
         "path": "scripts/qualify-agent-first-value-codex.mjs",
@@ -167,11 +167,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+        "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/first-value.contract.json",
@@ -193,13 +193,13 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d",
+      "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03",
       "expectedPackagePath": "kungfu/agent/commands.json"
     },
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56",
+      "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     },
     {

--- a/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "ec86da8274437dcb3cdc73d702bad6ab29097e606c618fe703c82d3622904055"
+        "sha256": "2f7a01536e263c63c683cc6e3d7a7635d56b4add37d800eb5fda22dc712ca88e"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "ec86da8274437dcb3cdc73d702bad6ab29097e606c618fe703c82d3622904055"
+        "sha256": "2f7a01536e263c63c683cc6e3d7a7635d56b4add37d800eb5fda22dc712ca88e"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+            "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+            "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },
@@ -92,7 +92,7 @@
           "pointer": {
             "kind": "file",
             "path": "scripts/check-cli-catalog-parity.mjs",
-            "sha256": "5278a6073ac9c013d1d9496800878d6c4d1bad91971b79ffa5e0c450ef987b09"
+            "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
           },
           "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
         },
@@ -258,7 +258,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+            "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -347,7 +347,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "ec86da8274437dcb3cdc73d702bad6ab29097e606c618fe703c82d3622904055"
+            "sha256": "2f7a01536e263c63c683cc6e3d7a7635d56b4add37d800eb5fda22dc712ca88e"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "bbbe087280374ac6a407c639b722ec04b7929fdf",
+    "sourceSha": "f08ade5b49115e6ff00409b8dce86a377d4b3f3d",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:a7489f665b391207851189e6da19cd1625d194ec257c72b701229e407cfc454c"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:9d2ac8b5167ca6044d1fd8a4c1eecb936ce2ec46941c45502543ee16661dcd00"
+            "sha256": "sha256:6f3cf3af027987f35971d081ab0ef0a098a75e710e5b6ad1f0ebc72279397664"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/crates/trunk/src/launch.rs
+++ b/crates/trunk/src/launch.rs
@@ -278,9 +278,8 @@ fn tree_python() -> Result<PathBuf, String> {
     if !python.is_file() {
         return Err(format!(
             "assembled runtime tree not found at {} — the `kungfu` entry only \
-             runs next to the tree the product ships (dev: use `python -m \
-             kungfu` on the managed interpreter, or kungfu-trunk for env \
-             commands)",
+             runs next to the tree the product ships (dev: invoke repository \
+             tasks through `./shifu`, or use kungfu-trunk for env commands)",
             python.display()
         ));
     }

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -16,7 +16,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       "description": "Machine-readable command catalog and mode maturity metadata."
     },
@@ -25,7 +25,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+        "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
       },
       "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
     },
@@ -79,7 +79,7 @@
       "pointer": {
         "kind": "file",
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "5278a6073ac9c013d1d9496800878d6c4d1bad91971b79ffa5e0c450ef987b09"
+        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
       },
       "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
     },
@@ -117,11 +117,11 @@
     "evidenceSha256": [
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+        "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/first-value.contract.json",
@@ -145,7 +145,7 @@
       },
       {
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "5278a6073ac9c013d1d9496800878d6c4d1bad91971b79ffa5e0c450ef987b09"
+        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
       },
       {
         "path": "scripts/qualify-agent-first-value-codex.mjs",
@@ -167,11 +167,11 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-        "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+        "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
       },
       {
         "path": "framework/core/src/python/kungfu/agent/first-value.contract.json",
@@ -193,13 +193,13 @@
     {
       "name": "agent-command-catalog",
       "path": "framework/core/src/python/kungfu/agent/commands.json",
-      "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d",
+      "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03",
       "expectedPackagePath": "kungfu/agent/commands.json"
     },
     {
       "name": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-      "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56",
+      "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781",
       "expectedPackagePath": "kungfu/agent/cli_surface.catalog.json"
     },
     {

--- a/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-work-state-contract.json
@@ -52,7 +52,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "ec86da8274437dcb3cdc73d702bad6ab29097e606c618fe703c82d3622904055"
+        "sha256": "2f7a01536e263c63c683cc6e3d7a7635d56b4add37d800eb5fda22dc712ca88e"
       },
       "description": "Agent collaboration-interface registration for the work-model query."
     }
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-        "sha256": "ec86da8274437dcb3cdc73d702bad6ab29097e606c618fe703c82d3622904055"
+        "sha256": "2f7a01536e263c63c683cc6e3d7a7635d56b4add37d800eb5fda22dc712ca88e"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
+++ b/developer/sdk/kfd/kfd-2/claims/remote-fact-boundary.json
@@ -34,7 +34,7 @@
       "pointer": {
         "kind": "file",
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       "description": "Remote add/sync command declarations and mode metadata."
     },
@@ -62,7 +62,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/commands.json",
-        "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+        "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
       },
       {
         "path": "framework/core/src/python/kungfu/cli/commands/agent.py",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -29,7 +29,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+            "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
           },
           "description": "Machine-readable command catalog and mode maturity metadata."
         },
@@ -38,7 +38,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
-            "sha256": "03e2c7d85c0a19263dd56785cb11afa2399f50c1da2d63bd68fc8e8fa22aab56"
+            "sha256": "77e6ae9a2f1567572fafb098b17f21451b77eca7949267045364a4f09c488781"
           },
           "description": "Complete deterministic CLI surface graph shared by offline Agent capabilities and catalog parity checks."
         },
@@ -92,7 +92,7 @@
           "pointer": {
             "kind": "file",
             "path": "scripts/check-cli-catalog-parity.mjs",
-            "sha256": "5278a6073ac9c013d1d9496800878d6c4d1bad91971b79ffa5e0c450ef987b09"
+            "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
           },
           "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
         },
@@ -258,7 +258,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/commands.json",
-            "sha256": "a2c04235939688a128132d1949f4d80571326d676ffe9231952ea20accc9102d"
+            "sha256": "aaa590ec2bd998035fd4b478a7c6095d434b53549b18c813881ef0826bdc9b03"
           },
           "description": "Remote add/sync command declarations and mode metadata."
         },
@@ -347,7 +347,7 @@
           "pointer": {
             "kind": "file",
             "path": "framework/core/src/python/kungfu/agent/kfd3_api.registry.json",
-            "sha256": "ec86da8274437dcb3cdc73d702bad6ab29097e606c618fe703c82d3622904055"
+            "sha256": "2f7a01536e263c63c683cc6e3d7a7635d56b4add37d800eb5fda22dc712ca88e"
           },
           "description": "Agent collaboration-interface registration for the work-model query."
         }

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:9d2ac8b5167ca6044d1fd8a4c1eecb936ce2ec46941c45502543ee16661dcd00"
+            "sha256": "sha256:6f3cf3af027987f35971d081ab0ef0a098a75e710e5b6ad1f0ebc72279397664"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/framework/core/src/python/kungfu/__main__.py
+++ b/framework/core/src/python/kungfu/__main__.py
@@ -43,6 +43,7 @@ from kungfu.cli import available, select  # noqa: E402
 
 
 def main(**kwargs):
+    kwargs.setdefault("prog_name", "kungfu")
     select(available(), **kwargs)
 
 

--- a/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
+++ b/framework/core/src/python/kungfu/agent/cli_surface.catalog.json
@@ -1,7 +1,7 @@
 {
-  "catalogRoot": "sha256:6ffe9f0ea056d9ac0a3600e7650a419eae584471610ff23a67eee040c7594363",
+  "catalogRoot": "sha256:c222a780e3cc19da03bc63fd359c230a484947395de14ea00c43a7344855fe60",
   "contractId": "kungfu-cli-surface",
-  "contractRoot": "sha256:ef918dc7090f977eb77a8c1cbf0f2d1b0fc11d16f63c78380c8d2c9ed5510d59",
+  "contractRoot": "sha256:7eabb436c64b34ea2bf42231f9637e1e2312e2537f9ce57bc176a822b9d5c79f",
   "kfd3Linkage": [
     {"apiIds":[],"reason":"navigation-only","state":"unlinked","surfaceId":"kungfu.cli.commands.kfc"},
     {"apiIds":[],"reason":"no-agent-first-api-declared","state":"unlinked","surfaceId":"kungfu.cli.commands.action.action"},
@@ -510,7 +510,7 @@
     "regeneration": "./shifu fix:cli-catalog-parity",
     "validation": "./shifu check:cli-catalog-parity"
   },
-  "registryRoot": "sha256:a9bae37e782a6bad4443aa4df9c0c362ce523ab19724954b6995acb476513584",
+  "registryRoot": "sha256:3f9db213fdf3b5d873f6ed7f358240e756081242ba3f5ffdc4923aaae9d57c06",
   "schema": "kungfu.cli-surface-catalog/v1",
   "schemaRoot": "sha256:30e0c49658aee967b24294362af12e977c8d62eaa455eb83ffdaa50072021569",
   "source": {

--- a/framework/core/src/python/kungfu/agent/commands.json
+++ b/framework/core/src/python/kungfu/agent/commands.json
@@ -447,12 +447,6 @@
     },
     {
       "apiId": "kungfu.exit.verify",
-      "name": "python -m kungfu.exit_verifier --file <package.json> --json",
-      "maturity": "experimental",
-      "purpose": "Invoke the same registry-free verifier directly from an installed Python module."
-    },
-    {
-      "apiId": "kungfu.exit.verify",
       "name": "kungfu exit verify --file <package.json> --json",
       "maturity": "experimental",
       "purpose": "Invoke the packaged verifier through the integrated Kungfu CLI when a configured runtime is already available."

--- a/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
+++ b/framework/core/src/python/kungfu/agent/kfd3_api.registry.json
@@ -1140,7 +1140,6 @@
       "surface": "cli",
       "name": "kungfu-exit-verify --file <package.json> --json",
       "aliases": [
-        "python -m kungfu.exit_verifier --file <package.json> --json",
         "kungfu exit verify --file <package.json> --json",
         "kungfu exit history verify --file <exit.json> --json"
       ],

--- a/framework/core/src/python/kungfu/cli/surface_contract.registry.json
+++ b/framework/core/src/python/kungfu/cli/surface_contract.registry.json
@@ -80,11 +80,6 @@
       "prefix": "kungfu-exit-verify",
       "target": "kungfu exit verify",
       "source": "framework/core/src/python/kungfu/exit_verifier.py"
-    },
-    {
-      "prefix": "python -m kungfu.exit_verifier",
-      "target": "kungfu exit verify",
-      "source": "framework/core/src/python/kungfu/exit_verifier.py"
     }
   ],
   "mutationRules": {

--- a/framework/core/tests/python/test_cli_progressive_help.py
+++ b/framework/core/tests/python/test_cli_progressive_help.py
@@ -232,6 +232,27 @@ def test_live_unknown_section_is_a_named_usage_error():
     assert "unknown help section 'missing'" in result.output
 
 
+def test_module_entry_uses_the_canonical_product_name(monkeypatch):
+    pytest.importorskip("pykungfu")
+    from kungfu import __main__ as module_entry
+
+    observed = []
+    monkeypatch.setattr(module_entry, "available", lambda: ["fixture"])
+    monkeypatch.setattr(
+        module_entry,
+        "select",
+        lambda modules, **kwargs: observed.append((modules, kwargs)),
+    )
+
+    module_entry.main()
+    module_entry.main(prog_name="embedded-fixture")
+
+    assert observed == [
+        (["fixture"], {"prog_name": "kungfu"}),
+        (["fixture"], {"prog_name": "embedded-fixture"}),
+    ]
+
+
 def test_live_interactive_bare_command_enters_tui_without_materializing_runtime(
     monkeypatch,
 ):

--- a/scripts/check-cli-catalog-parity.mjs
+++ b/scripts/check-cli-catalog-parity.mjs
@@ -68,6 +68,13 @@ function canonicalPath(name) {
   return tokens.join(' ');
 }
 
+function usesInternalModuleEntrypoint(value) {
+  return (
+    typeof value === 'string' &&
+    /(?:^|\s)python(?:\d+(?:\.\d+)*)?\s+-m\s+kungfu(?:[.\s]|$)/u.test(value)
+  );
+}
+
 function resolvePath(name, byPath, standaloneRoutes = []) {
   for (const route of standaloneRoutes) {
     const { prefix, target } = route;
@@ -133,6 +140,12 @@ export function auditCatalogParity({
     fail('CLI registry must contain zero aliases');
   if (registry.aliasDispositionProfiles)
     fail('CLI registry retains obsolete alias disposition policy');
+  for (const route of registry.standaloneCatalogRoutes || []) {
+    if (usesInternalModuleEntrypoint(route.prefix))
+      fail(
+        `public standalone route exposes internal module entrypoint ${route.prefix}`,
+      );
+  }
   if (
     (schema.maturity || []).some((value) =>
       ['deprecated', 'compatibility'].includes(value),
@@ -201,6 +214,10 @@ export function auditCatalogParity({
 
   const apiById = new Map((kfd3.apis || []).map((row) => [row.id, row]));
   for (const row of kfd3.apis || []) {
+    for (const name of [row.name, ...(row.aliases || [])]) {
+      if (usesInternalModuleEntrypoint(name))
+        fail(`KFD-3 registry exposes internal module entrypoint ${name}`);
+    }
     if (row.anchor?.kind === 'runtime-click' && !linkedApiIds.has(row.id))
       fail(`orphan runtime KFD-3 API ${row.id}`);
   }
@@ -213,6 +230,8 @@ export function auditCatalogParity({
   }
   const actualCommands = new Map();
   for (const row of commands.commands || []) {
+    if (usesInternalModuleEntrypoint(row.name))
+      fail(`commands.json exposes internal module entrypoint ${row.name}`);
     actualCommands.set(row.name, row.apiId);
     const api = apiById.get(row.apiId);
     if (!api) {

--- a/scripts/check-cli-catalog-parity.test.mjs
+++ b/scripts/check-cli-catalog-parity.test.mjs
@@ -103,9 +103,41 @@ test('standalone command routes require an explicit live Click target', () => {
       'commands.json orphan path kungfu-exit-verify --file <package.json> --json',
     ),
   );
+});
+
+test('public catalogs reject internal Python module entrypoints', () => {
+  const fixture = inputs();
+  const leaked = 'python -m kungfu.exit_verifier --file <package.json> --json';
+  const api = fixture.kfd3.apis.find((row) => row.id === 'kungfu.exit.verify');
+  assert(api);
+  api.aliases = [...(api.aliases || []), leaked];
+  fixture.commands.commands.push({
+    apiId: api.id,
+    name: leaked,
+    maturity: api.maturity,
+    purpose: api.purpose,
+  });
+  fixture.registry.standaloneCatalogRoutes.push({
+    prefix: 'python -m kungfu.exit_verifier',
+    target: 'kungfu exit verify',
+    source: 'framework/core/src/python/kungfu/exit_verifier.py',
+  });
+
+  const result = auditCatalogParity(fixture);
+  assert.equal(result.ok, false);
   assert(
     result.issues.includes(
-      'commands.json orphan path python -m kungfu.exit_verifier --file <package.json> --json',
+      'public standalone route exposes internal module entrypoint python -m kungfu.exit_verifier',
+    ),
+  );
+  assert(
+    result.issues.includes(
+      `KFD-3 registry exposes internal module entrypoint ${leaked}`,
+    ),
+  );
+  assert(
+    result.issues.includes(
+      `commands.json exposes internal module entrypoint ${leaked}`,
     ),
   );
 });


### PR DESCRIPTION
## Summary

Ensure participant-facing CLI help and errors consistently identify the product as `kungfu`, even though the assembled launcher internally dispatches through Python's module entrypoint.

## Related issue

Fixes the observed `Usage: python -m kungfu ...` leakage from commands such as `kungfu dogfood --help`.

## Changes

- Pin the Click module entrypoint's default program name to `kungfu` while preserving explicit embedded overrides.
- Remove the internal `python -m kungfu.exit_verifier` route from public CLI, Agent, and KFD-3 catalogs.
- Fail closed if internal Python module entrypoints reappear in participant-facing catalogs.
- Replace the native launcher's developer diagnostic with canonical Shifu/trunk guidance.
- Regenerate CLI, KFD-2, and support-matrix evidence projections.

## Verification

- `./shifu check:staged`
- `./shifu test:cli-surface-contract` (43 passed)
- `./shifu exec node --test scripts/check-cli-catalog-parity.test.mjs` (8 passed)
- `./shifu build:cli`
- `./shifu product cli dist` including installed-layout smoke
- assembled `kungfu dogfood --help` and invalid-command smoke both render `Usage: kungfu ...`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the existing CLI architecture and product identity while preventing an internal Python module invocation from leaking into public help, errors, and catalogs."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change narrows product identity to the canonical `kungfu` name and regenerates bounded KFD evidence; it does not change package identity, release channel, or publish behavior.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no prose update required; public catalogs and regression tests are updated)
