### PR TITLE
fix(product): stabilize runtime digest before manifest generation

### DIFF
--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:a754241abadd488fca5ad7944316d02861106213916c96a226451d4136f6a3a1",
+  "sourceRoot": "sha256:bd35c1509b151fc934b2fe9e36043581cbe794df7a52c52b3c377d9ddf9a4021",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -652,9 +652,9 @@
         },
         {
           "path": "product/scripts/dist.mjs",
-          "currentLines": 1942,
+          "currentLines": 1956,
           "baselineLines": 2514,
-          "currentRoot": "sha256:4d05f42f2685ed497d3c7a4c8a43eda62618e11a2ec256f85152165a6e40a6b4",
+          "currentRoot": "sha256:fae18c57373bad7730ea851b511f5d048776ba75e85b370710cbb21902522834",
           "baselineRoot": "sha256:6cfd6c55e296163ab863fb1d79a4a51198ad12943274fc0858338bb651a108da",
           "changedSinceBaseline": true
         },
@@ -1948,7 +1948,7 @@
         "topology": "product-assembly",
         "kind": "line-count",
         "status": "remediated",
-        "metric": 1942,
+        "metric": 1956,
         "threshold": 2450,
         "finding": null
       },

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -942,9 +942,23 @@ function stageTrunk(runtimePinSnapshot) {
     runtimePinSnapshot.runtimePins,
     'utf8',
   );
+  materializeProductRuntimeEntrypoints(CORE_DIST);
   console.log(
     '[product] kungfu-trunk + runtime-pins.env staged into core dist',
   );
+}
+
+export function materializeProductRuntimeEntrypoints(
+  runtimeRoot,
+  platform = process.platform,
+) {
+  if (platform === 'win32') return;
+  for (const executable of [
+    path.join(runtimeRoot, 'kungfu'),
+    path.join(runtimeRoot, 'python', 'bin', 'python3'),
+  ]) {
+    symlinks.materializeRegularFile(executable);
+  }
 }
 
 function platformId() {

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -20,6 +20,7 @@ import {
   installedKungfuInvocation,
   isShippedKfdSupport,
   kfxBundleExternalModules,
+  materializeProductRuntimeEntrypoints,
   requiresManagedEsbuildPlatform,
   runInstalledKungfuAgentHubSmoke,
   runInstalledKungfuAssignmentAdmissionSmoke,
@@ -325,6 +326,31 @@ test('CLI product materializes symlinked demo executables as regular files', (t)
   assert.equal(fs.lstatSync(python).isSymbolicLink(), false);
   assert.equal(fs.readFileSync(python, 'utf8'), 'python\n');
   assert.notEqual(fs.statSync(python).mode & 0o111, 0);
+});
+
+test('CLI runtime identity is stable after demo executable metadata', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-runtime-id-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const layout = cliArchiveLayout('linux');
+  const runtimeRoot = path.join(root, layout.runtimeDirectory);
+  const python = path.join(root, layout.pythonEntrypoint);
+  const pythonTarget = path.join(path.dirname(python), 'python3.13');
+  fs.mkdirSync(path.dirname(python), { recursive: true });
+  fs.writeFileSync(path.join(root, layout.launcherName), '#!/bin/sh\nexit 0\n');
+  fs.writeFileSync(path.join(root, layout.runtimeEntrypoint), 'runtime\n');
+  fs.writeFileSync(pythonTarget, 'python\n');
+  fs.chmodSync(pythonTarget, 0o755);
+  fs.symlinkSync('python3.13', python);
+
+  materializeProductRuntimeEntrypoints(runtimeRoot, 'linux');
+  const manifest = buildCliUpgradeManifest({ stageRoot: root, layout });
+  writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root);
+
+  assert.equal(fs.lstatSync(python).isFile(), true);
+  assert.equal(
+    manifest.runtimeArtifactDigest,
+    `sha256:${sha256Tree(runtimeRoot)}`,
+  );
 });
 
 test('CLI product rejects demo executable symlinks to non-files', (t) => {


### PR DESCRIPTION
## Summary

Materialize POSIX runtime entrypoints before Product identity manifests are computed so later executable metadata cannot invalidate the declared CLI runtime digest.

## Changes

- Materialize the bundled `kungfu` and Python entrypoints before manifest hashing.
- Add a focused regression covering a symlinked Python runtime and later demo metadata writes.
- Refresh the generated semantic amplification report after the bounded Product change.

## Verification

- `node --test product/scripts/dist.test.mjs` (40 passed)
- `./shifu check:source`
- `./shifu maintainability:amplification --write` (0 issues)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded packaging-order bug fix preserves the existing Product identity and promotion contracts."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change preserves existing release identity authority and adds a regression test for digest stability.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
- [x] Relevant checks and focused tests pass






