### PR TITLE
fix(qualification): serialize source suites before distribution

### DIFF
--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -26,6 +26,7 @@ const PRODUCT_CONSUMER_SUITES = new Set([
   'product-verification',
   'product-catalog',
 ]);
+const PRODUCT_DISTRIBUTION_SUITE = 'product-distribution';
 
 export const SUITES = [
   {
@@ -444,9 +445,10 @@ export async function runSuite(suite, outputDir) {
 }
 
 /**
- * Execute source/runtime producers together, then fan out product consumers
- * after product-distribution has settled. Every required suite runs and the
- * returned order remains the declared contract order.
+ * Execute source/runtime qualification before product-distribution mutates the
+ * shared build layout, then fan out product consumers after the distribution
+ * has settled. Every required suite runs and the returned order remains the
+ * declared contract order.
  */
 export async function executeQualificationSuites(
   suites,
@@ -457,14 +459,19 @@ export async function executeQualificationSuites(
   if (!Number.isInteger(maxParallelism) || maxParallelism < 1)
     throw new Error('runtime activation maxParallelism must be positive');
   const required = suites.filter((suite) => suite.required);
-  const producers = required.filter(
-    (suite) => !PRODUCT_CONSUMER_SUITES.has(suite.id),
+  const sourceSuites = required.filter(
+    (suite) =>
+      suite.id !== PRODUCT_DISTRIBUTION_SUITE &&
+      !PRODUCT_CONSUMER_SUITES.has(suite.id),
+  );
+  const distribution = required.filter(
+    (suite) => suite.id === PRODUCT_DISTRIBUTION_SUITE,
   );
   const consumers = required.filter((suite) =>
     PRODUCT_CONSUMER_SUITES.has(suite.id),
   );
   const results = new Map();
-  for (const group of [producers, consumers]) {
+  for (const group of [sourceSuites, distribution, consumers]) {
     let cursor = 0;
     const workers = Array.from(
       { length: Math.min(maxParallelism, group.length) },

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -162,7 +162,7 @@ test('product catalog qualification is bound to the build from this checkout', (
   ]);
 });
 
-test('runtime activation uses a bounded producer and consumer DAG without hiding sibling failures', async () => {
+test('runtime activation protects source bindings behind a distribution barrier', async () => {
   const suites = qualificationPlan({ mode: 'execute', withProduct: true });
   const events = [];
   let active = 0;
@@ -194,19 +194,21 @@ test('runtime activation uses a bounded producer and consumer DAG without hiding
     'failed',
   );
   assert.ok(result.every((suite) => suite.status !== 'planned'));
+  const distributionStart = events.indexOf('start:product-distribution');
+  const distributionEnd = events.indexOf('end:product-distribution');
+  for (const id of [
+    'activation-core',
+    'profile-action-admission',
+    'runtime-surface-parity',
+    'activation-performance',
+  ])
+    assert.ok(events.indexOf(`end:${id}`) < distributionStart, id);
   const firstConsumer = Math.min(
     ...['product-runtime-smoke', 'product-verification', 'product-catalog'].map(
       (id) => events.indexOf(`start:${id}`),
     ),
   );
-  for (const id of [
-    'activation-core',
-    'product-distribution',
-    'profile-action-admission',
-    'runtime-surface-parity',
-    'activation-performance',
-  ])
-    assert.ok(events.indexOf(`end:${id}`) < firstConsumer, id);
+  assert.ok(distributionEnd < firstConsumer, 'product-distribution');
 });
 
 test('source qualification uv runs preserve the exact tracked lockfile', () => {


### PR DESCRIPTION
## Summary

Prevent runtime activation source suites from racing product distribution while both use the shared Core build layout.

## Root cause

The Linux x64 Formal Build ran profile-action-admission concurrently with product-distribution. Distribution rebuilt the shared Core layout after pykungfu had been assembled, so the profile suite transiently lost the exact current-checkout binding.

## Changes

- complete all source and runtime suites before product distribution mutates the shared layout
- run product distribution as an explicit barrier
- fan out product consumers only after distribution settles
- retain every existing suite and failure result

## Verification

- node --test framework/core/tests/qualification/runtime-activation/run.test.mjs (21/21)
- repository commit-time staged gate
- 73 Dev-gate tests, 17 invariant tests, and 138 documentation tests
- native Assignment run gate with exact Work Control and Dogfood Profile roots

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This qualification scheduling fix preserves the existing runtime activation, Profile, and release contracts while removing a shared-build-layout race."
}
-->

Evolution impact: none

Governance risk: release qualification evidence is affected; verification keeps every required gate and makes their execution order deterministic.

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [x] Commits are signed off (DCO)
- [x] Documentation is not required because the public behavior and contracts are unchanged.