### PR TITLE
fix(delivery): pin immutable warrant readback

### DIFF
--- a/.github/workflows/dev-delivery-warrant-terminal.yml
+++ b/.github/workflows/dev-delivery-warrant-terminal.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kungfu-systems/buildchain
-          ref: 5d302bd11fcac694e716e4a62550c6024c40aa30
+          ref: 4f491a61dd2a4ba127ddbb8d67c6b51a903b1567
           path: .buildchain/runtime
           persist-credentials: false
 
@@ -137,9 +137,9 @@ jobs:
   close:
     needs: prepare
     if: needs.prepare.outputs.active == 'true'
-    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@5d302bd11fcac694e716e4a62550c6024c40aa30
+    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@4f491a61dd2a4ba127ddbb8d67c6b51a903b1567
     with:
-      buildchain-ref: 5d302bd11fcac694e716e4a62550c6024c40aa30
+      buildchain-ref: 4f491a61dd2a4ba127ddbb8d67c6b51a903b1567
       target-branch: ${{ github.event.pull_request.base.ref }}
       expected-pr-number: ${{ github.event.pull_request.number }}
       expected-head-sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -199,9 +199,9 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@5d302bd11fcac694e716e4a62550c6024c40aa30
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@4f491a61dd2a4ba127ddbb8d67c6b51a903b1567
     with:
-      buildchain-ref: 5d302bd11fcac694e716e4a62550c6024c40aa30
+      buildchain-ref: 4f491a61dd2a4ba127ddbb8d67c6b51a903b1567
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number || '0') }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -493,9 +493,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:69a75abadefe081543fc5cf67e8097daa0c35084568b10bc80ef24bdd108a6bb",
+          "definitionDigest": "sha256:59f07d3b86dc7bfa649d3bb4a9b560b8f0045df15d73cf0a928539e5184f0cb3",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@5d302bd11fcac694e716e4a62550c6024c40aa30"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@4f491a61dd2a4ba127ddbb8d67c6b51a903b1567"],
           "steps": []
         },
         {
@@ -503,10 +503,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:98fa85be7b40decb85bd52993f290f11c1f8aa093723668342216f5eb9d2832e",
+          "definitionDigest": "sha256:64a9fa83f1b60371cad9782b6c7f0c6635c7c3844d85c8d2af025325f7cbae31",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:fca54aff7e6dfcbe8ab1286eeebbb4e6eb4726953bf089cb283b2357bc18f5d5"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:27d33234108145000881cac9974391105c78a69896db4e6260bb0fbeb7e1f7f7"}]
+          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:4f7c38c5216964aa2011dab24d7171471cabd56fddfc3d0c5b0ed9bd804d51b6"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:27d33234108145000881cac9974391105c78a69896db4e6260bb0fbeb7e1f7f7"}]
         }
       ]
     },
@@ -547,9 +547,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:f93706753c6d4ed3ae0bd7363d5fc827dae968ff39b9ccb10c47a6d664bb054c",
+          "definitionDigest": "sha256:48e154fca239ccf8be3d52fddba68047d84197f51a20e72f453cbf26f36d7e9c",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@5d302bd11fcac694e716e4a62550c6024c40aa30"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@4f491a61dd2a4ba127ddbb8d67c6b51a903b1567"],
           "steps": []
         },
         {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -177,14 +177,14 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:edbb20029239b9cdf6e9fc7eb3f40836b5ffaf8f87f503adaf51e76415e783fd"
+          "sourceRoot": "sha256:df7207f06ae3e2181469ab80e3898756ae553dded0e695da7dffc016700e8516"
         },
         {
           "path": ".github/workflows/dev-pr-auto-merge.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:874033eb95dc00ccc22c253018a1ecdb5fb14501fbebec3a0ba7a6f27fc01bdb"
+          "sourceRoot": "sha256:48d566ea96c8ab5c7cfae7c953711e3f0b6e464ddd1e7e6641231c7eee24fb51"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:748fc81c080458ce0c3d44d7fb02fd16d68af695d85b3e13dc02e62341076e74"
+  "registryRoot": "sha256:a70f81bad843fffb98660f67c142bf27103c8d9e53a917f9fa6541a6004b6923"
 }

--- a/scripts/dev-delivery-warrant-input.test.mjs
+++ b/scripts/dev-delivery-warrant-input.test.mjs
@@ -176,7 +176,7 @@ test('terminal consumer executes only protected event and Buildchain authority',
   assert.match(workflow, /GITHUB_TOKEN: \$\{\{ github\.token \}\}/u);
   assert.match(
     workflow,
-    /dev-delivery-warrant-close\.yml@5d302bd11fcac694e716e4a62550c6024c40aa30/u,
+    /dev-delivery-warrant-close\.yml@4f491a61dd2a4ba127ddbb8d67c6b51a903b1567/u,
   );
   assert.doesNotMatch(workflow, /github\.event\.pull_request\.head\.ref/u);
   assert.doesNotMatch(workflow, /checkout[^\n]*pull_request\.head/u);

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -13,7 +13,7 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
   const reusableRef = workflow.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/u,
   )?.[1];
-  assert.equal(reusableRef, '5d302bd11fcac694e716e4a62550c6024c40aa30');
+  assert.equal(reusableRef, '4f491a61dd2a4ba127ddbb8d67c6b51a903b1567');
   assert.match(workflow, new RegExp(`buildchain-ref: ${reusableRef}`, 'u'));
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(workflow, /cron: "23,53 \* \* \* \*"/u);


### PR DESCRIPTION
## Summary

Bootstrap the trusted Kungfu base to the already merged Buildchain immutable queue-commit readback fix. This bounded PR intentionally uses delivery-warrant-mode off because the trusted base workflow cannot consume the corrected writer until this pin itself lands.

AWS Windows Burst and macOS campaigns remain disabled.

## Verification

- Kungfu workflow authority: pass
- Release publication control plane: pass
- Targeted tests: 18/18
- Full staged hook: pass
- Project Cut merge-queue admission: required before enqueue

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bootstrap changes trusted workflow and publication pins without changing an ADR record or architecture contract"
}
-->

## Governance risk check

This PR touches release evidence and workflow authority. It does not enable cloud runner campaigns.