### PR TITLE
fix(build): use non-interactive demo transport smoke

### DIFF
--- a/.buildchain/auditable-demo.json
+++ b/.buildchain/auditable-demo.json
@@ -21,10 +21,10 @@
     "environment": {}
   },
   "transportSmoke": {
-    "argv": ["agent-work-lab", "autoplay"],
+    "argv": ["agent-work-lab", "demo", "--json"],
     "timeoutSeconds": 60,
     "expectedExitCodes": [0],
-    "stdoutIncludes": ["KUNGFU_TUI_DEMO_COMPLETE"]
+    "stdoutIncludes": ["kungfu.agent-work-lab.report/v1"]
   },
   "renditions": [
     {"id": "1080p", "role": "primary", "columns": 150, "rows": 36, "width": 1920, "height": 1080},

--- a/docs/qualification/auditable-demo-artifact-pipeline.md
+++ b/docs/qualification/auditable-demo-artifact-pipeline.md
@@ -9,8 +9,8 @@ confidence: high
 sensitivity: public
 evidence_grade: A
 review_state: self-reviewed
-last_reviewed: 2026-08-02
-ai_provenance: GPT-5 via Codex on 2026-08-02; based on checked-in Kungfu, Buildchain, and Build Images contracts plus exact workflow evidence visible to this task; no claim is made for a render that has not passed the retained Gate
+last_reviewed: 2026-08-03
+ai_provenance: GPT-5 via Codex on 2026-08-02; updated by GPT-5 via Codex on 2026-08-03 to separate non-interactive artifact transport verification from native PTY playback after an exact Build failure; based on checked-in Kungfu, Buildchain, and Build Images contracts plus exact workflow evidence visible to this task; no claim is made for a render that has not passed the retained Gate
 ---
 
 # Declarative Multi-demo Animation Pipeline
@@ -28,9 +28,16 @@ The single source of scenario intent is
 | Agent Work Lab autoplay | `kungfu agent-work-lab autoplay` | 90 seconds |
 | Guided Project Tour | `kungfu agent-work-lab project-tour --speed 0.8` | 180 seconds |
 
-Both commands are non-interactive, deterministic under the declared isolated
-environment, credential-free, and bounded by the `long-form` duration class.
-They are executed directly as argv, never through a shell command string.
+Both playback commands are self-driving, deterministic under the declared
+isolated environment, credential-free, and bounded by the `long-form` duration
+class. They intentionally run inside native PTYs and are executed directly as
+argv, never through a shell command string.
+
+Before upload, a distinct non-interactive transport smoke runs
+`kungfu agent-work-lab demo --json` from the copied standalone distribution and
+requires the `kungfu.agent-work-lab.report/v1` sentinel. This verifies that
+transport retained an executable product without pretending that a pipe is a
+PTY or replacing either native playback capture.
 
 ## One reusable path
 

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -36,11 +36,19 @@ test('one exact Buildchain workflow owns every declared demo', () => {
   assert.equal(scenario.execution.durationClass, 'long-form');
   assert.equal(scenario.execution.totalTimeoutSeconds, 180);
   assert.deepEqual(scenario.transportSmoke, {
-    argv: ['agent-work-lab', 'autoplay'],
+    argv: ['agent-work-lab', 'demo', '--json'],
     timeoutSeconds: 60,
     expectedExitCodes: [0],
-    stdoutIncludes: ['KUNGFU_TUI_DEMO_COMPLETE'],
+    stdoutIncludes: ['kungfu.agent-work-lab.report/v1'],
   });
+  assert.equal(
+    scenario.demos.some(
+      ({ steps }) =>
+        JSON.stringify(steps[0].argv) ===
+        JSON.stringify(scenario.transportSmoke.argv),
+    ),
+    false,
+  );
   assert.equal(
     demo.with['media-profile'],
     'responsive-long-form-web-delivery-v1',


### PR DESCRIPTION
## Summary

Use the existing bounded JSON report command for the pre-upload transport smoke while retaining the two declared auditable demo captures as native PTY playback. This closes the exact Build failure where a non-interactive pipe invoked the PTY-only autoplay command.

## Root cause

The Buildchain transport smoke is intentionally non-interactive, but the scenario configured `agent-work-lab autoplay`, whose truthful contract requires a native interactive terminal. The product correctly returned `kungfu.tui.non-interactive/v1` with reason `interactive terminal required`, so the probe was invalid even though native playback remains correct.

## Verification

- `./shifu node --test scripts/auditable-demo-workflow.test.mjs` (6/6)
- `./shifu docs:check` (deterministic docs gate passed)
- `./shifu check` (changed-scope gate passed)
- `./shifu check:source` (build-free source gate passed)
- `./shifu project-cut:queue-admission -- --base 90e7cd0c95fea96c3e50c9ef18f78903c137ce4d --head ce403fbfdd0ea2c3a5925f1f21928142eecb0d7f` (qualified; one replayed commit; zero diagnostics)
- complete staged pre-commit gate passed, including 73 gate-latency tests, 17 invariant tests, 138 documentation tests, KFD gates, and formatting

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct a non-interactive qualification probe to use an existing non-interactive product surface without changing PTY playback, product semantics, or architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The fail-closed transport contract remains authoritative; the probe now exercises a command whose declared terminal contract matches the transport environment.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added
- [x] Protected replay was validated before upload
- [x] No secrets, credentials, tokens, or private logs are included
