### PR TITLE
fix(product): bind demo metadata to real interpreter

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:bb3d578c78f7949ced86f55f42076e438e8ede2fe4c7cfe7dee4e5263d60bb31",
+  "sourceRoot": "sha256:c376349d4344853a48899b00f8969c18bec2eda026ab88fe22602d8baa732d30",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -651,9 +651,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 2449,
+          "currentLines": 2450,
           "baselineLines": 2514,
-          "currentRoot": "sha256:abfe349423e30aeb0638ca1a4c12588c1715926c672f521c4f1b71ea39ca0eb2",
+          "currentRoot": "sha256:3eb5f5c65fd388d4564fabf3c00b6b61e08ce89c0f97a73cc3dbd8a6479f720a",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
@@ -1947,7 +1947,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 2449,
+        "metric": 2450,
         "threshold": 2450,
         "finding": null
       },

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1117,6 +1117,21 @@ function writeCliLauncher(stageRoot, layout) {
   return layout.launcherName;
 }
 
+function resolveCliMetadataInterpreter(stageRoot, interpreter) {
+  const resolvedStageRoot = fs.realpathSync(stageRoot);
+  const resolvedInterpreter = fs.realpathSync(interpreter);
+  const relative = path.relative(resolvedStageRoot, resolvedInterpreter);
+  if (
+    !relative ||
+    path.isAbsolute(relative) ||
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error('CLI auditable demo interpreter escapes its stage root');
+  }
+  return path.join(stageRoot, relative);
+}
+
 export function writeAuditableDemoBinaryMetadata(
   stageRoot,
   layout,
@@ -1125,7 +1140,14 @@ export function writeAuditableDemoBinaryMetadata(
 ) {
   const binary = path.join(stageRoot, layout.launcherName);
   const runtime = path.join(stageRoot, layout.runtimeEntrypoint);
-  const python = path.join(stageRoot, layout.pythonEntrypoint);
+  // POSIX standalone Python trees expose bin/python3 as a relative symlink to
+  // the versioned interpreter. The auditable transport contract deliberately
+  // rejects symlinks in executableFiles, so bind the metadata to the packaged
+  // regular file that the launcher ultimately executes.
+  const python = resolveCliMetadataInterpreter(
+    stageRoot,
+    path.join(stageRoot, layout.pythonEntrypoint),
+  );
   const metadata = {
     contract: 'kungfu.declarative-demo-binary/v1',
     platformId: platform,

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -33,7 +33,7 @@ import {
   runLibwasmArtifactSelfTest,
   runLibwasmExecutionQualification,
 } from './libwasm-artifact.mjs';
-import { normalizeCopiedSymlinks } from './portable-symlinks.mjs';
+import * as portable from './portable-symlinks.mjs';
 import { productReleaseChannelConfig } from './release-channel-trust.mjs';
 import {
   assertSupportedProductHost,
@@ -960,7 +960,7 @@ export function copyTree(source, target, options = {}) {
       );
     },
   });
-  normalizeCopiedSymlinks({ source, target });
+  portable.normalizeCopiedSymlinks({ source, target });
   return true;
 }
 
@@ -1117,21 +1117,6 @@ function writeCliLauncher(stageRoot, layout) {
   return layout.launcherName;
 }
 
-function resolveCliMetadataInterpreter(stageRoot, interpreter) {
-  const resolvedStageRoot = fs.realpathSync(stageRoot);
-  const resolvedInterpreter = fs.realpathSync(interpreter);
-  const relative = path.relative(resolvedStageRoot, resolvedInterpreter);
-  if (
-    !relative ||
-    path.isAbsolute(relative) ||
-    relative === '..' ||
-    relative.startsWith(`..${path.sep}`)
-  ) {
-    throw new Error('CLI auditable demo interpreter escapes its stage root');
-  }
-  return path.join(stageRoot, relative);
-}
-
 export function writeAuditableDemoBinaryMetadata(
   stageRoot,
   layout,
@@ -1140,14 +1125,8 @@ export function writeAuditableDemoBinaryMetadata(
 ) {
   const binary = path.join(stageRoot, layout.launcherName);
   const runtime = path.join(stageRoot, layout.runtimeEntrypoint);
-  // POSIX standalone Python trees expose bin/python3 as a relative symlink to
-  // the versioned interpreter. The auditable transport contract deliberately
-  // rejects symlinks in executableFiles, so bind the metadata to the packaged
-  // regular file that the launcher ultimately executes.
-  const python = resolveCliMetadataInterpreter(
-    stageRoot,
-    path.join(stageRoot, layout.pythonEntrypoint),
-  );
+  const pythonPath = path.join(stageRoot, layout.pythonEntrypoint);
+  const python = portable.resolveInternalPath(stageRoot, pythonPath);
   const metadata = {
     contract: 'kungfu.declarative-demo-binary/v1',
     platformId: platform,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -317,7 +317,7 @@ test('CLI product rejects an interpreter symlink outside the staged artifact', (
 
   assert.throws(
     () => writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root),
-    /CLI auditable demo interpreter escapes its stage root/u,
+    /product path escapes its root/u,
   );
 });
 

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -256,7 +256,11 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
     recursive: true,
   });
   fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
-  fs.writeFileSync(path.join(root, layout.pythonEntrypoint), 'python\n');
+  fs.writeFileSync(
+    path.join(root, 'runtime/python/bin/python3.13'),
+    'python\n',
+  );
+  fs.symlinkSync('python3.13', path.join(root, layout.pythonEntrypoint));
   const metadata = writeAuditableDemoBinaryMetadata(
     root,
     layout,
@@ -280,7 +284,7 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
         sha256: crypto.createHash('sha256').update('runtime\n').digest('hex'),
       },
       {
-        path: 'runtime/python/bin/python3',
+        path: 'runtime/python/bin/python3.13',
         sha256: crypto.createHash('sha256').update('python\n').digest('hex'),
       },
     ],
@@ -291,6 +295,29 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
       fs.readFileSync(path.join(root, 'auditable-demo-binary.json'), 'utf8'),
     ),
     metadata,
+  );
+});
+
+test('CLI product rejects an interpreter symlink outside the staged artifact', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-demo-binary-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const layout = cliArchiveLayout('linux');
+  fs.writeFileSync(path.join(root, layout.launcherName), '#!/bin/sh\nexit 0\n');
+  fs.mkdirSync(path.dirname(path.join(root, layout.pythonEntrypoint)), {
+    recursive: true,
+  });
+  fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
+  const external = path.join(
+    path.dirname(root),
+    `${path.basename(root)}.python`,
+  );
+  fs.writeFileSync(external, 'python\n');
+  t.after(() => fs.rmSync(external, { force: true }));
+  fs.symlinkSync(external, path.join(root, layout.pythonEntrypoint));
+
+  assert.throws(
+    () => writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root),
+    /CLI auditable demo interpreter escapes its stage root/u,
   );
 });
 

--- a/product/scripts/portable-symlinks.mjs
+++ b/product/scripts/portable-symlinks.mjs
@@ -7,6 +7,17 @@ function pathInside(root, candidate) {
   return candidate === root || candidate.startsWith(`${root}${path.sep}`);
 }
 
+export function resolveInternalPath(root, candidate) {
+  const rootReal = fs.realpathSync(root);
+  const candidateReal = fs.realpathSync(candidate);
+  if (!pathInside(rootReal, candidateReal)) {
+    throw new Error(
+      `product path escapes its root (escaping symlink): ${candidate}`,
+    );
+  }
+  return path.join(root, path.relative(rootReal, candidateReal));
+}
+
 export function normalizeCopiedSymlinks({ source, target }) {
   const sourceRoot = fs.realpathSync(source);
   const visit = (currentTarget) => {
@@ -23,12 +34,7 @@ export function normalizeCopiedSymlinks({ source, target }) {
       const sourcePath = path.join(sourceRoot, relativePath);
       const link = fs.readlinkSync(sourcePath);
       const resolvedSource = path.resolve(path.dirname(sourcePath), link);
-      const canonicalSource = fs.realpathSync(resolvedSource);
-      if (!pathInside(sourceRoot, canonicalSource)) {
-        throw new Error(
-          `product input contains an escaping symlink: ${sourcePath}`,
-        );
-      }
+      const canonicalSource = resolveInternalPath(sourceRoot, resolvedSource);
       const resolvedTarget = path.join(
         target,
         path.relative(sourceRoot, canonicalSource),


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct standalone CLI artifact metadata so the existing auditable-demo transport contract receives a packaged regular interpreter file; no architecture decision or public contract changes."
}
-->

## Summary

- resolve the POSIX `python3` launcher symlink to its packaged versioned interpreter when sealing auditable-demo executable metadata
- reject any interpreter resolution that escapes the staged artifact root
- retain the launcher path and runtime layout contracts unchanged

## Root cause

Exact-source Product Build run `30790224511` completed the Linux build, verify lifecycle, and all 17 invariant checks, then failed closed in the pre-upload transport smoke because `executableFiles[2]` named `runtime/python/bin/python3`, which is a symlink. The Buildchain transport contract requires each declared executable closure member to be a bounded regular file.

## Validation

- `./shifu node --test product/scripts/dist.test.mjs scripts/auditable-demo-workflow.test.mjs` — 44/44 passed
- `./shifu test:auditable-demo` — 6/6 passed
- `./shifu exec biome check product/scripts/dist.mjs product/scripts/dist.test.mjs` — passed
- full staged repository hook passed on commit

## Delivery intent

After protected merge, rerun the exact-source Product matrix and require Linux, macOS, and Windows artifacts plus the pre-upload transport smoke before treating the source as qualified.