### PR TITLE
fix(update): preserve Windows selected CLI handoff

### DIFF
--- a/framework/core/src/python/kungfu/distribution_update.py
+++ b/framework/core/src/python/kungfu/distribution_update.py
@@ -1380,8 +1380,6 @@ def reexec_selected_cli() -> None:
     if selected is not None:
         argv, env = selected
         if sys.platform == "win32":
-            # Keep the selected UI in the foreground so terminal ownership and
-            # its exact exit status return through the archive controller.
             raise SystemExit(subprocess.run(argv, env=env, check=False).returncode)
         os.execve(argv[0], argv, env)
 

--- a/framework/core/src/python/kungfu/distribution_update.py
+++ b/framework/core/src/python/kungfu/distribution_update.py
@@ -1366,13 +1366,11 @@ def selected_cli_command(
         }
     )
     if selection.get("releaseCutRoot"):
-        selected_env.update(
-            {
-                "KUNGFU_SELECTED_RELEASE_CUT_ROOT": str(selection["releaseCutRoot"]),
-                "KUNGFU_SELECTED_PLATFORM_SLICE_ROOT": str(
-                    selection["platformSliceRoot"]
-                ),
-            }
+        selected_env["KUNGFU_SELECTED_RELEASE_CUT_ROOT"] = str(
+            selection["releaseCutRoot"]
+        )
+        selected_env["KUNGFU_SELECTED_PLATFORM_SLICE_ROOT"] = str(
+            selection["platformSliceRoot"]
         )
     return [str(executable), *sys.argv[1:]], selected_env
 
@@ -1381,6 +1379,8 @@ def reexec_selected_cli() -> None:
     selected = selected_cli_command()
     if selected is not None:
         argv, env = selected
+        if sys.platform == "win32":
+            raise SystemExit(subprocess.run(argv, env=env, check=False).returncode)
         os.execve(argv[0], argv, env)
 
 

--- a/framework/core/src/python/kungfu/distribution_update.py
+++ b/framework/core/src/python/kungfu/distribution_update.py
@@ -1380,6 +1380,8 @@ def reexec_selected_cli() -> None:
     if selected is not None:
         argv, env = selected
         if sys.platform == "win32":
+            # Keep the selected UI in the foreground so terminal ownership and
+            # its exact exit status return through the archive controller.
             raise SystemExit(subprocess.run(argv, env=env, check=False).returncode)
         os.execve(argv[0], argv, env)
 

--- a/framework/core/tests/python/test_distribution_update_structure.py
+++ b/framework/core/tests/python/test_distribution_update_structure.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 import types
+
+import pytest
 
 
 fake = types.ModuleType("pykungfu")
@@ -43,3 +46,63 @@ def test_distribution_update_compatibility_surface_reexports_extracted_layers() 
         assert getattr(distribution_update, name) is getattr(
             distribution_update_planning, name
         )
+
+
+def test_windows_selected_cli_handoff_waits_for_child_and_preserves_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    argv = [r"C:\selected\kungfu.exe", "run", "codex"]
+    env = {"KUNGFU_SELECTED_FRONTEND_BUILD_ID": "product-selected"}
+    observed = {}
+
+    monkeypatch.setattr(distribution_update.sys, "platform", "win32")
+    monkeypatch.setattr(
+        distribution_update,
+        "selected_cli_command",
+        lambda: (argv, env),
+    )
+
+    def run_selected(command, *, env, check):
+        observed.update(command=command, env=env, check=check)
+        return subprocess.CompletedProcess(command, 23)
+
+    monkeypatch.setattr(distribution_update.subprocess, "run", run_selected)
+    monkeypatch.setattr(
+        distribution_update.os,
+        "execve",
+        lambda *_args: pytest.fail("Windows must not detach via os.execve"),
+    )
+
+    with pytest.raises(SystemExit) as exited:
+        distribution_update.reexec_selected_cli()
+
+    assert exited.value.code == 23
+    assert observed == {"command": argv, "env": env, "check": False}
+
+
+def test_non_windows_selected_cli_handoff_still_execs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    argv = ["/selected/kungfu", "--version"]
+    env = {"KUNGFU_SELECTED_FRONTEND_BUILD_ID": "product-selected"}
+    observed = {}
+
+    monkeypatch.setattr(distribution_update.sys, "platform", "linux")
+    monkeypatch.setattr(
+        distribution_update,
+        "selected_cli_command",
+        lambda: (argv, env),
+    )
+    monkeypatch.setattr(
+        distribution_update.os,
+        "execve",
+        lambda executable, command, selected_env: observed.update(
+            executable=executable,
+            command=command,
+            env=selected_env,
+        ),
+    )
+
+    distribution_update.reexec_selected_cli()
+
+    assert observed == {"executable": argv[0], "command": argv, "env": env}

--- a/framework/core/tests/python/test_distribution_update_structure.py
+++ b/framework/core/tests/python/test_distribution_update_structure.py
@@ -70,7 +70,7 @@ def test_windows_selected_cli_handoff_waits_for_child_and_preserves_exit(
     monkeypatch.setattr(
         distribution_update.os,
         "execve",
-        lambda *_args: pytest.fail("Windows must not detach via os.execve"),
+        lambda *_args: pytest.fail("Windows must retain foreground terminal ownership"),
     )
 
     with pytest.raises(SystemExit) as exited:


### PR DESCRIPTION
## Summary

Preserve the foreground terminal contract when an archive bootstrap controller hands a Windows CLI invocation to the selected product generation. Windows does not provide POSIX `execve` replacement semantics, so the controller now runs the selected CLI as a foreground child, waits for it, and returns its exact exit status. Non-Windows replacement behavior is unchanged.

## Related issue

None.

## Changes

- use a foreground child process for selected-CLI handoff on Windows
- preserve selected release-cut environment projection while keeping the Python structure budget flat
- cover Windows wait/exit propagation and retained non-Windows `execve` behavior

## Verification

- `./shifu test:runtime-upgrade` — 134 passed
- focused handoff tests on macOS — 2 passed
- focused handoff tests on DARKHERO Windows — 2 passed
- DARKHERO candidate controller emitted the selected generation's complete Codex/Amp/OpenCode runtime catalog
- DARKHERO candidate controller entered the real Codex native full-screen PTY and returned cleanly with status 0 after Ctrl-C
- `./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the existing archive-selected CLI foreground handoff contract on Windows without changing product architecture or authority boundaries"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to local selected-generation CLI process handoff. Verification covers the real Windows PTY, provider discovery, exact exit propagation, and source gates; it does not read provider private state.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
