### PR TITLE
fix(agent): support native sessions on Windows

### DIFF
--- a/framework/core/src/python/kungfu/agent/native_launch.py
+++ b/framework/core/src/python/kungfu/agent/native_launch.py
@@ -34,11 +34,15 @@ def _non_terminal_streams() -> list[str]:
 
 def _native_terminal_route(provider: str) -> NativeTerminalRoute | None:
     missing = _non_terminal_streams()
-    if not missing:
-        return None
-
     if os.name == "nt":
+        # Windows console launchers can expose CRT descriptors that Python
+        # reports as TTYs while their inherited Win32 handles are not usable as
+        # terminal input by a child Node/Rust UI.  Reopen the controlling
+        # console for every provider-native child so the child receives stable
+        # console handles instead of launcher-specific inherited handles.
         route = NativeTerminalRoute("CONIN$", "CONOUT$", "CONOUT$")
+    elif not missing:
+        return None
     elif os.name == "posix":
         route = NativeTerminalRoute("/dev/tty", "/dev/tty", "/dev/tty")
     else:
@@ -51,7 +55,7 @@ def _native_terminal_route(provider: str) -> NativeTerminalRoute | None:
             if not os.isatty(terminal.fileno()):
                 raise OSError("controlling terminal is not a TTY")
     except OSError as error:
-        descriptors = ", ".join(missing)
+        descriptors = ", ".join(missing) or "inherited Windows console handles"
         raise ValueError(
             f"provider-native UI '{provider}' requires an interactive terminal; "
             f"non-terminal descriptors: {descriptors}. No controlling terminal is "

--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -1,19 +1,176 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import hashlib
+import json
+import math
 import os
 from pathlib import Path
 import shutil
 import socket
 import sys
+import time
 from typing import Protocol
 
 from kungfu.agent.session_contract import semantic_root
 from kungfu.workspace import WorkspaceTargetRequired, resolve_workspace_target
 
 
-MAX_RESPONSE_BYTES = 1024 * 1024
+MAX_MESSAGE_BYTES = 1024 * 1024
+_READ_CHUNK_BYTES = 65536
+
+
+def _deadline(timeout):
+    if timeout <= 0:
+        raise ValueError("Agent Session timeout must be positive")
+    return time.monotonic() + timeout
+
+
+def _remaining_milliseconds(deadline, operation):
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise TimeoutError(f"Agent Session {operation} timed out")
+    return max(1, math.ceil(remaining * 1000))
+
+
+def _encode_request(request):
+    payload = json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n"
+    if len(payload) > MAX_MESSAGE_BYTES:
+        raise ValueError("Agent Session request exceeds 1 MiB")
+    return payload
+
+
+def _decode_response(response):
+    decoded = json.loads(bytes(response).split(b"\n", 1)[0])
+    if not isinstance(decoded, dict):
+        raise ValueError("Agent Session response must be a JSON object")
+    return decoded
+
+
+def _append_response(response, chunk):
+    if not chunk:
+        raise ValueError("Agent Session surface closed without a response")
+    response.extend(chunk)
+    if len(response) > MAX_MESSAGE_BYTES:
+        raise ValueError("Agent Session response exceeds 1 MiB")
+
+
+def _invoke_unix_socket(target, payload, timeout):
+    if not hasattr(socket, "AF_UNIX"):
+        raise ValueError("Agent Session Unix socket transport is unavailable")
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout)
+        client.connect(target)
+        client.sendall(payload)
+        response = bytearray()
+        while b"\n" not in response:
+            _append_response(response, client.recv(_READ_CHUNK_BYTES))
+    return response
+
+
+def _open_named_pipe(target, deadline, api):
+    retryable = {api.ERROR_PIPE_BUSY, api.ERROR_SEM_TIMEOUT}
+    while True:
+        wait_ms = _remaining_milliseconds(deadline, "named-pipe connect")
+        try:
+            api.WaitNamedPipe(target, wait_ms)
+            return api.CreateFile(
+                target,
+                api.GENERIC_READ | api.GENERIC_WRITE,
+                0,
+                api.NULL,
+                api.OPEN_EXISTING,
+                api.FILE_FLAG_OVERLAPPED,
+                api.NULL,
+            )
+        except OSError as error:
+            if getattr(error, "winerror", None) not in retryable:
+                raise
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    "Agent Session named-pipe connect timed out"
+                ) from error
+
+
+def _complete_overlapped(api, overlapped, error, deadline, operation):
+    if error == api.ERROR_IO_PENDING:
+        wait_ms = _remaining_milliseconds(deadline, operation)
+        wait_result = api.WaitForMultipleObjects([overlapped.event], False, wait_ms)
+        if wait_result == api.WAIT_TIMEOUT:
+            overlapped.cancel()
+            try:
+                overlapped.GetOverlappedResult(True)
+            except OSError:
+                pass
+            raise TimeoutError(f"Agent Session {operation} timed out")
+        if wait_result != api.WAIT_OBJECT_0:
+            overlapped.cancel()
+            raise OSError(
+                f"Agent Session {operation} wait failed with status {wait_result}"
+            )
+    transferred, completion_error = overlapped.GetOverlappedResult(True)
+    return transferred, completion_error
+
+
+def _write_named_pipe(api, handle, payload, deadline):
+    overlapped, error = api.WriteFile(handle, payload, overlapped=True)
+    transferred, completion_error = _complete_overlapped(
+        api, overlapped, error, deadline, "named-pipe write"
+    )
+    if completion_error:
+        message = (
+            "Agent Session named-pipe write failed with Windows error "
+            f"{completion_error}"
+        )
+        raise OSError(completion_error, message)
+    if transferred != len(payload):
+        raise OSError("Agent Session named-pipe write was incomplete")
+
+
+def _read_named_pipe(api, handle, deadline):
+    response = bytearray()
+    while b"\n" not in response:
+        try:
+            overlapped, error = api.ReadFile(handle, _READ_CHUNK_BYTES, overlapped=True)
+            transferred, completion_error = _complete_overlapped(
+                api, overlapped, error, deadline, "named-pipe read"
+            )
+        except OSError as raised:
+            if getattr(raised, "winerror", None) == api.ERROR_BROKEN_PIPE:
+                raise ValueError(
+                    "Agent Session surface closed without a response"
+                ) from raised
+            raise
+        if completion_error not in (0, api.ERROR_MORE_DATA):
+            if completion_error == api.ERROR_BROKEN_PIPE:
+                raise ValueError("Agent Session surface closed without a response")
+            raise OSError(
+                completion_error,
+                "Agent Session named-pipe read failed with Windows error "
+                f"{completion_error}",
+            )
+        _append_response(response, bytes(overlapped.getbuffer())[:transferred])
+    return response
+
+
+def _invoke_windows_named_pipe(target, payload, timeout):
+    import _winapi as api
+
+    deadline = _deadline(timeout)
+    handle = _open_named_pipe(target, deadline, api)
+    try:
+        _write_named_pipe(api, handle, payload, deadline)
+        return _read_named_pipe(api, handle, deadline)
+    finally:
+        getattr(api, "CloseHandle")(handle)
+
+
+def _invoke_transport(request, endpoint, timeout):
+    payload = _encode_request(request)
+    if sys.platform == "win32":
+        response = _invoke_windows_named_pipe(endpoint, payload, timeout)
+    else:
+        response = _invoke_unix_socket(endpoint, payload, timeout)
+    return _decode_response(response)
 
 
 def effective_work_ref(envelope):
@@ -166,26 +323,7 @@ def invoke(request, endpoint=None, timeout=5.0):
             "Agent Session surface is unavailable; open the Kungfu product or "
             "run inside a Kungfu Agent Console"
         )
-    if not hasattr(socket, "AF_UNIX"):
-        raise ValueError(
-            "Agent Session local actions are currently supported on macOS/Linux"
-        )
-    payload = json.dumps(request, separators=(",", ":")).encode("utf-8") + b"\n"
-    if len(payload) > MAX_RESPONSE_BYTES:
-        raise ValueError("Agent Session request exceeds 1 MiB")
-    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
-        client.settimeout(timeout)
-        client.connect(target)
-        client.sendall(payload)
-        response = bytearray()
-        while b"\n" not in response:
-            chunk = client.recv(65536)
-            if not chunk:
-                raise ValueError("Agent Session surface closed without a response")
-            response.extend(chunk)
-            if len(response) > MAX_RESPONSE_BYTES:
-                raise ValueError("Agent Session response exceeds 1 MiB")
-    decoded = json.loads(bytes(response).split(b"\n", 1)[0])
+    decoded = _invoke_transport(request, target, timeout)
     if not decoded.get("ok"):
         error = decoded.get("error") or {}
         raise ValueError(

--- a/framework/core/tests/python/test_agent_native_terminal_contract.py
+++ b/framework/core/tests/python/test_agent_native_terminal_contract.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import sys
 from types import SimpleNamespace
 
 from click.testing import CliRunner
@@ -9,6 +10,7 @@ import pytest
 from kungfu.agent import native_launch
 from kungfu.agent import run_agent
 from kungfu.agent import runtime_profiles
+from kungfu.agent import session_surface
 from kungfu.cli.commands import agent as agent_commands, kfc
 
 
@@ -249,3 +251,249 @@ def test_native_terminal_route_reports_the_non_terminal_descriptors(monkeypatch)
 
     assert "non-terminal descriptors: stdin, stderr" in str(error.value)
     assert "terminal or PTY" in str(error.value)
+
+
+def test_windows_native_terminal_route_reopens_console_even_when_crt_fds_are_ttys(
+    monkeypatch,
+):
+    opened = []
+
+    class ConsoleInput:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def fileno(self):
+            return 0
+
+    monkeypatch.setattr(native_launch.os, "name", "nt")
+    monkeypatch.setattr(native_launch.os, "isatty", lambda _descriptor: True)
+    monkeypatch.setattr(
+        native_launch,
+        "open",
+        lambda path, *_args, **_kwargs: opened.append(path) or ConsoleInput(),
+        raising=False,
+    )
+
+    route = native_launch._native_terminal_route("codex")
+
+    assert route == native_launch.NativeTerminalRoute("CONIN$", "CONOUT$", "CONOUT$")
+    assert opened == ["CONIN$"]
+
+
+class WindowsError(OSError):
+    def __init__(self, winerror, message="Windows named-pipe error"):
+        super().__init__(winerror, message)
+        self.winerror = winerror
+
+
+class FakeOverlapped:
+    def __init__(self, buffer, completion_error=0):
+        self.event = object()
+        self.buffer = buffer
+        self.completion_error = completion_error
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+    def GetOverlappedResult(self, _wait):
+        if self.cancelled:
+            raise WindowsError(995, "operation aborted")
+        return len(self.buffer), self.completion_error
+
+    def getbuffer(self):
+        return self.buffer
+
+
+class FakeWinApi:
+    ERROR_BROKEN_PIPE = 109
+    ERROR_IO_PENDING = 997
+    ERROR_MORE_DATA = 234
+    ERROR_PIPE_BUSY = 231
+    ERROR_SEM_TIMEOUT = 121
+    FILE_FLAG_OVERLAPPED = 0x40000000
+    GENERIC_READ = 0x80000000
+    GENERIC_WRITE = 0x40000000
+    NULL = 0
+    OPEN_EXISTING = 3
+    WAIT_OBJECT_0 = 0
+    WAIT_TIMEOUT = 258
+
+    def __init__(
+        self,
+        response=b'{"ok":true,"value":{"answer":42}}\n',
+        *,
+        busy_count=0,
+        unavailable=False,
+        wait_results=None,
+    ):
+        self.read_buffer = bytearray(response)
+        self.busy_count = busy_count
+        self.unavailable = unavailable
+        self.wait_results = list(wait_results or [])
+        self.wait_named_pipe_calls = []
+        self.writes = []
+        self.overlapped = []
+        self.closed = []
+
+    def WaitNamedPipe(self, target, timeout):
+        self.wait_named_pipe_calls.append((target, timeout))
+        if self.unavailable:
+            raise WindowsError(2, "pipe not found")
+        if self.busy_count:
+            self.busy_count -= 1
+            raise WindowsError(self.ERROR_PIPE_BUSY, "pipe busy")
+
+    def CreateFile(self, *_args):
+        return 73
+
+    def WriteFile(self, _handle, payload, *, overlapped):
+        assert overlapped is True
+        self.writes.append(payload)
+        operation = FakeOverlapped(payload)
+        self.overlapped.append(operation)
+        return operation, self.ERROR_IO_PENDING
+
+    def ReadFile(self, _handle, size, *, overlapped):
+        assert overlapped is True
+        if not self.read_buffer:
+            raise WindowsError(self.ERROR_BROKEN_PIPE, "pipe closed")
+        chunk = bytes(self.read_buffer[:size])
+        del self.read_buffer[:size]
+        operation = FakeOverlapped(chunk)
+        self.overlapped.append(operation)
+        return operation, self.ERROR_IO_PENDING
+
+    def WaitForMultipleObjects(self, _events, _wait_all, _timeout):
+        if self.wait_results:
+            return self.wait_results.pop(0)
+        return self.WAIT_OBJECT_0
+
+    def CloseHandle(self, handle):
+        self.closed.append(handle)
+
+
+def install_windows_api(monkeypatch, api):
+    monkeypatch.setattr(session_surface.sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "_winapi", api)
+
+
+def test_windows_endpoint_uses_the_runtime_scoped_named_pipe(monkeypatch, tmp_path):
+    monkeypatch.setattr(session_surface.sys, "platform", "win32")
+    first = session_surface.endpoint_for_runtime(tmp_path / "runtime")
+    second = session_surface.endpoint_for_runtime(tmp_path / "runtime")
+
+    assert first == second
+    assert first.startswith(r"\\.\pipe\kungfu-agent-session-")
+
+
+def test_windows_named_pipe_preserves_json_line_framing(monkeypatch):
+    api = FakeWinApi()
+    install_windows_api(monkeypatch, api)
+
+    result = session_surface._invoke_transport(
+        {"operation": "capabilities"},
+        r"\\.\pipe\kungfu-agent-session-test",
+        timeout=1.0,
+    )
+
+    assert result == {"ok": True, "value": {"answer": 42}}
+    assert api.writes == [b'{"operation":"capabilities"}\n']
+    assert api.closed == [73]
+
+
+def test_windows_named_pipe_retries_a_busy_instance(monkeypatch):
+    api = FakeWinApi(busy_count=1)
+    install_windows_api(monkeypatch, api)
+
+    session_surface._invoke_transport(
+        {"operation": "list"},
+        r"\\.\pipe\kungfu-agent-session-test",
+        timeout=1.0,
+    )
+
+    assert len(api.wait_named_pipe_calls) == 2
+    assert api.closed == [73]
+
+
+def test_windows_named_pipe_surfaces_an_unavailable_endpoint(monkeypatch):
+    api = FakeWinApi(unavailable=True)
+    install_windows_api(monkeypatch, api)
+
+    with pytest.raises(OSError) as raised:
+        session_surface._invoke_transport(
+            {"operation": "list"},
+            r"\\.\pipe\missing",
+            timeout=1.0,
+        )
+
+    assert raised.value.winerror == 2
+    assert api.closed == []
+
+
+def test_windows_named_pipe_cancels_a_timed_out_read(monkeypatch):
+    api = FakeWinApi(wait_results=[FakeWinApi.WAIT_OBJECT_0, FakeWinApi.WAIT_TIMEOUT])
+    install_windows_api(monkeypatch, api)
+
+    with pytest.raises(TimeoutError, match="named-pipe read timed out"):
+        session_surface._invoke_transport(
+            {"operation": "list"},
+            r"\\.\pipe\kungfu-agent-session-test",
+            timeout=1.0,
+        )
+
+    assert api.overlapped[-1].cancelled is True
+    assert api.closed == [73]
+
+
+def test_windows_named_pipe_rejects_a_malformed_response(monkeypatch):
+    api = FakeWinApi(response=b"{not-json}\n")
+    install_windows_api(monkeypatch, api)
+
+    with pytest.raises(json.JSONDecodeError):
+        session_surface._invoke_transport(
+            {"operation": "list"},
+            r"\\.\pipe\kungfu-agent-session-test",
+            timeout=1.0,
+        )
+
+
+def test_windows_named_pipe_rejects_a_non_object_response(monkeypatch):
+    api = FakeWinApi(response=b"[]\n")
+    install_windows_api(monkeypatch, api)
+
+    with pytest.raises(ValueError, match="response must be a JSON object"):
+        session_surface._invoke_transport(
+            {"operation": "list"},
+            r"\\.\pipe\kungfu-agent-session-test",
+            timeout=1.0,
+        )
+
+
+def test_windows_named_pipe_rejects_an_oversized_response(monkeypatch):
+    api = FakeWinApi(response=b"x" * (session_surface.MAX_MESSAGE_BYTES + 1))
+    install_windows_api(monkeypatch, api)
+
+    with pytest.raises(ValueError, match="response exceeds 1 MiB"):
+        session_surface._invoke_transport(
+            {"operation": "list"},
+            r"\\.\pipe\kungfu-agent-session-test",
+            timeout=1.0,
+        )
+
+
+def test_transport_rejects_an_oversized_request_before_connect(monkeypatch):
+    api = FakeWinApi()
+    install_windows_api(monkeypatch, api)
+
+    with pytest.raises(ValueError, match="request exceeds 1 MiB"):
+        session_surface._invoke_transport(
+            {"payload": "x" * session_surface.MAX_MESSAGE_BYTES},
+            r"\\.\pipe\kungfu-agent-session-test",
+            timeout=1.0,
+        )
+
+    assert api.wait_named_pipe_calls == []


### PR DESCRIPTION
## Summary

Enable the existing provider-native Agent Session architecture on Windows without changing Work authority or provider-specific semantics.

## Related issue

Atlas goal `2026-08-04-kungfu-windows-native-agent-session`.

## Changes

- add a bounded Windows named-pipe client beside the existing Unix socket transport
- reopen `CONIN$` and `CONOUT$` for every Windows provider-native child so packaged launchers do not pass unusable inherited handles
- retain the existing 1 MiB JSON-line contract, deadlines, cancellation, and fail-closed errors
- add transport, timeout, framing, size, close, and terminal-route regression coverage

## Verification

- `./shifu check:source`
- macOS Agent Console contract suite: passed
- DARKHERO focused Python contract suite: 137 passed, 2 skipped
- DARKHERO packaged TUI: rendered and exited normally
- DARKHERO packaged `kungfu run codex`, `kungfu run opencode`, and `kungfu run amp`: native UI entered, observer fresh, and exit normal
- DARKHERO same-Work concurrency: first provider bound; second provider remained usable but bind was rejected with actionable `native_work_already_active`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix activates the existing Agent Session transport and provider-native terminal contract on Windows without changing architecture ownership, Work authority, or public command semantics."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The touched provider boundary is limited to terminal handles and local Agent Session transport. Real Codex, OpenCode, and Amp CLIs were exercised on DARKHERO.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

No prose update is required because the public command and architecture contract are platform-neutral; executable tests now cover the Windows implementation.