### PR TITLE
fix(product): stage Work conformance in assembled runtime

### DIFF
--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -41,6 +41,39 @@ function copyConfigContract() {
   copyContractArtifacts(path.join(CORE, 'dist', 'kungfu'));
 }
 
+function copyWorkProfileConformance(kungfuPackage, repositoryRoot) {
+  const source = path.join(
+    repositoryRoot,
+    'framework',
+    'work-profile-conformance',
+  );
+  const destination = path.join(kungfuPackage, 'work_profile_conformance');
+  fs.cpSync(source, destination, { recursive: true });
+
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(source, 'authority-manifest.json'), 'utf8'),
+  );
+  const resolvedRoot = path.resolve(repositoryRoot);
+  for (const coordinate of manifest.files) {
+    const sourceFile = path.resolve(resolvedRoot, coordinate.path);
+    if (
+      sourceFile !== resolvedRoot &&
+      !sourceFile.startsWith(`${resolvedRoot}${path.sep}`)
+    ) {
+      throw new Error(
+        `invalid Work conformance authority path: ${coordinate.path}`,
+      );
+    }
+    const destinationFile = path.join(
+      destination,
+      'authority',
+      coordinate.path,
+    );
+    fs.mkdirSync(path.dirname(destinationFile), { recursive: true });
+    fs.copyFileSync(sourceFile, destinationFile);
+  }
+}
+
 function buildType() {
   return shell.getConfigValue('build_type') || 'Release';
 }
@@ -900,6 +933,10 @@ function assembleTree(bt) {
     path.join(CORE, '..', 'exit', 'kungfu-exit-bundle.contract.json'),
     path.join(layout.sitePackages, 'kungfu', 'exit_bundle.contract.json'),
   );
+  copyWorkProfileConformance(
+    path.join(layout.sitePackages, 'kungfu'),
+    path.resolve(CORE, '..', '..'),
+  );
   const documentationDestination = path.join(
     layout.sitePackages,
     'kungfu',
@@ -1100,6 +1137,7 @@ if (require.main === module) main();
 module.exports = {
   assemblySelector,
   copyFirstPartyProfile,
+  copyWorkProfileConformance,
   documentationAtlasSource,
   firstPartyProfileFilter,
   portableAtlasBundleSource,

--- a/framework/core/.gyp/run-freeze.js
+++ b/framework/core/.gyp/run-freeze.js
@@ -41,6 +41,10 @@ function copyConfigContract() {
   copyContractArtifacts(path.join(CORE, 'dist', 'kungfu'));
 }
 
+/**
+ * @param {string} kungfuPackage
+ * @param {string} repositoryRoot
+ */
 function copyWorkProfileConformance(kungfuPackage, repositoryRoot) {
   const source = path.join(
     repositoryRoot,

--- a/framework/work-profile-conformance/work-profile-conformance.test.mjs
+++ b/framework/work-profile-conformance/work-profile-conformance.test.mjs
@@ -3,6 +3,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -18,6 +19,10 @@ import {
 const ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../..',
+);
+const require = createRequire(import.meta.url);
+const { copyWorkProfileConformance } = require(
+  path.join(ROOT, 'framework/core/.gyp/run-freeze.js'),
 );
 const SCRIPT = path.join(
   ROOT,
@@ -62,6 +67,45 @@ test('qualifies agent, calendar, and non-agent reference scenarios', () => {
       { scenarioId: 'course-production', verdict: 'compatible' },
     ],
   );
+});
+
+test('stages the Work conformance checker and exact authority bundle into assembled products', (t) => {
+  const temporary = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-work-conformance-product-'),
+  );
+  t.after(() => fs.rmSync(temporary, { recursive: true, force: true }));
+
+  copyWorkProfileConformance(temporary, ROOT);
+  assert.ok(
+    fs
+      .statSync(
+        path.join(
+          temporary,
+          'work_profile_conformance/work-profile-conformance.mjs',
+        ),
+      )
+      .isFile(),
+  );
+  const manifest = JSON.parse(
+    fs.readFileSync(
+      path.join(temporary, 'work_profile_conformance/authority-manifest.json'),
+      'utf8',
+    ),
+  );
+  for (const coordinate of manifest.files) {
+    assert.ok(
+      fs
+        .statSync(
+          path.join(
+            temporary,
+            'work_profile_conformance/authority',
+            coordinate.path,
+          ),
+        )
+        .isFile(),
+      coordinate.path,
+    );
+  }
 });
 
 test('returns a versioned, rooted, schema-valid compatible result', () => {


### PR DESCRIPTION
## Summary

Stage the Work Profile conformance checker and its exact authority bundle into the assembled Product runtime, matching the existing wheel package-data contract and unblocking installed-layout CLI smoke.

## Changes

- Add one bounded freeze helper that copies the checker and every authority-manifest coordinate into the assembled `kungfu` package.
- Reject repository-escaping authority coordinates before copying.
- Add a regression that proves the checker and every declared authority file reach the Product package.

## Verification

- `./shifu check:work-profile-conformance` (15 passed)
- `./node_modules/.bin/biome check --no-errors-on-unmatched framework/core/.gyp/run-freeze.js framework/work-profile-conformance/work-profile-conformance.test.mjs`
- `./shifu check:staged`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded package-data closure aligns the assembled runtime with the existing wheel contract and preserves Work Profile authority semantics."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change adds missing package data without weakening Product smoke or promotion gates.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
- [x] Relevant checks and focused tests pass