### PR TITLE
fix(ci): fence merged dequeue Warrant settlement

### DIFF
--- a/.github/workflows/dev-delivery-warrant-terminal.yml
+++ b/.github/workflows/dev-delivery-warrant-terminal.yml
@@ -57,6 +57,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .buildchain/dev-delivery-terminal
+          if [ "$EVENT_ACTION" = "dequeued" ] && [ "$MERGED" = "true" ]; then
+            echo "active=false" >> "$GITHUB_OUTPUT"
+            echo "queued=false" >> "$GITHUB_OUTPUT"
+            echo "Merged dequeue events defer Warrant settlement to the exact closed event."
+            exit 0
+          fi
           observation=.buildchain/dev-delivery-terminal/observation.json
           # shifu-entry-contract: allow protected Buildchain Warrant observation without executing consumer source
           node .buildchain/runtime/scripts/dev-delivery-warrant.mjs observe \

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -513,10 +513,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:30e33b4b048112be5fa02794f428bfe3ad6b561666895f6fd8d2b863212ecb0a",
+          "definitionDigest": "sha256:cd0eb8400ae90a0e67e4a2e7d1d9ec10228f8278cd31d32e2ce231d57916556d",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:92f89811b9317f223d12a30cf905a95309f37363d606014f480d522339834ce9"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:ae748475089b545118ef1108571a26228d1f4a3017d559e4ed61f6499c85ebad"}]
+          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:92f89811b9317f223d12a30cf905a95309f37363d606014f480d522339834ce9"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:51f803ec2de044579e22c43a68ed6cf3c9c53db4305ccce528db04075c324f09"}]
         }
       ]
     },

--- a/scripts/dev-delivery-warrant-input.test.mjs
+++ b/scripts/dev-delivery-warrant-input.test.mjs
@@ -171,6 +171,18 @@ test('terminal consumer executes only protected event and Buildchain authority',
   );
   assert.match(workflow, /pull_request_target:/u);
   assert.match(workflow, /types: \[closed, dequeued\]/u);
+  const mergedDequeueFence = workflow.indexOf(
+    'if [ "$EVENT_ACTION" = "dequeued" ] && [ "$MERGED" = "true" ]; then',
+  );
+  const warrantObservation = workflow.indexOf(
+    'dev-delivery-warrant.mjs observe',
+  );
+  assert.ok(mergedDequeueFence >= 0);
+  assert.ok(warrantObservation > mergedDequeueFence);
+  assert.match(
+    workflow,
+    /Merged dequeue events defer Warrant settlement to the exact closed event/u,
+  );
   assert.match(workflow, /No matching active Warrant or queued candidate/u);
   assert.match(workflow, /\.observation\.queued\[\]\?/u);
   assert.match(workflow, /needs\.prepare\.outputs\.queued == 'true'/u);


### PR DESCRIPTION
Defer Dev Delivery Warrant settlement when GitHub emits dequeue with merged=true, so the exact pull_request.closed event remains the sole merged terminal authority. Adds a regression guard assertion, refreshes workflow authority digests, and refreshes the release publication inventory root.

Validated with KUNGFU_DEV_BRANCH=origin/dev/v4/v4.0 ./shifu check.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This bugfix only fences merged dequeue settlement and refreshes existing workflow authority roots; it does not change an ADR decision."}
-->