### PR TITLE
fix(profile): restore installed Work conformance

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -304,6 +304,42 @@ function copyFirstPartyProfile(source, destination) {
 }
 
 /**
+ * Stage the same Work Profile conformance closure as the wheel build.  The
+ * assembled product copies Python sources directly, so wheel build_py hooks do
+ * not run for this tree.
+ *
+ * @param {string} destination
+ * @param {string} repositoryRoot
+ */
+function copyWorkProfileConformance(
+  destination,
+  repositoryRoot = path.resolve(CORE, '..', '..'),
+) {
+  const source = path.join(
+    repositoryRoot,
+    'framework',
+    'work-profile-conformance',
+  );
+  fs.cpSync(source, destination, { recursive: true });
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(source, 'authority-manifest.json'), 'utf8'),
+  );
+  const authorityRoot = path.join(destination, 'authority');
+  const repositoryBoundary = path.resolve(repositoryRoot) + path.sep;
+  for (const coordinate of manifest.files) {
+    const sourceFile = path.resolve(repositoryRoot, coordinate.path);
+    if (!sourceFile.startsWith(repositoryBoundary)) {
+      throw new Error(
+        `[freeze] invalid Work conformance authority path: ${coordinate.path}`,
+      );
+    }
+    const destinationFile = path.join(authorityRoot, coordinate.path);
+    fs.mkdirSync(path.dirname(destinationFile), { recursive: true });
+    fs.copyFileSync(sourceFile, destinationFile);
+  }
+}
+
+/**
  * A hoisted pnpm install can satisfy a Suite dependency only from the
  * repository root, leaving the Suite's own node_modules absent.  Installed
  * Profiles cannot depend on that build-worktree layout, so copy every declared
@@ -900,6 +936,9 @@ function assembleTree(bt) {
     path.join(CORE, '..', 'exit', 'kungfu-exit-bundle.contract.json'),
     path.join(layout.sitePackages, 'kungfu', 'exit_bundle.contract.json'),
   );
+  copyWorkProfileConformance(
+    path.join(layout.sitePackages, 'kungfu', 'work_profile_conformance'),
+  );
   const documentationDestination = path.join(
     layout.sitePackages,
     'kungfu',
@@ -1100,6 +1139,7 @@ if (require.main === module) main();
 module.exports = {
   assemblySelector,
   copyFirstPartyProfile,
+  copyWorkProfileConformance,
   documentationAtlasSource,
   firstPartyProfileFilter,
   portableAtlasBundleSource,

--- a/framework/core/src/python/kungfu/profile_sdk.py
+++ b/framework/core/src/python/kungfu/profile_sdk.py
@@ -94,6 +94,26 @@ def _work_profile_conformance_script() -> Path | None:
     return next((candidate for candidate in candidates if candidate.is_file()), None)
 
 
+def _work_profile_conformance_invocation(
+    checker: Path,
+) -> tuple[list[str], dict[str, str] | None]:
+    for variable in (
+        "KUNGFU_CONTROLLER_ENTRYPOINT",
+        "KUNGFU_AGENT_SESSION_EXECUTABLE",
+    ):
+        value = os.environ.get(variable)
+        embedded = Path(value).expanduser().resolve() if value else None
+        if embedded is not None and embedded.is_file():
+            environment = os.environ.copy()
+            environment["KUNGFU_AS_VARIANT"] = "node"
+            environment["KUNGFU_NODE_VARIANT_ENTRY"] = str(checker)
+            return [str(embedded), str(checker)], environment
+    if node := shutil.which("node"):
+        return [node, str(checker)], None
+    message = "Work Profile conformance checker is unavailable"
+    raise ProfileSdkError("work-profile-conformance-checker-unavailable", message)
+
+
 def _work_profile_conformance(
     inspection: Mapping[str, Any], surface: str
 ) -> dict[str, Any] | None:
@@ -123,16 +143,16 @@ def _work_profile_conformance(
             expected=expected,
             actual=actual,
         )
-    checker, node = _work_profile_conformance_script(), shutil.which("node")
-    if checker is None or node is None:
+    checker = _work_profile_conformance_script()
+    if checker is None:
         raise ProfileSdkError(
             "work-profile-conformance-checker-unavailable",
             "Work Profile conformance checker is unavailable",
         )
+    command, environment = _work_profile_conformance_invocation(checker)
     completed = subprocess.run(
         [
-            node,
-            str(checker),
+            *command,
             "--declaration",
             str(declaration_path),
             "--surface",
@@ -141,6 +161,7 @@ def _work_profile_conformance(
         ],
         check=False,
         capture_output=True,
+        env=environment,
         text=True,
     )
     if completed.returncode != 0:

--- a/framework/core/tests/python/test_agent_profile_sdk.py
+++ b/framework/core/tests/python/test_agent_profile_sdk.py
@@ -88,6 +88,37 @@ def create_symlink_or_skip(link: Path, target: Path) -> None:
         raise
 
 
+def test_work_conformance_prefers_the_embedded_product_node_host(tmp_path, monkeypatch):
+    front_door = tmp_path / "kungfu"
+    front_door.write_bytes(b"")
+    checker = tmp_path / "work-profile-conformance.mjs"
+    checker.write_bytes(b"")
+    monkeypatch.setenv("KUNGFU_CONTROLLER_ENTRYPOINT", str(front_door))
+    monkeypatch.setattr(profile_sdk.shutil, "which", lambda _name: "/poison/node")
+
+    command, environment = profile_sdk._work_profile_conformance_invocation(checker)
+
+    assert command == [str(front_door.resolve()), str(checker)]
+    assert environment is not None
+    assert environment["KUNGFU_AS_VARIANT"] == "node"
+    assert environment["KUNGFU_NODE_VARIANT_ENTRY"] == str(checker)
+
+
+def test_work_conformance_falls_back_to_path_node_without_a_product_host(
+    tmp_path, monkeypatch
+):
+    checker = tmp_path / "work-profile-conformance.mjs"
+    checker.write_bytes(b"")
+    monkeypatch.delenv("KUNGFU_CONTROLLER_ENTRYPOINT", raising=False)
+    monkeypatch.delenv("KUNGFU_AGENT_SESSION_EXECUTABLE", raising=False)
+    monkeypatch.setattr(profile_sdk.shutil, "which", lambda _name: "/toolchain/node")
+
+    command, environment = profile_sdk._work_profile_conformance_invocation(checker)
+
+    assert command == ["/toolchain/node", str(checker)]
+    assert environment is None
+
+
 def test_scaffold_writes_the_exact_planned_utf8_bytes(tmp_path):
     source = tmp_path / "profile"
     plan = profile_sdk.scaffold_plan(brief(), source)

--- a/framework/maintainability/abstraction-integrity-report.json
+++ b/framework/maintainability/abstraction-integrity-report.json
@@ -6,14 +6,14 @@
   "measurement": {
     "aggregates": {
       "kungfu-cli": 20550,
-      "kungfu-flat-root": 36590,
+      "kungfu-flat-root": 36611,
       "kungfu-runtime-family": 6246
     },
     "counts": {
       "productionFiles": 254,
-      "productionPhysicalLines": 87175,
+      "productionPhysicalLines": 87196,
       "testFiles": 107,
-      "testPhysicalLines": 47859
+      "testPhysicalLines": 47890
     },
     "hiddenProductionFiles": [],
     "modulesOver1000": [
@@ -79,7 +79,7 @@
       },
       {
         "path": "framework/core/src/python/kungfu/profile_sdk.py",
-        "physicalLines": 2068
+        "physicalLines": 2089
       },
       {
         "path": "framework/core/src/python/kungfu/rewind/reflection_fb.py",
@@ -109,7 +109,7 @@
     "modulesOver2000": [
       {
         "path": "framework/core/src/python/kungfu/profile_sdk.py",
-        "physicalLines": 2068
+        "physicalLines": 2089
       },
       {
         "path": "framework/core/src/python/kungfu/runtime_service.py",
@@ -208,10 +208,10 @@
         "responsibilities": 34
       },
       {
-        "contentRoot": "sha256:c749c2f64c3ef8087d95286a9fd6cdc2b4f7e223947504da12476fb6cc107a0f",
+        "contentRoot": "sha256:bf08cb858e48ae62160bdf8d822da986174efb2106dabf47d0f3a1420c9f6ee9",
         "path": "framework/core/src/python/kungfu/profile_sdk.py",
-        "physicalLines": 2068,
-        "responsibilities": 58
+        "physicalLines": 2089,
+        "responsibilities": 59
       },
       {
         "contentRoot": "sha256:fdca45c45c93bbaf9cc8090eb7813e386bc4cf47d235a3c8c237655caca17235",
@@ -364,7 +364,7 @@
       }
     ],
     "schema": "kungfu.python-structure-measurement/v1",
-    "sourceRoot": "sha256:9d9d6a810edf4602318888a9116af28db2d16e064aa6967c2df7ef5748f279c0",
+    "sourceRoot": "sha256:3ca7f244da4e8fad613d064ffcdeefadc1eb970479eddabce963764ed005c094",
     "sourceRoots": {
       "production": [
         "framework/core/src/python"
@@ -576,9 +576,9 @@
     "kungfu.runtime_broker.NativeReadinessAuthority",
     "kungfu.runtime_service.ProcessRuntimeHost"
   ],
-  "reportRoot": "sha256:1866962470566e332408b9fae6ec90e3fd5268426ad1ffc5e7aec26286670660",
+  "reportRoot": "sha256:00c6fc5ff91fc91bbbeb2f975a83954b5e84b85b2c799dae328a603436195eb8",
   "schema": "kungfu.abstraction-integrity-report/v1",
-  "sourceRoot": "sha256:9d9d6a810edf4602318888a9116af28db2d16e064aa6967c2df7ef5748f279c0",
+  "sourceRoot": "sha256:3ca7f244da4e8fad613d064ffcdeefadc1eb970479eddabce963764ed005c094",
   "summary": {
     "blockingIssues": 0
   },

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:65e68c3c0664a18e6f18f29ff22ed983daaa1c9541bd6239ee3e9cf098860dd4",
+  "sourceRoot": "sha256:444d322292cf6f8b9dfecfb05c352082e36afb3afa360f7384c299ef69453bf8",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -409,9 +409,9 @@
         },
         {
           "path": "framework/core/src/python/kungfu/profile_sdk.py",
-          "currentLines": 2068,
+          "currentLines": 2089,
           "baselineLines": 3138,
-          "currentRoot": "sha256:c749c2f64c3ef8087d95286a9fd6cdc2b4f7e223947504da12476fb6cc107a0f",
+          "currentRoot": "sha256:bf08cb858e48ae62160bdf8d822da986174efb2106dabf47d0f3a1420c9f6ee9",
           "baselineRoot": "sha256:fb62fb8c4e1e944811c954d22786ebaeb21ff45dbb3fc1db705feb37fbb5dc1c",
           "changedSinceBaseline": true
         },
@@ -596,9 +596,9 @@
         },
         {
           "path": "framework/core/src/python/kungfu/profile_sdk.py",
-          "currentLines": 2068,
+          "currentLines": 2089,
           "baselineLines": 3138,
-          "currentRoot": "sha256:c749c2f64c3ef8087d95286a9fd6cdc2b4f7e223947504da12476fb6cc107a0f",
+          "currentRoot": "sha256:bf08cb858e48ae62160bdf8d822da986174efb2106dabf47d0f3a1420c9f6ee9",
           "baselineRoot": "sha256:fb62fb8c4e1e944811c954d22786ebaeb21ff45dbb3fc1db705feb37fbb5dc1c",
           "changedSinceBaseline": true
         },

--- a/framework/spec/generated/registry.json
+++ b/framework/spec/generated/registry.json
@@ -96,7 +96,7 @@
       "protocol_id": "kungfu.kfx.manifest/v1",
       "source": "config/kungfu-kfx.contract.json",
       "source_role": "KFX-identity-neutral-package-declaration-schema",
-      "source_root": "sha256:5df5537fa161de8a210b1facac7cec5cf054b3a5eff4096fb27fec4370fd9e6c",
+      "source_root": "sha256:f0e6cfddac711123a969d7d88c8995b95fcb397b99438674902372fb38ff8d0c",
       "version_axis": "KFX package manifest schema version"
     },
     {
@@ -157,7 +157,7 @@
       },
       {
         "path": "config/kungfu-kfx.contract.json",
-        "root": "sha256:5df5537fa161de8a210b1facac7cec5cf054b3a5eff4096fb27fec4370fd9e6c"
+        "root": "sha256:f0e6cfddac711123a969d7d88c8995b95fcb397b99438674902372fb38ff8d0c"
       },
       {
         "path": "framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/common.h",

--- a/scripts/documentation-product-pack.test.mjs
+++ b/scripts/documentation-product-pack.test.mjs
@@ -16,6 +16,7 @@ const require = createRequire(import.meta.url);
 const {
   assemblySelector,
   copyFirstPartyProfile,
+  copyWorkProfileConformance,
   documentationAtlasSource,
   firstPartyProfileFilter,
   requireAssemblySelector,
@@ -138,6 +139,34 @@ test('freeze assembly stages the selected verified Atlas into the product', () =
   assert.match(source, /documentationDestination/);
   assert.match(source, /portableAtlasBundleSource\(\)/);
   assert.match(source, /classification\.json\.gz/);
+});
+
+test('freeze assembly stages the complete Work conformance checker closure', (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-work-conformance-pack-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+  copyWorkProfileConformance(temporary, ROOT);
+
+  assert.equal(
+    fs.existsSync(path.join(temporary, 'work-profile-conformance.mjs')),
+    true,
+  );
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(temporary, 'authority-manifest.json'), 'utf8'),
+  );
+  for (const coordinate of manifest.files) {
+    const installed = path.join(temporary, 'authority', coordinate.path);
+    assert.equal(fs.existsSync(installed), true, coordinate.path);
+    assert.equal(
+      `sha256:${crypto
+        .createHash('sha256')
+        .update(fs.readFileSync(installed))
+        .digest('hex')}`,
+      coordinate.sha256,
+      coordinate.path,
+    );
+  }
 });
 
 test('freeze assembly accepts only the assembled product selector', () => {


### PR DESCRIPTION
## Summary

- stage the complete Work Profile conformance checker closure into assembled CLI products
- execute installed conformance through the embedded Kungfu Node front door
- preserve standalone node fallback for source and wheel development
- refresh deterministic authority and maintainability projections required by current Dev

## Validation

- ./shifu check:source: passed
- cold read-only bootstrap: passed
- documentation product pack: 9 passed, including complete checker closure hash verification
- Python structure: blockingIssues 0
- semantic amplification: issues 0
- Spec generated authority: current
- Project Cut replay against current Dev: qualified

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded installed-product repair restores the existing Work Profile conformance contract and changes no ADR authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above