### PR TITLE
fix(source): close protected checkout write paths

### DIFF
--- a/framework/maintainability/readonly-source-routes.json
+++ b/framework/maintainability/readonly-source-routes.json
@@ -12,7 +12,19 @@
       "command": "./shifu check:source",
       "classification": "read-only-source",
       "implementation": "scripts/source-acceptance.mjs",
-      "transitiveWriters": [],
+      "runtimeImplementation": "scripts/readonly-source-toolchain.mjs",
+      "writerOwner": "source-acceptance-runtime",
+      "transitiveWriters": [
+        "disposable OS test directories only"
+      ],
+      "deniedCheckoutWriters": [
+        "_tmp_*",
+        ".buildchain/diagnostics/*.tmp-*",
+        ".pnpm-store/**",
+        "generated-fixtures/**",
+        "nested-task-output/**"
+      ],
+      "recovery": "move disposable writes to the declared OS runtime root; run legitimate materialization in an isolated worktree and exclude it from ./shifu check:source",
       "network": false,
       "dependencyInstallation": false
     },
@@ -123,6 +135,35 @@
       "transitiveWriters": [],
       "network": false,
       "dependencyInstallation": false
+    },
+    {
+      "id": "work-design-open-card-preflight",
+      "command": "./shifu work-design:open-card-preflight",
+      "classification": "read-only-source",
+      "implementation": "framework/work-design-open-card/tooling/open-card-preflight.mjs",
+      "transitiveWriters": [],
+      "network": false,
+      "dependencyInstallation": false
+    },
+    {
+      "id": "work-design-feedback",
+      "command": "./shifu work-design:feedback",
+      "classification": "read-only-source",
+      "implementation": "framework/work-design-policy-replay/tooling/check-work-design-policy-replay.mjs",
+      "transitiveWriters": [],
+      "network": false,
+      "dependencyInstallation": false
+    },
+    {
+      "id": "documentation-readonly-checkout",
+      "command": "./shifu docs:check:readonly",
+      "classification": "explicit-materialization",
+      "implementation": "scripts/run-docs-readonly.mjs",
+      "transitiveWriters": [
+        "declared external documentation tool cache and manifest mirror"
+      ],
+      "network": true,
+      "dependencyInstallation": true
     },
     {
       "id": "documentation-material-qualification",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -3,9 +3,9 @@
   "verdict": "pass",
   "authoritySemantics": "navigation-only-projection-over-existing-authorities",
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
-  "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
+  "manifestRoot": "sha256:3510a3caaf84d7224a167b0183615793b3234078486f5bf92f54b08cdba73923",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:e16aaef84e911792171816c047c62d00767f4dde4c66e9bca92ae191b4f9b2d7",
+  "sourceRoot": "sha256:0807aa0f241e23c825e4501d4f7ff866edaea0c049380fd602c3957d32bc08f7",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -651,9 +651,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 1937,
+          "currentLines": 1959,
           "baselineLines": 2514,
-          "currentRoot": "sha256:033b7bda4f390dd9017918371b87bda1e8c75eed0d6ba24c721708e783c7fc77",
+          "currentRoot": "sha256:235f7db3bd9c3e551dc7dde368f2efbc5c47541a1a1e70bc040918e2c4bf1026",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
@@ -1390,14 +1390,14 @@
       "rollback": "Move the read-only evidence helpers back and preserve the existing re-export surface."
     },
     {
-      "id": "product-assembly-lifecycle",
+      "id": "product-assembly-runtime",
       "original": [
         "product/scripts/dist.mjs"
       ],
-      "boundary": "Lifecycle ordering and product target guards form one pure assembly plan; product mechanics, platform adapters, and release behavior remain in dist.mjs.",
+      "boundary": "Source pins, platform package selection, no-optional acquisition, and lifecycle ordering form one explicit-input assembly runtime; product mechanics and release behavior remain in dist.mjs.",
       "target": "product/scripts/runtime-pin-snapshot.mjs",
-      "owner": "product/release",
-      "dependencyInvariant": "The plan receives all mechanics explicitly, preserves the existing Buildchain event order, and exposes no second CLI or product authority.",
+      "owner": "product/release-assembly-runtime",
+      "dependencyInvariant": "The runtime receives repository paths, command execution, logging, environment, package resolution, and product mechanics explicitly; it preserves Buildchain event order and exposes no CLI, publication, or second product authority.",
       "tests": [
         "product/scripts/dist.test.mjs",
         "framework/maintainability/semantic-amplification.test.mjs"
@@ -1947,7 +1947,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 1937,
+        "metric": 1959,
         "threshold": 2450,
         "finding": null
       },

--- a/framework/maintainability/semantic-amplification.manifest.json
+++ b/framework/maintainability/semantic-amplification.manifest.json
@@ -1201,14 +1201,14 @@
       "rollback": "Move the read-only evidence helpers back and preserve the existing re-export surface."
     },
     {
-      "id": "product-assembly-lifecycle",
+      "id": "product-assembly-runtime",
       "original": [
         "product/scripts/dist.mjs"
       ],
-      "boundary": "Lifecycle ordering and product target guards form one pure assembly plan; product mechanics, platform adapters, and release behavior remain in dist.mjs.",
+      "boundary": "Source pins, platform package selection, no-optional acquisition, and lifecycle ordering form one explicit-input assembly runtime; product mechanics and release behavior remain in dist.mjs.",
       "target": "product/scripts/runtime-pin-snapshot.mjs",
-      "owner": "product/release",
-      "dependencyInvariant": "The plan receives all mechanics explicitly, preserves the existing Buildchain event order, and exposes no second CLI or product authority.",
+      "owner": "product/release-assembly-runtime",
+      "dependencyInvariant": "The runtime receives repository paths, command execution, logging, environment, package resolution, and product mechanics explicitly; it preserves Buildchain event order and exposes no CLI, publication, or second product authority.",
       "tests": [
         "product/scripts/dist.test.mjs",
         "framework/maintainability/semantic-amplification.test.mjs"

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1132,6 +1132,21 @@ function writeCliLauncher(stageRoot, layout) {
   return layout.launcherName;
 }
 
+function resolveCliMetadataInterpreter(stageRoot, interpreter) {
+  const resolvedStageRoot = fs.realpathSync(stageRoot);
+  const resolvedInterpreter = fs.realpathSync(interpreter);
+  const relative = path.relative(resolvedStageRoot, resolvedInterpreter);
+  if (
+    !relative ||
+    path.isAbsolute(relative) ||
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`)
+  ) {
+    throw new Error('CLI auditable demo interpreter escapes its stage root');
+  }
+  return path.join(stageRoot, relative);
+}
+
 export function writeAuditableDemoBinaryMetadata(
   stageRoot,
   layout,
@@ -1140,7 +1155,14 @@ export function writeAuditableDemoBinaryMetadata(
 ) {
   const binary = path.join(stageRoot, layout.launcherName);
   const runtime = path.join(stageRoot, layout.runtimeEntrypoint);
-  const python = path.join(stageRoot, layout.pythonEntrypoint);
+  // POSIX standalone Python trees expose bin/python3 as a relative symlink to
+  // the versioned interpreter. The auditable transport contract deliberately
+  // rejects symlinks in executableFiles, so bind the metadata to the packaged
+  // regular file that the launcher ultimately executes.
+  const python = resolveCliMetadataInterpreter(
+    stageRoot,
+    path.join(stageRoot, layout.pythonEntrypoint),
+  );
   const metadata = {
     contract: 'kungfu.declarative-demo-binary/v1',
     platformId: platform,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -256,7 +256,11 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
     recursive: true,
   });
   fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
-  fs.writeFileSync(path.join(root, layout.pythonEntrypoint), 'python\n');
+  fs.writeFileSync(
+    path.join(root, 'runtime/python/bin/python3.13'),
+    'python\n',
+  );
+  fs.symlinkSync('python3.13', path.join(root, layout.pythonEntrypoint));
   const metadata = writeAuditableDemoBinaryMetadata(
     root,
     layout,
@@ -280,7 +284,7 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
         sha256: crypto.createHash('sha256').update('runtime\n').digest('hex'),
       },
       {
-        path: 'runtime/python/bin/python3',
+        path: 'runtime/python/bin/python3.13',
         sha256: crypto.createHash('sha256').update('python\n').digest('hex'),
       },
     ],
@@ -291,6 +295,29 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
       fs.readFileSync(path.join(root, 'auditable-demo-binary.json'), 'utf8'),
     ),
     metadata,
+  );
+});
+
+test('CLI product rejects an interpreter symlink outside the staged artifact', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-demo-binary-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const layout = cliArchiveLayout('linux');
+  fs.writeFileSync(path.join(root, layout.launcherName), '#!/bin/sh\nexit 0\n');
+  fs.mkdirSync(path.dirname(path.join(root, layout.pythonEntrypoint)), {
+    recursive: true,
+  });
+  fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
+  const external = path.join(
+    path.dirname(root),
+    `${path.basename(root)}.python`,
+  );
+  fs.writeFileSync(external, 'python\n');
+  t.after(() => fs.rmSync(external, { force: true }));
+  fs.symlinkSync(external, path.join(root, layout.pythonEntrypoint));
+
+  assert.throws(
+    () => writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root),
+    /CLI auditable demo interpreter escapes its stage root/u,
   );
 });
 

--- a/scripts/check-readonly-source-routes.mjs
+++ b/scripts/check-readonly-source-routes.mjs
@@ -18,6 +18,15 @@ const REQUIRED_AGENT_DISCOVERY = [
   'kungfu agent status --target <agent> --json',
   'kungfu agent work inspect --ref <ref> --json',
 ];
+const REQUIRED_EXPLICIT_SOURCE_ROUTES = ['./shifu docs:check:readonly'];
+const REQUIRED_SOURCE_ACCEPTANCE_DENIALS = [
+  '_tmp_*',
+  '.buildchain/diagnostics/*.tmp-*',
+  '.pnpm-store/**',
+  'generated-fixtures/**',
+  'nested-task-output/**',
+];
+const SOURCE_ACCEPTANCE_WRITER_OWNER = 'source-acceptance-runtime';
 
 function sourceCommand(command) {
   const normalized = command
@@ -69,6 +78,31 @@ export function validateReadonlyRouteInventory(
     }
     if (!route.implementation || !exists(path.join(ROOT, route.implementation)))
       diagnostics.push({ code: 'route-implementation', id: route.id || '' });
+    if (route.id === 'source-acceptance') {
+      if (
+        !route.runtimeImplementation ||
+        !exists(path.join(ROOT, route.runtimeImplementation))
+      )
+        diagnostics.push({
+          code: 'source-runtime-implementation',
+          id: route.id,
+        });
+      if (route.writerOwner !== SOURCE_ACCEPTANCE_WRITER_OWNER)
+        diagnostics.push({ code: 'source-writer-owner', id: route.id });
+      if (!String(route.recovery || '').includes('OS runtime root'))
+        diagnostics.push({ code: 'source-writer-recovery', id: route.id });
+      const denied = new Set(route.deniedCheckoutWriters || []);
+      for (const writer of REQUIRED_SOURCE_ACCEPTANCE_DENIALS) {
+        if (!denied.has(writer))
+          diagnostics.push({
+            code: 'source-writer-denial',
+            id: route.id,
+            writer,
+            owner: SOURCE_ACCEPTANCE_WRITER_OWNER,
+            recovery: route.recovery || '',
+          });
+      }
+    }
   }
   const declaredSource = new Set(
     routes
@@ -81,6 +115,9 @@ export function validateReadonlyRouteInventory(
   for (const command of REQUIRED_AGENT_DISCOVERY)
     if (!commands.has(command))
       diagnostics.push({ code: 'agent-route-unclassified', command });
+  for (const command of REQUIRED_EXPLICIT_SOURCE_ROUTES)
+    if (!commands.has(command))
+      diagnostics.push({ code: 'explicit-source-route-unclassified', command });
   return diagnostics;
 }
 

--- a/scripts/check-readonly-source-routes.test.mjs
+++ b/scripts/check-readonly-source-routes.test.mjs
@@ -29,3 +29,61 @@ test('unclassified, writing, or missing routes fail closed', () => {
   assert.ok(codes.includes('read-route-side-effect'));
   assert.ok(codes.includes('route-implementation'));
 });
+
+test('every shim-routed Work Design query remains classified', () => {
+  for (const id of [
+    'work-design-open-card-preflight',
+    'work-design-feedback',
+  ]) {
+    const broken = structuredClone(inventory);
+    broken.routes = broken.routes.filter((route) => route.id !== id);
+    assert.ok(
+      validateReadonlyRouteInventory(broken).some(
+        (item) => item.code === 'source-route-unclassified',
+      ),
+      `${id} must not disappear behind a self-consistent inventory`,
+    );
+  }
+});
+
+test('checkout-readonly documentation materialization stays explicit', () => {
+  const route = inventory.routes.find(
+    (candidate) => candidate.id === 'documentation-readonly-checkout',
+  );
+  assert.equal(route?.classification, 'explicit-materialization');
+  assert.equal(route?.network, true);
+  assert.equal(route?.dependencyInstallation, true);
+  const broken = structuredClone(inventory);
+  broken.routes = broken.routes.filter(
+    (candidate) => candidate.id !== 'documentation-readonly-checkout',
+  );
+  assert.ok(
+    validateReadonlyRouteInventory(broken).some(
+      (item) => item.code === 'explicit-source-route-unclassified',
+    ),
+  );
+});
+
+test('source acceptance requires exact writer ownership, recovery, and checkout denials', () => {
+  const broken = structuredClone(inventory);
+  const source = broken.routes.find(
+    (route) => route.id === 'source-acceptance',
+  );
+  source.writerOwner = 'nested-task';
+  source.recovery = '';
+  source.deniedCheckoutWriters = [];
+  const diagnostics = validateReadonlyRouteInventory(broken);
+  const codes = diagnostics.map((item) => item.code);
+  assert.ok(codes.includes('source-writer-owner'));
+  assert.ok(codes.includes('source-writer-recovery'));
+  assert.equal(
+    diagnostics.filter((item) => item.code === 'source-writer-denial').length,
+    5,
+  );
+  for (const item of diagnostics.filter(
+    (diagnostic) => diagnostic.code === 'source-writer-denial',
+  )) {
+    assert.equal(item.owner, 'source-acceptance-runtime');
+    assert.equal(item.recovery, '');
+  }
+});

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -9,6 +9,11 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { checkRoot, scanText } from './check-shifu-entry-contract.mjs';
+import {
+  assertSourceCheckoutUnchanged,
+  prepareSourceAcceptanceRuntime,
+  sourceCheckoutSnapshot,
+} from './readonly-source-toolchain.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -611,12 +616,36 @@ test('runtime guard rejects a direct task and accepts Shifu provenance', () => {
   assert.equal(accepted.status, 0);
 });
 
-test('package manager cannot run a guarded root task without a canonical Shifu correction', () => {
+test('real package manager cannot run a guarded task or write the checkout', (t) => {
+  const runtime = prepareSourceAcceptanceRuntime(ROOT);
+  t.after(runtime.cleanup);
+  const before = sourceCheckoutSnapshot(ROOT);
+  const fixture = fs.mkdtempSync(
+    path.join(runtime.runtimeRoot, 'kungfu-package-manager-guard-'),
+  );
+  const guard = path.join(ROOT, 'scripts', 'require-shifu.mjs');
+  const node = JSON.stringify(process.execPath);
+  const guardPath = JSON.stringify(guard);
+  fs.writeFileSync(
+    path.join(fixture, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: 'kungfu-package-manager-guard-fixture',
+        private: true,
+        packageManager: 'pnpm@11.7.0',
+        scripts: {
+          'check:entry-contract': `${node} ${guardPath} check:entry-contract`,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
   const corepack = process.platform === 'win32' ? 'corepack.cmd' : 'corepack';
   const direct = spawnSync(corepack, ['pnpm', 'run', 'check:entry-contract'], {
-    cwd: ROOT,
+    cwd: fixture,
     encoding: 'utf8',
-    env: { ...process.env, SHIFU_ENTRYPOINT: '' },
+    env: { ...runtime.env, SHIFU_ENTRYPOINT: '' },
     shell: process.platform === 'win32',
   });
   const output = `${direct.stdout}\n${direct.stderr}`;
@@ -627,4 +656,10 @@ test('package manager cannot run a guarded root task without a canonical Shifu c
     /\[shifu-entry\] Run: \.\/shifu (?:install|check:entry-contract)(?:\r?\n|$)/,
   );
   assert.doesNotMatch(output, /\[shifu-entry\] Run: (?:corepack|node|pnpm)\b/);
+  assert.equal(
+    path.relative(runtime.runtimeRoot, fixture).startsWith('..'),
+    false,
+  );
+  assert.equal(fs.existsSync(path.join(fixture, 'package.json')), true);
+  assertSourceCheckoutUnchanged(before, sourceCheckoutSnapshot(ROOT));
 });

--- a/scripts/readonly-agent-bootstrap.test.mjs
+++ b/scripts/readonly-agent-bootstrap.test.mjs
@@ -75,6 +75,16 @@ function executableOnPath(name) {
   throw new Error(`${name} is not available on PATH`);
 }
 
+function declaredExecutable(name, candidate) {
+  if (!candidate) return null;
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return candidate;
+  } catch {
+    throw new Error(`${name} is not executable: ${candidate}`);
+  }
+}
+
 function snapshotSource(root) {
   const rows = [];
   const visit = (directory) => {
@@ -99,6 +109,36 @@ function snapshotSource(root) {
   };
   visit(root);
   return rows;
+}
+
+function sourceAuditRoot(rows) {
+  const hash = crypto.createHash('sha256');
+  for (const row of rows) hash.update(row).update('\0');
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function boundedDiagnosticTail(...values) {
+  const [stderr] = values;
+  if (stderr) return stderr.slice(-24 * 1024);
+  const output = values.filter(Boolean).join('\n');
+  const lines = output.split(/\r?\n/u);
+  const failingTestsIndex = lines.findLastIndex(
+    (line) => line.trim() === '✖ failing tests:',
+  );
+  if (failingTestsIndex >= 0)
+    return lines
+      .slice(failingTestsIndex, failingTestsIndex + 120)
+      .join('\n')
+      .slice(0, 24 * 1024);
+  const failureSummaryIndex = lines.findLastIndex((line) =>
+    /^(?:ℹ fail [1-9]|# fail [1-9])/u.test(line.trimStart()),
+  );
+  if (failureSummaryIndex >= 0)
+    return lines
+      .slice(Math.max(0, failureSummaryIndex - 8), failureSummaryIndex + 40)
+      .join('\n')
+      .slice(0, 24 * 1024);
+  return output.slice(-24 * 1024);
 }
 
 function makeReadOnly(root) {
@@ -159,9 +199,11 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
   assert.equal(cloned.status, 0, cloned.stderr);
   const base = sourceMergeBase();
   const corePytest = path.join(ROOT, 'framework/core/.venv/bin/pytest');
-  const pytest = fs.existsSync(corePytest)
-    ? corePytest
-    : executableOnPath('pytest');
+  const pytest =
+    declaredExecutable(
+      'KUNGFU_READONLY_PYTEST',
+      process.env.KUNGFU_READONLY_PYTEST,
+    ) || (fs.existsSync(corePytest) ? corePytest : executableOnPath('pytest'));
   const fixedBase = spawnSync(
     git,
     ['update-ref', 'refs/heads/dev/v4/v4.0', base.sha],
@@ -544,6 +586,7 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
   }
 
   const before = snapshotSource(fixture);
+  const beforeAuditRoot = sourceAuditRoot(before);
   const protectedRef = base.sha;
   makeReadOnly(fixture);
   fs.chmodSync(home, 0o555);
@@ -653,11 +696,18 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
   assert.equal(
     sourceAcceptance.status,
     0,
-    `check:source:\n${[sourceAcceptance.stderr, sourceAcceptance.stdout]
-      .filter(Boolean)
-      .join('\n')}`,
+    `check:source (bounded tail):\n${boundedDiagnosticTail(
+      sourceAcceptance.stderr,
+      sourceAcceptance.stdout,
+    )}`,
   );
-  assert.deepEqual(snapshotSource(fixture), before);
+  const after = snapshotSource(fixture);
+  const afterAuditRoot = sourceAuditRoot(after);
+  assert.deepEqual(after, before);
+  assert.equal(afterAuditRoot, beforeAuditRoot);
+  console.log(
+    `[readonly-source] filesystem-write-audit before=${beforeAuditRoot} after=${afterAuditRoot} byteUnchanged=true`,
+  );
   assert.equal(fs.existsSync(toolLog), false, 'bootstrap tool was invoked');
   assert.deepEqual(fs.readdirSync(home), [], 'read-only route wrote into HOME');
   assert.equal(

--- a/scripts/readonly-source-toolchain.mjs
+++ b/scripts/readonly-source-toolchain.mjs
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-check
 
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
 import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
 
 // A bounded YAML 1.2 reader for committed GitHub workflow contracts. It covers
 // mappings, sequences, quoted/plain scalars, flow collections, and literal or
@@ -311,4 +316,162 @@ export function optionalAjv2020() {
     else throw error;
   }
   return cachedAjv;
+}
+
+export const SOURCE_ACCEPTANCE_RUNTIME_OWNER = 'source-acceptance-runtime';
+export const SOURCE_ACCEPTANCE_RECOVERY =
+  'move disposable writes to the declared OS runtime root; run legitimate materialization in an isolated worktree and exclude it from ./shifu check:source';
+
+function digestRows(rows) {
+  const hash = crypto.createHash('sha256');
+  for (const row of rows) hash.update(row).update('\0');
+  return `sha256:${hash.digest('hex')}`;
+}
+
+function gitNull(root, args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'buffer',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status !== 0)
+    throw new Error(
+      `git ${args.join(' ')} failed: ${String(result.stderr || '').trim()}`,
+    );
+  return result.stdout.toString('utf8').split('\0').filter(Boolean);
+}
+
+function pathInside(root, target) {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== '..' &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function resolveThroughExistingAncestor(target) {
+  let cursor = path.resolve(target);
+  const suffix = [];
+  while (!fs.existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) break;
+    suffix.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+  return path.resolve(fs.realpathSync(cursor), ...suffix);
+}
+
+export function assertExternalSourceAcceptanceTarget(
+  checkoutRoot,
+  target,
+  label = 'write target',
+) {
+  const canonicalCheckout = fs.realpathSync(checkoutRoot);
+  const canonicalTarget = resolveThroughExistingAncestor(target);
+  if (pathInside(canonicalCheckout, canonicalTarget))
+    throw new Error(
+      `${label} is inside the protected checkout; owner=${SOURCE_ACCEPTANCE_RUNTIME_OWNER}; recovery=${SOURCE_ACCEPTANCE_RECOVERY}`,
+    );
+  return canonicalTarget;
+}
+
+export function sourceCheckoutSnapshot(root) {
+  const rows = (kind, paths) =>
+    paths.sort().map((relative) => {
+      const absolute = path.join(root, relative);
+      const stat = fs.lstatSync(absolute);
+      const bytes = stat.isSymbolicLink()
+        ? Buffer.from(fs.readlinkSync(absolute))
+        : fs.readFileSync(absolute);
+      return `${kind}:${stat.isSymbolicLink() ? 'link' : 'file'}:${relative}:${crypto
+        .createHash('sha256')
+        .update(bytes)
+        .digest('hex')}`;
+    });
+  const tracked = gitNull(root, ['ls-files', '-z']);
+  const untracked = gitNull(root, [
+    'ls-files',
+    '--others',
+    '--exclude-standard',
+    '-z',
+  ]);
+  return {
+    trackedTreeRoot: digestRows(rows('tracked', tracked)),
+    untrackedInventoryRoot: digestRows(rows('untracked', untracked)),
+    trackedCount: tracked.length,
+    untrackedCount: untracked.length,
+  };
+}
+
+export function assertSourceCheckoutUnchanged(before, after) {
+  for (const key of ['trackedTreeRoot', 'untrackedInventoryRoot'])
+    if (before[key] !== after[key])
+      throw new Error(
+        `protected checkout ${key} changed during source acceptance; owner=${SOURCE_ACCEPTANCE_RUNTIME_OWNER}; recovery=${SOURCE_ACCEPTANCE_RECOVERY}`,
+      );
+}
+
+export function prepareSourceAcceptanceRuntime(
+  checkoutRoot,
+  baseEnv = process.env,
+) {
+  // tsx opens an IPC socket below TMPDIR. Darwin's Unix-domain socket path is
+  // short enough that the normal per-user os.tmpdir() prefix can overflow it,
+  // so POSIX source acceptance owns a deliberately short OS runtime root.
+  // Windows has no Unix socket path limit and retains its runner/system temp.
+  const runtimeParent =
+    process.platform === 'win32' ? baseEnv.RUNNER_TEMP || os.tmpdir() : '/tmp';
+  const osTemp = assertExternalSourceAcceptanceTarget(
+    checkoutRoot,
+    runtimeParent,
+    'OS temporary root',
+  );
+  const runtimeRoot = fs.mkdtempSync(path.join(osTemp, 'kf-sa-'));
+  const directories = Object.fromEntries(
+    [
+      'tmp',
+      'cache',
+      'state',
+      'corepack',
+      'pnpm-home',
+      'npm-cache',
+      'uv-cache',
+      'ruff-cache',
+      'mypy-cache',
+      'diagnostics',
+    ].map((name) => [name, path.join(runtimeRoot, name)]),
+  );
+  for (const directory of Object.values(directories))
+    fs.mkdirSync(directory, { recursive: true });
+  return {
+    owner: SOURCE_ACCEPTANCE_RUNTIME_OWNER,
+    recovery: SOURCE_ACCEPTANCE_RECOVERY,
+    runtimeRoot,
+    env: {
+      ...baseEnv,
+      TMPDIR: directories.tmp,
+      TMP: directories.tmp,
+      TEMP: directories.tmp,
+      XDG_CACHE_HOME: directories.cache,
+      XDG_STATE_HOME: directories.state,
+      COREPACK_HOME: directories.corepack,
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+      PNPM_HOME: directories['pnpm-home'],
+      npm_config_cache: directories['npm-cache'],
+      NPM_CONFIG_CACHE: directories['npm-cache'],
+      UV_CACHE_DIR: directories['uv-cache'],
+      RUFF_CACHE_DIR: directories['ruff-cache'],
+      MYPY_CACHE_DIR: directories['mypy-cache'],
+      SHIFU_CACHE_RECEIPT: path.join(
+        directories.diagnostics,
+        'shifu-cache-resolution.json',
+      ),
+      KUNGFU_SOURCE_ACCEPTANCE_RUNTIME_ROOT: runtimeRoot,
+    },
+    cleanup() {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    },
+  };
 }

--- a/scripts/shifu-gate-executor.test.mjs
+++ b/scripts/shifu-gate-executor.test.mjs
@@ -549,6 +549,7 @@ test('task actions re-enter an existing lightweight Shifu task beside an active 
       SHIFU_CACHE_PROFILE_REF: profilePath,
       SHIFU_CACHE_PROFILE_DIGEST: sha256(profileBytes),
       SHIFU_CACHE_SCOPE: 'self-hosted-runner',
+      SHIFU_CACHE_RECEIPT: path.join(directory, 'shifu-cache-resolution.json'),
       RUNNER_NAME: runnerName,
       SHIFU_CACHE_ACTIVE: undefined,
       SHIFU_CACHE_BYPASS: undefined,

--- a/scripts/shifu-readonly-entry.mjs
+++ b/scripts/shifu-readonly-entry.mjs
@@ -21,6 +21,8 @@ const READONLY_SOURCE_COMMANDS = [
   'maintainability:python-structure',
   'maintainability:amplification',
   'maintainability:query',
+  'work-design:open-card-preflight',
+  'work-design:feedback',
 ];
 
 function route(command, args) {

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -11,6 +11,13 @@ import {
   checkDevChannelAuthority,
   devMergeBaseCandidates,
 } from './candidate-timeline-events.cjs';
+import {
+  SOURCE_ACCEPTANCE_RECOVERY,
+  SOURCE_ACCEPTANCE_RUNTIME_OWNER,
+  assertSourceCheckoutUnchanged,
+  prepareSourceAcceptanceRuntime,
+  sourceCheckoutSnapshot,
+} from './readonly-source-toolchain.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CPP = /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/;
@@ -649,7 +656,6 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
       env:
         label === 'documentation contracts' && evidenceBaseCommit
           ? {
-              ...process.env,
               KUNGFU_ADR_EVIDENCE_BASE_SHA: evidenceBaseCommit,
             }
           : undefined,
@@ -859,13 +865,6 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
 
   const python = files.filter((file) => file.endsWith('.py'));
   if (python.length) {
-    const ruffEnv = {
-      ...process.env,
-      RUFF_CACHE_DIR: path.join(
-        process.env.XDG_CACHE_HOME || process.env.RUNNER_TEMP || '/tmp',
-        'kungfu-source-ruff',
-      ),
-    };
     const format = sourcePythonCommand([
       'format',
       '--no-cache',
@@ -887,12 +886,10 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
       {
         label: 'changed Python format',
         ...format,
-        env: ruffEnv,
       },
       {
         label: 'changed Python lint',
         ...lint,
-        env: ruffEnv,
       },
     );
   }
@@ -906,13 +903,6 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
       label: 'Python type baseline',
       ...mypy,
       cwd: path.join(ROOT, 'framework/core'),
-      env: {
-        ...process.env,
-        MYPY_CACHE_DIR: path.join(
-          process.env.RUNNER_TEMP || '/tmp',
-          'kungfu-source-mypy',
-        ),
-      },
     });
   }
 
@@ -932,18 +922,52 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
   return plan;
 }
 
-/** @param {Command} step */
-function run(step) {
+const SOURCE_ACCEPTANCE_RUNTIME_ENV = [
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'XDG_CACHE_HOME',
+  'XDG_STATE_HOME',
+  'COREPACK_HOME',
+  'COREPACK_ENABLE_DOWNLOAD_PROMPT',
+  'PNPM_HOME',
+  'npm_config_cache',
+  'NPM_CONFIG_CACHE',
+  'UV_CACHE_DIR',
+  'RUFF_CACHE_DIR',
+  'MYPY_CACHE_DIR',
+  'SHIFU_CACHE_RECEIPT',
+  'KUNGFU_SOURCE_ACCEPTANCE_RUNTIME_ROOT',
+];
+
+export function sourceAcceptanceChildEnv(sourceEnv, stepEnv = {}) {
+  const childEnv = { ...sourceEnv, ...stepEnv };
+  for (const key of SOURCE_ACCEPTANCE_RUNTIME_ENV) {
+    if (sourceEnv[key] !== undefined) childEnv[key] = sourceEnv[key];
+  }
+  return childEnv;
+}
+
+/**
+ * @param {Command} step
+ * @param {NodeJS.ProcessEnv} sourceEnv
+ * @param {typeof spawnSync} spawn
+ */
+export function runSourceAcceptanceStep(
+  step,
+  sourceEnv = process.env,
+  spawn = spawnSync,
+) {
   console.log(`\n[source-acceptance] ${step.label}`);
   console.log(`[source-acceptance] $ ${step.command} ${step.args.join(' ')}`);
-  const result = spawnSync(step.command, step.args, {
+  const result = spawn(step.command, step.args, {
     cwd: step.cwd || ROOT,
-    env: step.env || process.env,
+    env: sourceAcceptanceChildEnv(sourceEnv, step.env),
     stdio: 'inherit',
   });
   if (result.error || result.status !== 0) {
     throw new Error(
-      `${step.label} failed: ${result.error?.message || result.status}`,
+      `${step.label} failed: ${result.error?.message || result.status}; owner=${SOURCE_ACCEPTANCE_RUNTIME_OWNER}; recovery=${SOURCE_ACCEPTANCE_RECOVERY}`,
     );
   }
   if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE === '1') {
@@ -957,25 +981,46 @@ function run(step) {
 }
 
 function main() {
-  const files = sourceChangedFiles();
-  console.log(`[source-acceptance] changed files: ${files.length}`);
-  if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE !== '1') {
-    assertYijinjingWriterInterface();
-    console.log('[source-acceptance] yijinjing writer interface passed');
-  }
-  const devChannels = checkDevChannelAuthority();
+  const before = sourceCheckoutSnapshot(ROOT);
+  const runtime = prepareSourceAcceptanceRuntime(ROOT);
   console.log(
-    `\n[source-acceptance] dev channel authority\n${JSON.stringify(devChannels, null, 2)}`,
+    `[source-acceptance] trackedTreeRoot=${before.trackedTreeRoot} untrackedInventoryRoot=${before.untrackedInventoryRoot}`,
   );
-  if (devChannels.verdict !== 'pass')
-    throw new Error('dev channel authority failed');
-  if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE === '1') {
-    console.warn(
-      '[source-acceptance] cold read-only lane: the installed TypeScript dependency graph is absent; normal source acceptance and CI enforce tooling type checks.',
+  let failure;
+  try {
+    const files = sourceChangedFiles();
+    console.log(`[source-acceptance] changed files: ${files.length}`);
+    if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE !== '1') {
+      assertYijinjingWriterInterface();
+      console.log('[source-acceptance] yijinjing writer interface passed');
+    }
+    const devChannels = checkDevChannelAuthority();
+    console.log(
+      `\n[source-acceptance] dev channel authority\n${JSON.stringify(devChannels, null, 2)}`,
     );
+    if (devChannels.verdict !== 'pass')
+      throw new Error('dev channel authority failed');
+    if (process.env.KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE === '1') {
+      console.warn(
+        '[source-acceptance] cold read-only lane: the installed TypeScript dependency graph is absent; normal source acceptance and CI enforce tooling type checks.',
+      );
+    }
+    for (const step of sourceAcceptancePlan(files, sourceMergeBase().sha))
+      runSourceAcceptanceStep(step, runtime.env);
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      const after = sourceCheckoutSnapshot(ROOT);
+      assertSourceCheckoutUnchanged(before, after);
+      console.log(
+        `[source-acceptance] zero-write trackedTreeRoot=${after.trackedTreeRoot} untrackedInventoryRoot=${after.untrackedInventoryRoot}`,
+      );
+    } finally {
+      runtime.cleanup();
+    }
   }
-  for (const step of sourceAcceptancePlan(files, sourceMergeBase().sha))
-    run(step);
+  if (failure) throw failure;
   console.log('\n[source-acceptance] build-free source gate passed');
 }
 

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -9,11 +9,18 @@ import { fileURLToPath } from 'node:url';
 
 import { scanTree } from './no-bash-guard.mjs';
 import {
+  SOURCE_ACCEPTANCE_RUNTIME_OWNER,
+  assertExternalSourceAcceptanceTarget,
+  prepareSourceAcceptanceRuntime,
+} from './readonly-source-toolchain.mjs';
+import {
   assertKfdEvidenceSourceBinding,
   findGitTreeEquivalentAncestor,
   isLocalQualificationRuntime,
   resolveKfdProductGateCheckedAt,
+  runSourceAcceptanceStep,
   selectKfdEvidenceSourceSha,
+  sourceAcceptanceChildEnv,
   sourceAcceptancePlan,
   sourceClangFormatCommand,
   sourceMypyCommand,
@@ -21,6 +28,139 @@ import {
 } from './source-acceptance.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('source acceptance owns one external runtime for every writable tool surface', (t) => {
+  const runtime = prepareSourceAcceptanceRuntime(ROOT);
+  t.after(runtime.cleanup);
+  assert.equal(runtime.owner, SOURCE_ACCEPTANCE_RUNTIME_OWNER);
+  if (process.platform !== 'win32') {
+    assert.equal(
+      runtime.runtimeRoot.startsWith('/private/tmp/kf-sa-') ||
+        runtime.runtimeRoot.startsWith('/tmp/kf-sa-'),
+      true,
+    );
+    assert.equal(runtime.env.TMPDIR.length < 80, true);
+  }
+  for (const key of [
+    'TMPDIR',
+    'XDG_CACHE_HOME',
+    'XDG_STATE_HOME',
+    'COREPACK_HOME',
+    'PNPM_HOME',
+    'npm_config_cache',
+    'UV_CACHE_DIR',
+    'RUFF_CACHE_DIR',
+    'MYPY_CACHE_DIR',
+    'SHIFU_CACHE_RECEIPT',
+  ]) {
+    assert.doesNotThrow(() =>
+      assertExternalSourceAcceptanceTarget(ROOT, runtime.env[key], key),
+    );
+  }
+});
+
+test('step overrides cannot escape the source-acceptance runtime', (t) => {
+  const runtime = prepareSourceAcceptanceRuntime(ROOT);
+  t.after(runtime.cleanup);
+  const checkoutCache = path.join(ROOT, '_tmp_hostile_child_cache');
+  const child = sourceAcceptanceChildEnv(runtime.env, {
+    ...process.env,
+    TMPDIR: checkoutCache,
+    XDG_CACHE_HOME: checkoutCache,
+    UV_CACHE_DIR: checkoutCache,
+    RUFF_CACHE_DIR: checkoutCache,
+    MYPY_CACHE_DIR: checkoutCache,
+    SHIFU_CACHE_RECEIPT: path.join(checkoutCache, 'receipt.json'),
+    KUNGFU_ADR_EVIDENCE_BASE_SHA: 'a'.repeat(40),
+  });
+  for (const key of [
+    'TMPDIR',
+    'XDG_CACHE_HOME',
+    'UV_CACHE_DIR',
+    'RUFF_CACHE_DIR',
+    'MYPY_CACHE_DIR',
+    'SHIFU_CACHE_RECEIPT',
+  ]) {
+    assert.equal(child[key].startsWith(runtime.runtimeRoot), true, key);
+  }
+  assert.equal(child.KUNGFU_ADR_EVIDENCE_BASE_SHA, 'a'.repeat(40));
+  assert.equal(fs.existsSync(checkoutCache), false);
+});
+
+test('the executed child receives the protected runtime plus narrow overrides', (t) => {
+  const runtime = prepareSourceAcceptanceRuntime(ROOT);
+  t.after(runtime.cleanup);
+  let captured;
+  runSourceAcceptanceStep(
+    {
+      label: 'hostile child env fixture',
+      command: 'fixture',
+      args: [],
+      env: {
+        ...process.env,
+        TMPDIR: path.join(ROOT, '_tmp_hostile_spawn'),
+        UV_CACHE_DIR: path.join(ROOT, '.uv-cache'),
+        KUNGFU_ADR_EVIDENCE_BASE_SHA: 'b'.repeat(40),
+      },
+    },
+    runtime.env,
+    (_command, _args, options) => {
+      captured = options.env;
+      return { status: 0 };
+    },
+  );
+  assert.equal(captured.TMPDIR, runtime.env.TMPDIR);
+  assert.equal(captured.UV_CACHE_DIR, runtime.env.UV_CACHE_DIR);
+  assert.equal(captured.KUNGFU_ADR_EVIDENCE_BASE_SHA, 'b'.repeat(40));
+  assert.equal(fs.existsSync(path.join(ROOT, '_tmp_hostile_spawn')), false);
+  assert.equal(fs.existsSync(path.join(ROOT, '.uv-cache')), false);
+});
+
+test('repo-local temporary, cache, fixture, and nested task writers fail before mutation', (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-source-writer-denial-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+  const checkout = path.join(temporary, 'checkout');
+  fs.mkdirSync(checkout);
+  const sentinel = path.join(checkout, 'sentinel');
+  fs.writeFileSync(sentinel, 'unchanged\n');
+  for (const relative of [
+    '_tmp_guard',
+    '.buildchain/diagnostics/shifu-cache-resolution.json.tmp-1',
+    '.pnpm-store/state.json',
+    'generated-fixtures/result.json',
+    'nested-task-output/receipt.json',
+  ]) {
+    assert.throws(
+      () =>
+        assertExternalSourceAcceptanceTarget(
+          checkout,
+          path.join(checkout, relative),
+          relative,
+        ),
+      /owner=source-acceptance-runtime; recovery=/u,
+    );
+    assert.equal(fs.existsSync(path.join(checkout, relative)), false);
+  }
+  const checkoutAlias = path.join(temporary, 'checkout-alias');
+  fs.symlinkSync(
+    checkout,
+    checkoutAlias,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+  assert.throws(
+    () =>
+      assertExternalSourceAcceptanceTarget(
+        checkout,
+        path.join(checkoutAlias, 'aliased-output'),
+        'aliased-output',
+      ),
+    /owner=source-acceptance-runtime; recovery=/u,
+  );
+  assert.equal(fs.existsSync(path.join(checkout, 'aliased-output')), false);
+  assert.equal(fs.readFileSync(sentinel, 'utf8'), 'unchanged\n');
+});
 
 test('no-bash guard ignores local Kungfu qualification runtimes', (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-no-bash-'));


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Close protected source-acceptance write paths and restore product assembly maintainability headroom without changing public product or architecture contracts."
}
-->

## Summary
- close remaining protected-checkout writer paths in source acceptance
- keep runtime/tool caches and readonly fixtures outside the checkout
- bind demo metadata to a real bounded interpreter file for artifact transport

## Validation
- exact `./shifu build:core` passed
- exact `./shifu check:source` passed: 988 tests, 978 pass, 10 skip, 0 fail
- Python contract suites: 40 + 134 passed
- desktop update adapter: 73 passed
- tracked and untracked source roots remained byte-identical