### PR TITLE
fix(python): fail closed on invalid RSS evidence

### DIFF
--- a/docs/qualification/python-kfx-asyncio-performance.md
+++ b/docs/qualification/python-kfx-asyncio-performance.md
@@ -9,8 +9,8 @@ confidence: high
 sensitivity: public
 evidence_grade: A
 review_state: self-reviewed
-last_reviewed: 2026-08-02
-ai_provenance: GPT-5 via Codex on 2026-08-02; derived from the frozen profile, public runtime APIs, exact-revision runner, and retained observations; no unretained platform result is claimed
+last_reviewed: 2026-08-03
+ai_provenance: GPT-5 via Codex on 2026-08-03; derived from the frozen profile, public runtime APIs, exact-revision runner, and retained observations; no unretained platform result is claimed
 ---
 
 # Python KFX asyncio Performance Qualification
@@ -55,6 +55,14 @@ Before measurements, the runner builds the exact checkout and requires
 `test:native-kfx-admission` to pass. A dirty tree, unsupported CPython/platform,
 failed correctness gate, malformed/missing observation, or diagnostic `--quick`
 run cannot produce a qualified claim.
+
+Peak RSS is mandatory evidence. Windows reads the current process through the
+typed `GetCurrentProcess` and `GetProcessMemoryInfo` APIs with the native
+64-bit handle and `SIZE_T` layout. An API failure, process-exit race, missing
+value, non-integer value, or value less than one byte fails the workload or
+invalidates the report; the harness never converts unavailable memory evidence
+to zero. The independent verifier applies the same positive-integer rule to
+retained raw observations.
 
 Dry-run is the default and does not write evidence or make a claim:
 

--- a/framework/core/tests/qualification/python-kfx-asyncio-performance/profiles/cross-platform-v1.json
+++ b/framework/core/tests/qualification/python-kfx-asyncio-performance/profiles/cross-platform-v1.json
@@ -44,6 +44,7 @@
     "unsupported CPython, operating system, or architecture",
     "Core build or correctness gate failure",
     "missing, failed, or malformed observation",
+    "missing, zero, non-integer, or unavailable peak RSS observation",
     "silent task, future, cancellation, timeout, error, relay, or shutdown failure",
     "deleted or selectively excluded scored observation"
   ],

--- a/framework/core/tests/qualification/python-kfx-asyncio-performance/run.mjs
+++ b/framework/core/tests/qualification/python-kfx-asyncio-performance/run.mjs
@@ -219,7 +219,23 @@ export function parseObservationStream(text) {
   if (observations.some((record) => record.status !== 'passed')) {
     throw new Error('workload emitted a non-passing observation');
   }
+  validatePeakRssObservations(observations);
   return { observations, manifest: manifests[0] };
+}
+
+function crediblePeakRss(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+export function validatePeakRssObservations(observations) {
+  const invalid = observations.findIndex(
+    (record) => !crediblePeakRss(record.peak_rss_bytes),
+  );
+  if (invalid !== -1) {
+    throw new Error(
+      `observation ${invalid + 1} peak_rss_bytes must be a positive safe integer`,
+    );
+  }
 }
 
 export function validateCoverage(
@@ -407,6 +423,11 @@ export function evaluateReport({
     invalidations.push('correctness gate failed');
   if (mode === 'execute' && !observations.length)
     invalidations.push('scored observations are missing');
+  if (
+    mode === 'execute' &&
+    observations.some((record) => !crediblePeakRss(record.peak_rss_bytes))
+  )
+    invalidations.push('peak RSS observation is missing or non-credible');
   if (mode === 'execute' && quick)
     invalidations.push('quick workload is diagnostic-only');
   if (
@@ -601,6 +622,7 @@ export function verifyEvidence(
       'raw observations contain an invalid or non-passing record',
     );
   }
+  validatePeakRssObservations(observations);
   if (observations.length !== report.observations.count) {
     throw new Error('raw observation count does not match the report');
   }

--- a/framework/core/tests/qualification/python-kfx-asyncio-performance/run.test.mjs
+++ b/framework/core/tests/qualification/python-kfx-asyncio-performance/run.test.mjs
@@ -20,6 +20,7 @@ import {
   qualificationPlan,
   renderSummary,
   validateCoverage,
+  validatePeakRssObservations,
   validateReport,
   verifyEvidence,
 } from './run.mjs';
@@ -242,6 +243,19 @@ test('raw parser keeps every observation and rejects failure records', () => {
   );
 });
 
+test('zero, missing, and malformed peak RSS observations fail closed', () => {
+  for (const peak_rss_bytes of [0, null, '1024']) {
+    assert.throws(
+      () => validatePeakRssObservations([record({ peak_rss_bytes })]),
+      /peak_rss_bytes must be a positive safe integer/u,
+    );
+  }
+  assert.throws(
+    () => validatePeakRssObservations([record({ peak_rss_bytes: undefined })]),
+    /peak_rss_bytes must be a positive safe integer/u,
+  );
+});
+
 test('statistics retain tails, errors, cancellations, backpressure, and resources', () => {
   const statistics = deriveStatistics([
     record({ p99_microseconds: 10, cancelled_operations: 2 }),
@@ -340,6 +354,19 @@ test('dirty and quick evidence fail closed while dry-run makes no claim', () => 
     quick: true,
   });
   assert.equal(quick.verdict, 'unqualified');
+  const zeroRss = evaluateReport({
+    ...base,
+    mode: 'execute',
+    source: source(),
+    observations: [record({ peak_rss_bytes: 0 })],
+  });
+  assert.equal(zeroRss.verdict, 'unqualified');
+  assert.equal(zeroRss.claims.service_plane_envelope_qualified, false);
+  assert.ok(
+    zeroRss.invalidations.includes(
+      'peak RSS observation is missing or non-credible',
+    ),
+  );
   const planned = evaluateReport({
     ...base,
     mode: 'dry-run',

--- a/framework/core/tests/qualification/python-kfx-asyncio-performance/workload.py
+++ b/framework/core/tests/qualification/python-kfx-asyncio-performance/workload.py
@@ -41,36 +41,81 @@ def percentile(values: list[int], quantile: float) -> int:
     return ordered[index]
 
 
+def _positive_rss(value: int, source: str) -> int:
+    if value <= 0:
+        raise RuntimeError(f"{source} returned a non-positive peak RSS")
+    return value
+
+
+def _windows_peak_rss_bytes(ctypes_module: Any | None = None) -> int:
+    if ctypes_module is None:
+        import ctypes as ctypes_module
+
+    # Win32 DWORD and BOOL are always 32-bit, including on 64-bit Windows.
+    # Fixed-width declarations also let non-Windows unit tests verify the ABI
+    # layout without inheriting the host C long width.
+    dword = ctypes_module.c_uint32
+    bool32 = ctypes_module.c_int32
+    handle = ctypes_module.c_void_p
+
+    class ProcessMemoryCounters(ctypes_module.Structure):
+        _fields_ = [
+            ("cb", dword),
+            ("PageFaultCount", dword),
+            ("PeakWorkingSetSize", ctypes_module.c_size_t),
+            ("WorkingSetSize", ctypes_module.c_size_t),
+            ("QuotaPeakPagedPoolUsage", ctypes_module.c_size_t),
+            ("QuotaPagedPoolUsage", ctypes_module.c_size_t),
+            ("QuotaPeakNonPagedPoolUsage", ctypes_module.c_size_t),
+            ("QuotaNonPagedPoolUsage", ctypes_module.c_size_t),
+            ("PagefileUsage", ctypes_module.c_size_t),
+            ("PeakPagefileUsage", ctypes_module.c_size_t),
+        ]
+
+    kernel32 = ctypes_module.WinDLL("kernel32", use_last_error=True)
+    psapi = ctypes_module.WinDLL("psapi", use_last_error=True)
+    get_current_process = kernel32.GetCurrentProcess
+    get_current_process.argtypes = []
+    get_current_process.restype = handle
+    get_process_memory_info = psapi.GetProcessMemoryInfo
+    get_process_memory_info.argtypes = [
+        handle,
+        ctypes_module.POINTER(ProcessMemoryCounters),
+        dword,
+    ]
+    get_process_memory_info.restype = bool32
+
+    counters = ProcessMemoryCounters()
+    counters.cb = ctypes_module.sizeof(counters)
+    if not get_process_memory_info(
+        get_current_process(), ctypes_module.byref(counters), counters.cb
+    ):
+        error_code = ctypes_module.get_last_error()
+        detail = ctypes_module.FormatError(error_code).strip()
+        raise OSError(error_code, f"GetProcessMemoryInfo failed: {detail}")
+    return _positive_rss(int(counters.PeakWorkingSetSize), "GetProcessMemoryInfo")
+
+
+def _posix_peak_rss_bytes(
+    resource_module: Any | None = None, platform_name: str | None = None
+) -> int:
+    if resource_module is None:
+        import resource as resource_module
+
+    platform_name = platform_name or sys.platform
+    value = int(resource_module.getrusage(resource_module.RUSAGE_SELF).ru_maxrss)
+    return _positive_rss(
+        value if platform_name == "darwin" else value * 1024,
+        "getrusage",
+    )
+
+
 def peak_rss_bytes() -> int:
-    if sys.platform == "win32":
-        import ctypes
-        from ctypes import wintypes
-
-        class ProcessMemoryCounters(ctypes.Structure):
-            _fields_ = [
-                ("cb", wintypes.DWORD),
-                ("PageFaultCount", wintypes.DWORD),
-                ("PeakWorkingSetSize", ctypes.c_size_t),
-                ("WorkingSetSize", ctypes.c_size_t),
-                ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
-                ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
-                ("PagefileUsage", ctypes.c_size_t),
-                ("PeakPagefileUsage", ctypes.c_size_t),
-            ]
-
-        counters = ProcessMemoryCounters()
-        counters.cb = ctypes.sizeof(counters)
-        process_handle = ctypes.windll.kernel32.GetCurrentProcess()
-        ok = ctypes.windll.psapi.GetProcessMemoryInfo(
-            process_handle, ctypes.byref(counters), counters.cb
-        )
-        return int(counters.PeakWorkingSetSize) if ok else 0
-    import resource
-
-    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
-    return value if sys.platform == "darwin" else value * 1024
+    return (
+        _windows_peak_rss_bytes()
+        if sys.platform == "win32"
+        else _posix_peak_rss_bytes()
+    )
 
 
 def observation(

--- a/framework/core/tests/qualification/python-kfx-asyncio-performance/workload_test.py
+++ b/framework/core/tests/qualification/python-kfx-asyncio-performance/workload_test.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import ctypes
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -23,11 +25,97 @@ workload = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(workload)
 
 
+class _FakeFunction:
+    def __init__(self, implementation):
+        self.implementation = implementation
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, *args):
+        return self.implementation(*args)
+
+
+def fake_windows_ctypes(*, peak_rss: int = 4096, ok: bool = True, error: int = 5):
+    current_process = _FakeFunction(lambda: 0x1234)
+
+    def memory_info(handle, counters_pointer, size):
+        assert handle == 0x1234
+        assert size == ctypes.sizeof(counters_pointer._obj)
+        counters_pointer._obj.PeakWorkingSetSize = peak_rss
+        return int(ok)
+
+    get_process_memory_info = _FakeFunction(memory_info)
+    libraries = {
+        "kernel32": SimpleNamespace(GetCurrentProcess=current_process),
+        "psapi": SimpleNamespace(GetProcessMemoryInfo=get_process_memory_info),
+    }
+    fake = SimpleNamespace(
+        Structure=ctypes.Structure,
+        POINTER=ctypes.POINTER,
+        byref=ctypes.byref,
+        c_int32=ctypes.c_int32,
+        c_uint32=ctypes.c_uint32,
+        c_size_t=ctypes.c_size_t,
+        c_void_p=ctypes.c_void_p,
+        sizeof=ctypes.sizeof,
+        WinDLL=lambda name, use_last_error: libraries[name],
+        get_last_error=lambda: error,
+        FormatError=lambda code: f"fixture error {code}",
+    )
+    return fake, current_process, get_process_memory_info
+
+
 def test_percentile_retains_tail_observations():
     values = list(range(1, 101))
     assert workload.percentile(values, 0.50) == 50
     assert workload.percentile(values, 0.95) == 95
     assert workload.percentile(values, 0.99) == 99
+
+
+def test_windows_peak_rss_uses_typed_64_bit_process_memory_api():
+    fake, current_process, get_process_memory_info = fake_windows_ctypes(
+        peak_rss=8_388_608
+    )
+    assert workload._windows_peak_rss_bytes(fake) == 8_388_608
+    assert current_process.argtypes == []
+    assert current_process.restype is ctypes.c_void_p
+    assert get_process_memory_info.restype is ctypes.c_int32
+    assert get_process_memory_info.argtypes[0] is ctypes.c_void_p
+
+
+def test_windows_peak_rss_surfaces_api_failure():
+    fake, _current_process, _get_process_memory_info = fake_windows_ctypes(
+        ok=False, error=5
+    )
+    with pytest.raises(OSError) as failure:
+        workload._windows_peak_rss_bytes(fake)
+    assert failure.value.errno == 5
+    assert "GetProcessMemoryInfo failed" in str(failure.value)
+
+
+def test_windows_peak_rss_rejects_zero_result():
+    fake, _current_process, _get_process_memory_info = fake_windows_ctypes(peak_rss=0)
+    with pytest.raises(RuntimeError, match="non-positive peak RSS"):
+        workload._windows_peak_rss_bytes(fake)
+
+
+def test_windows_peak_rss_surfaces_process_exit_race():
+    fake, _current_process, _get_process_memory_info = fake_windows_ctypes(
+        ok=False, error=6
+    )
+    with pytest.raises(OSError) as failure:
+        workload._windows_peak_rss_bytes(fake)
+    assert failure.value.errno == 6
+
+
+def test_posix_peak_rss_normalizes_platform_units_and_rejects_zero():
+    usage = SimpleNamespace(ru_maxrss=2048)
+    resource = SimpleNamespace(RUSAGE_SELF=0, getrusage=lambda _target: usage)
+    assert workload._posix_peak_rss_bytes(resource, "darwin") == 2048
+    assert workload._posix_peak_rss_bytes(resource, "linux") == 2048 * 1024
+    usage.ru_maxrss = 0
+    with pytest.raises(RuntimeError, match="non-positive peak RSS"):
+        workload._posix_peak_rss_bytes(resource, "linux")
 
 
 def test_quick_workload_covers_every_required_service_plane_facet():


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Bounded evidence hardening for an existing Python KFX asyncio qualification; no ADR record changes."}
-->

## Summary

- use typed Win32 process-memory APIs for Python KFX peak RSS collection
- fail closed on missing, zero, malformed, or unavailable RSS evidence
- enforce the same rule during parsing, qualification, and independent evidence verification
- supersede #2351 after a range-diff-equivalent replay onto the latest protected base

## Verification

- `./shifu test:python-kfx-asyncio-performance`
- `./shifu check:source`
- `git range-diff 3d3a62efd9fc5054cb4cee137123731067bc6e55..fc4aa89f9c830d3ae9954caca9b851d104eb5910 ec1553bc66c22798303827ac18b97030f01db517..0f130cae81a141abbabf7f47948912ab63c088b5`

## Assignment

- Initiative: `2026-07-15-kungfu-core-native-kfx-runtime`
- Assignment: `2026-08-03-kungfu-python-kfx-asyncio-evidence-hardening`
- Work-definition root: `sha256:56750de84d13515d282cd2ed8f30481d795be176ee8a4e5ca097bc29df5afc81`