### PR TITLE
fix(build): materialize demo executable symlinks

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "977e78bc43034c3f9080f5a02787cb157d04d680",
+    "sourceSha": "631fa2f9bacb70ff60ba130ad351f7aeca270d90",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:0ae59781511ce958cd3a7e020f8e1f6d6a4e9c1245ae20afaf610a372e274ff5"
   },

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:e16aaef84e911792171816c047c62d00767f4dde4c66e9bca92ae191b4f9b2d7",
+  "sourceRoot": "sha256:093e9d38754d838f58115629c4a2cb383c1d771704d0a92a87ed0bcaa9468661",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -651,9 +651,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 1937,
+          "currentLines": 1938,
           "baselineLines": 2514,
-          "currentRoot": "sha256:033b7bda4f390dd9017918371b87bda1e8c75eed0d6ba24c721708e783c7fc77",
+          "currentRoot": "sha256:ff33ae87fb0a644fd2f9829403a19fe72edf914a8236a7f2d33cc7ee44cc81fe",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
@@ -1947,7 +1947,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 1937,
+        "metric": 1938,
         "threshold": 2450,
         "finding": null
       },

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -48,7 +48,7 @@ import {
   runLibwasmArtifactSelfTest,
   runLibwasmExecutionQualification,
 } from './libwasm-artifact.mjs';
-import { normalizeCopiedSymlinks } from './portable-symlinks.mjs';
+import * as symlinks from './portable-symlinks.mjs';
 import { productReleaseChannelConfig } from './release-channel-trust.mjs';
 import {
   assertSupportedProductHost,
@@ -975,7 +975,7 @@ export function copyTree(source, target, options = {}) {
       );
     },
   });
-  normalizeCopiedSymlinks({ source, target });
+  symlinks.normalizeCopiedSymlinks({ source, target });
   return true;
 }
 
@@ -1141,6 +1141,7 @@ export function writeAuditableDemoBinaryMetadata(
   const binary = path.join(stageRoot, layout.launcherName);
   const runtime = path.join(stageRoot, layout.runtimeEntrypoint);
   const python = path.join(stageRoot, layout.pythonEntrypoint);
+  [binary, runtime, python].forEach(symlinks.materializeRegularFile);
   const metadata = {
     contract: 'kungfu.declarative-demo-binary/v1',
     platformId: platform,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -294,6 +294,62 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
   );
 });
 
+test('CLI product materializes symlinked demo executables as regular files', (t) => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX symlink contract');
+    return;
+  }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-demo-symlink-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const layout = cliArchiveLayout('linux');
+  fs.writeFileSync(path.join(root, layout.launcherName), '#!/bin/sh\nexit 0\n');
+  fs.mkdirSync(path.dirname(path.join(root, layout.pythonEntrypoint)), {
+    recursive: true,
+  });
+  fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
+  const pythonTarget = path.join(root, layout.runtimeDirectory, 'python-real');
+  fs.writeFileSync(pythonTarget, 'python\n');
+  fs.chmodSync(pythonTarget, 0o755);
+  fs.symlinkSync(
+    path.relative(
+      path.dirname(path.join(root, layout.pythonEntrypoint)),
+      pythonTarget,
+    ),
+    path.join(root, layout.pythonEntrypoint),
+  );
+
+  writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root);
+
+  const python = path.join(root, layout.pythonEntrypoint);
+  assert.equal(fs.lstatSync(python).isFile(), true);
+  assert.equal(fs.lstatSync(python).isSymbolicLink(), false);
+  assert.equal(fs.readFileSync(python, 'utf8'), 'python\n');
+  assert.notEqual(fs.statSync(python).mode & 0o111, 0);
+});
+
+test('CLI product rejects demo executable symlinks to non-files', (t) => {
+  if (process.platform === 'win32') {
+    t.skip('POSIX symlink contract');
+    return;
+  }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-demo-symlink-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const layout = cliArchiveLayout('linux');
+  const python = path.join(root, layout.pythonEntrypoint);
+  fs.writeFileSync(path.join(root, layout.launcherName), '#!/bin/sh\nexit 0\n');
+  fs.mkdirSync(path.dirname(python), { recursive: true });
+  fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
+  const directory = path.join(root, layout.runtimeDirectory, 'python-dir');
+  fs.mkdirSync(directory);
+  fs.symlinkSync(path.relative(path.dirname(python), directory), python);
+
+  assert.throws(
+    () => writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root),
+    /executable symlink target is not a regular file/u,
+  );
+  assert.equal(fs.lstatSync(python).isSymbolicLink(), true);
+});
+
 test('CLI product manifest channel config contains only runtime trust fields', () => {
   const publicKey = Buffer.alloc(32, 7).toString('base64');
   const keyId = releaseChannelKeyId(publicKey);

--- a/product/scripts/portable-symlinks.mjs
+++ b/product/scripts/portable-symlinks.mjs
@@ -7,6 +7,19 @@ function pathInside(root, candidate) {
   return candidate === root || candidate.startsWith(`${root}${path.sep}`);
 }
 
+export function materializeRegularFile(file) {
+  if (!fs.lstatSync(file).isSymbolicLink()) return;
+  const resolved = fs.realpathSync(file);
+  const entry = fs.statSync(resolved);
+  if (!entry.isFile()) {
+    throw new Error(`executable symlink target is not a regular file: ${file}`);
+  }
+  const materialized = `${file}.materialized-regular-file`;
+  fs.copyFileSync(resolved, materialized);
+  fs.chmodSync(materialized, entry.mode & 0o777);
+  fs.renameSync(materialized, file);
+}
+
 export function normalizeCopiedSymlinks({ source, target }) {
   const sourceRoot = fs.realpathSync(source);
   const visit = (currentTarget) => {


### PR DESCRIPTION
## Summary

Materialize any symlinked executable declared by the auditable-demo binary metadata before packaging. This preserves the declared path and bytes while making the transport closure satisfy Buildchain's bounded regular-file contract.

This latest-dev one-commit replacement supersedes #2309, #2308, #2295 (and predecessor #2290). PR #2309 passed exact candidate checks and approval but became merge-dirty after preceding dev promotions changed generated KFD evidence. This replacement is based on exact current dev `59c23825b14399dc0a48421289393b45977bb12f` and rebinds the same functional fix as one replay-safe commit.

## Root cause

The Linux packaged CPython entrypoint `runtime/python/bin/python3` remained a symlink. Product qualification followed the link successfully, but the pre-upload transport smoke correctly rejected the declared executable itself because it was not a regular file.

## Verification

- `./shifu project-cut:queue-admission -- --base 59c23825b14399dc0a48421289393b45977bb12f --head dbc39aae607424d6348ce64e14458ff7439df629` (qualified; one replayed commit; zero diagnostics)
- `./shifu test:cli-surface-qualification` (51/51)
- `./shifu maintainability:amplification --check` (6 families, 81 surfaces, zero issues)
- regenerated `./shifu kfd:buildchain` evidence and `./shifu kfd:buildchain:check` passed
- complete staged pre-commit gate passed, including 73 gate-latency tests, 17 invariant tests, 138 documentation tests, KFD gates, and formatting

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct the packaged filesystem shape of an already-declared executable without changing the product or architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The existing fail-closed Buildchain transport contract is preserved; the producer now emits the required bounded regular-file closure.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added
- [x] Protected replay was validated before upload
- [x] No secrets, credentials, tokens, or private logs are included
