### PR TITLE
docs(readme): sharpen the agent-first product entry

### DIFF
--- a/.buildchain/auditable-demo.json
+++ b/.buildchain/auditable-demo.json
@@ -33,7 +33,7 @@
   "demos": [
     {
       "id": "agent-work-lab-autoplay",
-      "title": "Kungfu Agent Work Lab autoplay",
+      "title": "Can Work survive a new Agent?",
       "claimBoundary": "This exact standalone Kungfu artifact proves only the bounded offline Agent Work Lab autoplay observed in two independently captured native PTYs; it grants no Work, release, capability, or production authority.",
       "steps": [
         {
@@ -48,7 +48,7 @@
     },
     {
       "id": "project-tour-episode-1",
-      "title": "Kungfu Project Tour episode 1 at 1x",
+      "title": "Can Work survive failure?",
       "claimBoundary": "This exact standalone Kungfu artifact proves only the bounded disposable Project Tour episode 1 observed at 1x in two independently captured native PTYs; Mock Agent output and terminal observations grant no Work, release, capability, or production authority.",
       "steps": [
         {
@@ -63,7 +63,7 @@
     },
     {
       "id": "project-tour-episode-2",
-      "title": "Kungfu Project Tour episode 2 at 1x",
+      "title": "Who is allowed to complete Work?",
       "claimBoundary": "This exact standalone Kungfu artifact proves only the bounded disposable Project Tour episode 2 observed at 1x in two independently captured native PTYs; Mock Agent output and terminal observations grant no Work, release, capability, or production authority.",
       "steps": [
         {

--- a/README.md
+++ b/README.md
@@ -9,18 +9,21 @@ agent takes over.
 Use the best Agent when it matters. Use a cheaper one when it does not. Keep the
 same Work across Codex, Claude, OpenCode, Amp, or your own execution surface.
 
-> **Kungfu UNGFU™** · Never Guess. Facts Unfold. [Why this signature
-> exists](docs/concepts/why-kungfu.md).
+## Start where you already work
 
-Before asking an agent to use Kungfu, make sure the `kungfu` command is on its
-`PATH`. [Set up the Kungfu command](docs/guides/installing-cli.md#make-kungfu-available-in-path),
-then paste this one sentence into the agent you already use:
+Once the `kungfu` command is on your
+[`PATH`](docs/guides/installing-cli.md#make-kungfu-available-in-path), choose the
+entry that matches how you already work.
+
+**Stay in your current Agent.** Paste this sentence into Codex, Claude, OpenCode,
+Amp, or another Agent that can run local commands:
 
 ```text
 Run `kungfu agent brief`, then guide me through my first Project and Work. Keep me in my current agent, and use Kungfu as the durable Work layer.
 ```
 
-Keep working in that agent when you are ready:
+**Start an Agent through Kungfu.** Use its familiar native console while Kungfu
+keeps the Work behind it:
 
 ```sh
 cd your-project
@@ -34,95 +37,17 @@ already use. Pass a task to create the first Work directly:
 kungfu run codex "Prepare the release notes"
 ```
 
-A successful agent process is retained for independent review; it does not
-complete Work by itself.
+**Open the optional global view later.** The Kungfu TUI and GUI can show and
+manage Kungfu Projects and Work across Agent Sessions. They are sidecar views,
+not a requirement for every Agent conversation.
 
-<!-- kungfu:auditable-demo:agent-work-lab-autoplay:start -->
-## Kungfu Agent Work Lab autoplay
-
-[![Kungfu Agent Work Lab autoplay](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/demo.gif)](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/public-evidence.json)
-
-Animation scenario:
-
-```text
-$ kungfu agent-work-lab autoplay
-```
-
-Native renditions: [1080p MP4](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/demo.mp4) · [1080p WebM](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/demo.webm) · [720p MP4](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/demo-720p.mp4) · [720p WebM](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/demo-720p.webm)
-
-[Static poster / reduced-motion fallback](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/poster.png)
-
-<details>
-<summary>Evidence and claim boundary</summary>
-
-This exact standalone Kungfu artifact proves only the bounded offline Agent Work Lab autoplay observed in two independently captured native PTYs; it grants no Work, release, capability, or production authority.
-
-[Release Passport](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/release-passport.json) · [auditable evidence](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/public-evidence.json)
-
-</details>
-<!-- kungfu:auditable-demo:agent-work-lab-autoplay:end -->
-
-<!-- kungfu:auditable-demo:project-tour-episode-1:start -->
-## Kungfu Project Tour episode 1 at 1x
-
-[![Kungfu Project Tour episode 1 at 1x](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/demo.gif)](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/public-evidence.json)
-
-Animation scenario:
-
-```text
-$ kungfu agent-work-lab project-tour --episode 1 --speed 1
-```
-
-Native renditions: [1080p MP4](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/demo.mp4) · [1080p WebM](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/demo.webm) · [720p MP4](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/demo-720p.mp4) · [720p WebM](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/demo-720p.webm)
-
-[Static poster / reduced-motion fallback](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/poster.png)
-
-<details>
-<summary>Evidence and claim boundary</summary>
-
-This exact standalone Kungfu artifact proves only the bounded disposable Project Tour episode 1 observed at 1x in two independently captured native PTYs; Mock Agent output and terminal observations grant no Work, release, capability, or production authority.
-
-[Release Passport](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/release-passport.json) · [auditable evidence](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/public-evidence.json)
-
-</details>
-<!-- kungfu:auditable-demo:project-tour-episode-1:end -->
-
-<!-- kungfu:auditable-demo:project-tour-episode-2:start -->
-## Kungfu Project Tour episode 2 at 1x
-
-[![Kungfu Project Tour episode 2 at 1x](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/demo.gif)](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/public-evidence.json)
-
-Animation scenario:
-
-```text
-$ kungfu agent-work-lab project-tour --episode 2 --speed 1
-```
-
-Native renditions: [1080p MP4](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/demo.mp4) · [1080p WebM](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/demo.webm) · [720p MP4](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/demo-720p.mp4) · [720p WebM](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/demo-720p.webm)
-
-[Static poster / reduced-motion fallback](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/poster.png)
-
-<details>
-<summary>Evidence and claim boundary</summary>
-
-This exact standalone Kungfu artifact proves only the bounded disposable Project Tour episode 2 observed at 1x in two independently captured native PTYs; Mock Agent output and terminal observations grant no Work, release, capability, or production authority.
-
-[Release Passport](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/release-passport.json) · [auditable evidence](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/public-evidence.json)
-
-</details>
-<!-- kungfu:auditable-demo:project-tour-episode-2:end -->
-
-Want to explore without leaving Kungfu first? Run the terminal product:
-
-```sh
-kungfu
-```
-
-Getting Started leads to the same Agent-first prompt. Agent Work Lab is the
-lowest-friction optional demonstration, and Guided Project Tour leaves a
-Project you can keep using. After onboarding, bare `kungfu` opens Work directly.
+> **Kungfu UNGFU™** · Never Guess. Facts Unfold. [Why this signature
+> exists](docs/concepts/why-kungfu.md).
 
 ## What Kungfu preserves
+
+Kungfu keeps the Work—not the chat—outside every Agent Session: its objective,
+progress, evidence, next action, and completion state.
 
 - **Work continuity.** Change the Agent without losing what was done, what
   remains, or which Work is continuing.
@@ -130,220 +55,100 @@ Project you can keep using. After onboarding, bare `kungfu` opens Work directly.
   conflicts, decisions, and uncertainty remain visible instead of being guessed.
 - **Inspectable history.** People and Agents can see what happened, what the
   next action is, and where the supporting evidence came from.
+- **Completion authority.** An Agent can produce a result and its evidence;
+  independent review and Kungfu settlement decide whether Work is complete.
 
 The first visible value should arrive within minutes. The deeper value appears
-over the following days, when the same work survives context loss, changed
+over the following days, when the same Work survives context loss, changed
 understanding, failed attempts, handoff, and restart.
 
-See the [continuity handoff](https://kungfu.tech/#continuity-demo) and
-[how it was tested](https://kungfu.tech/how-tested/continuity/), or inspect the
-[source protocol and retained evidence](docs/qualification/continuity-pilot.md).
-The current result is preparatory fixture evidence—not a provider comparison,
-multi-day durability or retention result, or FO10 qualification.
+## Three proofs that Work is durable
 
-## Change the Agent, not the Work
+Durable Work must answer three questions in order: can it survive a new Agent,
+can it survive failure, and who is allowed to complete it?
 
-`kungfu run <agent>` is the scriptable golden path across Codex, Claude Code,
-OpenCode, Amp, and other Agent surfaces. Kungfu does not replace those surfaces;
-it keeps the Work behind them. The provider-neutral low-level launcher remains
-available as the advanced `kungfu run agent` command. Registered third-party
-PTY Agents use `kungfu run agent --agent <profile-id>` and the bounded
-[native adapter contract](docs/guides/native-agent-adapters.md). The same local
-contracts and Work state remain available through the Kungfu TUI, GUI, CLI,
-and APIs.
+### 1. Can Work survive a new Agent?
 
-Projects can start blank, use the guided Agent Work Starter template, or safely
-remember an existing folder without changing its files. You can open several
-terminals in the same Project and run the same bare command in each one; Kungfu
-gives every launch its own Console. The Agent binds that Console to exact Work
-before it changes the Project. If another live Agent already owns that Work,
-Kungfu stops the second writer and points back to the existing attempt. Use
-`--work` when more than one captured Work item is eligible.
+Yes. The first proof isolates continuity: one Work continues across two fresh
+Agent Sessions without copied chat.
 
-## Build from source
+<!-- kungfu:auditable-demo:agent-work-lab-autoplay:start -->
+[![Can Work survive a new Agent?](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/demo.gif)](docs/qualification/evidence/auditable-demo/74f7cf0b18f261001755c43dfd2954262bdb32c865a34f8316e3ec38331fb35b/agent-work-lab-autoplay/public-evidence.json)
+<!-- kungfu:auditable-demo:agent-work-lab-autoplay:end -->
 
-Public release artifacts are not available yet. To evaluate the current source
-tree:
+### 2. Can Work survive failure?
 
-```sh
-git clone https://github.com/kungfu-systems/kungfu.git
-cd kungfu
-./shifu doctor
-./shifu sync && ./shifu build
-```
+Yes. The second proof moves from mechanism to real failure conditions. Inside
+a disposable Project, the connection drops, a new process resumes, that process
+crashes, and both Attempts remain under the same Work.
 
-## Understand the system
+<!-- kungfu:auditable-demo:project-tour-episode-1:start -->
+[![Can Work survive failure?](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/demo.gif)](docs/qualification/evidence/auditable-demo/6751bfdf7a27dd2c4b0c3f0916a512fb7abd172543c94dee220b41a0d679632e/project-tour-episode-1/public-evidence.json)
+<!-- kungfu:auditable-demo:project-tour-episode-1:end -->
 
-If your goal is to understand Kungfu as a system, do not begin by comparing
-repository directories and current modules side by side. Start with the
-[Evolution Map](docs/evolution/README.md): it establishes the historical
-pressures, abstraction compressions, and authority transitions that produced
-the current cross-section. Then use its reader routes to enter the exact
-current module, contract, and source authority for your question.
+Work survival is only the first step. If an Agent can declare its own result
+complete, continuity still is not trustworthy.
 
-If you already have one bounded implementation or operational task, use
-[AGENTS.md](AGENTS.md) and the task-specific Xinfa route instead of loading the
-whole history first.
+### 3. Who is allowed to complete Work?
 
-- [Start with Kungfu's longitudinal Evolution Map](docs/evolution/README.md)
-- [Why Kungfu begins with a minimal human sovereign core](docs/concepts/bootstrapping-agent-work.md)
-- [Inspect and reanalyze the bounded public work sample](https://kungfu.tech/about/bootstrapping/evidence/)
-- [How the complete Kungfu system works](docs/concepts/system-overview.md)
-- [How runtime selection stays explicit and auditable](docs/concepts/runtime-surface-provenance.md)
-- [Agent Supply Chain architecture and evaluation](docs/architecture/agent-supply-chain.md)
-- [Documentation Guide](docs/README.md)
-- [Documentation Map](docs/MAP.md)
-- [Known Limits](docs/qualification/known-limits.md)
-- [Build and contribute](CONTRIBUTING.md)
+Only the governed review and settlement path—not the Agent that did the work.
+The third proof separates Agent exit, independent review, and Kungfu settlement.
+An Agent can produce the candidate and evidence; it cannot approve its own Work.
 
-Agents working from a source checkout should begin with [AGENTS.md](AGENTS.md)
-and [Verified Context for Agents](docs/guides/xinfa-agent-context.md). An
-installed runtime carries its own local agent brief:
+<!-- kungfu:auditable-demo:project-tour-episode-2:start -->
+[![Who is allowed to complete Work?](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/demo.gif)](docs/qualification/evidence/auditable-demo/2ceca18c5d030d98f693e433bad4981c7931a2ca1f4b2efcbdc7d63538e642db/project-tour-episode-2/public-evidence.json)
+<!-- kungfu:auditable-demo:project-tour-episode-2:end -->
+
+These are bounded exact-artifact demonstrations—not provider rankings,
+production certification, or authority to complete real Work. See the
+[animation technical specification and auditable evidence](docs/qualification/auditable-demo-artifact-pipeline.md).
+
+Open the optional terminal view whenever you want the larger Work picture:
 
 ```sh
-kungfu agent brief
+kungfu
 ```
 
-To discover the exact Fact and Episode invariants, their owners, current
-evidence routes, and residual risks from a source checkout, run:
+Getting Started leads to the same Agent-first prompt. Keep your familiar Agent
+interface as the primary workspace and open Kungfu when you need a global view,
+a handoff, or an explicit review.
 
-```sh
-./shifu invariant:verify -- --list --json
-```
+## One Work, several ways in
 
-The human route is [Invariant Verification](docs/qualification/invariant-verification.md).
+A **Project** remembers where related Work belongs. A **Work** keeps one durable
+objective and its current truth. An **Attempt** records what one Agent tried,
+including failure, without replacing or erasing the Work.
 
-## Trust, portability, and the open system
+The same Work state is available from native Agent consoles, the Kungfu TUI and
+GUI, the CLI, and APIs. You can spend most of your time in the Agent you already
+know, then open Kungfu for a global view, a handoff, or an explicit review. If
+another live Agent already owns a Work, Kungfu stops a second writer instead of
+letting two Agents silently diverge.
 
-The following sections expose the release, migration, and interoperability
-contracts for technical evaluation. They preserve the evidence behind Kungfu's
-claims without making that evidence the first step in understanding the product.
+## Go deeper when you need to
 
-### Release status
+The README stops at the product entry. Detailed implementation, evidence, and
+claim boundaries live in their own maintained routes:
 
-Kungfu v4 is **Coming soon**. Source-built capabilities and qualification
-slices exist, but public packaging, cross-platform evidence, strong power-loss
-durability, and the institutional profile remain staged unless linked evidence
-says otherwise.
+- **Use and understand Kungfu:** [System Overview](docs/concepts/system-overview.md),
+  the [Documentation Guide](docs/README.md), and the complete
+  [Documentation Map](docs/MAP.md).
+- **Build or contribute:** [Contributing to Kungfu](CONTRIBUTING.md),
+  [AGENTS.md](AGENTS.md), [Verified Context for Agents](docs/guides/xinfa-agent-context.md),
+  and [runtime surface provenance](docs/concepts/runtime-surface-provenance.md).
+- **Verify guarantees and current limits:** [Contracts](docs/qualification/contracts.md),
+  [Known Limits](docs/qualification/known-limits.md), and the
+  [KFD support matrix](docs/qualification/kfd-support-matrix.md).
+- **Evaluate release, update, and migration behavior:**
+  [Upgrade Kungfu](docs/guides/upgrading.md) and the
+  [Exit and version compatibility policy](docs/guides/exit-and-version-compatibility.md).
+- **Evaluate the wider ecosystem thesis:** the
+  [Agent Supply Chain architecture](docs/architecture/agent-supply-chain.md).
 
-UNGFU is Kungfu's source-identifying signature, not a second product or runtime.
-See [Why Kungfu](docs/concepts/why-kungfu.md) for the naming boundary.
-
-The first public Alpha is additionally gated by one ordered activation
-transaction. Artifact publication, Release Passport sealing, exact site
-publication, public read-back, and installed-product qualification must all
-bind the same product/site source SHAs, artifact root, version, tag, and
-channel. Released evidence is synthesized only from those receipts; a
-preparation file cannot make a released-use or first-use claim. See
-[Trademark public-use qualification](docs/qualification/trademark-public-use.md).
-
-An installed Kungfu gives a person or Agent the same direct answer:
-
-```sh
-kungfu release status
-kungfu release verify <release-status-or-evidence.json>
-kungfu release explain
-```
-
-The human result says what passed and what did not; `--json` returns the stable
-KFD-3 surface. Before activation, the truthful answer is `VERIFIED, NOT
-AVAILABLE`. These commands do not make trademark-registration, legal, or
-first-use-date claims.
-
-Design intent, implemented behavior, qualified guarantees, and released
-artifacts are deliberately distinct. Before relying on a claim, check
-[Contracts](docs/qualification/contracts.md),
-[Known Limits](docs/qualification/known-limits.md), and the applicable retained
-qualification evidence.
-
-Kungfu's complete KFD-1 through KFD-13 adoption and claim boundary is published
-in the generated [KFD support matrix](docs/qualification/kfd-support-matrix.md).
-Source implementation, verification, Buildchain gating, and shipped release
-support are reported separately; a declared badge is not a release
-qualification.
-
-Inspect the current checkout before installing dependencies or initializing a
-Kungfu runtime:
-
-```sh
-./shifu kfd status
-./shifu kfd query KFD-3 --json
-./shifu kfd check --json
-```
-
-The first command gives an immediate human verdict. The JSON forms expose the
-same checked-in facts and non-claims to an Agent. They qualify source evidence,
-not an installed product: use `kungfu agent hub qualify` and
-`kungfu agent hub verify` for the installed Agent Hub path.
-
-### Exit and migration
-
-Kungfu treats Exit and migration as a product contract. Qualified stable
-releases on the same `major.minor` line preserve registered authoritative
-semantics, not physical provider paths, caches, or presentation. The current v4
-alpha remains exact-evidence-only; it does not yet carry that stable promise.
-
-Read the [Exit, migration, and version compatibility policy](docs/guides/exit-and-version-compatibility.md)
-for the support boundary, current qualification matrix, and non-claims. An
-installed artifact exposes its exact policy and protocol inventory without
-initializing a runtime:
-
-```sh
-kungfu exit verify --info --json
-```
-
-The public install/update claim is still closed. The exact current matrix,
-one-command behavior, activation boundary, rollback guidance, and explicit
-non-claims are in [Upgrade Kungfu](docs/guides/upgrading.md); source fixtures
-and prepared package-manager adapters are not public release artifacts.
-
-### Kungfu in the Agent Supply Chain
-
-Kungfu lights the first loop by keeping Work alive across the Agents a person
-already uses. The Agent experiences explicit capabilities, inspectable evidence,
-and durable Work—then can recognize and ask for those qualities elsewhere.
-
-That creates a possible market loop: Agents recommend within human or Hub
-authority, builders receive a demand signal, and more Agent-native products can
-ship the same qualities. Those products can restart the loop without Kungfu.
-This is an adoption thesis, not a claim of broad external demand or a multi-Hub
-market. [See the Agent Supply Chain loop](https://kungfu.tech/agent-supply-chain/).
-
-The technical chain is:
-
-```text
-KFD-3 discovery -> Buildchain artifact evidence -> KFD-2 assessment
-  -> libkungfu / .kungfu durable work facts -> independent Agent Hubs
-```
-
-Kungfu and libkungfu own the fourth layer: recording, ordering, querying,
-verifying, exporting, and recovering durable work facts and Episodes. The
-application still owns its domain facts, and JSON is an edge projection rather
-than a second authority. The public KFD Agent Hub profile lets independently
-owned products carry bounded responsibility objects across that edge while
-each receiver retains admission.
-
-The current proof is exact-source and first-party: source-built runtime slices,
-retained qualification, and one OpenCode-shaped reference adapter. It does not
-claim OpenCode endorsement, external vendor adoption, a second independent
-production Hub, public Kungfu Cloud, stable cross-platform compatibility, or
-physical power-loss qualification. Read the
-[architecture and evaluation route](docs/architecture/agent-supply-chain.md).
-
-If Kungfu is installed, ask the product itself. The first command runs the
-bundled fixed KFD Hub 20 suite and explains the exact result; the second
-independently rechecks the retained evidence:
-
-```sh
-kungfu agent hub qualify --output-dir ./kungfu-agent-hub-check
-kungfu agent hub verify --qualification-dir ./kungfu-agent-hub-check
-```
-
-Use `--json` when an Agent is the reader. A pass proves only the named local
-artifact, two isolated local authority domains, and the fixed KFD package cut.
-It is not KFD certification, security assessment, production fitness,
-remote-network interoperability, external adoption, or evidence for an
-unobserved platform.
+Kungfu v4 is **Coming soon**. The current repository contains source-built
+capabilities and retained qualification evidence; public release artifacts are
+not available yet. Exact status and non-claims live in
+[Known Limits](docs/qualification/known-limits.md).
 
 <!-- buildchain:badges:start -->
 [![KFD-1: declared](https://buildchain.libkungfu.dev/badges/v1/kfd-1/declared.svg)](https://github.com/kungfu-systems/kungfu/releases/latest/download/buildchain.release.json)


### PR DESCRIPTION
## Summary

Make the root README a focused first-use product entry for people who already work across multiple Agent interfaces.

## Related issue

None.

## Changes

- present the existing Agent, managed console, and optional TUI or GUI sidecar as three low-friction entry paths
- organize the retained demonstrations as continuity, failure retention, and completion-authority proofs
- keep the Project, Work, and Attempt model concise and route technical evaluation to maintained documentation
- bind future demo titles to the same user-facing questions in the Kungfu consumer configuration

## Verification

- `./shifu docs:check`
- `./shifu docs:prose`
- `./shifu node --test scripts/check-project-work-agent-product.test.mjs`
- `./shifu node --test scripts/check-trademark-public-use.test.mjs`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This change simplifies README presentation and demo headings without altering an architecture contract or implementation status."
}
-->

## Evolution Map impact

Evolution impact: none

This change clarifies the current product entry and does not add an authority transition or abstraction.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The existing KUNGFU mark remains on the first screen, and the retained demo evidence is linked without changing its authority or claim boundary. No release artifact is generated.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed