### PR TITLE
fix(ci): align v3 checkout bootstrap workflow pins

### DIFF
--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -79,9 +79,9 @@ jobs:
       pull-requests: write
     # The reusable workflow and its runtime are pinned to the same merged,
     # immutable Buildchain source.
-    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@978520e86134683f66b607bc70c2d18f623e2410
+    uses: kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '978520e86134683f66b607bc70c2d18f623e2410' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || '825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3' }}
       source-branch: ${{ needs.resolve-channels.outputs.source-branch }}
       target-branch: ${{ needs.resolve-channels.outputs.target-branch }}
       dev-workflow-path: .github/workflows/dev-verify-patrol.yml

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3
     with:
       # Keep the reviewed Gate workflow shell and its streamed runtime aligned
       # by default. Trusted manual runs may still supply an exact SHA or train

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -466,9 +466,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c429cbf8300dc962fdc7f975241e9454b55f3a36caeb65239fdade78673bb85d",
+          "definitionDigest": "sha256:dcf6a1a0429ae7df5abe3a28910df41cc199b51b52c45d1add0d22a62e5f1cc0",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@978520e86134683f66b607bc70c2d18f623e2410"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-alpha-candidate-patrol.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3"],
           "steps": []
         },
         {
@@ -584,9 +584,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:5c48dc34b7eab862016e0fe250421066fc17139476cec001f545eaa2f92f2d5c",
+          "definitionDigest": "sha256:194cbfe3c7186b5d57cc595ba9f491fbb742eec49d2bc1e7b0a669f06374df8b",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3"],
           "steps": []
         }
       ]

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -341,7 +341,7 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3",
         "with": {
           "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
           "cargo-registry-index": "${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -170,7 +170,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:4943256e8198fa1a8dc868202e8307728ba186de82de37e51522b39582f30816"
+          "sourceRoot": "sha256:bb5717535c601db3746cce2812e03b35b20e6bf2db3c7434e3d2af9b99d0c479"
         },
         {
           "path": ".github/workflows/dev-pr-auto-merge.yml",
@@ -213,7 +213,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:fad9a5a41a0f91fdf60e3f7eea658906e8c133a5fb5d5cbaeb3abc5af11d6bf8"
+          "sourceRoot": "sha256:093b14145afce7081c12b1042a24649557f9eb10fdab2d1aed939be36860c3b6"
         },
         {
           "path": ".github/workflows/docs-check.yml",
@@ -853,5 +853,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:802e4611bff0dc4d14d1a364f6007f8ed32811da6f6bd82c5e34ee28619a6fe1"
+  "registryRoot": "sha256:b7a7074b41a732580723d260fbd093bb27b7d744762a99178f49e97c26475c4f"
 }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -1019,7 +1019,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@f8ef93be41b0badd75eb35cc1506c2be12198984',
+        '.gate-profile.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3',
         '.gate-profile.yml@v2-alpha',
       ),
   );

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { test } from 'node:test';
 
 const ROOT = process.cwd();
+const BUILDCHAIN_TIMEOUT_SAFE_RUNTIME =
+  '825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3';
 
 function workflow(name) {
   return fs.readFileSync(path.join(ROOT, '.github/workflows', name), 'utf8');
@@ -28,6 +30,10 @@ test('Dev Patrol is exact-source dispatch-only behind the qualification controll
     source,
     /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| '[0-9a-f]{40}' \}\}/u,
   );
+  const reusableRef = source.match(
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.gate-profile\.yml@([0-9a-f]{40})/u,
+  )?.[1];
+  assert.equal(reusableRef, BUILDCHAIN_TIMEOUT_SAFE_RUNTIME);
 });
 
 test('qualification patrol coalesces the latest Dev SHA behind release priority', () => {
@@ -64,7 +70,7 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
     /uses: kungfu-systems\/buildchain\/.github\/workflows\/dev-alpha-candidate-patrol\.yml@([0-9a-f]{40})/u,
   )?.[1];
   assert.match(reusableRef || '', /^[0-9a-f]{40}$/u);
-  assert.equal(reusableRef, '978520e86134683f66b607bc70c2d18f623e2410');
+  assert.equal(reusableRef, BUILDCHAIN_TIMEOUT_SAFE_RUNTIME);
   assert.match(
     source,
     new RegExp(


### PR DESCRIPTION
## Summary

Align both qualification controllers with the merged Buildchain v3 timeout-safe runtime `825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3`. The shell-level checkout bootstrap and candidate default now resolve the same immutable runtime, and generated governance projections are refreshed.

## Root cause

Dev Verify accepted the new runtime input but its initial shell checkout still downloaded `locked-source-checkout.mjs` from the older `f8ef...` pin. That artifact did not contain the new `git-fetch-process-tree.mjs`, so all platforms failed before the runtime could take authority.

## Verification

- complete staged pre-commit gate passed
- `./shifu project-cut:queue-admission -- --base origin/dev/v4/v4.0 --head HEAD` qualified one replayed commit with zero diagnostics
- `./shifu check:source` reached 1001/1012 before environment-only cold-fixture dependency discovery
- `SHIFU_CACHE_ACTIVE=1 ./shifu exec node --test scripts/readonly-agent-bootstrap.test.mjs` passed the isolated cold fixture after a frozen project sync
- Atlas exact-head work admission verified at `61193b82a1dcfb497adc42f2d236dc7d76f21377`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair immutable workflow runtime alignment for an already-approved Buildchain v3 implementation without changing product architecture or authority semantics."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage updated
- [x] Protected replay was validated before upload
- [x] No secrets, credentials, tokens, or private logs are included
