### PR TITLE
fix(release): close hosted platform verification gaps

### DIFF
--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -77,7 +77,7 @@ jobs:
       gate-profile: dev-patrol
       runner-preset: custom
       platforms-json: >-
-        [{"id":"linux-x64","name":"Linux x64","platform":"linux","runner":"[\"ubuntu-24.04\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"macos-arm64","name":"macOS ARM64","platform":"macos","runner":"[\"macos-15\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"windows-x64","name":"Windows x64","platform":"windows","runner":"[\"windows-2022\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]}]
+        [{"id":"linux-x64","name":"Linux x64","platform":"linux","runner":"[\"ubuntu-24.04\"]","capabilities":["node","native-toolchain","product-artifacts","rust"],"environment":{"CC":"gcc-14","CXX":"g++-14"}},{"id":"macos-arm64","name":"macOS ARM64","platform":"macos","runner":"[\"macos-15\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"windows-x64","name":"Windows x64","platform":"windows","runner":"[\"windows-2022\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]}]
       artifact-name: kungfu-dev-patrol-gates
       # Buildchain projects the cache profile as environment. Keep the Gate
       # argv direct so the controller can append `gate plan/run ...` safely.

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4
     with:
       # Keep the reviewed Gate workflow shell and its streamed runtime aligned
       # by default. Trusted manual runs may still supply an exact SHA or train

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -72,8 +72,11 @@ jobs:
       checkout-cache-mode: off
       checkout-cache-fallback: github
       rust-toolchain: "1.96.0"
-      rustup-dist-server: https://rsproxy.cn
-      rustup-update-root: https://rsproxy.cn/rustup
+      # GitHub-hosted runners use the public Rust distribution plane directly.
+      # The China mirror remains appropriate for office runners, but routing a
+      # US-hosted macOS runner back through it caused setup timeouts.
+      rustup-dist-server: https://static.rust-lang.org
+      rustup-update-root: https://static.rust-lang.org/rustup
       gate-profile: dev-patrol
       runner-preset: custom
       platforms-json: >-

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@22338823464024efb0bb72231c29cca9f61d72bb
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0
     with:
       # Keep the reviewed Gate workflow shell and its streamed runtime aligned
       # by default. Trusted manual runs may still supply an exact SHA or train

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4
+    uses: kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@916fc84d488ae6f5af271a67487e79ecb47b9ae2
     with:
       # Keep the reviewed Gate workflow shell and its streamed runtime aligned
       # by default. Trusted manual runs may still supply an exact SHA or train

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -621,9 +621,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:7597bc879a0b4b824652d2c8baca30ce60afadd17e8022d9e79ec4639932a48f",
+          "definitionDigest": "sha256:eb5f18067ccc2ffb61042fc732572ae92956ba3281a60ecce54c7baf3224ebb2",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4"],
           "steps": []
         }
       ]

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -621,7 +621,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:589d7350c4c96fd6e50c0a2000ab8964e098c698b56e9681a717615ad43d3cb4",
+          "definitionDigest": "sha256:c7f0f61942dbc7f67dc132506b1d45ef3fdbe7248678ababa68ad9de3e655a88",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@916fc84d488ae6f5af271a67487e79ecb47b9ae2"],
           "steps": []

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -621,7 +621,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:24e0e28811e0f2ce4273148fb23a73038695febf76c9abfffb80ea026b6c3574",
+          "definitionDigest": "sha256:74126dbdceaadea9c8622578e9f81b88c36589a48c7e16d85d6cbfe81f0bd5ed",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@22338823464024efb0bb72231c29cca9f61d72bb"],
           "steps": []

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -621,9 +621,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:eb5f18067ccc2ffb61042fc732572ae92956ba3281a60ecce54c7baf3224ebb2",
+          "definitionDigest": "sha256:589d7350c4c96fd6e50c0a2000ab8964e098c698b56e9681a717615ad43d3cb4",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@916fc84d488ae6f5af271a67487e79ecb47b9ae2"],
           "steps": []
         }
       ]

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -621,9 +621,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:74126dbdceaadea9c8622578e9f81b88c36589a48c7e16d85d6cbfe81f0bd5ed",
+          "definitionDigest": "sha256:7597bc879a0b4b824652d2c8baca30ce60afadd17e8022d9e79ec4639932a48f",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@22338823464024efb0bb72231c29cca9f61d72bb"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0"],
           "steps": []
         }
       ]

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -341,7 +341,7 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@916fc84d488ae6f5af271a67487e79ecb47b9ae2",
         "with": {
           "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
           "checkout-cache-fallback": "github",

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -341,7 +341,7 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@22338823464024efb0bb72231c29cca9f61d72bb",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0",
         "with": {
           "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
           "checkout-cache-fallback": "github",

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -348,8 +348,8 @@
           "checkout-cache-mode": "off",
           "gate-profile": "dev-patrol",
           "rust-toolchain": "1.96.0",
-          "rustup-dist-server": "https://rsproxy.cn",
-          "rustup-update-root": "https://rsproxy.cn/rustup",
+          "rustup-dist-server": "https://static.rust-lang.org",
+          "rustup-update-root": "https://static.rust-lang.org/rustup",
           "runner-preset": "custom",
           "platforms-json": "[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"],\"environment\":{\"CC\":\"gcc-14\",\"CXX\":\"g++-14\"}},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]",
           "gate-command-json": "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}"

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -341,7 +341,7 @@
       ],
       "activation": "daily or manual on dev",
       "invocation": {
-        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4",
         "with": {
           "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
           "checkout-cache-fallback": "github",

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -351,7 +351,7 @@
           "rustup-dist-server": "https://rsproxy.cn",
           "rustup-update-root": "https://rsproxy.cn/rustup",
           "runner-preset": "custom",
-          "platforms-json": "[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]",
+          "platforms-json": "[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"],\"environment\":{\"CC\":\"gcc-14\",\"CXX\":\"g++-14\"}},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]",
           "gate-command-json": "{\"linux\":[\"./shifu\"],\"macos\":[\"./shifu\"],\"windows\":[\"./shifu.cmd\"]}"
         }
       }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -220,7 +220,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:feec90b6dd3ea56a4694797f188b5b41d92d4e156c727dc470f8284d324332c7"
+          "sourceRoot": "sha256:fe6b676dcdcab77234d225eb00ca126ae718a00c496b87a3734134c4039b8ecc"
         },
         {
           "path": ".github/workflows/docs-check.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:748fc81c080458ce0c3d44d7fb02fd16d68af695d85b3e13dc02e62341076e74"
+  "registryRoot": "sha256:bd433ef281b8264b7d3d6d8d72b543eb969ca8885c4ab449a03112ff478fe981"
 }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -1019,7 +1019,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4',
+        '.gate-profile.yml@916fc84d488ae6f5af271a67487e79ecb47b9ae2',
         '.gate-profile.yml@v2-alpha',
       ),
   );

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -1019,7 +1019,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@22338823464024efb0bb72231c29cca9f61d72bb',
+        '.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0',
         '.gate-profile.yml@v2-alpha',
       ),
   );

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -1019,7 +1019,7 @@ test('direct Gate arguments and profile inputs fail closed on drift', () => {
     fs
       .readFileSync(profileRefWorkflow, 'utf8')
       .replace(
-        '.gate-profile.yml@8d3b882a70adededd19eeeac8cfe9f73b58cc1c0',
+        '.gate-profile.yml@d036820df1c0eed012023cc5e44c4b8d7b209bd4',
         '.gate-profile.yml@v2-alpha',
       ),
   );

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 
 const ROOT = process.cwd();
 const BUILDCHAIN_DEV_VERIFY_RUNTIME =
-  '8d3b882a70adededd19eeeac8cfe9f73b58cc1c0';
+  'd036820df1c0eed012023cc5e44c4b8d7b209bd4';
 const BUILDCHAIN_TIMEOUT_SAFE_RUNTIME =
   '22338823464024efb0bb72231c29cca9f61d72bb';
 

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 
 const ROOT = process.cwd();
 const BUILDCHAIN_DEV_VERIFY_RUNTIME =
-  'd036820df1c0eed012023cc5e44c4b8d7b209bd4';
+  '916fc84d488ae6f5af271a67487e79ecb47b9ae2';
 const BUILDCHAIN_TIMEOUT_SAFE_RUNTIME =
   '22338823464024efb0bb72231c29cca9f61d72bb';
 

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -6,6 +6,8 @@ import path from 'node:path';
 import { test } from 'node:test';
 
 const ROOT = process.cwd();
+const BUILDCHAIN_DEV_VERIFY_RUNTIME =
+  '8d3b882a70adededd19eeeac8cfe9f73b58cc1c0';
 const BUILDCHAIN_TIMEOUT_SAFE_RUNTIME =
   '22338823464024efb0bb72231c29cca9f61d72bb';
 
@@ -44,7 +46,7 @@ test('Dev Patrol is exact-source dispatch-only behind the qualification controll
   const reusableRef = source.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.gate-profile\.yml@([0-9a-f]{40})/u,
   )?.[1];
-  assert.equal(reusableRef, BUILDCHAIN_TIMEOUT_SAFE_RUNTIME);
+  assert.equal(reusableRef, BUILDCHAIN_DEV_VERIFY_RUNTIME);
 });
 
 test('qualification patrol coalesces the latest Dev SHA behind release priority', () => {

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -32,8 +32,14 @@ test('Dev Patrol is exact-source dispatch-only behind the qualification controll
   );
   assert.match(source, /checkout-cache-mode: off/u);
   assert.ok(source.includes(String.raw`"runner":"[\"ubuntu-24.04\"]"`));
+  assert.ok(
+    source.includes(
+      String.raw`"platform":"linux","runner":"[\"ubuntu-24.04\"]","capabilities":["node","native-toolchain","product-artifacts","rust"],"environment":{"CC":"gcc-14","CXX":"g++-14"}`,
+    ),
+  );
   assert.ok(source.includes(String.raw`"runner":"[\"macos-15\"]"`));
   assert.ok(source.includes(String.raw`"runner":"[\"windows-2022\"]"`));
+  assert.doesNotMatch(source, /gate-environment-json:[\s\S]*"CC":"gcc-14"/u);
   assert.doesNotMatch(source, /kungfu-build-v4-(?:linux|macos|windows)/u);
   const reusableRef = source.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.gate-profile\.yml@([0-9a-f]{40})/u,

--- a/scripts/kungfu-invariant.test.mjs
+++ b/scripts/kungfu-invariant.test.mjs
@@ -7,6 +7,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { optionalAjv2020 } from './readonly-source-toolchain.mjs';
 
+import { findBin } from '../tests/fixtures/_harness.mjs';
 import {
   canonicalJson,
   checkEvolution,
@@ -37,6 +38,14 @@ const registry = readJson('framework/invariant/kungfu-invariant.registry.json');
 const contract = readJson(
   'framework/invariant/kungfu-invariant-system.contract.json',
 );
+
+test('fixture binary discovery resolves executables through PATH', () => {
+  const discovered = findBin([
+    process.platform === 'win32' ? 'node.exe' : 'node',
+  ]);
+  assert.ok(discovered);
+  assert.equal(fs.realpathSync(discovered), fs.realpathSync(process.execPath));
+});
 
 function qualificationSubject(overrides = {}) {
   const evidence = Object.fromEntries(

--- a/tests/fixtures/_harness.mjs
+++ b/tests/fixtures/_harness.mjs
@@ -334,12 +334,26 @@ export function assertFileContains(file, pattern, label) {
 /** Find an executable among candidate paths (replaces slice find_bin). */
 export function findBin(candidates) {
   for (const c of candidates) {
-    const p = isWin && !c.endsWith('.exe') ? `${c}.exe` : c;
-    try {
-      fs.accessSync(p, fs.constants.X_OK);
-      return p;
-    } catch {
-      /* next */
+    const extensions =
+      isWin && !path.extname(c)
+        ? (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';')
+        : [''];
+    const roots =
+      path.isAbsolute(c) || c.includes(path.sep)
+        ? ['']
+        : (process.env.PATH || '').split(path.delimiter);
+    for (const root of roots) {
+      for (const extension of extensions) {
+        const candidate = root
+          ? path.join(root, `${c}${extension}`)
+          : `${c}${extension}`;
+        try {
+          fs.accessSync(candidate, fs.constants.X_OK);
+          return candidate;
+        } catch {
+          /* next */
+        }
+      }
     }
   }
   return null;

--- a/tests/fixtures/rewind-demo-cross-runtime/run.mjs
+++ b/tests/fixtures/rewind-demo-cross-runtime/run.mjs
@@ -8,10 +8,10 @@
 // Usage: node tests/fixtures/rewind-demo-cross-runtime/run.mjs
 
 import path from 'node:path';
-import { locate, tmpDir, background, waitForFile, kfc, uvPython, findBin, skip } from '../_harness.mjs';
+import { locate, tmpDir, background, waitForFile, kfc, uvPython, findBin, skip, corePython } from '../_harness.mjs';
 
-const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
+const PY = corePython(coreDir);
 
 if (!findBin(['node'])) skip('node not on PATH');
 

--- a/tests/fixtures/rewind-demo-export/run.mjs
+++ b/tests/fixtures/rewind-demo-export/run.mjs
@@ -10,10 +10,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { locate, tmpDir, background, waitForFile, kfc, assertContains, fail } from '../_harness.mjs';
+import { locate, tmpDir, background, waitForFile, kfc, assertContains, fail, corePython } from '../_harness.mjs';
 
-const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
+const PY = corePython(coreDir);
 
 const home = tmpDir('rewind-export-home-');
 const opened = tmpDir('rewind-export-opened-');

--- a/tests/fixtures/rewind-demo-forensic-replay/run.mjs
+++ b/tests/fixtures/rewind-demo-forensic-replay/run.mjs
@@ -12,10 +12,10 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { locate, tmpDir, background, waitForFile, kfc, assertContains, findBin, skip, fail } from '../_harness.mjs';
+import { locate, tmpDir, background, waitForFile, kfc, assertContains, findBin, skip, fail, corePython } from '../_harness.mjs';
 
-const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
+const PY = corePython(coreDir);
 
 if (!findBin(['node'])) skip('node not on PATH');
 

--- a/tests/fixtures/rewind-demo-happy/run.mjs
+++ b/tests/fixtures/rewind-demo-happy/run.mjs
@@ -8,10 +8,10 @@
 // Usage: node tests/fixtures/rewind-demo-happy/run.mjs
 
 import path from 'node:path';
-import { locate, tmpDir, background, waitForFile, kfc, uvPython } from '../_harness.mjs';
+import { locate, tmpDir, background, waitForFile, kfc, uvPython, corePython } from '../_harness.mjs';
 
-const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
+const PY = corePython(coreDir);
 const home = tmpDir('rewind-happy-');
 const runId = `fixturehappy${Date.now()}`;
 

--- a/tests/fixtures/rewind-demo-langchain/run.mjs
+++ b/tests/fixtures/rewind-demo-langchain/run.mjs
@@ -31,11 +31,12 @@ import {
   fail,
   extractPackedKfx,
   kfxQualificationAuthorityFile,
+  corePython,
 } from '../_harness.mjs';
 
-const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
 const repoDir = path.resolve(coreDir, '..', '..');
+const PY = corePython(coreDir);
 
 // ── provision the real framework (cached across runs) ────────────────
 const venv = path.join(fixtureDir, '.venv-langchain');

--- a/tests/fixtures/rewind-demo-model-drift/run.mjs
+++ b/tests/fixtures/rewind-demo-model-drift/run.mjs
@@ -16,10 +16,11 @@ import {
   uvPython,
   assertContains,
   fail,
+  corePython,
 } from '../_harness.mjs';
 
-const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
+const PY = corePython(coreDir);
 const home = tmpDir('rewind-drift-');
 const runId = `fixturedrift${Date.now()}`;
 

--- a/tests/fixtures/rewind-demo-tool-failure/run.mjs
+++ b/tests/fixtures/rewind-demo-tool-failure/run.mjs
@@ -16,10 +16,11 @@ import {
   uvPython,
   assertContains,
   fail,
+  corePython,
 } from '../_harness.mjs';
 
-const PY = process.platform === 'win32' ? 'python' : 'python3';
 const { fixtureDir, coreDir } = locate(import.meta.url);
+const PY = corePython(coreDir);
 const home = tmpDir('rewind-toolfail-');
 const runId = `fixturetoolfail${Date.now()}`;
 


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Hosted runner isolation and release-flow reliability fixes do not change an ADR record"
}
-->

## Summary

- route Dev Verify through isolated GitHub-hosted Linux, macOS, and Windows runners
- scope GCC 14 only to Linux through the merged Buildchain runner-matrix contract
- use the public Rust distribution plane from GitHub-hosted runners instead of routing US runners through the China mirror
- make rewind mock fixtures use the qualified Core Python and restore real PATH/PATHEXT binary discovery
- pin the reusable Gate workflow to merged Buildchain commit `916fc84d488ae6f5af271a67487e79ecb47b9ae2`
- refresh the workflow authority and release publication source roots

## Validation

- Buildchain PR #2311 merged through the protected merge queue
- Buildchain full check: 1261 tests plus workflow, generated surface, action bundle, and maintainability gates
- Kungfu targeted Gate/catalog/publication checks: 28/28 plus qualifying publication control-plane check
- Kungfu full staged commit gate passed at `98f134767060d2dca6fca444f09c914be07bcb7c`
- effective hosted canary: https://github.com/kungfu-systems/kungfu/actions/runs/30892609630
- superseded diagnostic canary captured the rsproxy macOS timeout: https://github.com/kungfu-systems/kungfu/actions/runs/30893815022

The PR intentionally remains without `state/ready`; add it only after the final-coordinate three-platform receipts pass.