### PR TITLE
chore(buildchain): repin dev admission queue fix

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -120,9 +120,9 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@cf9d88fd08c604515baa0757bab2980e5cbc8740
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@12043e826f995f9f4ba5dfa457df55a869ab10b9
     with:
-      buildchain-ref: cf9d88fd08c604515baa0757bab2980e5cbc8740
+      buildchain-ref: 12043e826f995f9f4ba5dfa457df55a869ab10b9
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number || '0') }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -520,9 +520,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:94b036563321b10eabe02eeb9950fe9df544631fb8ae6335d38bdc5d620c132e",
+          "definitionDigest": "sha256:78aef7613bc615a018ed0ca13bf61bd0879376159e25d3f9bc9dbeae0e79ad21",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@cf9d88fd08c604515baa0757bab2980e5cbc8740"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@12043e826f995f9f4ba5dfa457df55a869ab10b9"],
           "steps": []
         },
         {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -177,7 +177,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:908d58d4c1f8dc4a1fff281c21f6ea97cbefb4129267860ff0f758004094e758"
+          "sourceRoot": "sha256:20bdd6b8aa01f08d1f019ee0b61092c411fb75c6e9e259d760ce50ce9eacb374"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -846,5 +846,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:7d22bad3ced9fd1c6576840a5c8e4ba87465bd92374c1d71070d9feaa070d862"
+  "registryRoot": "sha256:036ae3329b87cb0ee813957e149468143bfa332fd66a5e0375f83a400f052416"
 }

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -13,7 +13,7 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
   const reusableRef = workflow.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/u,
   )?.[1];
-  assert.equal(reusableRef, 'cf9d88fd08c604515baa0757bab2980e5cbc8740');
+  assert.equal(reusableRef, '12043e826f995f9f4ba5dfa457df55a869ab10b9');
   assert.match(workflow, new RegExp(`buildchain-ref: ${reusableRef}`, 'u'));
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(workflow, /cron: "23,53 \* \* \* \*"/u);


### PR DESCRIPTION
## Summary

- repin the Dev PR admission reusable workflow to protected Buildchain `12043e826f995f9f4ba5dfa457df55a869ab10b9`
- refresh workflow authority and publication source roots
- preserve exact-SHA, independent-review, required-check, readiness, and native merge-queue boundaries

## Verification

- focused Dev PR admission tests: 4/4
- Alpha promotion preflight: 67/67
- Gate Catalog: 38 gates aligned
- release publication control plane: 9/9
- repository staged source acceptance: passed

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Repin the existing Dev delivery controller to the protected Buildchain queue-mode parser fix without changing product decisions or public contracts."}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects Dev delivery control only and does not publish a release.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

Supersedes #2399 after protected dev advanced; r2 and its branch are retained as audit evidence.