### PR TITLE
fix(delivery): expose terminal store token

### DIFF
--- a/.github/workflows/dev-delivery-warrant-terminal.yml
+++ b/.github/workflows/dev-delivery-warrant-terminal.yml
@@ -42,6 +42,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           EVENT_ACTION: ${{ github.event.action }}
           EXPECTED_PR: ${{ github.event.pull_request.number }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -503,10 +503,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:02b59990c1403d4a0c1c9e0920cfa95a3ff094db00db6d28471077b8df5bfe78",
+          "definitionDigest": "sha256:89a78ee6c6d2857cdfbf1d1029635ca9f3d2f208e37aae501906784808c52d0d",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:e3330854a32bd7b28109442f181580e771da3c9c0f4ef7b9395ce63ce37fcabf"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:3c05dee3b497c2ac837219f3b85acca6daf345d3608a31c2cb5fa1761a102f96"}]
+          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:e3330854a32bd7b28109442f181580e771da3c9c0f4ef7b9395ce63ce37fcabf"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:27d33234108145000881cac9974391105c78a69896db4e6260bb0fbeb7e1f7f7"}]
         }
       ]
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -177,7 +177,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:31c245f48ca6c9cdf3c957065c0272b31a8f08ba4b02ed4c3b611e00351c5535"
+          "sourceRoot": "sha256:e3d3229deda0f87e7b900f9b80d77d95ee0f559bb9c58ed493d6d29825e30ef6"
         },
         {
           "path": ".github/workflows/dev-pr-auto-merge.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:3e8ca14c745aa73bfe890c32f28faac5710d780688bc8f13e546da5fc5ff331b"
+  "registryRoot": "sha256:ae5eed56d4232e2ecea3be764e8b4d7f7cfa2d722308407da5e394f8452a0c80"
 }

--- a/scripts/dev-delivery-warrant-input.test.mjs
+++ b/scripts/dev-delivery-warrant-input.test.mjs
@@ -172,6 +172,8 @@ test('terminal consumer executes only protected event and Buildchain authority',
   assert.match(workflow, /pull_request_target:/u);
   assert.match(workflow, /types: \[closed, dequeued\]/u);
   assert.match(workflow, /No matching active Warrant/u);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/u);
+  assert.match(workflow, /GITHUB_TOKEN: \$\{\{ github\.token \}\}/u);
   assert.match(
     workflow,
     /dev-delivery-warrant-close\.yml@3550081196f08f4dd5a195aee484dc1ddaa8bdd5/u,


### PR DESCRIPTION
## Summary

Expose the protected GitHub token under both names consumed by the terminal workflow: `GH_TOKEN` for `gh` and `GITHUB_TOKEN` for the pinned Buildchain Warrant store.

This repairs the protected evidence failure observed after #2463 without changing Warrant selection, queue admission, or terminal authority.

## Verification

- `node --test scripts/dev-delivery-warrant-input.test.mjs` (4 passed)
- `./shifu check:release-publication-control-plane`
- refreshed workflow authority and publication-control-plane roots
- full staged repository gate; the one transient Git-sensitive rehearsal passed 16/16 on isolated rerun
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded workflow environment repair preserves the existing delivery authority and changes no architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this only passes the existing ephemeral workflow token to the already-pinned protected Buildchain runtime; no token is persisted or broadened.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed