### PR TITLE
fix(core): deduplicate materialized Python entrypoint

### DIFF
--- a/framework/core/.gyp/core-platform-package.js
+++ b/framework/core/.gyp/core-platform-package.js
@@ -325,6 +325,51 @@ function copyPlatformPayload(packageRoot) {
 }
 
 /**
+ * Product assembly may materialize both the stable Python entrypoint and its
+ * versioned source as regular files. npm cannot express their original
+ * symlink relationship, so retain only the stable entrypoint when the bytes
+ * prove that the versioned file is redundant. Ambiguous or divergent runtime
+ * layouts fail closed instead of silently changing the packaged interpreter.
+ * @param {string} packageRoot
+ * @param {string} relative
+ * @returns {void}
+ */
+function deduplicateMaterializedPythonEntrypoint(packageRoot, relative) {
+  if (relative !== 'python/bin/python3') return;
+  const target = path.join(packageRoot, 'dist', 'kungfu', relative);
+  if (!fs.existsSync(target) || !fs.lstatSync(target).isFile()) return;
+  const directory = path.dirname(target);
+  const candidates = fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^python3\.\d+$/u.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  if (candidates.length === 0) return;
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Python entrypoint has ambiguous versioned sources: ${candidates.join(', ')}`,
+    );
+  }
+  const redundantTarget = path.join(directory, candidates[0]);
+  const targetBytes = fs.readFileSync(target);
+  const redundantBytes = fs.readFileSync(redundantTarget);
+  const targetRoot = crypto.createHash('sha256').update(targetBytes).digest();
+  const redundantRoot = crypto
+    .createHash('sha256')
+    .update(redundantBytes)
+    .digest();
+  if (
+    targetBytes.length !== redundantBytes.length ||
+    !crypto.timingSafeEqual(targetRoot, redundantRoot)
+  ) {
+    throw new Error(
+      `Python entrypoint differs from versioned source: ${candidates[0]}`,
+    );
+  }
+  fs.removeSync(redundantTarget);
+}
+
+/**
  * npm excludes symbolic links from package archives. Materialize only the
  * platform interpreter entrypoint that consumers execute directly; preserve
  * the rest of the assembled runtime tree unchanged.
@@ -336,7 +381,11 @@ function materializePythonEntrypoint(packageRoot) {
     process.platform === 'win32' ? 'python/python.exe' : 'python/bin/python3';
   const source = path.join(bindingDir, relative);
   const target = path.join(packageRoot, 'dist', 'kungfu', relative);
-  if (!fs.existsSync(target) || !fs.lstatSync(target).isSymbolicLink()) return;
+  if (!fs.existsSync(target)) return;
+  if (!fs.lstatSync(target).isSymbolicLink()) {
+    deduplicateMaterializedPythonEntrypoint(packageRoot, relative);
+    return;
+  }
   const realSource = fs.realpathSync(source);
   const mode = fs.statSync(realSource).mode;
   fs.removeSync(target);
@@ -920,6 +969,7 @@ if (require.main === module)
   });
 
 module.exports = {
+  deduplicateMaterializedPythonEntrypoint,
   evaluateLinuxPackageBudget,
   linuxReleaseStripCandidates,
   packageBudgetComponent,

--- a/framework/core/tests/core-platform-package.test.js
+++ b/framework/core/tests/core-platform-package.test.js
@@ -2,6 +2,8 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 const contract = require('../core-platform-package.contract.json');
@@ -13,6 +15,7 @@ const {
   resolveRuntimeDir,
 } = require('../lib/platform-packages');
 const {
+  deduplicateMaterializedPythonEntrypoint,
   evaluateLinuxPackageBudget,
   linuxReleaseStripCandidates,
   packageBudgetComponent,
@@ -20,6 +23,16 @@ const {
   summarizePackageBudgetComponents,
   verifyFinalLinuxPackageBudget,
 } = require('../.gyp/core-platform-package');
+
+function pythonPackageFixture(t) {
+  const packageRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-core-platform-package-'),
+  );
+  const binDir = path.join(packageRoot, 'dist', 'kungfu', 'python', 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  t.after(() => fs.rmSync(packageRoot, { recursive: true, force: true }));
+  return { packageRoot, binDir };
+}
 
 test('explicit package stage paths resolve from the repository root', () => {
   const repositoryRoot = path.resolve(__dirname, '..', '..', '..');
@@ -169,6 +182,41 @@ test('Linux package prunes the unused dbm accelerator before size enforcement', 
   const dbmAccelerator = 'lib/python3.13/lib-dynload/_dbm*';
   assert.ok(stdlibPrune.prune.linux.includes(dbmAccelerator));
   assert.equal(stdlibPrune.prune.darwin.includes(dbmAccelerator), false);
+});
+
+test('package projection removes a byte-identical versioned Python entrypoint', (t) => {
+  const { packageRoot, binDir } = pythonPackageFixture(t);
+  const stableEntrypoint = path.join(binDir, 'python3');
+  const versionedEntrypoint = path.join(binDir, 'python3.13');
+  fs.writeFileSync(stableEntrypoint, 'identical-python-runtime');
+  fs.writeFileSync(versionedEntrypoint, 'identical-python-runtime');
+
+  deduplicateMaterializedPythonEntrypoint(packageRoot, 'python/bin/python3');
+
+  assert.equal(
+    fs.readFileSync(stableEntrypoint, 'utf8'),
+    'identical-python-runtime',
+  );
+  assert.equal(fs.existsSync(versionedEntrypoint), false);
+});
+
+test('package projection rejects divergent materialized Python entrypoints', (t) => {
+  const { packageRoot, binDir } = pythonPackageFixture(t);
+  const stableEntrypoint = path.join(binDir, 'python3');
+  const versionedEntrypoint = path.join(binDir, 'python3.13');
+  fs.writeFileSync(stableEntrypoint, 'stable-python-runtime');
+  fs.writeFileSync(versionedEntrypoint, 'different-python-runtime');
+
+  assert.throws(
+    () =>
+      deduplicateMaterializedPythonEntrypoint(
+        packageRoot,
+        'python/bin/python3',
+      ),
+    /Python entrypoint differs from versioned source: python3\.13/u,
+  );
+  assert.equal(fs.existsSync(stableEntrypoint), true);
+  assert.equal(fs.existsSync(versionedEntrypoint), true);
 });
 
 test('Linux Release stripping is explicit and excludes runtimes owned upstream', () => {


### PR DESCRIPTION
## Summary

- deduplicate the identical materialized Python interpreter only inside the Linux npm package projection
- retain the complete source runtime and fail closed on ambiguous or divergent layouts
- restore the existing protected package hard ceiling without changing the ceiling

## Validation

- focused platform-package tests: 15/15 passed
- exact-checkout `./shifu build:core`: passed
- exact `./shifu check:source`: passed with identical before/after source roots on the equivalent repair
- agent-120 exact Linux x64 product build: passed
- npm tgz: 104776694 bytes; guarded 104842230; hard 104857600
- projected runtime contains one regular `python3`; source runtime remains unchanged

## Delivery boundary

This is a bounded packaging correction. Terminal completion remains bound to protected delivery, delivered-tree source acceptance, the exact-root Linux/macOS/Windows matrix, different-actor review, and native Assignment seal verification.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded package-projection correction preserves existing runtime and release contracts without changing ADR authority."
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTAxLWt1bmdmdS1wcm90ZWN0ZWQtc291cmNlLXRlcm1pbmFsLWNsb3N1cmUiLCJkZWxpdmVyeUNsYXNzIjoibmF0aXZlLXByb29mLXJlcXVpcmVkIiwiZGV2SGVhZCI6IjNjMjE2YTRiNzM5ZDVjZjhlMmRiNGViZDA1ZWE4MTY5YjRkMTVmYzIiLCJwdWxsUmVxdWVzdEhlYWQiOiIwZTUwMzNkZjI4ZTI0YTY1MTJiZWY1ZTEwNWUxM2NhZmNlOTlmZWU1IiwicmVwbGF5ZWRDYW5kaWRhdGUiOiIxNTMyNjViNWQ3MzZkZTBhY2U0MzQ1OTJkZDM4OGZlNTA1OWYzZDg5IiwicmVwbGF5ZWRUcmVlIjoiMmQ3MjJiN2U4MjQ4NzU4N2M2Yjg4OGI3ZGVkYTQxZTdiZDAwZTZkOSIsInF1ZXVlQXR0ZW1wdCI6IjBlNTAzM2RmMjhlMjRhNjUxMmJlZjVlMTA1ZTEzY2FmY2U5OWZlZTVAM2MyMTZhNGI3MzlkNWNmOGUyZGI0ZWJkMDVlYTgxNjliNGQxNWZjMiIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjplNDlmMTM0NTAwNDk1NjNmMTlmNThjODg2ZDcwYWFhYzZmZDQ1YTBlYzY3OGExMGQ5MGM0ODkwNzZmZjMzNWMwIiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6ZDkxZThjZTQxNDkyODAwZjEwNjlmYjkwMmFlY2ViNmU3OTJmYTk3ZDY1Y2Y4MWQyODlhNThkNDQyZjA3MjcyZSIsInNoYTI1NjplNDlmMTM0NTAwNDk1NjNmMTlmNThjODg2ZDcwYWFhYzZmZDQ1YTBlYzY3OGExMGQ5MGM0ODkwNzZmZjMzNWMwIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1Njo2Yzg1N2VmNzgzMjc1NjliNGVhYWMxMzU2ZWFiMzMyZjRhNWI3NzI1ZjgyM2I1OGQ3ODliZGEwYzJjNWRiZjQ3In0 -->