### PR TITLE
fix(qualification): serialize native materialization

### DIFF
--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -444,9 +444,11 @@ export async function runSuite(suite, outputDir) {
 }
 
 /**
- * Execute source/runtime producers together, then fan out product consumers
- * after product-distribution has settled. Every required suite runs and the
- * returned order remains the declared contract order.
+ * Materialize the product first, then execute source/runtime checks, and only
+ * then fan out product consumers. Product distribution rebuilds native
+ * bindings, so it must not overlap suites that import those bindings. Every
+ * required suite runs and the returned order remains the declared contract
+ * order.
  */
 export async function executeQualificationSuites(
   suites,
@@ -457,14 +459,19 @@ export async function executeQualificationSuites(
   if (!Number.isInteger(maxParallelism) || maxParallelism < 1)
     throw new Error('runtime activation maxParallelism must be positive');
   const required = suites.filter((suite) => suite.required);
-  const producers = required.filter(
-    (suite) => !PRODUCT_CONSUMER_SUITES.has(suite.id),
+  const distribution = required.filter(
+    (suite) => suite.id === 'product-distribution',
+  );
+  const sourceProducers = required.filter(
+    (suite) =>
+      suite.id !== 'product-distribution' &&
+      !PRODUCT_CONSUMER_SUITES.has(suite.id),
   );
   const consumers = required.filter((suite) =>
     PRODUCT_CONSUMER_SUITES.has(suite.id),
   );
   const results = new Map();
-  for (const group of [producers, consumers]) {
+  for (const group of [distribution, sourceProducers, consumers]) {
     let cursor = 0;
     const workers = Array.from(
       { length: Math.min(maxParallelism, group.length) },

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -162,7 +162,7 @@ test('product catalog qualification is bound to the build from this checkout', (
   ]);
 });
 
-test('runtime activation uses a bounded producer and consumer DAG without hiding sibling failures', async () => {
+test('runtime activation materializes native bindings before bounded producer and consumer fan-out', async () => {
   const suites = qualificationPlan({ mode: 'execute', withProduct: true });
   const events = [];
   let active = 0;
@@ -194,6 +194,17 @@ test('runtime activation uses a bounded producer and consumer DAG without hiding
     'failed',
   );
   assert.ok(result.every((suite) => suite.status !== 'planned'));
+  const distributionEnd = events.indexOf('end:product-distribution');
+  for (const id of [
+    'activation-core',
+    'profile-action-admission',
+    'runtime-surface-parity',
+    'activation-performance',
+    'product-runtime-smoke',
+    'product-verification',
+    'product-catalog',
+  ])
+    assert.ok(distributionEnd < events.indexOf(`start:${id}`), id);
   const firstConsumer = Math.min(
     ...['product-runtime-smoke', 'product-verification', 'product-catalog'].map(
       (id) => events.indexOf(`start:${id}`),
@@ -201,7 +212,6 @@ test('runtime activation uses a bounded producer and consumer DAG without hiding
   );
   for (const id of [
     'activation-core',
-    'product-distribution',
     'profile-action-admission',
     'runtime-surface-parity',
     'activation-performance',

--- a/scripts/alpha-promotion-preflight.mjs
+++ b/scripts/alpha-promotion-preflight.mjs
@@ -159,28 +159,44 @@ export function inspectAuditableDemoFastSentinel({
   }
   const demos = scenarioValue?.demos || [];
   const autoplay = demos.find((demo) => demo?.id === 'agent-work-lab-autoplay');
-  const projectTour = demos.find((demo) => demo?.id === 'project-tour');
+  const projectTourEpisode1 = demos.find(
+    (demo) => demo?.id === 'project-tour-episode-1',
+  );
+  const projectTourEpisode2 = demos.find(
+    (demo) => demo?.id === 'project-tour-episode-2',
+  );
   if (
     scenarioValue?.schema !== 'buildchain.declarative-binary-demo/v1' ||
     scenarioValue?.execution?.durationClass !== 'long-form' ||
     scenarioValue?.execution?.totalTimeoutSeconds !== 180 ||
     scenarioValue?.authority?.grants?.length !== 0 ||
-    demos.length !== 2 ||
+    demos.length !== 3 ||
     JSON.stringify(autoplay?.steps?.[0]?.argv) !==
       JSON.stringify(['agent-work-lab', 'autoplay']) ||
-    JSON.stringify(projectTour?.steps?.[0]?.argv) !==
+    autoplay?.steps?.[0]?.timeoutSeconds !== 90 ||
+    JSON.stringify(projectTourEpisode1?.steps?.[0]?.argv) !==
       JSON.stringify([
         'agent-work-lab',
         'project-tour',
         '--episode',
-        'all',
+        '1',
         '--speed',
-        '4',
+        '1',
       ]) ||
-    projectTour?.steps?.[0]?.timeoutSeconds !== 180
+    projectTourEpisode1?.steps?.[0]?.timeoutSeconds !== 180 ||
+    JSON.stringify(projectTourEpisode2?.steps?.[0]?.argv) !==
+      JSON.stringify([
+        'agent-work-lab',
+        'project-tour',
+        '--episode',
+        '2',
+        '--speed',
+        '1',
+      ]) ||
+    projectTourEpisode2?.steps?.[0]?.timeoutSeconds !== 180
   ) {
     issues.push(
-      'auditable-demo scenario no longer declares the exact bounded two-demo cut',
+      'auditable-demo scenario no longer declares the exact bounded three-demo cut',
     );
   }
   requirePattern(

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -478,7 +478,7 @@ test('fast sentinels fail the representative recent invalid fixtures', () => {
   assert.ok(demoIssues.length >= 4);
   assert.match(
     demoIssues.join('\n'),
-    /bounded two-demo cut|exact Buildchain SHA/u,
+    /bounded three-demo cut|exact Buildchain SHA/u,
   );
 });
 


### PR DESCRIPTION
## Summary

- run product distribution as an explicit native-materialization barrier
- start source/runtime qualification only after native bindings are complete
- retain bounded concurrency for independent source suites and product consumers

## Verification

- runtime activation unit tests: 21/21
- related release/runtime tests: 51/51
- full staged repository gate passed
- clean exact-source runtime qualification: 8/8 suites passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This removes a qualification scheduling race without changing architecture authority or public runtime semantics."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change restores deterministic exact-source qualification required before declarative demo rendering.