### PR TITLE
fix(shifu): normalize Windows guard fixture paths

### DIFF
--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -624,8 +624,8 @@ test('real package manager cannot run a guarded task or write the checkout', (t)
     path.join(runtime.runtimeRoot, 'kungfu-package-manager-guard-'),
   );
   const guard = path.join(ROOT, 'scripts', 'require-shifu.mjs');
-  const node = JSON.stringify(process.execPath);
-  const guardPath = JSON.stringify(guard);
+  const node = JSON.stringify(process.execPath.replaceAll('\\', '/'));
+  const guardPath = JSON.stringify(guard.replaceAll('\\', '/'));
   fs.writeFileSync(
     path.join(fixture, 'package.json'),
     `${JSON.stringify(


### PR DESCRIPTION
## Summary

Normalize absolute Windows paths in the package-manager guard test fixture before nested JSON and cmd.exe serialization.

## Changes

- Convert Node and guard fixture paths to forward-slash form before JSON stringification.
- Preserve Shifu commands, authority, safety boundaries, and product behavior.

## Verification

- `node --test scripts/check-shifu-entry-contract.test.mjs` (27/27)
- `./shifu check:entry-contract`
- full staged pre-commit gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This test-fixture path serialization fix does not alter an architecture contract or production behavior"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation is unchanged because product behavior is unchanged
