### PR TITLE
fix(core): invalidate embedded profile contracts

### DIFF
--- a/framework/core/src/libkungfu/CMakeLists.txt
+++ b/framework/core/src/libkungfu/CMakeLists.txt
@@ -14,7 +14,8 @@ configure_file(
   @ONLY
 )
 
-# Embed the exact KFX contract as the sole Profile schema owner.
+# Embed the exact KFX contracts and invalidate restored configurations when either owner changes.
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/../../../kfx/kungfu-kfx.contract.json" "${PROJECT_SOURCE_DIR}/../../../kfx/kungfu-kfx-domain-profile.contract.json")
 file(READ "${PROJECT_SOURCE_DIR}/../../../kfx/kungfu-kfx.contract.json" KFX_CONTRACT_JSON)
 file(READ "${PROJECT_SOURCE_DIR}/../../../kfx/kungfu-kfx-domain-profile.contract.json" KFX_DOMAIN_PROFILE_JSON)
 # MSVC limits one string literal to 65,535 bytes. Preserve the exact contract
@@ -40,7 +41,6 @@ configure_file(
   "${KUNGFU_GENERATED_INCLUDE_DIR}/kungfu/runtime/profile/profile_source_contract.h"
   @ONLY
 )
-
 # KF-ADR-019f86da-4f90-7b3f-9ef3-84f5a878f302 assessment jobs use an independent FlatBuffers authority while
 # sharing the ActionEnvelope and Episode substrates with KF-ADR-019f86da-4f90-7d81-90a0-d144fc27fe03.
 file(READ "${PROJECT_SOURCE_DIR}/schemas/assessment_event.fbs" ASSESSMENT_EVENT_FBS)

--- a/scripts/run-kfx-profile-suite-tests.mjs
+++ b/scripts/run-kfx-profile-suite-tests.mjs
@@ -73,6 +73,29 @@ function assertNoLegacyProductIdentity() {
   );
 }
 
+function assertEmbeddedSourceContractDependencies() {
+  const cmake = readFileSync(
+    path.join(root, 'framework/core/src/libkungfu/CMakeLists.txt'),
+    'utf8',
+  );
+  const dependencyBlock = cmake.match(
+    /set_property\(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ([^)]+)\)/u,
+  )?.[1];
+  for (const contract of [
+    'kungfu-kfx.contract.json',
+    'kungfu-kfx-domain-profile.contract.json',
+  ]) {
+    if (!dependencyBlock?.includes(contract)) {
+      throw new Error(
+        `${contract} must invalidate cached CMake configuration before its bytes are embedded`,
+      );
+    }
+  }
+  process.stdout.write(
+    '[kfx-profile-suite] embedded source contracts invalidate cached CMake configuration\n',
+  );
+}
+
 const pythonPath = [
   path.join(root, 'framework/core/src/python'),
   agentWorkLabOnly
@@ -83,6 +106,8 @@ const pythonPath = [
 ]
   .filter(Boolean)
   .join(path.delimiter);
+
+assertEmbeddedSourceContractDependencies();
 
 if (agentWorkLabOnly) {
   assertNoLegacyProductIdentity();


### PR DESCRIPTION
## Summary

- declare both embedded KFX source contracts as CMake configure dependencies
- force restored build trees to regenerate the native Profile schema when either contract changes
- add a source-level regression guard so cached contract embedding cannot silently drift again

This fixes the strict auditable-demo Project Tour failure caused by a restored Core build tree embedding an older Profile Suite schema that rejected the current `work` root.

Supersedes #2521 with one linear commit on the current protected `dev/v4/v4.0` head so merge-queue replay is exact.

## Validation

- `./shifu test:kfx-profile-suite` passed on the current protected base
- identical patch previously passed two native Core builds, including a contract-mtime invalidation rebuild
- `KUNGFU_DEV_BRANCH=dev/v4/v4.0 ./shifu check:source` passed for the identical patch

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix makes restored CMake configurations observe existing KFX contract authorities; it does not change architecture or product APIs."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: deterministic embedding of existing KFX Profile contracts into restored native build trees.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and generated projections are current
