### PR TITLE
fix(build): isolate alpha qualification from build history

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "afc978c36cb8f46ea88445ca2386376f25325223",
+    "sourceSha": "8ab403ef6339049430056fc9b401460fcddd80ff",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:bfafb87155fad6661464fb09ad1b173b6d1d856f1da0943a3a483895a25a4a42"
   },

--- a/crates/shifu/src/artifact_catalog.rs
+++ b/crates/shifu/src/artifact_catalog.rs
@@ -9,13 +9,97 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use shifu_core::json;
+use shifu_core::{host, json};
 
 const CONTRACT: &str = include_str!("../../../docs/shifu/artifact-contract.json");
 const SCHEMA: &str =
     include_str!("../../../docs/shifu/schema/local-artifact-catalog-v1.schema.json");
 const RECEIPT_SCHEMA: &str =
     include_str!("../../../docs/shifu/schema/local-promotion-receipt-v1.schema.json");
+pub const CURRENT_REGISTRATION_RELATIVE: &str =
+    ".buildchain/runtime/shifu-product-registration.env";
+
+fn env_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', ""))
+}
+
+pub fn begin_current_registration(root: &Path, product_id: &str) -> Result<(), String> {
+    if product_id != "kungfu" {
+        return Ok(());
+    }
+    let pointer = root.join(CURRENT_REGISTRATION_RELATIVE);
+    match fs::remove_file(&pointer) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "cannot clear stale current-build registration {}: {error}",
+            pointer.display()
+        )),
+    }
+}
+
+pub fn publish_current_registration(
+    root: &Path,
+    product_id: &str,
+    slot: &Path,
+    build_sha: &str,
+    artifact_digest: &str,
+) -> Result<(), String> {
+    if product_id != "kungfu" {
+        return Ok(());
+    }
+    let build_id = slot
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| "registered product slot has no build id".to_string())?;
+    let pointer = root.join(CURRENT_REGISTRATION_RELATIVE);
+    let parent = pointer
+        .parent()
+        .ok_or_else(|| "current-build registration has no parent".to_string())?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "cannot create current-build registration directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    let staged = parent.join(format!(
+        ".shifu-product-registration.env.tmp-{}",
+        std::process::id()
+    ));
+    let content = [
+        format!("SHIFU_REGISTERED_PRODUCT={}", env_quote(product_id)),
+        format!("SHIFU_REGISTERED_PLATFORM={}", env_quote(&host::os_arch())),
+        format!("SHIFU_REGISTERED_BUILD_ID={}", env_quote(&build_id)),
+        format!("SHIFU_REGISTERED_BUILD_SHA={}", env_quote(build_sha)),
+        format!(
+            "SHIFU_REGISTERED_ARTIFACT_SHA256={}",
+            env_quote(artifact_digest)
+        ),
+        String::new(),
+    ]
+    .join("\n");
+    fs::write(&staged, content).map_err(|error| {
+        format!(
+            "cannot stage current-build registration {}: {error}",
+            staged.display()
+        )
+    })?;
+    if pointer.exists() {
+        let _ = fs::remove_file(&staged);
+        return Err(format!(
+            "current-build registration {} was recreated concurrently; refusing to overwrite it",
+            pointer.display()
+        ));
+    }
+    fs::rename(&staged, &pointer).map_err(|error| {
+        let _ = fs::remove_file(&staged);
+        format!(
+            "cannot publish current-build registration {}: {error}",
+            pointer.display()
+        )
+    })
+}
 
 pub fn product_mainline_ref() -> String {
     let contract = json::parse(CONTRACT).expect("embedded artifact contract must be valid JSON");
@@ -407,6 +491,27 @@ mod tests {
         let text = fs::read_to_string(root.join("last-promotion.json")).unwrap();
         assert!(text.contains("\"relation\": \"descendant\""));
         assert!(!text.contains(&root.display().to_string()));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn next_distribution_cannot_reuse_or_overwrite_a_prior_coordinate() {
+        let root = shifu_core::host::unique_temp_dir("product-registration").unwrap();
+        let slot = root.join("registry/20260803T000000Z-111111111");
+        fs::create_dir_all(&slot).unwrap();
+        publish_current_registration(&root, "kungfu", &slot, &"1".repeat(40), &"a".repeat(64))
+            .unwrap();
+        assert!(root.join(CURRENT_REGISTRATION_RELATIVE).is_file());
+        assert!(publish_current_registration(
+            &root,
+            "kungfu",
+            &slot,
+            &"1".repeat(40),
+            &"a".repeat(64),
+        )
+        .is_err());
+        begin_current_registration(&root, "kungfu").unwrap();
+        assert!(!root.join(CURRENT_REGISTRATION_RELATIVE).exists());
         let _ = fs::remove_dir_all(root);
     }
 

--- a/crates/shifu/src/dispatch.rs
+++ b/crates/shifu/src/dispatch.rs
@@ -18,7 +18,7 @@ use std::process::Command;
 
 use shifu_core::json;
 
-use crate::{registrar, tools, util};
+use crate::{artifact_catalog, registrar, tools, util};
 
 pub fn run_pnpm(root: &Path, args: &[String]) -> ! {
     let fnm = tools::ensure_tool(&tools::FNM, root);
@@ -60,6 +60,13 @@ pub fn run_pnpm(root: &Path, args: &[String]) -> ! {
     let Some(plan) = plan else {
         util::exec_or_exit(cmd)
     };
+    // A successful distribution must publish a fresh, worktree-local
+    // registration pointer. Remove any prior pointer before the task starts so
+    // a registration failure cannot make release qualification reuse an older
+    // build from the same checkout.
+    if let Err(error) = artifact_catalog::begin_current_registration(root, &plan.product_id) {
+        eprintln!("shifu registrar: {error}");
+    }
     registrar::configure_child_release_cut(&mut cmd);
     match cmd.status() {
         Ok(status) => {

--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -258,7 +258,7 @@ pub fn main_and_exit(args: &[String], invocation: InvocationContext) -> ! {
         promote::run_promote(&args[1..]);
     }
     if is_builds {
-        promote::run_builds(&args[1..]);
+        promote::run_builds(root.as_deref(), &args[1..]);
     }
     if is_artifacts {
         artifact_catalog::run_discovery(&args[1..]);

--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -32,7 +32,7 @@ use shifu_core::{bootstrap, host, json, style};
 use crate::artifact_catalog::{
     automatic, compact_branch, git_relation, json_escape, product_mainline_ref,
     select_unique_automatic, short_sha, state_for, write_promotion_receipt, GitRelation,
-    SelectionError,
+    SelectionError, CURRENT_REGISTRATION_RELATIVE,
 };
 use crate::native_update::{artifact_sha256, local_artifact_identity_valid};
 use crate::{envfile, native_update, util};
@@ -70,6 +70,7 @@ struct ListOptions {
     verbose: bool,
     json: bool,
     no_truncate: bool,
+    verify_current: bool,
 }
 
 fn registry_dir() -> PathBuf {
@@ -79,13 +80,48 @@ fn registry_dir() -> PathBuf {
 }
 
 fn read_meta(slot: &Path) -> Option<Vec<(String, String)>> {
-    let text = fs::read_to_string(slot.join("meta.env")).ok()?;
+    read_env(&slot.join("meta.env"))
+}
+
+fn read_env(path: &Path) -> Option<Vec<(String, String)>> {
+    let text = fs::read_to_string(path).ok()?;
     Some(
         text.lines()
             .filter_map(envfile::parse_line)
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect(),
     )
+}
+
+fn entry_from_slot(slot: PathBuf, name: String) -> Option<BuildEntry> {
+    let meta = read_meta(&slot)?;
+    let artifact = meta_get(&meta, "KUNGFU_BUILD_ARTIFACT");
+    if artifact.is_empty() || !slot.join(&artifact).exists() {
+        return None;
+    }
+    Some(BuildEntry {
+        sha: meta_get(&meta, "KUNGFU_BUILD_SHA"),
+        branch: meta_get(&meta, "KUNGFU_BUILD_BRANCH"),
+        repo: meta_get(&meta, "KUNGFU_BUILD_REPO"),
+        worktree: meta_get(&meta, "KUNGFU_BUILD_WORKTREE"),
+        built_at: meta_get(&meta, "KUNGFU_BUILD_TIME"),
+        kind: meta_get(&meta, "KUNGFU_BUILD_KIND"),
+        digest: meta_get(&meta, "KUNGFU_BUILD_SHA256"),
+        cli_archive: meta_get(&meta, "KUNGFU_BUILD_CLI_ARCHIVE"),
+        cli_archive_digest: meta_get(&meta, "KUNGFU_BUILD_CLI_ARCHIVE_SHA256"),
+        upgrade_manifest: meta_get(&meta, "KUNGFU_BUILD_UPGRADE_MANIFEST"),
+        upgrade_manifest_digest: meta_get(&meta, "KUNGFU_BUILD_UPGRADE_MANIFEST_SHA256"),
+        product_version: meta_get(&meta, "KUNGFU_BUILD_PRODUCT_VERSION"),
+        release_cut_root: meta_get(&meta, "KUNGFU_BUILD_RELEASE_CUT_ROOT"),
+        platform_slice_root: meta_get(&meta, "KUNGFU_BUILD_PLATFORM_SLICE_ROOT"),
+        mainline_ref: meta_get(&meta, "KUNGFU_BUILD_MAINLINE_REF"),
+        mainline_sha: meta_get(&meta, "KUNGFU_BUILD_MAINLINE_SHA"),
+        integrated: meta_get(&meta, "KUNGFU_BUILD_INTEGRATED") == "true",
+        qualified: meta_get(&meta, "KUNGFU_BUILD_QUALIFIED") == "true",
+        artifact,
+        slot,
+        name,
+    })
 }
 
 fn meta_get(meta: &[(String, String)], key: &str) -> String {
@@ -111,38 +147,67 @@ fn entries() -> Vec<BuildEntry> {
     names.reverse();
     names
         .into_iter()
-        .filter_map(|name| {
-            let slot = dir.join(&name);
-            let meta = read_meta(&slot)?;
-            let artifact = meta_get(&meta, "KUNGFU_BUILD_ARTIFACT");
-            if artifact.is_empty() || !slot.join(&artifact).exists() {
-                return None;
-            }
-            Some(BuildEntry {
-                sha: meta_get(&meta, "KUNGFU_BUILD_SHA"),
-                branch: meta_get(&meta, "KUNGFU_BUILD_BRANCH"),
-                repo: meta_get(&meta, "KUNGFU_BUILD_REPO"),
-                worktree: meta_get(&meta, "KUNGFU_BUILD_WORKTREE"),
-                built_at: meta_get(&meta, "KUNGFU_BUILD_TIME"),
-                kind: meta_get(&meta, "KUNGFU_BUILD_KIND"),
-                digest: meta_get(&meta, "KUNGFU_BUILD_SHA256"),
-                cli_archive: meta_get(&meta, "KUNGFU_BUILD_CLI_ARCHIVE"),
-                cli_archive_digest: meta_get(&meta, "KUNGFU_BUILD_CLI_ARCHIVE_SHA256"),
-                upgrade_manifest: meta_get(&meta, "KUNGFU_BUILD_UPGRADE_MANIFEST"),
-                upgrade_manifest_digest: meta_get(&meta, "KUNGFU_BUILD_UPGRADE_MANIFEST_SHA256"),
-                product_version: meta_get(&meta, "KUNGFU_BUILD_PRODUCT_VERSION"),
-                release_cut_root: meta_get(&meta, "KUNGFU_BUILD_RELEASE_CUT_ROOT"),
-                platform_slice_root: meta_get(&meta, "KUNGFU_BUILD_PLATFORM_SLICE_ROOT"),
-                mainline_ref: meta_get(&meta, "KUNGFU_BUILD_MAINLINE_REF"),
-                mainline_sha: meta_get(&meta, "KUNGFU_BUILD_MAINLINE_SHA"),
-                integrated: meta_get(&meta, "KUNGFU_BUILD_INTEGRATED") == "true",
-                qualified: meta_get(&meta, "KUNGFU_BUILD_QUALIFIED") == "true",
-                artifact,
-                slot,
-                name,
-            })
-        })
+        .filter_map(|name| entry_from_slot(dir.join(&name), name))
         .collect()
+}
+
+fn git_head(root: &Path) -> String {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "HEAD"])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_default()
+}
+
+fn valid_build_id(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+}
+
+fn current_entry_at(
+    root: &Path,
+    registry: &Path,
+    expected_sha: &str,
+) -> Result<BuildEntry, String> {
+    let pointer_path = root.join(CURRENT_REGISTRATION_RELATIVE);
+    let pointer = read_env(&pointer_path).ok_or_else(|| {
+        format!(
+            "no fresh current-build registration at {}; run the declared product distribution in this checkout first",
+            pointer_path.display()
+        )
+    })?;
+    let product = meta_get(&pointer, "SHIFU_REGISTERED_PRODUCT");
+    let platform = meta_get(&pointer, "SHIFU_REGISTERED_PLATFORM");
+    let build_id = meta_get(&pointer, "SHIFU_REGISTERED_BUILD_ID");
+    let build_sha = meta_get(&pointer, "SHIFU_REGISTERED_BUILD_SHA");
+    let artifact_digest = meta_get(&pointer, "SHIFU_REGISTERED_ARTIFACT_SHA256");
+    if product != "kungfu"
+        || platform != host::os_arch()
+        || !valid_build_id(&build_id)
+        || expected_sha.is_empty()
+        || build_sha != expected_sha
+    {
+        return Err("current-build registration does not bind this product, platform, and exact checkout revision".to_string());
+    }
+    let entry = entry_from_slot(registry.join(&build_id), build_id.clone()).ok_or_else(|| {
+        format!("current-build registration names an unreadable slot: {build_id}")
+    })?;
+    if entry.sha != build_sha || entry.digest != artifact_digest {
+        return Err(format!(
+            "current-build registration differs from slot metadata: {build_id}"
+        ));
+    }
+    Ok(entry)
 }
 
 fn no_builds_hint() -> ! {
@@ -237,6 +302,40 @@ fn build_relation(entry: &BuildEntry, installed: &str, entry_count: usize) -> Gi
 
 fn build_valid(entry: &BuildEntry) -> bool {
     build_previewable(entry)
+        && entry.integrated
+        && entry.qualified
+        && entry.sha == entry.mainline_sha
+}
+
+/// Deep verification for the artifact produced by the exact current checkout.
+/// Pre-integration qualification must prove payload bytes before a branch can
+/// be submitted, so mainline admission remains a promotion concern rather than
+/// a prerequisite for verifying the current build.
+fn current_payload_valid(entry: &BuildEntry) -> bool {
+    build_previewable(entry)
+}
+
+/// Fast catalog classification from the immutable registration envelope.
+/// This deliberately does not read artifact payload bytes. Promotion and
+/// `builds --verify-current` call `build_valid` and re-check the selected
+/// payload in full before making any safety claim or state change.
+fn build_recorded_valid(entry: &BuildEntry) -> bool {
+    !entry.sha.is_empty()
+        && entry.sha != "unknown"
+        && !entry.sha.ends_with("-dirty")
+        && matches!(entry.kind.as_str(), "app" | "installer" | "appimage")
+        && entry.digest.len() == 64
+        && entry.digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+        && !entry.cli_archive.is_empty()
+        && valid_root(&entry.cli_archive_digest)
+        && entry.slot.join(&entry.cli_archive).is_file()
+        && !entry.upgrade_manifest.is_empty()
+        && valid_root(&entry.upgrade_manifest_digest)
+        && entry.slot.join(&entry.upgrade_manifest).is_file()
+        && !entry.product_version.is_empty()
+        && valid_root(&entry.release_cut_root)
+        && valid_root(&entry.platform_slice_root)
+        && entry.mainline_ref == product_mainline_ref()
         && entry.integrated
         && entry.qualified
         && entry.sha == entry.mainline_sha
@@ -423,7 +522,7 @@ fn select_preview_build<'a>(
     entry
 }
 
-fn print_builds_json(entries: &[BuildEntry]) {
+fn print_builds_json(entries: &[BuildEntry], payload_verified: bool) {
     let installed = installed_sha();
     println!("{{");
     println!("  \"schema\": \"shifu.local-artifact-catalog/v1\",");
@@ -434,10 +533,14 @@ fn print_builds_json(entries: &[BuildEntry]) {
         .iter()
         .map(|entry| {
             let relation = build_relation(entry, &installed, entries.len());
-            let valid = build_valid(entry);
+            let valid = if payload_verified {
+                current_payload_valid(entry)
+            } else {
+                build_recorded_valid(entry)
+            };
             let state = state_for(relation, valid, false);
             format!(
-                "    {{\"id\":\"{}\",\"kind\":\"{}\",\"version\":\"{}\",\"commit\":\"{}\",\"branch\":\"{}\",\"digest\":\"{}\",\"releaseCutRoot\":\"{}\",\"platformSliceRoot\":\"{}\",\"cliArchivePath\":\"{}\",\"cliArchiveDigest\":\"{}\",\"upgradeManifestPath\":\"{}\",\"upgradeManifestDigest\":\"{}\",\"builtAt\":\"{}\",\"state\":\"{}\",\"relation\":\"{}\",\"automatic\":{},\"rollbackOnly\":false,\"dirty\":{},\"qualified\":{},\"integrated\":{},\"mainlineRef\":\"{}\",\"mainlineCommit\":\"{}\",\"repoPath\":\"{}\",\"worktreePath\":\"{}\",\"buildPath\":\"{}\",\"artifactPath\":\"{}\",\"pathDigest\":\"\",\"reason\":\"{}\"}}",
+                "    {{\"id\":\"{}\",\"kind\":\"{}\",\"version\":\"{}\",\"commit\":\"{}\",\"branch\":\"{}\",\"digest\":\"{}\",\"releaseCutRoot\":\"{}\",\"platformSliceRoot\":\"{}\",\"cliArchivePath\":\"{}\",\"cliArchiveDigest\":\"{}\",\"upgradeManifestPath\":\"{}\",\"upgradeManifestDigest\":\"{}\",\"builtAt\":\"{}\",\"state\":\"{}\",\"relation\":\"{}\",\"automatic\":{},\"rollbackOnly\":false,\"integrity\":\"{}\",\"dirty\":{},\"qualified\":{},\"integrated\":{},\"mainlineRef\":\"{}\",\"mainlineCommit\":\"{}\",\"repoPath\":\"{}\",\"worktreePath\":\"{}\",\"buildPath\":\"{}\",\"artifactPath\":\"{}\",\"pathDigest\":\"\",\"reason\":\"{}\"}}",
                 json_escape(&entry.name),
                 json_escape(schema_kind(entry)),
                 json_escape(&entry.product_version),
@@ -460,6 +563,11 @@ fn print_builds_json(entries: &[BuildEntry]) {
                 state.as_str(),
                 relation.as_str(),
                 automatic(relation, valid, false),
+                if payload_verified {
+                    "verified"
+                } else {
+                    "recorded"
+                },
                 entry.sha.ends_with("-dirty"),
                 entry.qualified,
                 entry.integrated,
@@ -478,22 +586,40 @@ fn print_builds_json(entries: &[BuildEntry]) {
     println!("}}");
 }
 
-pub fn run_builds(args: &[String]) -> ! {
+pub fn run_builds(root: Option<&Path>, args: &[String]) -> ! {
     let mut options = ListOptions::default();
     for arg in args {
         match arg.as_str() {
             "--verbose" => options.verbose = true,
             "--json" => options.json = true,
             "--no-truncate" => options.no_truncate = true,
-            _ => util::die("usage: shifu builds [--verbose] [--json] [--no-truncate]"),
+            "--verify-current" => options.verify_current = true,
+            _ => util::die(
+                "usage: shifu builds [--verbose] [--json] [--no-truncate] [--verify-current]",
+            ),
         }
     }
-    let entries = entries();
+    let entries = if options.verify_current {
+        let root =
+            root.unwrap_or_else(|| util::die("--verify-current requires a Kungfu source checkout"));
+        let expected_sha = git_head(root);
+        let entry = current_entry_at(root, &registry_dir(), &expected_sha)
+            .unwrap_or_else(|error| util::die(&error));
+        if !current_payload_valid(&entry) {
+            util::die(&format!(
+                "current registered build {} failed exact payload verification",
+                entry.name
+            ));
+        }
+        vec![entry]
+    } else {
+        entries()
+    };
     if entries.is_empty() {
         no_builds_hint();
     }
     if options.json {
-        print_builds_json(&entries);
+        print_builds_json(&entries, options.verify_current);
         std::process::exit(0);
     }
     let installed = installed_sha();
@@ -506,7 +632,12 @@ pub fn run_builds(args: &[String]) -> ! {
     );
     for (index, entry) in entries.iter().enumerate() {
         let relation = build_relation(entry, &installed, entries.len());
-        let state = state_for(relation, build_valid(entry), false);
+        let valid = if options.verify_current {
+            current_payload_valid(entry)
+        } else {
+            build_recorded_valid(entry)
+        };
+        let state = state_for(relation, valid, false);
         println!(
             "  {} {:10} {:9} {:34} {:10}",
             style::bold(&format!("[{index}]")),

--- a/crates/shifu/src/promote_tests.rs
+++ b/crates/shifu/src/promote_tests.rs
@@ -70,6 +70,120 @@ fn write_app_manifests(entry: &mut BuildEntry) {
     );
 }
 
+fn write_entry_meta(entry: &BuildEntry) {
+    fs::write(
+        entry.slot.join("meta.env"),
+        format!(
+            "KUNGFU_BUILD_SHA='{}'\n\
+             KUNGFU_BUILD_BRANCH='{}'\n\
+             KUNGFU_BUILD_REPO='{}'\n\
+             KUNGFU_BUILD_WORKTREE='{}'\n\
+             KUNGFU_BUILD_TIME='{}'\n\
+             KUNGFU_BUILD_KIND='{}'\n\
+             KUNGFU_BUILD_ARTIFACT='{}'\n\
+             KUNGFU_BUILD_SHA256='{}'\n\
+             KUNGFU_BUILD_CLI_ARCHIVE='{}'\n\
+             KUNGFU_BUILD_CLI_ARCHIVE_SHA256='{}'\n\
+             KUNGFU_BUILD_UPGRADE_MANIFEST='{}'\n\
+             KUNGFU_BUILD_UPGRADE_MANIFEST_SHA256='{}'\n\
+             KUNGFU_BUILD_PRODUCT_VERSION='{}'\n\
+             KUNGFU_BUILD_RELEASE_CUT_ROOT='{}'\n\
+             KUNGFU_BUILD_PLATFORM_SLICE_ROOT='{}'\n\
+             KUNGFU_BUILD_MAINLINE_REF='{}'\n\
+             KUNGFU_BUILD_MAINLINE_SHA='{}'\n\
+             KUNGFU_BUILD_INTEGRATED='{}'\n\
+             KUNGFU_BUILD_QUALIFIED='{}'\n",
+            entry.sha,
+            entry.branch,
+            entry.repo,
+            entry.worktree,
+            entry.built_at,
+            entry.kind,
+            entry.artifact,
+            entry.digest,
+            entry.cli_archive,
+            entry.cli_archive_digest,
+            entry.upgrade_manifest,
+            entry.upgrade_manifest_digest,
+            entry.product_version,
+            entry.release_cut_root,
+            entry.platform_slice_root,
+            entry.mainline_ref,
+            entry.mainline_sha,
+            entry.integrated,
+            entry.qualified,
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn current_build_verification_is_independent_of_unrelated_history() {
+    let root = shifu_core::host::unique_temp_dir("promote-current-registration").unwrap();
+    let registry = root.join("registry");
+    let slot = registry.join("current-build");
+    let mut entry = qualified_app(&slot);
+    entry.name = "current-build".into();
+    entry.integrated = false;
+    entry.qualified = false;
+    entry.mainline_sha = "2".repeat(40);
+    write_app_manifests(&mut entry);
+    write_entry_meta(&entry);
+
+    // These entries are deliberately unreadable as metadata files. Resolving
+    // the exact current registration must never enumerate or inspect them.
+    for index in 0..512 {
+        fs::create_dir_all(registry.join(format!("unrelated-{index}")).join("meta.env")).unwrap();
+    }
+    let pointer = root.join(CURRENT_REGISTRATION_RELATIVE);
+    fs::create_dir_all(pointer.parent().unwrap()).unwrap();
+    fs::write(
+        &pointer,
+        format!(
+            "SHIFU_REGISTERED_PRODUCT='kungfu'\n\
+             SHIFU_REGISTERED_PLATFORM='{}'\n\
+             SHIFU_REGISTERED_BUILD_ID='{}'\n\
+             SHIFU_REGISTERED_BUILD_SHA='{}'\n\
+             SHIFU_REGISTERED_ARTIFACT_SHA256='{}'\n",
+            host::os_arch(),
+            entry.name,
+            entry.sha,
+            entry.digest,
+        ),
+    )
+    .unwrap();
+
+    let mut selected = current_entry_at(&root, &registry, &entry.sha).unwrap();
+    assert_eq!(selected.name, entry.name);
+    assert!(current_payload_valid(&selected));
+    assert!(
+        !build_valid(&selected),
+        "pre-integration verification must not claim promotion eligibility"
+    );
+    assert!(current_entry_at(&root, &registry, &"2".repeat(40)).is_err());
+
+    selected.integrated = true;
+    selected.qualified = true;
+    selected.mainline_sha = selected.sha.clone();
+    fs::write(
+        selected
+            .slot
+            .join(&selected.artifact)
+            .join("Contents/MacOS/Kungfu Episodes"),
+        "tampered executable",
+    )
+    .unwrap();
+    assert!(
+        build_recorded_valid(&selected),
+        "metadata listing must not read retained payload bytes"
+    );
+    assert!(
+        !current_payload_valid(&selected),
+        "exact current-build verification must still fail closed on tampering"
+    );
+    let _ = fs::remove_dir_all(root);
+}
+
 #[test]
 fn qualified_app_requires_exact_product_manifests() {
     let root = shifu_core::host::unique_temp_dir("promote-manifests").unwrap();

--- a/crates/shifu/src/registrar.rs
+++ b/crates/shifu/src/registrar.rs
@@ -43,7 +43,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use shifu_core::{bootstrap, host, json, style};
 
-use crate::artifact_catalog::product_mainline_ref;
+use crate::artifact_catalog::{
+    product_mainline_ref, publish_current_registration as publish_current,
+};
 use crate::native_update::{
     artifact_sha256, installed_release_cut_root, local_artifact_identity_valid, valid_sha256_root,
 };
@@ -233,9 +235,8 @@ fn json_string(value: &str) -> String {
     out
 }
 
-/// FNV-1a 64-bit, hex — a fast, dependency-free cache-key hash. Not
-/// cryptographic; the cache file's stored root/version make any collision a
-/// harmless miss.
+/// FNV-1a 64-bit, hex — a fast, dependency-free cache-key hash. Stored
+/// root/version values make a non-cryptographic collision a harmless miss.
 fn fnv1a_hex(bytes: &[u8]) -> String {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for &b in bytes {
@@ -246,7 +247,7 @@ fn fnv1a_hex(bytes: &[u8]) -> String {
 }
 
 pub struct DistributionPlan {
-    product_id: String,
+    pub(crate) product_id: String,
     surface_id: String,
     artifacts: Vec<DeclaredArtifact>,
 }
@@ -607,6 +608,9 @@ pub fn register(root: &Path, plan: &DistributionPlan) {
         let _ = fs::remove_dir_all(&staging);
         return;
     }
+    if let Err(error) = publish_current(root, &plan.product_id, &slot, &build_sha, primary_sha) {
+        warn(&error);
+    }
     eprintln!(
         "\u{1f94b} {}",
         style::bold(&format!("registered build -> {}", slot.display()))
@@ -760,9 +764,8 @@ fn git_success(root: &Path, args: &[&str]) -> bool {
         .unwrap_or(false)
 }
 
-/// meta.env values use the build-local.env single-quote shape; single quotes
-/// cannot be escaped in it, so they are stripped (same rule as the historical
-/// register script).
+/// meta.env uses the build-local.env single-quote shape; unescapable single
+/// quotes are stripped by the same rule as the historical register script.
 fn quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', ""))
 }
@@ -1040,7 +1043,6 @@ mod tests {
         assert!(meta.contains(
             "KUNGFU_BUILD_SHA256='6521df166eb07efaf36eba5b6bedefd9d6a252e9c80bab1c99653700ec71473c'"
         ));
-
         // Layout-answer cache round-trip. This lives inside the single test
         // that owns XDG_CACHE_HOME (its writes land in the isolated cache);
         // running it here keeps env mutation from racing the parallel suite.

--- a/docs/adr/SHIFU-ADR-019f86da-4f90-7885-9597-bfdcb4fd4453.md
+++ b/docs/adr/SHIFU-ADR-019f86da-4f90-7885-9597-bfdcb4fd4453.md
@@ -76,7 +76,18 @@ Human list output is compact by default but must remain identifying. Long
 branches use middle truncation: preserve the branch-kind prefix, at least twelve
 characters after it, and a useful suffix. `--no-truncate` prints full branch
 names; `--verbose` adds full local paths and digests; `--json` emits the exact
-catalog contract.
+catalog contract. Listing reads registration envelopes only and marks their
+integrity as `recorded`; it never re-hashes every retained payload. Promotion
+still re-verifies the one selected payload before changing state.
+
+Release qualification is isolated from retained history. A declared product
+distribution clears its prior worktree-local registration coordinate before it
+starts and atomically publishes the exact new slot only after registration
+succeeds. `shifu builds --json --verify-current` binds that coordinate to the
+current product, platform, and checkout revision, then fully verifies only that
+payload. A stale or missing coordinate, metadata drift, or payload tampering
+fails closed. Unrelated historical slots are not enumerated and therefore
+cannot change the qualification result or its main execution cost.
 
 The canonical schema is
 [`local-artifact-catalog-v1.schema.json`](../shifu/schema/local-artifact-catalog-v1.schema.json).

--- a/docs/development/rust-adoption.md
+++ b/docs/development/rust-adoption.md
@@ -288,7 +288,11 @@ Timestamp order never authorizes promotion: one unique descendant advances
 automatically, while ancestor, divergent, and unknown builds require explicit
 selection. Compact lists retain an identifying branch prefix/suffix;
 `--no-truncate`, `--verbose`, and `--json` expose progressively more local
-provenance. The exact contract and schemas are available through
+provenance. Catalog listing uses recorded registration metadata and does not
+deep-hash retained payloads. `shifu promote` re-verifies its selected payload;
+release qualification uses `shifu builds --json --verify-current` to deep-hash
+only the slot atomically registered by the current checkout, so unrelated
+history is not a build input. The exact contract and schemas are available through
 `shifu artifacts contract|schema|receipt-schema`.
 
 ```json

--- a/docs/shifu/schema/local-artifact-catalog-v1.schema.json
+++ b/docs/shifu/schema/local-artifact-catalog-v1.schema.json
@@ -40,6 +40,7 @@
         "relation": { "enum": ["same", "descendant", "ancestor", "diverged", "unknown"] },
         "automatic": { "type": "boolean" },
         "rollbackOnly": { "type": "boolean" },
+        "integrity": { "enum": ["recorded", "verified"] },
         "dirty": { "type": ["boolean", "null"] },
         "qualified": { "type": "boolean" },
         "integrated": { "type": "boolean" },

--- a/framework/core/.cmake/compiler.cmake
+++ b/framework/core/.cmake/compiler.cmake
@@ -106,7 +106,10 @@ target_compile_definitions(kungfu_compile_contract INTERFACE
 target_compile_options(kungfu_compile_contract INTERFACE
   $<$<CXX_COMPILER_ID:AppleClang,Clang>:-Wall;-Werror=switch>
   $<$<CXX_COMPILER_ID:GNU>:-Wall;-Werror=switch;-ftemplate-backtrace-limit=0>
-  $<$<CXX_COMPILER_ID:MSVC>:/MP;/utf-8;/permissive-;/bigobj;/W3;/we4062;/Zc:__cplusplus;/EHsc;/Z7>)
+  # Ninja already owns translation-unit parallelism and emits /showIncludes;
+  # MSVC documents /MP as incompatible with /showIncludes. Keep one scheduler
+  # so the configured build budget remains explicit and auditable.
+  $<$<CXX_COMPILER_ID:MSVC>:/utf-8;/permissive-;/bigobj;/W3;/we4062;/Zc:__cplusplus;/EHsc;/Z7>)
 target_link_options(kungfu_compile_contract INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>:/DEBUG;/OPT:REF;/OPT:ICF;/IGNORE:4199>)
 

--- a/framework/core/.gyp/run-conan.js
+++ b/framework/core/.gyp/run-conan.js
@@ -152,12 +152,39 @@ function makeConanSettings(names) {
   return names.flatMap(makeConanSetting);
 }
 
+/** @param {string} banner */
+function conanMsvcVersionFromBanner(banner) {
+  // Keep the probe locale-independent: localized cl.exe banners preserve the
+  // numeric 19.xx toolset identity but may translate the word "Version".
+  const match = String(banner).match(/\b(19)\.(\d{2,})\.\d+(?:\.\d+)?\b/);
+  if (!match) {
+    throw new Error(
+      `cannot map the active MSVC banner to a Conan compiler.version: ${String(banner).trim() || '<empty>'}`,
+    );
+  }
+  return `${match[1]}${match[2][0]}`;
+}
+
+function activeMsvcConanSettings() {
+  const result = shell.runAndCollect('cl.exe', [], {
+    silent: true,
+    encoding: 'utf8',
+  });
+  const banner = `${result.stdout || ''}\n${result.stderr || ''}`;
+  const version = conanMsvcVersionFromBanner(banner);
+  return ['-s', 'compiler=msvc', '-s', `compiler.version=${version}`];
+}
+
 // KF-ADR-019f86da-4f90-79ce-888e-6fd6476f10f4: Conan package identity and the CMake language mode are one
 // contract. A dependency binary resolved as gnu17/17 must not share the cache
 // key of Kungfu's strict C++23 build merely because most current dependencies
 // happen to be header-only or C ABI.
 function platformConanSettings() {
-  return ['-s', 'compiler.cppstd=23'];
+  return [
+    '-s',
+    'compiler.cppstd=23',
+    ...(process.platform === 'win32' ? activeMsvcConanSettings() : []),
+  ];
 }
 
 /** @param {string} name */
@@ -172,6 +199,17 @@ function makeConanOption(name) {
 /** @param {string[]} names */
 function makeConanOptions(names) {
   return names.flatMap(makeConanOption).concat(getNodeVersionOptions());
+}
+
+function conanBuildJobsConf(environment = process.env) {
+  const jobs = String(environment.KUNGFU_BUILD_JOBS || '').trim();
+  if (!jobs) return [];
+  if (!/^[1-9]\d*$/.test(jobs)) {
+    throw new Error(
+      `KUNGFU_BUILD_JOBS must be a positive integer, got ${JSON.stringify(jobs)}`,
+    );
+  }
+  return ['-c', `tools.build:jobs=${jobs}`];
 }
 
 // conan2：-if/-bf → --output-folder；arch 是 setting 由 profile 自测，不再作 -o 选项。
@@ -192,6 +230,7 @@ function conanInstall() {
     '--output-folder',
     'build',
     '--build=missing',
+    ...conanBuildJobsConf(),
     ...settings,
     ...options,
   ]);
@@ -203,7 +242,15 @@ function conanBuild() {
     ...platformConanSettings(),
   ];
   const options = makeConanOptions(['log_level', 'build_profile']);
-  conan(['build', '.', '--output-folder', 'build', ...settings, ...options]);
+  conan([
+    'build',
+    '.',
+    '--output-folder',
+    'build',
+    ...conanBuildJobsConf(),
+    ...settings,
+    ...options,
+  ]);
 }
 
 // conan2 移除了独立的 `conan package` 本地命令(package() 经 conan create/export-pkg 触发)。
@@ -216,7 +263,15 @@ function conanPackage() {
     ...platformConanSettings(),
   ];
   const options = makeConanOptions(['log_level', 'build_profile']);
-  conan(['build', '.', '--output-folder', 'build', ...settings, ...options]);
+  conan([
+    'build',
+    '.',
+    '--output-folder',
+    'build',
+    ...conanBuildJobsConf(),
+    ...settings,
+    ...options,
+  ]);
 }
 
 const cli = require('sywac')
@@ -241,6 +296,8 @@ module.exports.cli = cli;
 module.exports.main = main;
 module.exports.conanInstall = conanInstall;
 module.exports.conanBuild = conanBuild;
+module.exports.conanBuildJobsConf = conanBuildJobsConf;
+module.exports.conanMsvcVersionFromBanner = conanMsvcVersionFromBanner;
 module.exports.repairInvalidUvEnvironment = repairInvalidUvEnvironment;
 
 if (require.main === module) main().catch(shell.utils.exitOnError);

--- a/framework/core/CMakeLists.txt
+++ b/framework/core/CMakeLists.txt
@@ -50,6 +50,20 @@ endif()
 if("python" IN_LIST KUNGFU_BUILD_BINDINGS)
   cmake_policy(SET CMP0148 OLD)
   find_package(pybind11 REQUIRED)
+  # pybind11::windows_extras injects an unbounded /MP into every non-Debug
+  # binding compile. Ninja already owns translation-unit scheduling, so keep
+  # pybind11's /bigobj support but remove its second scheduler.
+  if(MSVC AND TARGET pybind11::windows_extras)
+    get_target_property(KUNGFU_PYBIND11_WINDOWS_COMPILE_OPTIONS
+      pybind11::windows_extras INTERFACE_COMPILE_OPTIONS)
+    if(KUNGFU_PYBIND11_WINDOWS_COMPILE_OPTIONS)
+      list(FILTER KUNGFU_PYBIND11_WINDOWS_COMPILE_OPTIONS
+        EXCLUDE REGEX "/MP")
+      set_property(TARGET pybind11::windows_extras
+        PROPERTY INTERFACE_COMPILE_OPTIONS
+        "${KUNGFU_PYBIND11_WINDOWS_COMPILE_OPTIONS}")
+    endif()
+  endif()
 endif()
 
 # RxCpp 4.1.1 assigns to a const error_ptr in rx-notification.hpp. Conan's

--- a/framework/core/conanfile.py
+++ b/framework/core/conanfile.py
@@ -652,7 +652,7 @@ class KungfuCoreConan(ConanFile):
         # 统一配置,仓内不硬编码);其次 conan conf tools.build:jobs;最后回退 os.cpu_count()。
         # kungfu 开 -flto + 重模板,单路峰值约 2GB,大核机（如 agent-120 32 线程）默认满并行会
         # 撑爆内存换页 thrash,故需可按机封顶。
-        env_jobs = os.environ.get("KUNGFU_BUILD_JOBS", "")
+        env_jobs = os.environ.get("KUNGFU_BUILD_JOBS", "").strip()
         if env_jobs.isdigit() and int(env_jobs) > 0:
             return int(env_jobs)
         return build_jobs(self)
@@ -668,6 +668,10 @@ class KungfuCoreConan(ConanFile):
     ):
         log_level = self.__spdlog_level()
         parallel_level = self.__parallel_jobs()
+        # Cargo runs inside one Ninja slot while Ninja may schedule another
+        # translation unit. Reserve that outer slot so nested Rust work cannot
+        # exceed the caller's total build budget.
+        cargo_parallel_level = max(1, parallel_level - 1)
         # Conan itself runs under Shifu's pinned `uv run --frozen` interpreter.
         # Reuse that exact executable instead of nesting another uv invocation:
         # strict-cache overlays intentionally expose short-lived wrappers, and a
@@ -733,6 +737,7 @@ class KungfuCoreConan(ConanFile):
                 f"--CDPYTHON_EXECUTABLE={python_path}",
                 f"--CDSPDLOG_LOG_LEVEL_COMPILE={log_level}",
                 f"--CDCMAKE_BUILD_PARALLEL_LEVEL={parallel_level}",
+                f"--CDKF_LIBWASM_CARGO_JOBS={cargo_parallel_level}",
             ]
             + cargo_registry_option
             + ninja_option

--- a/framework/core/lib/kungfu-cli.js
+++ b/framework/core/lib/kungfu-cli.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { kfc } = require('./executable');
+const executable = require('./executable');
 const shell = require('./shell');
 
 /**
@@ -99,7 +99,7 @@ function sourceCliEnvironment(
 }
 
 if (require.main === module) {
-  shell.run(kfc, process.argv.slice(2), true, {
+  shell.run(executable.kfc, process.argv.slice(2), true, {
     silent: true,
     env: sourceCliEnvironment(),
   });

--- a/framework/core/src/libwasm/CMakeLists.txt
+++ b/framework/core/src/libwasm/CMakeLists.txt
@@ -19,6 +19,13 @@ if(DEFINED ENV{KF_LIBWASM_CARGO_REGISTRY})
 endif()
 set(KF_LIBWASM_CARGO_REGISTRY "${KF_LIBWASM_CARGO_REGISTRY_DEFAULT}" CACHE STRING
   "Optional sparse Cargo registry mirror, for example sparse+https://rsproxy.cn/index/")
+set(KF_LIBWASM_CARGO_JOBS "1" CACHE STRING
+  "Maximum Cargo jobs used by nested production libwasm builds")
+if(NOT KF_LIBWASM_CARGO_JOBS MATCHES "^[1-9][0-9]*$")
+  message(FATAL_ERROR
+    "KF_LIBWASM_CARGO_JOBS must be a positive integer; got '${KF_LIBWASM_CARGO_JOBS}'")
+endif()
+set(KF_LIBWASM_CARGO_JOB_ARGS --jobs "${KF_LIBWASM_CARGO_JOBS}")
 set(KF_LIBWASM_CARGO_SOURCE_ARGS)
 if(KF_LIBWASM_CARGO_REGISTRY)
   list(APPEND KF_LIBWASM_CARGO_SOURCE_ARGS
@@ -72,7 +79,8 @@ message(STATUS
 add_custom_command(
   OUTPUT "${KF_LIBWASM_WASMTIME_LIBRARY}"
   COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${KF_LIBWASM_WASMTIME_TARGET}"
-          "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build --release --locked
+          "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build
+          ${KF_LIBWASM_CARGO_JOB_ARGS} --release --locked
           --manifest-path "${KF_LIBWASM_ROOT}/wasmtime/Cargo.toml"
   COMMAND ${CMAKE_COMMAND} -E make_directory "${KF_LIBWASM_STAGE_DIR}"
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -91,7 +99,8 @@ add_custom_command(
 add_custom_command(
   OUTPUT "${KF_LIBWASM_WASMER_LIBRARY}"
   COMMAND ${CMAKE_COMMAND} -E env "CARGO_TARGET_DIR=${KF_LIBWASM_WASMER_TARGET}"
-          "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build --release --locked
+          "${KF_LIBWASM_CARGO}" ${KF_LIBWASM_CARGO_SOURCE_ARGS} build
+          ${KF_LIBWASM_CARGO_JOB_ARGS} --release --locked
           --manifest-path "${KF_LIBWASM_ROOT}/wasmer/Cargo.toml"
   COMMAND ${CMAKE_COMMAND} -E make_directory "${KF_LIBWASM_STAGE_DIR}"
   COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/framework/core/src/python/kungfu/coordination/locks.py
+++ b/framework/core/src/python/kungfu/coordination/locks.py
@@ -33,9 +33,12 @@ import errno
 import importlib
 import json
 import os
+import platform
 import subprocess
+import tempfile
 import threading
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
@@ -143,12 +146,50 @@ def _read(path: Path) -> dict[str, Any]:
     return payload
 
 
+def replace_file(source: Path, destination: Path) -> None:
+    """Replace one runtime file, tolerating bounded Windows sharing locks."""
+
+    replace_attempts = 20 if platform.system() == "Windows" else 1
+    for attempt in range(replace_attempts):
+        try:
+            os.replace(source, destination)
+            return
+        except PermissionError:
+            if attempt == replace_attempts - 1:
+                raise
+            time.sleep(0.05)
+
+
+def write_json(path: Path, value: Mapping[str, Any]) -> None:
+    """Write one coordination document through a unique atomic staging file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as output:
+            temporary = Path(output.name)
+            output.write(json.dumps(value, indent=2, sort_keys=True) + "\n")
+        replace_file(temporary, path)
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
+
+
 def _write(path: Path, payload: dict[str, Any]) -> None:
     payload["schema"] = SCHEMA
     payload["updatedAt"] = _now()
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", "utf-8")
-    os.replace(tmp, path)
+    write_json(path, payload)
 
 
 def _owner(pid: int) -> str:

--- a/framework/core/src/python/kungfu/peer_lifecycle.py
+++ b/framework/core/src/python/kungfu/peer_lifecycle.py
@@ -19,7 +19,6 @@ import re
 import signal
 import subprocess
 import sys
-import tempfile
 import time
 from pathlib import Path
 from typing import Any, Mapping
@@ -62,28 +61,7 @@ def _read_json(path: Path) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def _write_json(path: Path, value: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            newline="\n",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as output:
-            temporary = Path(output.name)
-            output.write(json.dumps(value, indent=2, sort_keys=True) + "\n")
-        os.replace(temporary, path)
-    finally:
-        if temporary is not None:
-            try:
-                temporary.unlink()
-            except FileNotFoundError:
-                pass
+_write_json = coordination_locks.write_json
 
 
 def _canonical_digest(value: Mapping[str, Any]) -> str:

--- a/framework/core/tests/python/test_peer_lifecycle.py
+++ b/framework/core/tests/python/test_peer_lifecycle.py
@@ -55,6 +55,35 @@ def test_json_write_is_atomic_across_interleaved_writers(tmp_path, monkeypatch):
     assert list(target.parent.glob(f".{target.name}.*.tmp")) == []
 
 
+def test_windows_json_write_retries_transient_replace_lock(tmp_path, monkeypatch):
+    target = tmp_path / "runtime" / "state.json"
+    original_replace = peer_lifecycle.coordination_locks.os.replace
+    attempts = []
+    sleeps = []
+
+    def replace_after_transient_lock(source, destination):
+        attempts.append((source, destination))
+        if len(attempts) == 1:
+            raise PermissionError(5, "Access is denied", str(destination))
+        original_replace(source, destination)
+
+    monkeypatch.setattr(
+        peer_lifecycle.coordination_locks.platform, "system", lambda: "Windows"
+    )
+    monkeypatch.setattr(
+        peer_lifecycle.coordination_locks.os,
+        "replace",
+        replace_after_transient_lock,
+    )
+    monkeypatch.setattr(peer_lifecycle.coordination_locks.time, "sleep", sleeps.append)
+
+    peer_lifecycle._write_json(target, {"status": "running"})
+
+    assert peer_lifecycle._read_json(target) == {"status": "running"}
+    assert len(attempts) == 2
+    assert sleeps == [0.05]
+
+
 def test_plan_is_stable_and_never_uses_a_shell(tmp_path):
     first = peer_lifecycle.plan(_spec(), tmp_path)
     second = peer_lifecycle.plan(_spec(), tmp_path)

--- a/framework/core/tests/qualification/runtime-activation/README.md
+++ b/framework/core/tests/qualification/runtime-activation/README.md
@@ -2,7 +2,10 @@
 
 This harness binds [KF-ADR-019f86da-4f90-7bc8-a3ed-a7b0a6363d6c](../../../../../docs/adr/KF-ADR-019f86da-4f90-7bc8-a3ed-a7b0a6363d6c.md) Stage 7 to source-exact, retained machine evidence.
 It composes the existing broker/service, Profile action, surface parity,
-distribution, full verification, and local artifact-catalog checks. It does not
+distribution, full verification, and an exact current-build artifact-catalog
+check. The catalog check follows the worktree-local registration coordinate
+published by the preceding distribution and deep-verifies only that payload;
+retained user-global history is not a qualification input. It does not
 replace any lower authority or reinterpret a passing process-crash test as a
 power-loss result.
 

--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -103,7 +103,10 @@ export const SUITES = [
   {
     id: 'product-catalog',
     product: true,
-    command: [LAUNCHER, 'builds', '--json'],
+    // The preceding product-distribution suite atomically records the exact
+    // slot produced by this checkout. Verify that one payload in full; old
+    // user-global history is not an input to the current qualification.
+    command: [LAUNCHER, 'builds', '--json', '--verify-current'],
   },
 ];
 

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -149,6 +149,18 @@ test('product verification checks the distribution outputs without rebuilding th
   assert.equal(verification.command.includes('--full'), false);
 });
 
+test('product catalog qualification is bound to the build from this checkout', () => {
+  const catalog = qualificationPlan({
+    mode: 'execute',
+    withProduct: true,
+  }).find((suite) => suite.id === 'product-catalog');
+  assert.deepEqual(catalog.command.slice(1), [
+    'builds',
+    '--json',
+    '--verify-current',
+  ]);
+});
+
 test('source qualification uv runs preserve the exact tracked lockfile', () => {
   const uvSuites = qualificationPlan({
     mode: 'execute',

--- a/framework/core/tests/run-conan.test.js
+++ b/framework/core/tests/run-conan.test.js
@@ -6,7 +6,27 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const { repairInvalidUvEnvironment } = require('../.gyp/run-conan');
+const {
+  conanBuildJobsConf,
+  conanMsvcVersionFromBanner,
+  repairInvalidUvEnvironment,
+} = require('../.gyp/run-conan');
+
+test('projects one validated build budget into Conan dependency builds', () => {
+  assert.deepEqual(conanBuildJobsConf({}), []);
+  assert.deepEqual(conanBuildJobsConf({ KUNGFU_BUILD_JOBS: ' 2 ' }), [
+    '-c',
+    'tools.build:jobs=2',
+  ]);
+  assert.throws(
+    () => conanBuildJobsConf({ KUNGFU_BUILD_JOBS: 'two' }),
+    /must be a positive integer/,
+  );
+  assert.throws(
+    () => conanBuildJobsConf({ KUNGFU_BUILD_JOBS: '0' }),
+    /must be a positive integer/,
+  );
+});
 
 function fixture() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uv-environment-'));
@@ -47,4 +67,23 @@ test('refuses to replace an invalid uv environment symlink', () => {
     /refusing to replace invalid uv environment/,
   );
   assert.equal(fs.existsSync(target), true);
+});
+
+test('binds Conan dependency identity to the active MSVC toolset', () => {
+  assert.equal(
+    conanMsvcVersionFromBanner(
+      'Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35207 for x64',
+    ),
+    '194',
+  );
+  assert.equal(
+    conanMsvcVersionFromBanner(
+      '用于 x64 的 Microsoft (R) C/C++ 优化编译器 19.51.36248 版',
+    ),
+    '195',
+  );
+  assert.throws(
+    () => conanMsvcVersionFromBanner('unexpected compiler banner'),
+    /cannot map the active MSVC banner/,
+  );
 });

--- a/framework/core/tests/sdk-core-build.test.js
+++ b/framework/core/tests/sdk-core-build.test.js
@@ -60,6 +60,9 @@ test('SDK Core build plan drives both orchestrators and the queue workflow', () 
   const corePackage = JSON.parse(read('framework/core/package.json'));
   const build = read('framework/core/.gyp/run-build.js');
   const conan = read('framework/core/conanfile.py');
+  const coreCmake = read('framework/core/CMakeLists.txt');
+  const compiler = read('framework/core/.cmake/compiler.cmake');
+  const libwasm = read('framework/core/src/libwasm/CMakeLists.txt');
   const workflow = read('.github/workflows/affected-native-pr.yml');
 
   assert.equal(
@@ -90,6 +93,17 @@ test('SDK Core build plan drives both orchestrators and the queue workflow', () 
   );
   assert.match(conan, /python_path = sys\.executable/);
   assert.match(conan, /--CDCMAKE_MAKE_PROGRAM=\{_cmake_path\(ninja_path\)\}/);
+  assert.match(conan, /cargo_parallel_level = max\(1, parallel_level - 1\)/);
+  assert.match(conan, /--CDKF_LIBWASM_CARGO_JOBS=\{cargo_parallel_level\}/);
+  assert.match(
+    libwasm,
+    /KF_LIBWASM_CARGO_JOBS[\s\S]*KF_LIBWASM_CARGO_JOB_ARGS --jobs[\s\S]*\$\{KF_LIBWASM_CARGO_JOB_ARGS\}/,
+  );
+  assert.doesNotMatch(compiler, /<CXX_COMPILER_ID:MSVC>:[^>]*\/MP/);
+  assert.match(
+    coreCmake,
+    /TARGET pybind11::windows_extras[\s\S]*list\(FILTER KUNGFU_PYBIND11_WINDOWS_COMPILE_OPTIONS[\s\S]*EXCLUDE REGEX "\/MP"\)/,
+  );
   assert.match(
     workflow,
     /name: Build Core SDK artifacts[\s\S]*run: \.\/shifu build:core:sdk/,

--- a/framework/maintainability/abstraction-integrity-report.json
+++ b/framework/maintainability/abstraction-integrity-report.json
@@ -6,14 +6,14 @@
   "measurement": {
     "aggregates": {
       "kungfu-cli": 20536,
-      "kungfu-flat-root": 36505,
+      "kungfu-flat-root": 36483,
       "kungfu-runtime-family": 6246
     },
     "counts": {
       "productionFiles": 254,
-      "productionPhysicalLines": 86900,
+      "productionPhysicalLines": 86919,
       "testFiles": 106,
-      "testPhysicalLines": 47398
+      "testPhysicalLines": 47427
     },
     "hiddenProductionFiles": [],
     "modulesOver1000": [
@@ -71,7 +71,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/peer_lifecycle.py",
-        "physicalLines": 1218
+        "physicalLines": 1196
       },
       {
         "path": "framework/core/src/python/kungfu/profile_composition.py",
@@ -192,10 +192,10 @@
         "responsibilities": 36
       },
       {
-        "contentRoot": "sha256:216529e0c2108a9ebd74c620a7008c5905e619c9c3aca8ed5677408b5f72cbea",
+        "contentRoot": "sha256:8260e896da5c67dbb9b44089e71d1be9eac59a1f177c6513a62f04b518cb332b",
         "path": "framework/core/src/python/kungfu/peer_lifecycle.py",
-        "physicalLines": 1218,
-        "responsibilities": 46
+        "physicalLines": 1196,
+        "responsibilities": 45
       },
       {
         "contentRoot": "sha256:9fe772a1932552a4374f11d652280c2e1d5bc86ae6baa0b0ee8d6a450d0445d5",
@@ -299,32 +299,32 @@
         "test": "os.name == 'nt' and sys.maxsize <= 2 ** 32"
       },
       {
-        "line": 55,
+        "line": 58,
         "path": "framework/core/src/python/kungfu/coordination/locks.py",
         "test": "os.name == 'nt'"
       },
       {
-        "line": 105,
+        "line": 108,
         "path": "framework/core/src/python/kungfu/coordination/locks.py",
         "test": "os.name == 'nt'"
       },
       {
-        "line": 127,
+        "line": 130,
         "path": "framework/core/src/python/kungfu/coordination/locks.py",
         "test": "acquired and os.name == 'nt'"
       },
       {
-        "line": 97,
+        "line": 75,
         "path": "framework/core/src/python/kungfu/peer_lifecycle.py",
         "test": "platform.system() == 'Windows'"
       },
       {
-        "line": 582,
+        "line": 560,
         "path": "framework/core/src/python/kungfu/peer_lifecycle.py",
         "test": "platform.system() == 'Windows'"
       },
       {
-        "line": 1016,
+        "line": 994,
         "path": "framework/core/src/python/kungfu/peer_lifecycle.py",
         "test": "platform.system() != 'Windows'"
       },
@@ -350,7 +350,7 @@
       }
     ],
     "schema": "kungfu.python-structure-measurement/v1",
-    "sourceRoot": "sha256:58761dda1826a134ea082e32d5cd47ddd7f3141b7179a0d6fd2d5aaa2f7bf600",
+    "sourceRoot": "sha256:f5f0eb461a875cccb01b23b4174a308ecf75074ff8b78f56680d65f91aa49948",
     "sourceRoots": {
       "production": [
         "framework/core/src/python"
@@ -562,9 +562,9 @@
     "kungfu.runtime_broker.NativeReadinessAuthority",
     "kungfu.runtime_service.ProcessRuntimeHost"
   ],
-  "reportRoot": "sha256:7477fbf18b23a5cc9aa85215c6a7f69a65c8e6ff1a47fb02b5046bc4de6f792b",
+  "reportRoot": "sha256:621a0ee40299f443a8c3261f61cd77e4403fde0d20c287ca0c3b490e1f1e7b20",
   "schema": "kungfu.abstraction-integrity-report/v1",
-  "sourceRoot": "sha256:58761dda1826a134ea082e32d5cd47ddd7f3141b7179a0d6fd2d5aaa2f7bf600",
+  "sourceRoot": "sha256:f5f0eb461a875cccb01b23b4174a308ecf75074ff8b78f56680d65f91aa49948",
   "summary": {
     "blockingIssues": 0
   },

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:574a9355c9d2880006894ed4aa423568223b7c95519bd1f77ba5df0e7e4d0411",
+  "sourceRoot": "sha256:2cab74d0caa7979bc14a57d93c7f8d8c1a89ecaf0ee54534cb065e27f13e6346",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -651,9 +651,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 1938,
+          "currentLines": 1942,
           "baselineLines": 2514,
-          "currentRoot": "sha256:ff33ae87fb0a644fd2f9829403a19fe72edf914a8236a7f2d33cc7ee44cc81fe",
+          "currentRoot": "sha256:4d05f42f2685ed497d3c7a4c8a43eda62618e11a2ec256f85152165a6e40a6b4",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
@@ -1947,7 +1947,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 1938,
+        "metric": 1942,
         "threshold": 2450,
         "finding": null
       },

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -263,8 +263,12 @@ export function installArgs(
 ) {
   const args = ['install', '--frozen-lockfile'];
   if (noOptional) {
-    args.push('--no-optional', '--config.confirmModulesPurge=false');
+    args.push('--no-optional');
   }
+  // Product distribution is an owned, non-interactive build boundary. A
+  // changed Shifu cache overlay may make the generated modules layout stale;
+  // authorize pnpm to replace it instead of requiring a TTY prompt.
+  args.push('--config.confirmModulesPurge=false');
   return args;
 }
 

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -1073,8 +1073,12 @@ test('no-optional builds isolate a mismatched esbuild platform binary', () => {
   );
 });
 
-test('no-optional installs authorize deterministic non-interactive purges', () => {
-  assert.deepEqual(installArgs(false), ['install', '--frozen-lockfile']);
+test('all product installs authorize deterministic non-interactive purges', () => {
+  assert.deepEqual(installArgs(false), [
+    'install',
+    '--frozen-lockfile',
+    '--config.confirmModulesPurge=false',
+  ]);
   assert.deepEqual(installArgs(true), [
     'install',
     '--frozen-lockfile',

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -478,6 +478,12 @@ function checkKungfuGateCatalog() {
 }
 
 function checkLayerQualification() {
+  run('portable format authority bundle', 'pnpm', [
+    '--filter',
+    '@kungfu-tech/spec',
+    'run',
+    'build',
+  ]);
   run(
     'KF-ADR-019f86da-4f90-7c91-9cc2-6dbd18d68dff layer qualification harness tests',
     'node',
@@ -721,14 +727,17 @@ function touchesBuildchainKfdEvidence(files) {
 }
 
 function checkBuildchainKfdEvidence(files = [], { force = false } = {}) {
-  if (!force && !touchesBuildchainKfdEvidence(files)) {
-    log('[check] no Buildchain KFD evidence inputs changed');
-    return;
-  }
+  // The committed source binding depends on Git ancestry as well as file
+  // content. A rebase or merge can stale it without placing any KFD path in
+  // the changed-file set, so keep this fast check unconditional.
   run('Buildchain KFD evidence check', 'node', [
     path.join('scripts', 'buildchain-kfd-evidence.mjs'),
     '--check',
   ]);
+  if (!force && !touchesBuildchainKfdEvidence(files)) {
+    log('[check] no additional Buildchain KFD evidence inputs changed');
+    return;
+  }
   run('KFD-4 perspective qualification', 'node', [
     path.join(
       'framework',

--- a/scripts/run-release-qualification.mjs
+++ b/scripts/run-release-qualification.mjs
@@ -348,6 +348,18 @@ export function prepareReleaseQualificationHistory(
   return prepare(root);
 }
 
+export function prepareReleaseQualificationOutput(root = ROOT) {
+  const output = path.join(root, 'product', 'release', 'qualification');
+  fs.rmSync(output, {
+    recursive: true,
+    force: true,
+    maxRetries: 20,
+    retryDelay: 50,
+  });
+  fs.mkdirSync(output, { recursive: true });
+  return output;
+}
+
 function gitRevision() {
   return spawnSync('git', ['rev-parse', 'HEAD'], {
     cwd: ROOT,
@@ -552,6 +564,7 @@ export function main(argv = process.argv.slice(2)) {
   }
   const options = parseReleaseQualificationOptions(argv);
   const execution = loadExecutionProfile(options.executionProfile);
+  prepareReleaseQualificationOutput();
   prepareReleaseQualificationHistory(
     ROOT,
     process.platform,

--- a/scripts/run-release-qualification.test.mjs
+++ b/scripts/run-release-qualification.test.mjs
@@ -17,6 +17,7 @@ import {
   parseExecutionProfile,
   parseReleaseQualificationOptions,
   prepareReleaseQualificationHistory,
+  prepareReleaseQualificationOutput,
   releaseQualificationEnvironment,
   releaseQualificationStages,
   verifyCorePlatformRelease,
@@ -146,6 +147,25 @@ test('qualification temp state is repository scoped on every platform', () => {
     assert.match(env.KF_DESKTOP_ARTIFACT_SIGNATURE, /#desktop$/);
     assert.match(env.KF_CLI_ARTIFACT_SIGNATURE, /#cli$/);
     assert.equal(fs.statSync(expected).isDirectory(), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('each qualification run replaces only its generated evidence root', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-release-output-'));
+  const qualification = path.join(root, 'product/release/qualification');
+  const releaseArtifact = path.join(root, 'product/release/desktop/app.zip');
+  try {
+    fs.mkdirSync(qualification, { recursive: true });
+    fs.writeFileSync(path.join(qualification, 'stale-report.json'), '{}\n');
+    fs.mkdirSync(path.dirname(releaseArtifact), { recursive: true });
+    fs.writeFileSync(releaseArtifact, 'artifact\n');
+
+    assert.equal(prepareReleaseQualificationOutput(root), qualification);
+    assert.equal(fs.statSync(qualification).isDirectory(), true);
+    assert.deepEqual(fs.readdirSync(qualification), []);
+    assert.equal(fs.readFileSync(releaseArtifact, 'utf8'), 'artifact\n');
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- make build catalog readback metadata-only by default and deep-verify only the explicitly selected current build
- bind qualification to the active toolchain and make dependency sync noninteractive
- bound cold-build work and remove the pybind parallel escape so each Alpha qualification is independent of accumulated history
- use a two-commit linear candidate replayable by Project Cut on current dev afc978c36cb8f46ea88445ca2386376f25325223
- regenerate semantic-amplification, Python structure, and KFD evidence after the final sync

## Qualification

- Linux, macOS ARM64, and Windows x86_64 completed the full install -> dist -> verify flow on the original exact candidate: 65/65 passed; Episode 5/5 scenarios and 9/9 semantic dimensions
- after synchronizing with current development, the user explicitly waived repeated local platform validation so protected Alpha can start immediately
- exact Project Cut queue admission for afc978c36cb8f46ea88445ca2386376f25325223..8bb91dcaf624254682e50c87c24cd422c25291d2 is qualified, with 2 replayed commits, no diagnostics, and no composition change
- protected source acceptance, DCO, proof probe, and Windows/macOS/Ubuntu structure checks passed on exact head 8bb91dcaf624254682e50c87c24cd422c25291d2

## Release boundary

Native signing and notarization remain delegated to protected Buildchain authority. Protected workflows must qualify the exact merge candidate and continue into the automated Alpha release chain.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["SHIFU-ADR-019f86da-4f90-7885-9597-bfdcb4fd4453"],"summary":"Make Alpha qualification independent from retained artifact history while preserving selected-payload integrity verification","verification":["Project Cut exact replay admission","semantic amplification, Python structure, and KFD evidence checks","prior Linux, macOS ARM64, and Windows x86_64 full product qualification"]}
-->