### PR TITLE
fix(product): bind demo metadata to regular interpreter

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:e16aaef84e911792171816c047c62d00767f4dde4c66e9bca92ae191b4f9b2d7",
+  "sourceRoot": "sha256:78d7bfeb8a6e625c95049a158ce68cb243090163093d5b36641eeb3456634766",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -651,9 +651,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 1937,
+          "currentLines": 1938,
           "baselineLines": 2514,
-          "currentRoot": "sha256:033b7bda4f390dd9017918371b87bda1e8c75eed0d6ba24c721708e783c7fc77",
+          "currentRoot": "sha256:b554f82f36a9f1f6d2dab972d36323b5b5553da6d852773300d995a67ec00bf6",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
@@ -1947,7 +1947,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 1937,
+        "metric": 1938,
         "threshold": 2450,
         "finding": null
       },

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -48,7 +48,7 @@ import {
   runLibwasmArtifactSelfTest,
   runLibwasmExecutionQualification,
 } from './libwasm-artifact.mjs';
-import { normalizeCopiedSymlinks } from './portable-symlinks.mjs';
+import * as portable from './portable-symlinks.mjs';
 import { productReleaseChannelConfig } from './release-channel-trust.mjs';
 import {
   assertSupportedProductHost,
@@ -975,7 +975,7 @@ export function copyTree(source, target, options = {}) {
       );
     },
   });
-  normalizeCopiedSymlinks({ source, target });
+  portable.normalizeCopiedSymlinks({ source, target });
   return true;
 }
 
@@ -1140,7 +1140,8 @@ export function writeAuditableDemoBinaryMetadata(
 ) {
   const binary = path.join(stageRoot, layout.launcherName);
   const runtime = path.join(stageRoot, layout.runtimeEntrypoint);
-  const python = path.join(stageRoot, layout.pythonEntrypoint);
+  const pythonPath = path.join(stageRoot, layout.pythonEntrypoint);
+  const python = portable.resolveInternalPath(stageRoot, pythonPath);
   const metadata = {
     contract: 'kungfu.declarative-demo-binary/v1',
     platformId: platform,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -256,7 +256,11 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
     recursive: true,
   });
   fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
-  fs.writeFileSync(path.join(root, layout.pythonEntrypoint), 'python\n');
+  fs.writeFileSync(
+    path.join(root, 'runtime/python/bin/python3.13'),
+    'python\n',
+  );
+  fs.symlinkSync('python3.13', path.join(root, layout.pythonEntrypoint));
   const metadata = writeAuditableDemoBinaryMetadata(
     root,
     layout,
@@ -280,7 +284,7 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
         sha256: crypto.createHash('sha256').update('runtime\n').digest('hex'),
       },
       {
-        path: 'runtime/python/bin/python3',
+        path: 'runtime/python/bin/python3.13',
         sha256: crypto.createHash('sha256').update('python\n').digest('hex'),
       },
     ],
@@ -291,6 +295,29 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
       fs.readFileSync(path.join(root, 'auditable-demo-binary.json'), 'utf8'),
     ),
     metadata,
+  );
+});
+
+test('CLI product rejects an interpreter symlink outside the staged artifact', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-demo-binary-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const layout = cliArchiveLayout('linux');
+  fs.writeFileSync(path.join(root, layout.launcherName), '#!/bin/sh\nexit 0\n');
+  fs.mkdirSync(path.dirname(path.join(root, layout.pythonEntrypoint)), {
+    recursive: true,
+  });
+  fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
+  const external = path.join(
+    path.dirname(root),
+    `${path.basename(root)}.python`,
+  );
+  fs.writeFileSync(external, 'python\n');
+  t.after(() => fs.rmSync(external, { force: true }));
+  fs.symlinkSync(external, path.join(root, layout.pythonEntrypoint));
+
+  assert.throws(
+    () => writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root),
+    /product path escapes its root/u,
   );
 });
 

--- a/product/scripts/portable-symlinks.mjs
+++ b/product/scripts/portable-symlinks.mjs
@@ -7,6 +7,17 @@ function pathInside(root, candidate) {
   return candidate === root || candidate.startsWith(`${root}${path.sep}`);
 }
 
+export function resolveInternalPath(root, candidate) {
+  const rootReal = fs.realpathSync(root);
+  const candidateReal = fs.realpathSync(candidate);
+  if (!pathInside(rootReal, candidateReal)) {
+    throw new Error(
+      `product path escapes its root (escaping symlink): ${candidate}`,
+    );
+  }
+  return path.join(root, path.relative(rootReal, candidateReal));
+}
+
 export function normalizeCopiedSymlinks({ source, target }) {
   const sourceRoot = fs.realpathSync(source);
   const visit = (currentTarget) => {
@@ -23,12 +34,7 @@ export function normalizeCopiedSymlinks({ source, target }) {
       const sourcePath = path.join(sourceRoot, relativePath);
       const link = fs.readlinkSync(sourcePath);
       const resolvedSource = path.resolve(path.dirname(sourcePath), link);
-      const canonicalSource = fs.realpathSync(resolvedSource);
-      if (!pathInside(sourceRoot, canonicalSource)) {
-        throw new Error(
-          `product input contains an escaping symlink: ${sourcePath}`,
-        );
-      }
+      const canonicalSource = resolveInternalPath(sourceRoot, resolvedSource);
       const resolvedTarget = path.join(
         target,
         path.relative(sourceRoot, canonicalSource),


### PR DESCRIPTION
## Summary
- resolve the staged Python entrypoint symlink to its bounded regular-file target before writing auditable demo metadata
- reject interpreter symlinks that escape the staged product root
- keep the governed semantic-amplification projection current

## Validation
- `node --test product/scripts/dist.test.mjs`: 38/38
- `./shifu test:auditable-demo`: 6/6
- `./shifu maintainability:amplification --check`: pass
- full staged pre-commit gate: pass
- queue admission at exact head `206728fc1258bff1e803bcbcd73cd6b90a0aad90`: qualified, replayedCommitCount=1, diagnostics=[]

## Supersession
Supersedes queue-ineligible #2307. This branch is an exact protected-base fork with one replayable semantic commit; no force-push or gate bypass was used.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded product packaging bugfix preserves existing architecture contracts while correcting transported interpreter metadata."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the listed governance boundaries