### PR TITLE
fix(trunk): normalize Windows Node entry paths

### DIFF
--- a/crates/trunk/src/launch.rs
+++ b/crates/trunk/src/launch.rs
@@ -211,6 +211,35 @@ fn product_tui_command(
     command
 }
 
+#[cfg(windows)]
+fn node_compatible_windows_path(path: &Path) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    const VERBATIM_PREFIX: &[u16] = &[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16];
+    const VERBATIM_UNC_PREFIX: &[u16] = &[
+        b'\\' as u16,
+        b'\\' as u16,
+        b'?' as u16,
+        b'\\' as u16,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        b'\\' as u16,
+    ];
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    if let Some(rest) = wide.strip_prefix(VERBATIM_UNC_PREFIX) {
+        let mut normalized = vec![b'\\' as u16, b'\\' as u16];
+        normalized.extend_from_slice(rest);
+        return PathBuf::from(OsString::from_wide(&normalized));
+    }
+    if let Some(rest) = wide.strip_prefix(VERBATIM_PREFIX) {
+        return PathBuf::from(OsString::from_wide(rest));
+    }
+    path.to_path_buf()
+}
+
 /// Launch the bundled terminal product through the native libnode host.
 ///
 /// Returns `Ok(false)` when the fast path is not applicable, so callers can
@@ -232,6 +261,11 @@ pub fn launch_tui(args: &[String]) -> Result<bool, String> {
     let exe = env::current_exe()
         .and_then(|path| path.canonicalize())
         .map_err(|error| format!("cannot resolve the entry binary path: {error}"))?;
+    // Windows canonicalization returns an extended-length `\\?\` path. Node's
+    // module entry resolver does not accept that form and truncates the drive
+    // path to `C:`, so normalize only the argv/env boundary handed to libnode.
+    #[cfg(windows)]
+    let exe = node_compatible_windows_path(&exe);
     let runtime = exe
         .parent()
         .ok_or_else(|| "the entry binary has no parent directory".to_string())?;
@@ -527,5 +561,18 @@ mod tests {
             Some("xterm-256color"),
             Some("1")
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn native_tui_argv_removes_windows_verbatim_path_prefixes() {
+        assert_eq!(
+            node_compatible_windows_path(Path::new(r"\\?\C:\Users\dkr\Kungfu\tui\tui.mjs")),
+            PathBuf::from(r"C:\Users\dkr\Kungfu\tui\tui.mjs")
+        );
+        assert_eq!(
+            node_compatible_windows_path(Path::new(r"\\?\UNC\server\share\Kungfu\tui\tui.mjs")),
+            PathBuf::from(r"\\server\share\Kungfu\tui\tui.mjs")
+        );
     }
 }

--- a/product/scripts/cli-launcher.mjs
+++ b/product/scripts/cli-launcher.mjs
@@ -7,6 +7,8 @@ export function cliLauncherContent(platform = process.platform) {
       'set "KUNGFU_PRODUCT_MANIFEST=%~dp0product.json"',
       'set "KUNGFU_UPGRADE_MANIFEST=%~dp0upgrade\\kungfu-release-manifest.json"',
       'set "KF_BUNDLED_EXTENSION_ROOT=%~dp0extensions"',
+      'set "KUNGFU_AGENT_SESSION_EXECUTABLE=%~dp0runtime\\kungfu.exe"',
+      'set "KUNGFU_CONTROLLER_ENTRYPOINT=%~dp0runtime\\kungfu.exe"',
       'set "PYTHONUTF8=1"',
       'set "PYTHONIOENCODING=utf-8"',
       '"%~dp0runtime\\kungfu.exe" %*',
@@ -27,6 +29,8 @@ here=$(cd "$(dirname "$target")" && pwd)
 export KUNGFU_PRODUCT_MANIFEST="$here/product.json"
 export KUNGFU_UPGRADE_MANIFEST="$here/upgrade/kungfu-release-manifest.json"
 export KF_BUNDLED_EXTENSION_ROOT="$here/extensions"
+export KUNGFU_AGENT_SESSION_EXECUTABLE="$here/runtime/kungfu"
+export KUNGFU_CONTROLLER_ENTRYPOINT="$here/runtime/kungfu"
 exec "$here/runtime/kungfu" "$@"
 `;
 }

--- a/product/scripts/cli-launcher.test.mjs
+++ b/product/scripts/cli-launcher.test.mjs
@@ -10,6 +10,11 @@ test('CLI launchers defer install ownership to the colocated product manifest', 
   const posix = cliLauncherContent('linux');
   assert.match(posix, /KUNGFU_PRODUCT_MANIFEST="\$here\/product\.json"/);
   assert.match(posix, /KF_BUNDLED_EXTENSION_ROOT="\$here\/extensions"/);
+  assert.match(
+    posix,
+    /KUNGFU_AGENT_SESSION_EXECUTABLE="\$here\/runtime\/kungfu"/,
+  );
+  assert.match(posix, /KUNGFU_CONTROLLER_ENTRYPOINT="\$here\/runtime\/kungfu"/);
   assert.match(posix, /while \[ -L "\$target" \]/);
   assert.match(posix, /exec "\$here\/runtime\/kungfu" "\$@"/);
   assert.doesNotMatch(posix, /KUNGFU_INSTALL_SOURCE/);
@@ -18,6 +23,14 @@ test('CLI launchers defer install ownership to the colocated product manifest', 
   const windows = cliLauncherContent('win32');
   assert.match(windows, /%~dp0runtime\\kungfu\.exe/);
   assert.match(windows, /KF_BUNDLED_EXTENSION_ROOT=%~dp0extensions/);
+  assert.match(
+    windows,
+    /KUNGFU_AGENT_SESSION_EXECUTABLE=%~dp0runtime\\kungfu\.exe/,
+  );
+  assert.match(
+    windows,
+    /KUNGFU_CONTROLLER_ENTRYPOINT=%~dp0runtime\\kungfu\.exe/,
+  );
   assert.match(windows, /set "PYTHONUTF8=1"/);
   assert.match(windows, /set "PYTHONIOENCODING=utf-8"/);
   assert.ok(


### PR DESCRIPTION
## Summary

Normalize Windows paths at the embedded Node boundary and expose packaged Agent Session entrypoints from generated CLI launchers.

## Changes

- Strip Windows extended-length prefixes only when constructing Node argv and environment values.
- Export the packaged Agent Session executable and controller entrypoint from POSIX and Windows launchers.
- Add launcher and native trunk regression coverage.

## Verification

- node --test product/scripts/cli-launcher.test.mjs (2 passed)
- cargo test --manifest-path crates/trunk/Cargo.toml (54 passed)
- Windows native kungfu-trunk test passed on DARKHERO
- Project Cut merge-queue replay qualified against the current dev base

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This compatibility fix preserves the existing native Agent Session and launcher architecture and does not modify ADR records or architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above