### PR TITLE
fix(product): match Linux node-pty runtime closure

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1008,16 +1008,13 @@ export function stageNodePtyForCli(
     const nativeDirectory = path.join('build', 'Release');
     const targetNativeDirectory = path.join(target, nativeDirectory);
     fs.mkdirSync(targetNativeDirectory, { recursive: true });
-    for (const name of ['pty.node', 'spawn-helper']) {
-      const input = path.join(source, nativeDirectory, name);
-      if (!fs.existsSync(input) || !fs.lstatSync(input).isFile()) {
-        throw new Error(
-          `required Linux node-pty runtime not found: ${rel(input)}`,
-        );
-      }
-      fs.copyFileSync(input, path.join(targetNativeDirectory, name));
+    const input = path.join(source, nativeDirectory, 'pty.node');
+    if (!fs.existsSync(input) || !fs.lstatSync(input).isFile()) {
+      throw new Error(
+        `required Linux node-pty runtime not found: ${rel(input)}`,
+      );
     }
-    fs.chmodSync(path.join(targetNativeDirectory, 'spawn-helper'), 0o755);
+    fs.copyFileSync(input, path.join(targetNativeDirectory, 'pty.node'));
   } else if (platform === 'darwin') {
     fs.chmodSync(
       path.join(
@@ -1194,19 +1191,6 @@ export function writeAuditableDemoBinaryMetadata(
   const runtime = path.join(stageRoot, layout.runtimeEntrypoint);
   const python = path.join(stageRoot, layout.pythonEntrypoint);
   const executableFiles = [binary, runtime, python];
-  if (platform.startsWith('linux-')) {
-    executableFiles.push(
-      path.join(
-        stageRoot,
-        'tui',
-        'node_modules',
-        'node-pty',
-        'build',
-        'Release',
-        'spawn-helper',
-      ),
-    );
-  }
   executableFiles.forEach(symlinks.materializeRegularFile);
   const metadata = {
     contract: 'kungfu.declarative-demo-binary/v1',

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -54,22 +54,6 @@ const {
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
 
-function writeLinuxNodePtyHelper(root, content = 'spawn-helper\n') {
-  const helper = path.join(
-    root,
-    'tui',
-    'node_modules',
-    'node-pty',
-    'build',
-    'Release',
-    'spawn-helper',
-  );
-  fs.mkdirSync(path.dirname(helper), { recursive: true });
-  fs.writeFileSync(helper, content);
-  fs.chmodSync(helper, 0o755);
-  return helper;
-}
-
 test('Intel macOS is rejected by the product-wide host policy', () => {
   for (const architecture of ['x64', 'x86_64']) {
     for (const operation of [
@@ -279,7 +263,6 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
     'python\n',
   );
   fs.symlinkSync('python3.13', path.join(root, layout.pythonEntrypoint));
-  writeLinuxNodePtyHelper(root);
   const metadata = writeAuditableDemoBinaryMetadata(
     root,
     layout,
@@ -305,13 +288,6 @@ test('CLI product emits exact standalone demo metadata beside the launcher', (t)
       {
         path: 'runtime/python/bin/python3',
         sha256: crypto.createHash('sha256').update('python\n').digest('hex'),
-      },
-      {
-        path: 'tui/node_modules/node-pty/build/Release/spawn-helper',
-        sha256: crypto
-          .createHash('sha256')
-          .update('spawn-helper\n')
-          .digest('hex'),
       },
     ],
     runtimeDependencies: [],
@@ -347,8 +323,6 @@ test('CLI product materializes symlinked demo executables as regular files', (t)
     ),
     path.join(root, layout.pythonEntrypoint),
   );
-  writeLinuxNodePtyHelper(root);
-
   writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root);
 
   const python = path.join(root, layout.pythonEntrypoint);
@@ -371,8 +345,6 @@ test('CLI runtime identity is stable after demo executable metadata', (t) => {
   fs.writeFileSync(pythonTarget, 'python\n');
   fs.chmodSync(pythonTarget, 0o755);
   fs.symlinkSync('python3.13', python);
-  writeLinuxNodePtyHelper(root);
-
   materializeProductRuntimeEntrypoints(runtimeRoot, 'linux');
   const manifest = buildCliUpgradeManifest({ stageRoot: root, layout });
   writeAuditableDemoBinaryMetadata(root, layout, 'linux-x64', root);
@@ -479,7 +451,6 @@ test('Linux CLI staging restores only the exact node-pty native runtime closure'
     ['package.json', '{}\n'],
     ['index.js', 'export {};\n'],
     ['build/Release/pty.node', 'native-addon\n'],
-    ['build/Release/spawn-helper', 'native-helper\n'],
     ['build/Debug/pty.node', 'debug-addon\n'],
     ['build/Release/obj.target/unshipped.o', 'object\n'],
   ]) {
@@ -498,9 +469,10 @@ test('Linux CLI staging restores only the exact node-pty native runtime closure'
     fs.readFileSync(path.join(target, 'build/Release/pty.node'), 'utf8'),
     'native-addon\n',
   );
-  const helper = path.join(target, 'build/Release/spawn-helper');
-  assert.equal(fs.readFileSync(helper, 'utf8'), 'native-helper\n');
-  assert.notEqual(fs.statSync(helper).mode & 0o111, 0);
+  assert.equal(
+    fs.existsSync(path.join(target, 'build/Release/spawn-helper')),
+    false,
+  );
   assert.equal(fs.existsSync(path.join(target, 'build/Debug')), false);
   assert.equal(
     fs.existsSync(path.join(target, 'build/Release/obj.target')),
@@ -525,17 +497,13 @@ test('Darwin CLI staging preserves the prebuilt node-pty helper contract', (t) =
   assert.notEqual(fs.statSync(helper).mode & 0o111, 0);
 });
 
-test('Linux CLI staging fails closed when node-pty native runtime is incomplete', (t) => {
+test('Linux CLI staging fails closed when the node-pty native addon is missing', (t) => {
   const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-node-pty-'));
   t.after(() => fs.rmSync(parent, { recursive: true, force: true }));
   const source = path.join(parent, 'source');
   const target = path.join(parent, 'target');
   fs.mkdirSync(path.join(source, 'build', 'Release'), { recursive: true });
   fs.writeFileSync(path.join(source, 'package.json'), '{}\n');
-  fs.writeFileSync(
-    path.join(source, 'build', 'Release', 'pty.node'),
-    'addon\n',
-  );
 
   assert.throws(
     () => stageNodePtyForCli(source, target, 'linux', 'x64'),


### PR DESCRIPTION
## Outcome

Correct Linux CLI staging to preserve the exact native runtime emitted by node-pty 1.1.0 source builds.

## Terminal evidence

Formal Build run 30951014869 installed node-pty on GitHub-hosted Linux x64. Its successful node-gyp log emitted only:

- build/Release/pty.node

The current staging contract then failed by requiring a non-existent Linux build/Release/spawn-helper. That helper belongs to the Darwin prebuild contract and remains preserved there.

## Change

- Linux staging copies and fail-closes on pty.node only.
- Linux demo metadata no longer declares a non-existent helper executable.
- Darwin spawn-helper staging and executable-mode coverage are unchanged.
- Tests now model the observed Linux source-build layout and still reject a missing native addon.

## Validation

- git diff --check: passed.
- Repository pre-commit code gates passed through the changed-code checks.
- The local hook later stopped on an absent markdownlint-cli2 dependency in the fresh worktree; no Markdown files changed.
- Per release direction, no redundant local full build was run; protected CI is authoritative.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This packaging correction restores the existing Linux node-pty runtime closure without changing architecture, authority boundaries, or release semantics"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to the already-declared CLI runtime payload and is backed by exact GitHub-hosted terminal evidence.

## Release impact

This repairs the exact terminal blocker from run 30951014869 before Project Tour demo capture and is required before opening the next Alpha candidate.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation impact assessed; no documentation change required