### PR TITLE
fix(update): rebind selected CLI runtime environment

### DIFF
--- a/framework/core/src/python/kungfu/distribution_update.py
+++ b/framework/core/src/python/kungfu/distribution_update.py
@@ -1337,8 +1337,7 @@ def selected_cli_command(
     if env.get("KUNGFU_INSTALL_SOURCE") != "archive":
         return None
     config_home = Path(env.get("KF_CONFIG_HOME") or "~/.kungfu-config").expanduser()
-    selected = _read_cli_selection(config_home)
-    if selected is None:
+    if (selected := _read_cli_selection(config_home)) is None:
         return None
     selection, image = selected
     if release_cut.is_legacy_bootstrap(selection):
@@ -1351,10 +1350,8 @@ def selected_cli_command(
             "cli-selection-invalid", "selected CLI executable is missing or unsafe"
         )
     current = Path(current_executable or sys.executable).resolve()
-    if (
-        current == executable
-        or env.get("KUNGFU_SELECTED_FRONTEND_BUILD_ID") == frontend_build_id
-    ):
+    selected_id = env.get("KUNGFU_SELECTED_FRONTEND_BUILD_ID")
+    if current == executable or selected_id == frontend_build_id:
         return None
     selected_env = dict(env)
     selected_env.update(

--- a/framework/core/src/python/kungfu/distribution_update.py
+++ b/framework/core/src/python/kungfu/distribution_update.py
@@ -1360,8 +1360,12 @@ def selected_cli_command(
     selected_env.update(
         {
             "KUNGFU_SELECTED_FRONTEND_BUILD_ID": frontend_build_id,
+            "KUNGFU_DIR": str(executable.parent),
             "KUNGFU_PRODUCT_MANIFEST": str(root / image["productManifest"]),
             "KUNGFU_UPGRADE_MANIFEST": str(root / image["upgradeManifest"]),
+            "KF_BUNDLED_EXTENSION_ROOT": str(root / "extensions"),
+            "KUNGFU_AGENT_SESSION_EXECUTABLE": str(executable),
+            "KUNGFU_CONTROLLER_ENTRYPOINT": str(executable),
         }
     )
     if selection.get("releaseCutRoot"):

--- a/framework/core/tests/python/test_distribution_update.py
+++ b/framework/core/tests/python/test_distribution_update.py
@@ -1002,6 +1002,10 @@ def test_apply_installs_runtime_and_selects_versioned_cli_on_next_command(
         {
             "KUNGFU_INSTALL_SOURCE": "archive",
             "KF_CONFIG_HOME": str(tmp_path / "config"),
+            "KUNGFU_DIR": str(tmp_path / "stale-runtime"),
+            "KF_BUNDLED_EXTENSION_ROOT": str(tmp_path / "stale-extensions"),
+            "KUNGFU_AGENT_SESSION_EXECUTABLE": str(tmp_path / "stale-agent"),
+            "KUNGFU_CONTROLLER_ENTRYPOINT": str(tmp_path / "stale-controller"),
         },
         current_executable=tmp_path / "original" / "kungfu",
     )
@@ -1011,6 +1015,14 @@ def test_apply_installs_runtime_and_selects_versioned_cli_on_next_command(
     assert (
         selected_env["KUNGFU_SELECTED_FRONTEND_BUILD_ID"] == manifest["frontendBuildId"]
     )
+    selected_executable = Path(command[0])
+    selected_root = Path(frontend["productRoot"])
+    assert Path(selected_env["KUNGFU_DIR"]) == selected_executable.parent
+    assert (
+        Path(selected_env["KF_BUNDLED_EXTENSION_ROOT"]) == selected_root / "extensions"
+    )
+    assert Path(selected_env["KUNGFU_AGENT_SESSION_EXECUTABLE"]) == selected_executable
+    assert Path(selected_env["KUNGFU_CONTROLLER_ENTRYPOINT"]) == selected_executable
     assert (
         distribution_update.selected_cli_command(
             selected_env,


### PR DESCRIPTION
## Summary

- rebind selected archive CLI runtime variables to the selected executable and product root
- prevent stale bootstrap environment from redirecting native Agent Session helpers to an older image
- preserve the exact Python structure budget while adding regression coverage

## Verification

- `./shifu check`
- 134 distribution, update, and runtime-upgrade tests passed
- `python3 scripts/check-python-structure.py --emit-report` (issues: none; `kungfu-flat-root`: 36612/36612)

## ADR release classification

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores the existing selected CLI image authority and does not change an architecture contract"
}
-->

## Evolution

- none

## Governance

- provider-native CLI path checked
