### PR TITLE
fix(delivery): pin queue qualification hotfix

### DIFF
--- a/.github/workflows/dev-delivery-warrant-terminal.yml
+++ b/.github/workflows/dev-delivery-warrant-terminal.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kungfu-systems/buildchain
-          ref: 3550081196f08f4dd5a195aee484dc1ddaa8bdd5
+          ref: 5d302bd11fcac694e716e4a62550c6024c40aa30
           path: .buildchain/runtime
           persist-credentials: false
 
@@ -137,9 +137,9 @@ jobs:
   close:
     needs: prepare
     if: needs.prepare.outputs.active == 'true'
-    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@3550081196f08f4dd5a195aee484dc1ddaa8bdd5
+    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@5d302bd11fcac694e716e4a62550c6024c40aa30
     with:
-      buildchain-ref: 3550081196f08f4dd5a195aee484dc1ddaa8bdd5
+      buildchain-ref: 5d302bd11fcac694e716e4a62550c6024c40aa30
       target-branch: ${{ github.event.pull_request.base.ref }}
       expected-pr-number: ${{ github.event.pull_request.number }}
       expected-head-sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -199,9 +199,9 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@3550081196f08f4dd5a195aee484dc1ddaa8bdd5
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@5d302bd11fcac694e716e4a62550c6024c40aa30
     with:
-      buildchain-ref: 3550081196f08f4dd5a195aee484dc1ddaa8bdd5
+      buildchain-ref: 5d302bd11fcac694e716e4a62550c6024c40aa30
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number || '0') }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -493,9 +493,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:9b895a6819cfabf5a5cdcdfc0186acc85b2a2081c2eb73442829f9d6310b7e11",
+          "definitionDigest": "sha256:69a75abadefe081543fc5cf67e8097daa0c35084568b10bc80ef24bdd108a6bb",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@3550081196f08f4dd5a195aee484dc1ddaa8bdd5"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@5d302bd11fcac694e716e4a62550c6024c40aa30"],
           "steps": []
         },
         {
@@ -503,10 +503,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:89a78ee6c6d2857cdfbf1d1029635ca9f3d2f208e37aae501906784808c52d0d",
+          "definitionDigest": "sha256:98fa85be7b40decb85bd52993f290f11c1f8aa093723668342216f5eb9d2832e",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:e3330854a32bd7b28109442f181580e771da3c9c0f4ef7b9395ce63ce37fcabf"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:27d33234108145000881cac9974391105c78a69896db4e6260bb0fbeb7e1f7f7"}]
+          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:fca54aff7e6dfcbe8ab1286eeebbb4e6eb4726953bf089cb283b2357bc18f5d5"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:27d33234108145000881cac9974391105c78a69896db4e6260bb0fbeb7e1f7f7"}]
         }
       ]
     },
@@ -547,9 +547,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:d0ce1b8b08b893b02608ff33f35f59b396ad3f77698a8f94505cfd46cece8c03",
+          "definitionDigest": "sha256:f93706753c6d4ed3ae0bd7363d5fc827dae968ff39b9ccb10c47a6d664bb054c",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@3550081196f08f4dd5a195aee484dc1ddaa8bdd5"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@5d302bd11fcac694e716e4a62550c6024c40aa30"],
           "steps": []
         },
         {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -177,14 +177,14 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:e3d3229deda0f87e7b900f9b80d77d95ee0f559bb9c58ed493d6d29825e30ef6"
+          "sourceRoot": "sha256:edbb20029239b9cdf6e9fc7eb3f40836b5ffaf8f87f503adaf51e76415e783fd"
         },
         {
           "path": ".github/workflows/dev-pr-auto-merge.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:a99292c91123e1a167e6a4e1c06d60cef81f1a29c505852cf10d8495d10b5fdd"
+          "sourceRoot": "sha256:874033eb95dc00ccc22c253018a1ecdb5fb14501fbebec3a0ba7a6f27fc01bdb"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:1ec4ef6580594e2faca453cdd428cc2f87bc709a924a40a91b4021c2138a6857"
+  "registryRoot": "sha256:748fc81c080458ce0c3d44d7fb02fd16d68af695d85b3e13dc02e62341076e74"
 }

--- a/scripts/dev-delivery-warrant-input.test.mjs
+++ b/scripts/dev-delivery-warrant-input.test.mjs
@@ -176,7 +176,7 @@ test('terminal consumer executes only protected event and Buildchain authority',
   assert.match(workflow, /GITHUB_TOKEN: \$\{\{ github\.token \}\}/u);
   assert.match(
     workflow,
-    /dev-delivery-warrant-close\.yml@3550081196f08f4dd5a195aee484dc1ddaa8bdd5/u,
+    /dev-delivery-warrant-close\.yml@5d302bd11fcac694e716e4a62550c6024c40aa30/u,
   );
   assert.doesNotMatch(workflow, /github\.event\.pull_request\.head\.ref/u);
   assert.doesNotMatch(workflow, /checkout[^\n]*pull_request\.head/u);

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -13,7 +13,7 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
   const reusableRef = workflow.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/u,
   )?.[1];
-  assert.equal(reusableRef, '3550081196f08f4dd5a195aee484dc1ddaa8bdd5');
+  assert.equal(reusableRef, '5d302bd11fcac694e716e4a62550c6024c40aa30');
   assert.match(workflow, new RegExp(`buildchain-ref: ${reusableRef}`, 'u'));
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(workflow, /cron: "23,53 \* \* \* \*"/u);


### PR DESCRIPTION
## Summary

Bootstrap the trusted base to the already merged Buildchain queue-qualification hotfix. This bounded PR intentionally uses delivery-warrant-mode off because the trusted base workflow cannot consume the fixed qualifier until this pin itself lands.

AWS Windows Burst and macOS campaigns remain disabled.

## Verification

- Kungfu workflow authority: pass
- Release publication control plane: pass
- Targeted tests: 18/18
- Project Cut merge-queue admission: qualified

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bootstrap changes trusted workflow and publication pins without changing an ADR record or architecture contract"
}
-->

## Governance risk check

This PR touches release evidence and workflow authority. It does not enable cloud runner campaigns.