### PR TITLE
fix(shifu): avoid quoted Windows package script executable

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -624,7 +624,12 @@ test('real package manager cannot run a guarded task or write the checkout', (t)
     path.join(runtime.runtimeRoot, 'kungfu-package-manager-guard-'),
   );
   const guard = path.join(ROOT, 'scripts', 'require-shifu.mjs');
-  const node = JSON.stringify(process.execPath);
+  // cmd.exe reparses a quoted executable in the first package-script token.
+  // Resolve the current Node through PATH on Windows so the guard itself runs.
+  const node =
+    process.platform === 'win32'
+      ? path.basename(process.execPath)
+      : JSON.stringify(process.execPath);
   const guardPath = JSON.stringify(guard);
   fs.writeFileSync(
     path.join(fixture, 'package.json'),


### PR DESCRIPTION
## Summary

Avoid a Windows cmd.exe reparsing failure in the package-manager guard fixture by resolving the current Node executable through PATH on Windows.

## Root cause

A quoted absolute executable was emitted as the first package-script token. pnpm passed that command through cmd.exe, which rejected the nested leading quotes before the Shifu guard could run.

## Verification

- node --test scripts/check-shifu-entry-contract.test.mjs scripts/run-shifu-lifecycle.test.mjs
- repository staged gate
- The candidate shifu CI reproduced the original failure twice on windows-2022

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This test-fixture correction preserves the existing Shifu entry contract and does not alter architecture authority."
}
-->

Evolution impact: none

Governance risk: none; the change is limited to a test fixture and preserves source-checkout immutability assertions.