### PR TITLE
fix(agent): tolerate undecodable provider output

### DIFF
--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -891,6 +891,8 @@ def run_process(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     )
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []

--- a/framework/core/tests/python/test_agent_console_contract.py
+++ b/framework/core/tests/python/test_agent_console_contract.py
@@ -2129,6 +2129,31 @@ def test_run_agent_process_streams_output_before_return(tmp_path):
     assert ("stderr", "notice") in streamed
 
 
+def test_run_agent_process_retains_undecodable_output_without_crashing(tmp_path):
+    script = tmp_path / "non_utf8.py"
+    script.write_text(
+        "import sys\n"
+        "sys.stdout.buffer.write(b'out\\xff\\n')\n"
+        "sys.stderr.buffer.write(b'err\\xfe\\n')\n",
+        encoding="utf-8",
+    )
+    streamed = []
+    result = run_agent.run_process(
+        [sys.executable, str(script)],
+        cwd=str(tmp_path),
+        env=os.environ,
+        timeout_seconds=5,
+        output_sink=lambda stream, line: streamed.append((stream, line)),
+    )
+    assert result.exit_code == 0
+    assert result.stdout == "out\ufffd\n"
+    assert result.stderr == "err\ufffd\n"
+    assert set(streamed) == {
+        ("stdout", "out\ufffd\n"),
+        ("stderr", "err\ufffd\n"),
+    }
+
+
 def test_run_agent_continuation_rejects_transcript_fields_and_root_drift():
     continuation = {
         "schema": "kungfu.agent-continuation-envelope/v1",

--- a/framework/maintainability/abstraction-integrity-report.json
+++ b/framework/maintainability/abstraction-integrity-report.json
@@ -11,9 +11,9 @@
     },
     "counts": {
       "productionFiles": 254,
-      "productionPhysicalLines": 86898,
+      "productionPhysicalLines": 86900,
       "testFiles": 106,
-      "testPhysicalLines": 47370
+      "testPhysicalLines": 47395
     },
     "hiddenProductionFiles": [],
     "modulesOver1000": [
@@ -23,7 +23,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/agent/run_agent.py",
-        "physicalLines": 1233
+        "physicalLines": 1235
       },
       {
         "path": "framework/core/src/python/kungfu/agent/work_profile.py",
@@ -120,9 +120,9 @@
         "responsibilities": 31
       },
       {
-        "contentRoot": "sha256:8f89d0869f72c8afd7a44b86212f0edb02b18ff581b271d8f79dd59a50a2cabb",
+        "contentRoot": "sha256:069d9c4ed44ef14ab452512ed7de195f8757688bf5a7921189c8d36156ea7715",
         "path": "framework/core/src/python/kungfu/agent/run_agent.py",
-        "physicalLines": 1233,
+        "physicalLines": 1235,
         "responsibilities": 36
       },
       {
@@ -350,7 +350,7 @@
       }
     ],
     "schema": "kungfu.python-structure-measurement/v1",
-    "sourceRoot": "sha256:10198888b662e58f8c8bc6acc516977cffc01df10a62ebdaa23d5d194c2044db",
+    "sourceRoot": "sha256:ff9bf4ab475676b1bb2a299b300cf04821b59dde61662ccc194fd460519b640e",
     "sourceRoots": {
       "production": [
         "framework/core/src/python"
@@ -562,9 +562,9 @@
     "kungfu.runtime_broker.NativeReadinessAuthority",
     "kungfu.runtime_service.ProcessRuntimeHost"
   ],
-  "reportRoot": "sha256:7261e8acfe5c46ba0d2a6192f06c9b50256665906e0bbb1fa7c893b2b0d5f28c",
+  "reportRoot": "sha256:b60bbd744af367c3b44d99741154d3d31386eb2310bb181fd7ab762a9af7a2d9",
   "schema": "kungfu.abstraction-integrity-report/v1",
-  "sourceRoot": "sha256:10198888b662e58f8c8bc6acc516977cffc01df10a62ebdaa23d5d194c2044db",
+  "sourceRoot": "sha256:ff9bf4ab475676b1bb2a299b300cf04821b59dde61662ccc194fd460519b640e",
   "summary": {
     "blockingIssues": 0
   },


### PR DESCRIPTION
## Summary

Keep Windows native Agent startup alive when provider diagnostics contain non-UTF-8 console-code-page bytes.

## Changes

- Decode managed provider stdout and stderr with the declared UTF-8 contract and bounded replacement for invalid bytes.
- Add raw invalid-byte regression coverage for streamed stdout and stderr.
- Refresh the Python abstraction-integrity report.

## Verification

- `test_agent_console_contract.py`: 60 passed
- `check:python-structure`: 4 passed, blocking=0
- staged repository gate: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded compatibility fix preserves the native Agent Session architecture and changes no ADR authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above