### PR TITLE
fix(agent): tolerate Windows provider version encoding

### DIFF
--- a/framework/core/src/python/kungfu/agent/verification_probe.py
+++ b/framework/core/src/python/kungfu/agent/verification_probe.py
@@ -51,7 +51,6 @@ class VerificationProbe:
             result = self.run(
                 [executable, *(str(value) for value in version_argv)],
                 capture_output=True,
-                text=True,
                 encoding="utf-8",
                 errors="replace",
                 timeout=timeout_seconds or self.default_timeout_seconds,
@@ -88,7 +87,6 @@ class VerificationProbe:
                 result = self.run(
                     [executable, *probe_argv],
                     capture_output=True,
-                    text=True,
                     encoding="utf-8",
                     errors="replace",
                     timeout=self.timeout(provider),

--- a/framework/core/src/python/kungfu/agent/verification_probe.py
+++ b/framework/core/src/python/kungfu/agent/verification_probe.py
@@ -52,6 +52,8 @@ class VerificationProbe:
                 [executable, *(str(value) for value in version_argv)],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=timeout_seconds or self.default_timeout_seconds,
                 check=False,
             )
@@ -87,6 +89,8 @@ class VerificationProbe:
                     [executable, *probe_argv],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=self.timeout(provider),
                     check=False,
                     env=(

--- a/framework/core/src/python/kungfu/config.py
+++ b/framework/core/src/python/kungfu/config.py
@@ -597,8 +597,6 @@ def _git_worktree_root(cwd: str) -> str | None:
             ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
             check=False,
             capture_output=True,
-            text=True,
-            encoding="utf-8",
             errors="replace",
         )
     except (OSError, ValueError):

--- a/framework/core/src/python/kungfu/config.py
+++ b/framework/core/src/python/kungfu/config.py
@@ -598,6 +598,8 @@ def _git_worktree_root(cwd: str) -> str | None:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except (OSError, ValueError):
         return None

--- a/framework/core/src/python/kungfu/rewind/cost/discovery.py
+++ b/framework/core/src/python/kungfu/rewind/cost/discovery.py
@@ -61,7 +61,8 @@ def _default_version_probe(path: str) -> Optional[str]:
         proc = subprocess.run(
             [path, "--version"],
             capture_output=True,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_VERSION_TIMEOUT_S,
             check=False,
         )

--- a/framework/core/src/python/kungfu/workspace_guidance.py
+++ b/framework/core/src/python/kungfu/workspace_guidance.py
@@ -499,6 +499,8 @@ def _git_root(path: str) -> str | None:
             check=False,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except OSError:
         return None

--- a/framework/core/src/python/kungfu/workspace_guidance.py
+++ b/framework/core/src/python/kungfu/workspace_guidance.py
@@ -498,8 +498,6 @@ def _git_root(path: str) -> str | None:
             ["git", "-C", path, "rev-parse", "--show-toplevel"],
             check=False,
             capture_output=True,
-            text=True,
-            encoding="utf-8",
             errors="replace",
         )
     except OSError:

--- a/framework/core/tests/python/test_agent_session_module_boundaries.py
+++ b/framework/core/tests/python/test_agent_session_module_boundaries.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+import subprocess
 import sys
 
+from kungfu import config
+from kungfu import workspace_guidance
 from kungfu.agent.managed_run import ManagedRunCoordinator
 from kungfu.agent.native_launch import NativeLaunchCoordinator
 from kungfu.agent.provider_bootstrap import ProviderBootstrapAdapter
@@ -45,6 +48,36 @@ def test_verification_probe_keeps_version_after_invalid_utf8():
 
     assert result["ok"] is True
     assert result["version"] == "1.2.3"
+
+
+def _invalid_utf8_git_failure(real_run):
+    def run(_argv, **kwargs):
+        return real_run(
+            [
+                sys.executable,
+                "-c",
+                "import os; os.write(2, b'not a repo: \\xb2\\n'); raise SystemExit(1)",
+            ],
+            **kwargs,
+        )
+
+    return run
+
+
+def test_runtime_home_git_probe_replaces_invalid_utf8(monkeypatch, tmp_path):
+    real_run = subprocess.run
+    monkeypatch.setattr(config.subprocess, "run", _invalid_utf8_git_failure(real_run))
+
+    assert config._git_worktree_root(str(tmp_path)) is None
+
+
+def test_workspace_guidance_git_probe_replaces_invalid_utf8(monkeypatch, tmp_path):
+    real_run = subprocess.run
+    monkeypatch.setattr(
+        workspace_guidance.subprocess, "run", _invalid_utf8_git_failure(real_run)
+    )
+
+    assert workspace_guidance._git_root(str(tmp_path)) is None
 
 
 def test_run_intent_dispatcher_keeps_native_and_managed_paths_explicit():

--- a/framework/core/tests/python/test_agent_session_module_boundaries.py
+++ b/framework/core/tests/python/test_agent_session_module_boundaries.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+import sys
 
 from kungfu.agent.managed_run import ManagedRunCoordinator
 from kungfu.agent.native_launch import NativeLaunchCoordinator
@@ -12,6 +13,38 @@ from kungfu.agent.verification_probe import VerificationProbe
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+def _invalid_utf8_version_command():
+    return [
+        "-c",
+        "import sys; sys.stdout.buffer.write(b'provider \\xff 1.2.3\\n')",
+    ]
+
+
+def test_verification_probe_replaces_invalid_utf8_from_provider():
+    probe = VerificationProbe(schema="test")
+
+    assert probe.raw_version(sys.executable, _invalid_utf8_version_command()) == (
+        "provider � 1.2.3"
+    )
+
+
+def test_verification_probe_keeps_version_after_invalid_utf8():
+    probe = VerificationProbe(schema="test")
+    result = probe.verify(
+        {
+            "id": "test.invalid-utf8",
+            "provider": "test",
+            "launch": {
+                "executable": sys.executable,
+                "versionArgv": _invalid_utf8_version_command(),
+            },
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["version"] == "1.2.3"
 
 
 def test_run_intent_dispatcher_keeps_native_and_managed_paths_explicit():

--- a/framework/core/tests/python/test_agent_session_module_boundaries.py
+++ b/framework/core/tests/python/test_agent_session_module_boundaries.py
@@ -13,6 +13,7 @@ from kungfu.agent.run_intent import RunIntentDispatcher
 from kungfu.agent.runtime_profile_catalog import RuntimeProfileCatalog
 from kungfu.agent.runtime_profile_store import RuntimeProfileStore
 from kungfu.agent.verification_probe import VerificationProbe
+from kungfu.rewind.cost import discovery as provider_discovery
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -48,6 +49,20 @@ def test_verification_probe_keeps_version_after_invalid_utf8():
 
     assert result["ok"] is True
     assert result["version"] == "1.2.3"
+
+
+def test_provider_discovery_replaces_invalid_utf8_from_version_probe(monkeypatch):
+    real_run = subprocess.run
+
+    def invalid_version(_argv, **kwargs):
+        return real_run(
+            [sys.executable, *_invalid_utf8_version_command()],
+            **kwargs,
+        )
+
+    monkeypatch.setattr(provider_discovery.subprocess, "run", invalid_version)
+
+    assert provider_discovery._default_version_probe("provider") == ("provider � 1.2.3")
 
 
 def _invalid_utf8_git_failure(real_run):


### PR DESCRIPTION
## Summary

Make Windows provider discovery tolerant of localized or non-UTF-8 command output so `kungfu run codex`, `kungfu run opencode`, and `kungfu run amp` can reach their provider-native UI.

## Related issue

Atlas goal `2026-08-04-kungfu-windows-native-agent-session`.

## Changes

- decode bounded provider `--version` probes as UTF-8 with replacement instead of raising `UnicodeDecodeError`
- keep localized Git diagnostics fail-visible while preventing Python text decoding from aborting Agent Session bootstrap
- retain the existing provider probe timeout, output bound, runtime profile identity, and Work authority
- add Windows-byte regression coverage for discovered provider versions and verification probes

## Verification

- focused Python module-boundary suite: 7 passed
- Python structure budget: `kungfu-flat-root=36612`, exact ceiling retained
- `./shifu check:source`: 1032 passed, 10 skipped; one environment-only failure because nested `pnpm install` required `CI=true` in a no-TTY shell
- exact failing gate executor test rerun with `CI=true`: 17 passed
- DARKHERO exact-source Windows CLI build at `d1e6404895f8fa2820e717f2a7c9b29d7c96653c`: installed-layout smoke passed
- DARKHERO Runtime Catalog discovered Codex 0.146.0, Amp 0.0.1785716348-g5ad872, and OpenCode 1.18.12 without decoding errors
- DARKHERO exact-source `kungfu run amp`: native UI entered, observer fresh/working at 353 ms, and provider-native double-Ctrl-C exited with status 0
- earlier full Windows provider-native acceptance on the same implementation line exercised TUI plus real Codex, OpenCode, and Amp UIs

Exact local release-cut evidence:

- source: `d1e6404895f8fa2820e717f2a7c9b29d7c96653c`
- release cut: `sha256:acce0b19d70a84d2d2e5a3705998b1625648249bed821c5404b7c7d8089f26dd`
- parent installed cut: `sha256:b6d3b7e07e0685713488eecd6a70cd4c109598e19a1e29b606d4e9caa3ab22dd`
- publication eligible: false (`shifu-local`)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This defensive decoding fix preserves the existing provider discovery, Agent Session, Work authority, and public command architecture."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The provider boundary remains a bounded local `--version` probe. No authentication, private logs, provider sessions, billing, or quota data are read.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

No prose update is required because the public command and architecture contract are unchanged; executable tests cover the Windows decoding boundary.
