### PR TITLE
fix(release): host candidate Dev Verify

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -67,7 +67,9 @@ jobs:
       # locked SHA and falls back to GitHub when a retained bundle is stale.
       buildchain-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}
       source-ref: ${{ needs.bind-source.outputs.source-sha }}
-      checkout-cache-mode: auto
+      # Candidate authority must not depend on persistent runner workspaces or
+      # LAN-only mirrors. Explicit diagnostics retain the self-hosted matrix.
+      checkout-cache-mode: off
       checkout-cache-fallback: github
       rust-toolchain: "1.96.0"
       rustup-dist-server: https://rsproxy.cn
@@ -76,7 +78,7 @@ jobs:
       gate-profile: dev-patrol
       runner-preset: custom
       platforms-json: >-
-        [{"id":"linux-x64","name":"Linux x64","platform":"linux","runner":"[\"self-hosted\",\"Linux\",\"X64\",\"kungfu-build-v4-linux-x64\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"macos-arm64","name":"macOS ARM64","platform":"macos","runner":"[\"self-hosted\",\"macOS\",\"ARM64\",\"kungfu-build-v4-macos-arm64\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"windows-x64","name":"Windows x64","platform":"windows","runner":"[\"self-hosted\",\"Windows\",\"X64\",\"kungfu-build-v4-windows-x64\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]}]
+        [{"id":"linux-x64","name":"Linux x64","platform":"linux","runner":"[\"ubuntu-24.04\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"macos-arm64","name":"macOS ARM64","platform":"macos","runner":"[\"macos-15\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"windows-x64","name":"Windows x64","platform":"windows","runner":"[\"windows-2022\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]}]
       artifact-name: kungfu-dev-patrol-gates
       # Buildchain projects the cache profile as environment. Keep the Gate
       # argv direct so the controller can append `gate plan/run ...` safely.
@@ -134,9 +136,9 @@ jobs:
           fi
 
           # Only a real verify failure is a dev-health signal. A cancelled or
-          # skipped run (e.g. the single self-hosted runner was pre-empted by a
-          # release build) says nothing about dev, so leave the tracking issue
-          # untouched rather than raising a false red.
+          # skipped run (for example, a provider-side cancellation) says
+          # nothing about dev, so leave the tracking issue untouched rather
+          # than raising a false red.
           if [ "${RESULT}" != "failure" ]; then
             echo "verify result '${RESULT}' is not a dev-health signal; leaving tracking issue unchanged"
             exit 0

--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -45,8 +45,8 @@ explains Kungfu's current policy and does not redefine Shifu semantics.
 | Profile | Current entry |
 | --- | --- |
 | `dev-pr` | GitHub-hosted build-free source, governance, docs-path, and Linux Shifu-path checks |
-| `dev-patrol` | daily or manual three-platform self-hosted full product verify plus advisory external links |
-| `alpha-pr` | three self-hosted full-product lanes plus one hosted Linux ARM64 Core lane, with build/verify/release evidence and conditional membrane and Shifu matrices |
+| `dev-patrol` | manual exact-source three-platform GitHub-hosted full product verify plus advisory external links |
+| `alpha-pr` | four GitHub-hosted full-product lanes, with build/verify/release evidence and conditional membrane and Shifu matrices |
 | `release-pr` | currently the same qualification strength as alpha, with the release publication channel |
 | `release-promotion` | post-merge promotion rehearsal and Buildchain artifact/passport admission |
 | `measurement` | manual three-platform source-bound observation of every task-backed Gate; all selected actions are advisory and it never publishes |

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -37,12 +37,15 @@ their protected credential authority, while finalization, publication, and
 activation independently verify the returned source-bound receipts. Moving
 the functional matrix does not move credentials or collapse those authorities.
 
-The version-line projection retains the exact-label self-hosted platform matrix
-for development patrols and explicit diagnostics. The manual macOS overflow
-controller also retains its independent self-hosted and GitHub-hosted candidate
-identities, always with `publish-channel: none`; neither path is the default
-formal Alpha route. Explicit self-hosted or custom diagnostics may still opt
-into the bounded checkout-cache policy.
+The exact-source Dev Verify that Candidate Patrol consumes uses the same fresh
+hosted Linux x64, macOS ARM64, and Windows x64 boundary, so an offline
+self-hosted diagnostic runner cannot prevent creation of the next Alpha
+candidate. The version-line projection still retains the exact-label
+self-hosted platform matrix for explicit diagnostics. The manual macOS
+overflow controller also retains its independent self-hosted and GitHub-hosted
+candidate identities, always with `publish-channel: none`; neither path is the
+default formal Alpha route. Explicit self-hosted or custom diagnostics may
+still opt into the bounded checkout-cache policy.
 
 ### Queue-aware macOS overflow
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -611,17 +611,17 @@
           "authority": "diagnostic",
           "publication": "none",
           "receipt": "none",
-          "definitionDigest": "sha256:2f624de37d5d71ac909f04bd17f59e21f48c515ed7d44fd6db9ff4a0eecdc783",
+          "definitionDigest": "sha256:0e79141716826770567c0c9eff59536299d03cc4ff4955c3b3e793d04c443b7f",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": [],
-          "steps": [{"index":1,"label":"name:Sync tracking issue with patrol result","authority":"diagnostic-write","definitionDigest":"sha256:f33e4ab9673c51d1a245249276274a2af1f662756bcc213c502405a136cf9a76"}]
+          "steps": [{"index":1,"label":"name:Sync tracking issue with patrol result","authority":"diagnostic-write","definitionDigest":"sha256:b012b8f7bf42066a11017bc08f7e341aa9b21ec09641ddc04edfbd49cd68efbb"}]
         },
         {
           "id": "verify",
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:194cbfe3c7186b5d57cc595ba9f491fbb742eec49d2bc1e7b0a669f06374df8b",
+          "definitionDigest": "sha256:cb68df807c17306aa4d51cd9cde0d5a3a59e40bbb588a927aec742463c784d96",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -346,13 +346,13 @@
           "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
           "cargo-registry-index": "${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}",
           "checkout-cache-fallback": "github",
-          "checkout-cache-mode": "auto",
+          "checkout-cache-mode": "off",
           "gate-profile": "dev-patrol",
           "rust-toolchain": "1.96.0",
           "rustup-dist-server": "https://rsproxy.cn",
           "rustup-update-root": "https://rsproxy.cn/rustup",
           "runner-preset": "custom",
-          "platforms-json": "[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"self-hosted\\\",\\\"Linux\\\",\\\"X64\\\",\\\"kungfu-build-v4-linux-x64\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"self-hosted\\\",\\\"macOS\\\",\\\"ARM64\\\",\\\"kungfu-build-v4-macos-arm64\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"self-hosted\\\",\\\"Windows\\\",\\\"X64\\\",\\\"kungfu-build-v4-windows-x64\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]",
+          "platforms-json": "[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]",
           "gate-command-json": "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}"
         }
       }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -220,7 +220,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:093b14145afce7081c12b1042a24649557f9eb10fdab2d1aed939be36860c3b6"
+          "sourceRoot": "sha256:2fbcd9972d32f3bbd14b6ac8f6ccd07923c1481ceb5893332172e771b5c1ee5b"
         },
         {
           "path": ".github/workflows/docs-check.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:6943b7af1825053ca3e96180bb0ad6131f2a5e7b58e7a71249339babe192c01f"
+  "registryRoot": "sha256:f3232f07a436ec202615c3f3b4026c252a06ae33eb8135aaaa5c1f23f8c14650"
 }

--- a/framework/version-line/check-version-line-authority.mjs
+++ b/framework/version-line/check-version-line-authority.mjs
@@ -153,13 +153,14 @@ function requireContains(text, fragment, label) {
 }
 
 function validateWorkflowProjections(root, projection) {
-  const native = JSON.stringify(projection.runnerRouting.matrices.native);
+  const nativeMatrix = projection.runnerRouting.matrices.native;
+  const native = JSON.stringify(nativeMatrix);
+  const devPatrol = JSON.stringify(
+    nativeMatrix.filter(({ id }) => id !== 'linux-arm64'),
+  );
   const line = projection.lines.find(({ id }) => id === projection.activeLine);
   if (!line) throw new Error('active line projection is missing');
   const nativePreset = `kungfu-v${line.major}-native`;
-  const selfHosted = JSON.stringify(
-    projection.runnerRouting.matrices.selfHosted,
-  );
   const build = fs.readFileSync(
     path.join(root, '.github/workflows/build.yml'),
     'utf8',
@@ -183,7 +184,7 @@ function validateWorkflowProjections(root, projection) {
     `runner-preset: ${nativePreset}`,
     'release runner preset',
   );
-  requireContains(patrol, selfHosted, 'dev patrol matrix');
+  requireContains(patrol, devPatrol, 'dev patrol matrix');
   requireContains(patrol, 'runner-preset: custom', 'dev patrol runner preset');
   const stable = fs.readFileSync(
     path.join(root, '.github/workflows/stable-candidate-patrol.yml'),

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -30,6 +30,11 @@ test('Dev Patrol is exact-source dispatch-only behind the qualification controll
     source,
     /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| '[0-9a-f]{40}' \}\}/u,
   );
+  assert.match(source, /checkout-cache-mode: off/u);
+  assert.ok(source.includes(String.raw`"runner":"[\"ubuntu-24.04\"]"`));
+  assert.ok(source.includes(String.raw`"runner":"[\"macos-15\"]"`));
+  assert.ok(source.includes(String.raw`"runner":"[\"windows-2022\"]"`));
+  assert.doesNotMatch(source, /kungfu-build-v4-(?:linux|macos|windows)/u);
   const reusableRef = source.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.gate-profile\.yml@([0-9a-f]{40})/u,
   )?.[1];


### PR DESCRIPTION
## Summary

- move authoritative Dev Verify to bounded GitHub-hosted Ubuntu, macOS, and Windows runners
- disable persistent checkout cache authority for the candidate path
- retain self-hosted runner labels only for explicit diagnostics
- preserve the newly merged Dev Delivery Warrant consumer contract

Supersedes #2470 after protected dev advanced through #2458.

## Validation

- Alpha promotion suite: 68/68
- Gate catalog: 38 gates, 6 profiles, 27 structured invocations, 36 workflows
- Version-line authority: 8/8
- Release publication control plane: qualifying
- Full repository pre-commit gate: passed

## Evolution impact

No accepted ADR changes. This is an ADR-neutral reliability repair to the existing release authority: formal candidate verification becomes ephemeral and provider-hosted while retained self-hosted matrices remain diagnostic-only.

## Governance risk

The protected PR, Dev Delivery Warrant, exact queue admission, hosted Dev Verify, and Alpha publication gates remain fail-closed. No release credential or publication authority is added to this PR.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair preserves accepted release authority while moving the exact candidate Dev Verify from persistent self-hosted runners to bounded GitHub-hosted runners."
}
-->