### PR TITLE
fix(product): retry Linux CLI runtime closure delivery

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -997,6 +997,40 @@ export function copyTree(source, target, options = {}) {
   return true;
 }
 
+export function stageNodePtyForCli(
+  source,
+  target,
+  platform = process.platform,
+  architecture = process.arch,
+) {
+  copyTree(source, target);
+  if (platform === 'linux') {
+    const nativeDirectory = path.join('build', 'Release');
+    const targetNativeDirectory = path.join(target, nativeDirectory);
+    fs.mkdirSync(targetNativeDirectory, { recursive: true });
+    for (const name of ['pty.node', 'spawn-helper']) {
+      const input = path.join(source, nativeDirectory, name);
+      if (!fs.existsSync(input) || !fs.lstatSync(input).isFile()) {
+        throw new Error(
+          `required Linux node-pty runtime not found: ${rel(input)}`,
+        );
+      }
+      fs.copyFileSync(input, path.join(targetNativeDirectory, name));
+    }
+    fs.chmodSync(path.join(targetNativeDirectory, 'spawn-helper'), 0o755);
+  } else if (platform === 'darwin') {
+    fs.chmodSync(
+      path.join(
+        target,
+        'prebuilds',
+        `${platform}-${architecture}`,
+        'spawn-helper',
+      ),
+      0o755,
+    );
+  }
+}
+
 function bundleSdkForCli(stageRoot, esbuildRuntime) {
   const esbuild = require(
     require.resolve('esbuild', {
@@ -1159,12 +1193,26 @@ export function writeAuditableDemoBinaryMetadata(
   const binary = path.join(stageRoot, layout.launcherName);
   const runtime = path.join(stageRoot, layout.runtimeEntrypoint);
   const python = path.join(stageRoot, layout.pythonEntrypoint);
-  [binary, runtime, python].forEach(symlinks.materializeRegularFile);
+  const executableFiles = [binary, runtime, python];
+  if (platform.startsWith('linux-')) {
+    executableFiles.push(
+      path.join(
+        stageRoot,
+        'tui',
+        'node_modules',
+        'node-pty',
+        'build',
+        'Release',
+        'spawn-helper',
+      ),
+    );
+  }
+  executableFiles.forEach(symlinks.materializeRegularFile);
   const metadata = {
     contract: 'kungfu.declarative-demo-binary/v1',
     platformId: platform,
     sha256: sha256File(binary),
-    executableFiles: [binary, runtime, python].map((file) => ({
+    executableFiles: executableFiles.map((file) => ({
       path: path.relative(artifactRoot, file).split(path.sep).join('/'),
       sha256: sha256File(file).slice('sha256:'.length),
     })),
@@ -1756,26 +1804,12 @@ function buildCliProduct(esbuildRuntime) {
       copyTree(CORE_DIST, path.join(stageRoot, layout.runtimeDirectory));
       copyTree(ASSEMBLED_EXTENSIONS, path.join(stageRoot, 'extensions'));
       copyTree(path.join(TUI_DIR, 'dist'), path.join(stageRoot, 'tui'));
-      copyTree(
+      stageNodePtyForCli(
         fs.realpathSync(
           path.join(AGENT_SESSION_DIR, 'node_modules', 'node-pty'),
         ),
         path.join(stageRoot, 'tui', 'node_modules', 'node-pty'),
       );
-      if (process.platform === 'darwin') {
-        fs.chmodSync(
-          path.join(
-            stageRoot,
-            'tui',
-            'node_modules',
-            'node-pty',
-            'prebuilds',
-            `${process.platform}-${process.arch}`,
-            'spawn-helper',
-          ),
-          0o755,
-        );
-      }
       bundleSdkForCli(stageRoot, esbuildRuntime);
       const bundledUpgradeManifest = buildCliUpgradeManifest({
         stageRoot,

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -26,6 +26,7 @@ import {
   runInstalledKungfuAssignmentAdmissionSmoke,
   runInstalledKungfuCommand,
   runInstalledTuiBootstrapSmoke,
+  stageNodePtyForCli,
   stageXinfaContract,
   verifyProductObservabilityEvents,
   writeAuditableDemoBinaryMetadata,
@@ -52,6 +53,22 @@ const {
   esmEntrypointArgs,
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
+
+function writeLinuxNodePtyHelper(root, content = 'spawn-helper\n') {
+  const helper = path.join(
+    root,
+    'tui',
+    'node_modules',
+    'node-pty',
+    'build',
+    'Release',
+    'spawn-helper',
+  );
+  fs.mkdirSync(path.dirname(helper), { recursive: true });
+  fs.writeFileSync(helper, content);
+  fs.chmodSync(helper, 0o755);
+  return helper;
+}
 
 test('Intel macOS is rejected by the product-wide host policy', () => {
   for (const architecture of ['x64', 'x86_64']) {
@@ -262,6 +279,7 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
     'python\n',
   );
   fs.symlinkSync('python3.13', path.join(root, layout.pythonEntrypoint));
+  writeLinuxNodePtyHelper(root);
   const metadata = writeAuditableDemoBinaryMetadata(
     root,
     layout,
@@ -287,6 +305,13 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
       {
         path: 'runtime/python/bin/python3',
         sha256: crypto.createHash('sha256').update('python\n').digest('hex'),
+      },
+      {
+        path: 'tui/node_modules/node-pty/build/Release/spawn-helper',
+        sha256: crypto
+          .createHash('sha256')
+          .update('spawn-helper\n')
+          .digest('hex'),
       },
     ],
     runtimeDependencies: [],
@@ -322,6 +347,7 @@ test('CLI product materializes symlinked demo executables as regular files', (t)
     ),
     path.join(root, layout.pythonEntrypoint),
   );
+  writeLinuxNodePtyHelper(root);
 
   writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root);
 
@@ -345,6 +371,7 @@ test('CLI runtime identity is stable after demo executable metadata', (t) => {
   fs.writeFileSync(pythonTarget, 'python\n');
   fs.chmodSync(pythonTarget, 0o755);
   fs.symlinkSync('python3.13', python);
+  writeLinuxNodePtyHelper(root);
 
   materializeProductRuntimeEntrypoints(runtimeRoot, 'linux');
   const manifest = buildCliUpgradeManifest({ stageRoot: root, layout });
@@ -441,6 +468,62 @@ test('product staging rewrites internal absolute symlinks as portable relative l
   } finally {
     fs.rmSync(parent, { recursive: true, force: true });
   }
+});
+
+test('Linux CLI staging restores only the exact node-pty native runtime closure', (t) => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-node-pty-'));
+  t.after(() => fs.rmSync(parent, { recursive: true, force: true }));
+  const source = path.join(parent, 'source');
+  const target = path.join(parent, 'target');
+  for (const [relative, content] of [
+    ['package.json', '{}\n'],
+    ['index.js', 'export {};\n'],
+    ['build/Release/pty.node', 'native-addon\n'],
+    ['build/Release/spawn-helper', 'native-helper\n'],
+    ['build/Debug/pty.node', 'debug-addon\n'],
+    ['build/Release/obj.target/unshipped.o', 'object\n'],
+  ]) {
+    const file = path.join(source, relative);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content);
+  }
+
+  stageNodePtyForCli(source, target, 'linux', 'x64');
+
+  assert.equal(
+    fs.readFileSync(path.join(target, 'index.js'), 'utf8'),
+    'export {};\n',
+  );
+  assert.equal(
+    fs.readFileSync(path.join(target, 'build/Release/pty.node'), 'utf8'),
+    'native-addon\n',
+  );
+  const helper = path.join(target, 'build/Release/spawn-helper');
+  assert.equal(fs.readFileSync(helper, 'utf8'), 'native-helper\n');
+  assert.notEqual(fs.statSync(helper).mode & 0o111, 0);
+  assert.equal(fs.existsSync(path.join(target, 'build/Debug')), false);
+  assert.equal(
+    fs.existsSync(path.join(target, 'build/Release/obj.target')),
+    false,
+  );
+});
+
+test('Linux CLI staging fails closed when node-pty native runtime is incomplete', (t) => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-node-pty-'));
+  t.after(() => fs.rmSync(parent, { recursive: true, force: true }));
+  const source = path.join(parent, 'source');
+  const target = path.join(parent, 'target');
+  fs.mkdirSync(path.join(source, 'build', 'Release'), { recursive: true });
+  fs.writeFileSync(path.join(source, 'package.json'), '{}\n');
+  fs.writeFileSync(
+    path.join(source, 'build', 'Release', 'pty.node'),
+    'addon\n',
+  );
+
+  assert.throws(
+    () => stageNodePtyForCli(source, target, 'linux', 'x64'),
+    /required Linux node-pty runtime not found/u,
+  );
 });
 
 test('product staging rejects an absolute symlink outside its source tree', (t) => {

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -507,6 +507,23 @@ test('Linux CLI staging restores only the exact node-pty native runtime closure'
     false,
   );
 });
+test('Darwin CLI staging preserves the prebuilt node-pty helper contract', (t) => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-node-pty-'));
+  t.after(() => fs.rmSync(parent, { recursive: true, force: true }));
+  const source = path.join(parent, 'source');
+  const target = path.join(parent, 'target');
+  const prebuild = path.join(source, 'prebuilds', 'darwin-arm64');
+  fs.mkdirSync(prebuild, { recursive: true });
+  fs.writeFileSync(path.join(prebuild, 'pty.node'), 'native-addon\n');
+  fs.writeFileSync(path.join(prebuild, 'spawn-helper'), 'native-helper\n');
+  fs.chmodSync(path.join(prebuild, 'spawn-helper'), 0o644);
+  stageNodePtyForCli(source, target, 'darwin', 'arm64');
+  const addon = path.join(target, 'prebuilds/darwin-arm64/pty.node');
+  assert.equal(fs.readFileSync(addon, 'utf8'), 'native-addon\n');
+  const helper = path.join(target, 'prebuilds/darwin-arm64/spawn-helper');
+  assert.equal(fs.readFileSync(helper, 'utf8'), 'native-helper\n');
+  assert.notEqual(fs.statSync(helper).mode & 0o111, 0);
+});
 
 test('Linux CLI staging fails closed when node-pty native runtime is incomplete', (t) => {
   const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-node-pty-'));


### PR DESCRIPTION
## Summary

- restore the exact Linux `node-pty` runtime closure (`pty.node` and `spawn-helper`) after generic product staging intentionally excludes build directories
- keep the generic copy filter unchanged and fail closed when either required Linux runtime file is absent
- bind the shipped Linux helper into auditable-demo executable metadata and preserve its executable mode
- preserve the existing Darwin prebuild helper handling without widening the packaged tree

This is the delivery successor to #2523 at the same exact source head. The prior PR's Warrant candidate is terminal after a failed queue attempt, and candidate identity is derived from the PR number; this new PR provides a fresh fail-closed Warrant identity without changing the qualified source bytes or bypassing the serialized controller.

The formal Build at protected source `0a3fb72098646dc7abf09060cb89aedf00a95f13` proved all platform builds and signing successful, while Project Tour failed only after the Linux CLI artifact omitted `node-pty/build/Release`. This patch repairs that bounded packaging defect without weakening the strict capture container or demo gate.

## Related issue

- Assignment: `2026-08-05-kungfu-cli-linux-agent-session-runtime-closure`
- Parent Assignment: `2026-08-03-atlas-assignment-profile-admission-closure`
- Supersedes delivery attempt: #2523

## Changes

- add a dedicated `stageNodePtyForCli` adapter that restores only the two required Linux native runtime files
- mark the Linux helper executable and include its exact digest in demo binary metadata
- add positive exact-closure, incomplete-runtime, and Darwin prebuilt-helper preservation tests

## Verification

- `./shifu test:cli-surface-qualification`: 55 passed, 0 failed
- `PATH=<qualified-core-venv>:$PATH ./shifu check:source`: build-free source gate passed
  - main Node suite: 1037 passed, 0 failed, 10 skipped
  - Agent Work Python suite: 40 passed
  - runtime upgrade suite: 134 passed
  - desktop update adapter suite: 73 passed
  - changed-file Biome check: clean
  - zero-write tracked and untracked roots unchanged
- `git diff --check`: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores already-required Linux CLI runtime bytes and evidence metadata without changing architecture, product APIs, authority, or release semantics."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: Linux CLI product staging and auditable-demo executable evidence only. The strict network-none, read-only, non-root capture container and existing Buildchain gate remain unchanged.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; behavior is restored and covered by tests)
