### PR TITLE
fix(release): isolate hosted acceleration inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,10 @@ jobs:
       fail-fast: ${{ github.event_name == 'pull_request' || !inputs.diagnostic-mode }}
       setup-rust: true
       rust-toolchain: "1.96.0"
-      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
+      # Organization Cargo mirrors are private acceleration for explicit
+      # self-hosted/custom diagnostics. Formal hosted candidates use Cargo's
+      # public default and must not depend on LAN reachability.
+      cargo-registry-index: ${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || inputs.platforms-json) && vars.BUILDCHAIN_CARGO_REGISTRY_INDEX || '' }}
       artifact-name: kungfu
       artifact-paths: |
         product/release
@@ -245,8 +248,8 @@ jobs:
       # they cannot use runner-local or LAN mirrors. Explicit custom or
       # self-hosted diagnostics retain the cache route they requested.
       checkout-cache-mode: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && 'auto' || (inputs.platforms-json && 'auto' || 'off') }}
-      checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}
-      checkout-cache-reference-repository-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE }}
+      checkout-cache-mirror-url-template: ${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || inputs.platforms-json) && vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE || '' }}
+      checkout-cache-reference-repository-template: ${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || inputs.platforms-json) && vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE || '' }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
       checkout-history-mode: full

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -74,7 +74,6 @@ jobs:
       rust-toolchain: "1.96.0"
       rustup-dist-server: https://rsproxy.cn
       rustup-update-root: https://rsproxy.cn/rustup
-      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
       gate-profile: dev-patrol
       runner-preset: custom
       platforms-json: >-
@@ -87,8 +86,6 @@ jobs:
       gate-environment-json: >-
         {"SHIFU_NATIVE":"1","KUNGFU_BUILDCHAIN_NO_OPTIONAL":"1",
         "KUNGFU_BUILDCHAIN_SOURCE_BUILD":"1","VSLANG":"1033"}
-      shifu-cache-profile-ref: ${{ vars.SHIFU_CACHE_PROFILE_REF }}
-      shifu-cache-profile-digest: ${{ vars.SHIFU_CACHE_PROFILE_DIGEST }}
 
   # Keep one tracking issue in sync with the patrol result: open or refresh it
   # when dev is red, close it when dev returns to green. This is the standing

--- a/.github/workflows/linux-arm64-alpha-qualification.yml
+++ b/.github/workflows/linux-arm64-alpha-qualification.yml
@@ -75,7 +75,6 @@ jobs:
       rust-toolchain: "1.96.0"
       rustup-dist-server: https://rsproxy.cn
       rustup-update-root: https://rsproxy.cn/rustup
-      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
       artifact-name: kungfu-hub-cli
       artifact-paths: |
         product/release/cli/kungfu-episodes-cli-linux-arm64.tar.gz
@@ -104,7 +103,7 @@ jobs:
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
       artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14
-      checkout-cache-mode: auto
+      checkout-cache-mode: off
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
       checkout-cache-github-timeout-seconds: 1200

--- a/docs/development/buildchain.md
+++ b/docs/development/buildchain.md
@@ -76,18 +76,23 @@ exists to hold.
 
 ## CI source checkout cache
 
-The release-candidate build uses Buildchain's locked source checkout cache in
-`auto` mode. Self-hosted runners first try the trusted local/LAN Git object cache
-declared by repository or organization variables, then fall back to GitHub if the
-cache is unavailable:
+Formal Alpha and Release candidates plus the Dev Verify consumed by Candidate
+Patrol use fresh GitHub-hosted runners with checkout-cache mode `off`. They fetch
+the immutable source directly from GitHub and do not receive private Cargo
+registry, Shifu cache-profile, Git mirror, or reference-repository inputs.
+Self-hosted and explicit custom diagnostics may instead use Buildchain's locked
+source checkout cache in `auto` mode. Those runners first try the trusted
+local/LAN Git object cache declared by repository or organization variables,
+then fall back to GitHub if the cache is unavailable:
 
 - `BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE`
 - `BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE`
 
-These values are intentionally not checked into this repository. They describe
-private runner or local-network topology. Buildchain still resolves and verifies
-the immutable source commit and tree before running lifecycle commands, and it
-writes sanitized `source-checkout.json` diagnostics into the platform artifacts.
+These values are intentionally not checked into this repository or projected
+into formal hosted jobs. They describe private runner or local-network topology.
+Buildchain still resolves and verifies the immutable source commit and tree
+before running lifecycle commands, and it writes sanitized
+`source-checkout.json` diagnostics into the platform artifacts.
 
 ## Alpha and release artifact relay
 

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -30,6 +30,9 @@ self-hosted workspace history, retained toolchains, and runner inventory state
 cannot alter formal release routing or qualification prerequisites.
 Formal lanes fetch the immutable source directly from GitHub instead of probing
 LAN or runner-local mirrors that are unreachable from hosted infrastructure.
+They also omit organization-level private Cargo registries and remote Shifu
+cache profiles; public/default dependency endpoints and checked-in portable
+profiles are the only inputs allowed on the formal hosted boundary.
 
 Buildchain still seals exact-source unsigned artifacts and detached signing
 requests in the functional matrix. Signing and notarization execute only in
@@ -45,7 +48,8 @@ self-hosted platform matrix for explicit diagnostics. The manual macOS
 overflow controller also retains its independent self-hosted and GitHub-hosted
 candidate identities, always with `publish-channel: none`; neither path is the
 default formal Alpha route. Explicit self-hosted or custom diagnostics may
-still opt into the bounded checkout-cache policy.
+still opt into the bounded checkout-cache policy and private acceleration
+variables.
 
 ### Queue-aware macOS overflow
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -301,7 +301,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:988cb646489d8b74bbb0bd1af3d6d57cfa0f064fbc3d1e24c4a782b0541ce339",
+          "definitionDigest": "sha256:af874940fc52fa9aec98a1c70b7bec84be6137a2a8ac2c61965f48a9000e7b34",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@22338823464024efb0bb72231c29cca9f61d72bb"],
           "steps": []
@@ -621,7 +621,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:f9a54af7af4fc829ebe2c1190e100b94e299435a833d96c6886ddf473e22f751",
+          "definitionDigest": "sha256:24e0e28811e0f2ce4273148fb23a73038695febf76c9abfffb80ea026b6c3574",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@22338823464024efb0bb72231c29cca9f61d72bb"],
           "steps": []
@@ -780,7 +780,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e7014e962c7d92dc5e39467025aae54fdfd622162cf813b7506ae6d3cdc212a6",
+          "definitionDigest": "sha256:05a579aed425ab3f19ea8f79bd2ff77b2aaec2e89588f607217f62e5649e3d58",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -344,7 +344,6 @@
         "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@22338823464024efb0bb72231c29cca9f61d72bb",
         "with": {
           "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
-          "cargo-registry-index": "${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}",
           "checkout-cache-fallback": "github",
           "checkout-cache-mode": "off",
           "gate-profile": "dev-patrol",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:e61da25a88bb549953f1319322d2cf8378207437ff82cd299ed84efe26c80128"
+          "sourceRoot": "sha256:4817d5603a2958fcb66f34272d7cbf625fd3d30912da6351587874f53f5aa6a3"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -220,7 +220,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:d4019df041ad86c1d93e3b369c186bace20eccceee1856dd086c65f694ec71af"
+          "sourceRoot": "sha256:feec90b6dd3ea56a4694797f188b5b41d92d4e156c727dc470f8284d324332c7"
         },
         {
           "path": ".github/workflows/docs-check.yml",
@@ -272,7 +272,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:62743a6b64d9b897792c572d6b8e3ad3eafd54b5ea330cb246b0467308ee8d3f"
+          "sourceRoot": "sha256:20618795b9bafbb08a12b41a48fe139549d76f9bedc2d14791d28956a7c4c63a"
         },
         {
           "path": ".github/workflows/kungfu-agent-patrol.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:8508cbed3bd2ed50871f01ead0ec97ab981ba73fa1f3a8d2467b70a6ec149a71"
+  "registryRoot": "sha256:1ec4ef6580594e2faca453cdd428cc2f87bc709a924a40a91b4021c2138a6857"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -471,6 +471,19 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
     workflow,
     /checkout-cache-mode: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.mode == 'self-hosted' && 'auto' \|\| \(inputs\.platforms-json && 'auto' \|\| 'off'\) \}\}/u,
   );
+  for (const input of [
+    'cargo-registry-index',
+    'checkout-cache-mirror-url-template',
+    'checkout-cache-reference-repository-template',
+  ]) {
+    assert.match(
+      workflow,
+      new RegExp(
+        `${input}: \\$\\{\\{ \\(fromJSON\\(inputs\\.macos-overflow-request-json \\|\\| '\\{\\}'\\)\\.mode == 'self-hosted' \\|\\| inputs\\.platforms-json\\) && vars\\.`,
+        'u',
+      ),
+    );
+  }
   assert.match(workflow, /self-hosted-offline-fallback: false/u);
   for (const runner of [
     String.raw`runner":"[\"ubuntu-24.04\"]"`,

--- a/scripts/linux-arm64-alpha-qualification-workflow.test.mjs
+++ b/scripts/linux-arm64-alpha-qualification-workflow.test.mjs
@@ -70,6 +70,8 @@ test('Linux ARM64 runs artifact qualification with an independent budget', () =>
     'node product/scripts/verify-cli-surface-qualification.mjs --qualification product/release/cli/kungfu-episodes-cli-linux-arm64.qualification.json --archive product/release/cli/kungfu-episodes-cli-linux-arm64.tar.gz --platform linux-arm64',
   );
   assert.equal(inputs['lifecycle-timeout-minutes'], 240);
+  assert.equal(inputs['checkout-cache-mode'], 'off');
+  assert.equal(inputs['cargo-registry-index'], undefined);
   assert.equal(
     inputs['shifu-cache-profile-ref'],
     'docs/shifu/linux-arm64-qualification-portable-off.cache-profile.json',
@@ -89,5 +91,9 @@ test('Linux ARM64 runs artifact qualification with an independent budget', () =>
   assert.doesNotMatch(
     fs.readFileSync(ARM_WORKFLOW, 'utf8'),
     /run-release-qualification/u,
+  );
+  assert.doesNotMatch(
+    fs.readFileSync(ARM_WORKFLOW, 'utf8'),
+    /BUILDCHAIN_CARGO_REGISTRY_INDEX/u,
   );
 });

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -428,6 +428,10 @@ test('dev patrol normalizes MSVC diagnostics for bounded Gate output', () => {
     'utf8',
   );
   assert.match(workflow, /"VSLANG":"1033"/);
+  assert.doesNotMatch(workflow, /BUILDCHAIN_CARGO_REGISTRY_INDEX/u);
+  assert.doesNotMatch(workflow, /SHIFU_CACHE_PROFILE_(?:REF|DIGEST)/u);
+  assert.doesNotMatch(workflow, /cargo-registry-index:/u);
+  assert.doesNotMatch(workflow, /shifu-cache-profile-(?:ref|digest):/u);
 });
 
 test('Python source checks use uvx when a bare ruff is unavailable', () => {


### PR DESCRIPTION
## Summary

- prevent formal GitHub-hosted Dev Verify and Alpha qualification from inheriting private LAN Cargo registry or Shifu cache profiles
- keep private acceleration available only for explicit self-hosted/custom diagnostic runs
- refresh the release publication workflow roots for the exact changed workflows

## Validation

- targeted runner-layering and Alpha authority tests: 70/70
- docs check: pass
- gate catalog: 38 gates, 6 profiles, 27 structured invocations, 36 workflows
- release publication control plane: qualifying
- source acceptance reaches the publication control plane successfully; the remaining local-only pytest discovery failure is absent in hosted source acceptance because that controller provisions its exact pytest tool

## Evolution impact

No accepted ADR changes. This is an ADR-neutral reliability repair: public hosted release lanes remain authoritative and cannot inherit private self-hosted acceleration.

## Governance risk

The protected PR, Dev Delivery Warrant, exact queue admission, hosted Dev Verify, and Alpha publication gates remain fail-closed. No release credential or publication authority is added to this PR.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair preserves accepted release authority while isolating formal GitHub-hosted workflows from private self-hosted acceleration inputs."
}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjMta3VuZ2Z1LXN0YW5kYWxvbmUtY2xpLWRpc3RyaWJ1dGlvbi1hbmQtb25lLWNvbW1hbmQtdXBkYXRlIiwiYXNzaWdubWVudElkIjoiMjAyNi0wNy0yNC1rdW5nZnUtcHVibGljLWFscGhhLXJlbGVhc2UtY2xvc3VyZSIsImRlbGl2ZXJ5Q2xhc3MiOiJyZWxlYXNlIiwiZGV2SGVhZCI6IjhhMjRlNGE3Y2QwMDFhOTAxNDU1ZmU4ODdiOGI0ZTFiYWRmMjBhYmIiLCJwdWxsUmVxdWVzdEhlYWQiOiIwNWIwOWFmYzY3ODE3ZmE5MGYwNzc3ZDk3NGE1YTk1MzVjMmQzYmIxIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiI5MzMzOWE4NWVlYTdkOTQ2NDM1MmZkNDQyY2VkMGQ3NWY5ZmQ3YzFjIiwicmVwbGF5ZWRUcmVlIjoiODM1MjM5OWYyMzlhOTc0YTA3YzE5NDhmNGI0MzcwZjkxYzc1NWQ5NCIsInF1ZXVlQXR0ZW1wdCI6IjA1YjA5YWZjNjc4MTdmYTkwZjA3NzdkOTc0YTVhOTUzNWMyZDNiYjFAOGEyNGU0YTdjZDAwMWE5MDE0NTVmZTg4N2I4YjRlMWJhZGYyMGFiYiIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjowZjU0ZjM4ZWRkZDkzNzNmNGVjNTllYjA1NjM5Mjk2YWUwMjQzMmE4YjllM2MxMzFjOTU4N2U3MzQ4ZjcwODAxIiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6MGY1NGYzOGVkZGQ5MzczZjRlYzU5ZWIwNTYzOTI5NmFlMDI0MzJhOGI5ZTNjMTMxYzk1ODdlNzM0OGY3MDgwMSIsInNoYTI1NjphOTc3Mjg4MjIxNzhhM2EwOGE1N2I4MmFiM2E5MjZhOTFjNjM5OGU3YjRjZmU3MzRjNzIwNDVjOTRlNzZiMzcwIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvYzQzZDlmZjViMWFhNjU1ZiIsImxlYXNlUm9vdCI6InNoYTI1NjpjOWMyYWQ5YTg4YjQyM2YxOWUyNGIxNWFiZWUwZDVlNjgxMzk2MWM0NDUyYjhjYThhM2ZjYjJkMzJhNzhjMjJmIn0 -->